### PR TITLE
fix(daemon): pin the Landlock root after chroot, not before

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1910,6 +1910,101 @@ mod module_access_tests {
         );
     }
 
+    /// A module served WITHOUT chroot keeps the real module path as its
+    /// Landlock root - the arm that always worked, pinned so the chroot arms
+    /// below cannot be satisfied by making the new root selection
+    /// unconditional.
+    #[test]
+    fn an_unchrooted_module_pins_landlock_to_the_real_module_path() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            path: PathBuf::from("/srv/data"),
+            ..Default::default()
+        });
+        assert_eq!(
+            landlock_root(&module, &PrivilegeOutcome::not_chrooted()),
+            LandlockRoot::Confine(Path::new("/srv/data")),
+        );
+    }
+
+    /// WHY: `engage_landlock_sandbox` runs AFTER `chroot()`, and
+    /// `restrict_to_module_paths` OPENS every root it is given. Handing it the
+    /// pre-chroot `module.path` therefore cannot work: the kernel returns
+    /// ENOENT and the layer degrades to a warning. MEASURED on Linux 7.0
+    /// x86_64 before this pin, with `use chroot = yes` and `path = /srv/data`:
+    /// `landlock setup failed: failed to open "/srv/data": No such file or
+    /// directory`, the transfer completing with chroot as the only
+    /// confinement. So: never the pre-chroot path once chrooted.
+    #[test]
+    fn a_chrooted_module_never_pins_landlock_to_the_pre_chroot_path() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            path: PathBuf::from("/srv/data"),
+            ..Default::default()
+        });
+        for inner in [Some(PathBuf::from("/")), Some(PathBuf::from("/inner")), None] {
+            let outcome = PrivilegeOutcome {
+                chroot_applied: true,
+                inner_module_path: inner.clone(),
+            };
+            assert_ne!(
+                landlock_root(&module, &outcome),
+                LandlockRoot::Confine(Path::new("/srv/data")),
+                "post-chroot the pre-chroot path opens nothing; inner={inner:?}"
+            );
+        }
+    }
+
+    /// A chroot whose root IS the module root subsumes the allowlist, so the
+    /// layer must stand aside as a TAKEN branch rather than attempt an install
+    /// that cannot succeed. Pinning `SubsumedByChroot` (not merely "not the old
+    /// path") keeps a future edit from substituting the post-chroot `/`: the
+    /// `READONLY_SYSTEM_PATHS` rules resolve inside the jail and a deeper
+    /// Landlock rule overrides a shallower one, so a module tree containing
+    /// `etc/` or `var/` would silently become read-only.
+    ///
+    /// upstream: clientserver.c:912-925 sets `module_dir = "/"` then zeroes
+    /// `module_dirlen`, so clientserver.c:1093
+    /// `use_secure_symlinks = am_daemon && (!am_chrooted || module_dirlen)`
+    /// is false here - upstream reaches the same conclusion for its own
+    /// path-confinement layer.
+    #[test]
+    fn a_chroot_at_the_module_root_subsumes_landlock() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            path: PathBuf::from("/srv/data"),
+            ..Default::default()
+        });
+        let outcome = PrivilegeOutcome {
+            chroot_applied: true,
+            inner_module_path: Some(PathBuf::from("/")),
+        };
+        assert_eq!(
+            landlock_root(&module, &outcome),
+            LandlockRoot::SubsumedByChroot,
+        );
+    }
+
+    /// The `/./` shape is the one that genuinely needs Landlock: the chroot
+    /// lands on the OUTER path, so nothing kernel-side confines the inner
+    /// module boundary. Pin the post-chroot inner directory as the root.
+    ///
+    /// upstream: clientserver.c:1084-1093 - "the kernel chroot confines the
+    /// outer path but not the inner module", which is why upstream keeps its
+    /// own secure-symlink path active for exactly this configuration.
+    #[test]
+    fn a_chroot_with_an_inner_boundary_pins_landlock_to_the_inner_path() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            path: PathBuf::from("/srv/outer/./inner"),
+            ..Default::default()
+        });
+        let outcome = PrivilegeOutcome {
+            chroot_applied: true,
+            inner_module_path: Some(PathBuf::from("/inner")),
+        };
+        assert_eq!(
+            landlock_root(&module, &outcome),
+            LandlockRoot::Confine(Path::new("/inner")),
+        );
+    }
+
     #[test]
     fn build_daemon_filter_rules_empty_module() {
         let module = test_module_with_defaults();

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -1940,7 +1940,11 @@ mod module_access_tests {
             path: PathBuf::from("/srv/data"),
             ..Default::default()
         });
-        for inner in [Some(PathBuf::from("/")), Some(PathBuf::from("/inner")), None] {
+        for inner in [
+            Some(PathBuf::from("/")),
+            Some(PathBuf::from("/inner")),
+            None,
+        ] {
             let outcome = PrivilegeOutcome {
                 chroot_applied: true,
                 inner_module_path: inner.clone(),

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -582,12 +582,17 @@ fn process_approved_module(
     // collected above are admitted to the allowlist alongside the module
     // root (URV-5.b.REOPEN): they are guaranteed in-tree and would
     // otherwise EACCES under a default-on flip.
+    //
+    // `privilege_outcome` is threaded through because the root itself depends
+    // on it: post-chroot, `module.path` is a name this process no longer has.
+    // It also carries the case where the layer deliberately stands aside -
+    // a chroot rooted at the module directory.
     let extra_allowed: Vec<&Path> = validated_client_paths
         .landlock_roots
         .iter()
         .map(|p| p.as_path())
         .collect();
-    if !engage_landlock_sandbox(ctx, module, &extra_allowed)? {
+    if !engage_landlock_sandbox(ctx, module, &privilege_outcome, &extra_allowed)? {
         let host_owned = ctx.host_display().to_owned();
         run_post_xfer_finalizer(
             ctx,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -416,6 +416,63 @@ fn landlock_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
     None
 }
 
+/// Where the Landlock allowlist must be pinned once chroot has already run,
+/// or why the layer deliberately stands aside.
+///
+/// `restrict_to_module_paths` opens every root it is handed, and it runs
+/// **after** `chroot()`. A pre-chroot absolute path is therefore not a path
+/// this process can name any more, which is why the root has to be re-derived
+/// from the privilege outcome rather than read off `module.path`.
+#[derive(Debug, PartialEq, Eq)]
+enum LandlockRoot<'a> {
+    /// Pin the allowlist beneath this (currently resolvable) directory.
+    Confine(&'a Path),
+    /// The chroot root *is* the module root, so the kernel already denies
+    /// exactly what the allowlist would deny. Skip, deliberately.
+    SubsumedByChroot,
+}
+
+/// Selects the Landlock root for a connection whose chroot and privilege drop
+/// have already been applied.
+///
+/// Three cases, and the split mirrors upstream's own predicate for "does the
+/// kernel chroot already confine this module?":
+///
+/// - **Not chrooted** (`use chroot = no`, or the unset rootless auto-fallback):
+///   confine to the real module path, as before.
+/// - **Chrooted at the module root** (no `/./` marker): upstream sets
+///   `module_dir = "/"` and `module_dirlen = 1`, then immediately zeroes that
+///   length - clientserver.c:912-925 - so its own
+///   `use_secure_symlinks = am_daemon && (!am_chrooted || module_dirlen)`
+///   (clientserver.c:1093) evaluates false: with no inner boundary the chroot
+///   is the whole confinement. Landlock over the post-chroot `/` would deny
+///   nothing extra, and it would actively *narrow* the module: the
+///   `READONLY_SYSTEM_PATHS` rules (`/etc`, `/usr`, `/var`, ...) are resolved
+///   inside the jail, and a Landlock rule on a deeper directory overrides a
+///   shallower one - so a module tree that happens to contain `etc/` or `var/`
+///   (a system backup, say) would become read-only. Stand aside.
+/// - **Chrooted with a `/./` inner boundary**: the chroot lands on the OUTER
+///   path, leaving the inner module boundary unguarded - upstream keeps its
+///   secure-symlink path active for exactly this shape (clientserver.c:1084-1093
+///   `the kernel chroot confines the outer path but not the inner module`).
+///   Confine to the post-chroot inner directory, which is the one root that is
+///   both resolvable now and narrower than the jail.
+///
+/// upstream: rsync has no Landlock layer at all; only the
+/// chrooted-vs-inner-boundary predicate above is mirrored from it.
+fn landlock_root<'a>(
+    module: &'a ModuleRuntime,
+    privilege_outcome: &'a PrivilegeOutcome,
+) -> LandlockRoot<'a> {
+    if !privilege_outcome.chroot_applied {
+        return LandlockRoot::Confine(module.path.as_path());
+    }
+    match privilege_outcome.inner_module_path.as_deref() {
+        Some(inner) if inner != Path::new("/") => LandlockRoot::Confine(inner),
+        _ => LandlockRoot::SubsumedByChroot,
+    }
+}
+
 /// Why a kernel sandbox layer must be skipped for a module that runs an
 /// `exec()` hook, or `None` when no hook is configured.
 ///
@@ -449,6 +506,11 @@ fn exec_hook_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
 /// non-Linux targets short-circuits to `Unavailable` so the wire-in does
 /// not need `#[cfg]` branching.
 ///
+/// Because it runs post-chroot, the root comes from [`landlock_root`] and not
+/// from `module.path`, which by then names nothing this process can open. That
+/// helper also decides the one case where the layer stands aside on purpose: a
+/// chroot whose root is already the module root.
+///
 /// `extra_allowed_paths` carries absolute, in-module paths that
 /// `validate_client_paths_in_module` admitted from the client args
 /// (`--temp-dir` / `--partial-dir` / `--backup-dir` / `--compare-dest` /
@@ -457,14 +519,13 @@ fn exec_hook_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
 /// Closing URV-5.b.REOPEN: without the widening, a default-on Landlock
 /// flip would EACCES the very paths the operator's configuration permits.
 ///
-/// Returns `Ok(true)` on every non-fatal outcome (engaged, downgraded,
-/// unavailable, skipped by the operator's `OC_RSYNC_NO_LANDLOCK` /
-/// `OC_RSYNC_DAEMON_LANDLOCK=0` opt-out, or skipped because a
-/// pre/post-xfer-exec hook is configured).
-/// Returns `Ok(false)` after emitting an `@ERROR` reply when the kernel
-/// advertised Landlock support but the helper failed to engage the ruleset -
-/// we treat that as a regression because the SEC-1.p design requires the
-/// sandbox to be live on supporting kernels.
+/// Always returns `Ok(true)`: no Landlock outcome aborts the connection,
+/// because SEC-1 `*at` helpers remain the primary defense in every one of
+/// them. The `Ok(false)` arm is kept in the signature so a future default-on
+/// flip can make a failed install fatal without rippling through the caller.
+/// A ruleset the kernel advertised but refused is logged as a WARNING naming
+/// the root and the OS error - it is a regression, and after the post-chroot
+/// root fix it can no longer be produced by our own path handling.
 ///
 /// When `pre_xfer_exec` or `post_xfer_exec` is configured, the sandbox is
 /// skipped: Landlock rulesets are inherited by child processes, so engaging
@@ -476,6 +537,7 @@ fn exec_hook_skip_reason(module: &ModuleRuntime) -> Option<&'static str> {
 fn engage_landlock_sandbox(
     ctx: &mut ModuleRequestContext<'_>,
     module: &ModuleRuntime,
+    privilege_outcome: &PrivilegeOutcome,
     extra_allowed_paths: &[&Path],
 ) -> io::Result<bool> {
     use fast_io::landlock::{
@@ -505,6 +567,28 @@ fn engage_landlock_sandbox(
         return Ok(true);
     }
 
+    // Chroot already ran, so the root must be re-derived: `module.path` is a
+    // pre-chroot absolute path this process can no longer name, and handing it
+    // to the kernel produced `landlock setup failed: failed to open <path>: No
+    // such file or directory` on every chrooted module - an attempted-and-
+    // failed layer reported as a warning rather than as a decision. MEASURED
+    // on Linux 7.0 x86_64 before this change, for both `path = /srv/data` and
+    // `path = /srv/outer/./inner`.
+    let root = match landlock_root(module, privilege_outcome) {
+        LandlockRoot::Confine(path) => path,
+        LandlockRoot::SubsumedByChroot => {
+            if let Some(log) = ctx.log_sink {
+                let text = format!(
+                    "module '{}': landlock=skipped reason=chroot root is the module root (the kernel chroot already confines this module; see clientserver.c:1093)",
+                    ctx.request,
+                );
+                let message = rsync_info!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            return Ok(true);
+        }
+    };
+
     if !is_supported() {
         if let Some(log) = ctx.log_sink {
             let text = format!(
@@ -517,17 +601,20 @@ fn engage_landlock_sandbox(
         return Ok(true);
     }
 
-    // Roots: the module path is the always-present writable surface plus
-    // any client-supplied alt-basis (`--compare-dest` / `--copy-dest` /
-    // `--link-dest`) or relocation (`--temp-dir` / `--partial-dir` /
-    // `--backup-dir`) paths that `validate_client_paths_in_module` has
-    // already confirmed to resolve beneath `module.path` (URV-5.b.1).
-    // Widening the allowlist to those paths is safe because the containment
-    // check already proved they cannot escape the module tree; without the
-    // widening, a default-on Landlock flip (URV-5.c.5) would EACCES
-    // legitimate writes the operator's configuration permits.
+    // Roots: the module root selected above is the always-present writable
+    // surface plus any client-supplied alt-basis (`--compare-dest` /
+    // `--copy-dest` / `--link-dest`) or relocation (`--temp-dir` /
+    // `--partial-dir` / `--backup-dir`) paths that
+    // `validate_client_paths_in_module` has already confirmed to resolve
+    // beneath that same root (URV-5.b.1) - it derives the root from the very
+    // same privilege outcome, so both halves of the allowlist live in the same
+    // (post-chroot) namespace. Widening the allowlist to those paths is safe
+    // because the containment check already proved they cannot escape the
+    // module tree; without the widening, a default-on Landlock flip
+    // (URV-5.c.5) would EACCES legitimate writes the operator's configuration
+    // permits.
     let mut roots: Vec<&Path> = Vec::with_capacity(1 + extra_allowed_paths.len());
-    roots.push(module.path.as_path());
+    roots.push(root);
     roots.extend_from_slice(extra_allowed_paths);
 
     match restrict_to_module_paths(&roots) {
@@ -591,11 +678,15 @@ fn engage_landlock_sandbox(
             // The kernel said yes to landlock but no to our ruleset; this
             // is a regression worth surfacing. Log a warning and continue
             // rather than killing the connection - the SEC-1 *at* chain
-            // still provides the primary defense.
+            // still provides the primary defense. Name the root we asked the
+            // kernel to pin: the previous message reported only the OS error,
+            // which read as an environment problem when it was in fact a
+            // pre-chroot path handed to a post-chroot process.
             if let Some(log) = ctx.log_sink {
                 let text = format!(
-                    "module '{}': landlock setup failed: {err}; relying on SEC-1 *at* defense",
+                    "module '{}': landlock setup failed for root {}: {err}; relying on SEC-1 *at* defense",
                     ctx.request,
+                    root.display(),
                 );
                 let message = rsync_warning!(text).with_role(Role::Daemon);
                 log_message(log, &message);

--- a/docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md
+++ b/docs/design/sec-1-p-landlock-defense-in-depth-2026-05-22.md
@@ -145,6 +145,8 @@ auth complete -> validate_module_path -> apply_module_privilege_restrictions
 The set of paths passed to `restrict_to_paths` is the union of:
 
 1. `module.path` - mandatory, always present (parsed in `crates/daemon/src/daemon/sections/config_parsing/module_directives.rs`).
+
+   **Correction (as shipped).** `module.path` is the wrong root once the module chroots, because the call site above runs *after* `chroot()` and `restrict_to_module_paths` opens every root it is handed. The shipped code re-derives the root from the privilege outcome (`landlock_root` in `module_access/transfer/sandbox.rs`): the real module path when not chrooted; the post-chroot inner directory for a `/./` module; and no ruleset at all when the chroot root already is the module root, where the kernel chroot supplies the same confinement (upstream reaches the same conclusion for its own path-confinement layer at `clientserver.c:1093`).
 2. The module lock file directory, if configured (`module.lock_file` - the daemon needs to update the file during the connection).
 3. Any auxiliary log paths the daemon writes per-connection (transfer log, xfer log).
 


### PR DESCRIPTION
## What was wrong

`engage_landlock_sandbox` runs **after** `chroot()` and `restrict_to_module_paths` **opens** every root it is handed. It was handed `module.path` - a pre-chroot absolute path the process can no longer name. So on every module with `use chroot = true` the sandbox attempted to install, failed, logged a warning, and continued.

Measured on Linux 7.0 x86_64, root daemon, before this change:

```
[..] chroot applied: '/tmp/ll1050/srv/data'
[..] oc-rsync warning: module 'plain': landlock setup failed: failed to open
     "/tmp/ll1050/srv/data": No such file or directory (os error 2);
     relying on SEC-1 *at* defense
```

Same failure for `path = /srv/outer/./inner`. Both transfers completed. This is the "a guard that exists and does not run" shape: wired, attempted, failed, and the failure reported as a warning rather than as a decision.

## Which option, and why

Neither (a) nor (b) alone. Upstream's own two-arm predicate decides it, and the shape of the module decides which arm applies:

```c
/* clientserver.c:1084-1093 */
/* Enable secure symlink handling for any non-chrooted daemon module, and
 * for a chroot module with a /./ inner boundary (module_dirlen) -- there
 * the kernel chroot confines the outer path but not the inner module ... */
use_secure_symlinks = am_daemon && (!am_chrooted || module_dirlen)
		    && !symlink_optout_allowed();
```

Upstream asks exactly the question this task asks - *does the kernel chroot already confine this module?* - and answers it in two arms. So:

| module shape | Landlock root | rationale |
|---|---|---|
| not chrooted (`use chroot = no`, or the rootless auto-fallback) | the real module path | unchanged |
| chrooted, **no** `/./` marker | **none - skipped, as a taken and logged branch** | option (a) |
| chrooted, **with** a `/./` inner boundary | the post-chroot inner directory | option (b) |

**Why (a) for the no-marker case rather than pinning the post-chroot `/`.** Upstream sets `module_dir = "/"`, `module_dirlen = 1`, then immediately zeroes that length (`clientserver.c:912-925`), so its predicate above evaluates false: with no inner boundary the chroot *is* the whole confinement. Landlock over `/` inside that jail would deny nothing extra. Worse, it would actively narrow the module: `restrict_to_module_paths` also adds read-only rules for `READONLY_SYSTEM_PATHS` (`/etc`, `/usr`, `/var`, ...), those resolve *inside* the jail, and a Landlock rule on a deeper directory overrides a shallower one - so a served tree that happens to contain `etc/` or `var/` (a system backup, the ordinary case) would silently become read-only. That is what option (b) would have cost here.

**Why (b) for the `/./` case.** There the chroot lands on the OUTER path and the inner module boundary is unguarded - upstream keeps its own secure-symlink path active for precisely this shape. This is the one configuration where Landlock adds confinement the kernel does not already provide, and it is the arm where the bug was not merely cosmetic.

**This is an oc-only divergence and the PR owns it as such.** Upstream rsync has no Landlock layer, no seccomp layer, and no LSM sandbox of any kind (`grep -rn 'landlock' rsync-3.5.0/*.c` returns nothing). Only the *decision predicate* is mirrored from upstream; the mechanism it gates is ours.

## The failure is not silent

- The skip is a taken branch with its own log line, in the same `landlock=skipped reason=...` form the existing exec-hook and `insecure links` skips use, and it names the upstream anchor:
  `module 'plain': landlock=skipped reason=chroot root is the module root (the kernel chroot already confines this module; see clientserver.c:1093)`
- A genuine install failure still warns, and now names the root it asked the kernel to pin - the old message reported only the OS error, which read as an environment problem when it was in fact our own path handling.
- The rustdoc claimed a failed install sends `@ERROR` and returns `Ok(false)`. It never did; the code has always returned `Ok(true)`. Doc corrected to match the code, with the reason the arm stays non-fatal.

## Verified

Real root daemon on Linux 7.0 x86_64, one daemon process per module (`chroot()` is process-wide).

After:

```
=== case 'plain'  path=/tmp/ll1050/srv/data ===             client exit=0
  chroot applied: '/tmp/ll1050/srv/data'
  module 'plain': landlock=skipped reason=chroot root is the module root (...)
=== case 'inner'  path=/tmp/ll1050/srv/outer/./inner ===    client exit=0
  chroot applied: '/tmp/ll1050/srv/outer'
  module 'inner': landlock fully enforced over 1 root(s)
```

The `inner` module now genuinely installs the ruleset it has never once installed before. Writes verified too (push into `read only = no` modules, all three shapes - `inner`, `plain`, `nochroot` - complete with exit 0 and the files land).

RED/GREEN by mutation - `landlock_root` reverted to the pre-fix `Confine(&module.path)`:

```
RED    Summary [0.184s] 7 tests run: 4 passed, 3 failed, 1894 skipped
GREEN  Summary [0.023s] 7 tests run: 7 passed, 1894 skipped
```

The one chroot-independent test (`an_unchrooted_module_pins_landlock_to_the_real_module_path`) passes in both legs by design - it is the non-vacuity companion that stops the three chroot tests being satisfied by an unconditional skip.

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p daemon --all-features --no-fail-fast` - `1895 tests run: 1895 passed, 6 skipped`
- `cargo run -p xtask -- citations` - 8628 citations check
- `cargo check -p daemon --all-features --target x86_64-pc-windows-gnu` clean

## Out of scope, found while measuring

Two pre-existing behaviours, neither touched here:

1. **`--temp-dir=<relative>` fails on a daemon push** with `error=No such file or directory (os error 2) at streams.rs(420)`, reproducing identically on the `use chroot = no` path whose behaviour this PR does not change. ENOENT, not EACCES, so it is not a Landlock denial.
2. **`chroot()` is process-wide but the daemon is threaded**, so the first chrooted module a daemon process serves relocates the root for every later connection in that process - a second module's path then fails to resolve. Reproducible with two chrooted modules in one config.
