### PR TITLE
docs: state that line coverage is not gated by CI

### DIFF
--- a/.github/RELEASE_NOTES_BETA.md
+++ b/.github/RELEASE_NOTES_BETA.md
@@ -78,11 +78,12 @@ This release is the first build that meets all four criteria simultaneously:
 2. **No production-path placeholders.** `tools/no_placeholders.sh` is clean;
    no `todo!`, `unimplemented!`, `FIXME`, or stub functions on live code
    paths.
-3. **Interop and coverage.** `tools/ci/run_interop.sh` passes against
-   upstream rsync **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** with zero
-   entries in `KNOWN_FAILURES.conf`; `cargo llvm-cov` line coverage at or
-   above **95%**; all required CI checks green on master (fmt+clippy,
+3. **Interop.** `tools/ci/run_interop.sh` passes against upstream rsync
+   **3.0.9**, **3.1.3**, **3.4.1**, and **3.4.2** with zero entries in
+   `KNOWN_FAILURES.conf`; all required CI checks green on master (fmt+clippy,
    nextest stable, Windows stable, macOS stable, Linux musl stable).
+   Line coverage is deliberately absent from this list: no workflow measures
+   it, so it cannot be a release criterion. See *Coverage* below.
 4. **Unsafe-code policy honored.** `#[allow(unsafe_code)]` confined to the
    permitted crates only: `metadata`, `fast_io`, `checksums`, `engine`,
    `protocol` (plus the documented `windows-gnu-eh` shim and the
@@ -371,11 +372,14 @@ Headline numbers (TBD once the post-tag benchmark workflow completes):
 
 ### Coverage
 
-- Workspace `cargo llvm-cov` line coverage: **TBD%** (BR-4a baseline once
-  recorded; target >= 95%).
-- Per-crate breakdown and any crates below target are recorded in the
-  BR-4a audit report under `docs/audits/`. Replace this bullet with the
-  final number and a link to the recorded baseline at tag time.
+- Not enforced by CI. The `Coverage` workflow was removed in `4cf315af9`
+  after repeated 45-minute timeouts on `master`, and nothing replaced it, so
+  no workflow computes a coverage number. The >= 95% figure is a project
+  aspiration, not a gate, and no release is blocked on it.
+- Last recorded workspace measurement: **85.52%** line coverage (145 055 /
+  169 620 lines), 13 of 27 members below 95%. Source:
+  `docs/audits/br-4a-workspace-coverage-2026-05-20.md`, measured 2026-05-20
+  and not refreshed since. Re-measure locally before quoting it at tag time.
 
 ---
 

--- a/docs/audits/br-4a-workspace-coverage-2026-05-20.md
+++ b/docs/audits/br-4a-workspace-coverage-2026-05-20.md
@@ -1,12 +1,18 @@
 # BR-4a: Workspace `cargo llvm-cov` Baseline (2026-05-20)
 
+> **Historical record.** The `Coverage` workflow this baseline came from was
+> deleted in `4cf315af9` (2026-06-14) after repeated 45-minute timeouts on
+> `master`. No workflow computes coverage today, so the 84% figure below is no
+> longer enforced anywhere and the numbers are frozen at 2026-05-20. Kept as
+> the last measured per-crate breakdown, not as a description of current CI.
+
 Read-only measurement of workspace line- and function-coverage produced by the
 `Coverage` GitHub Actions workflow. Captures the beta-readiness baseline against
 the project target of **>= 95% line coverage** (declared in
-`.github/workflows/coverage.yml` header and step summary). The current
-informational gate enforced in CI is 84% line coverage; this audit records
-where each crate sits between that gate and the 95% target so that BR-4b can
-attack the largest gaps first.
+`.github/workflows/coverage.yml` header and step summary). The informational
+gate then configured in CI was 84% line coverage; this audit records where each
+crate sits between that gate and the 95% target so that BR-4b can attack the
+largest gaps first.
 
 ## Data source
 

--- a/docs/audits/br-5b-non-required-ci-triage.md
+++ b/docs/audits/br-5b-non-required-ci-triage.md
@@ -199,6 +199,8 @@ caller (CI, ci-skip, benchmark). They are not separately triageable.
 
 ### Coverage (`coverage.yml`)
 
+- **Since deleted** in `4cf315af9` (2026-06-14) over 45-minute timeouts on
+  `master`. No workflow computes coverage now. Triage below is a record.
 - Workflow id: 250331833
 - Last 20 runs: 8 success, 4 cancelled (superseded by newer pushes),
   8 skipped (PRs without `coverage-required` label).

--- a/docs/audits/ci-workflow-hazards.md
+++ b/docs/audits/ci-workflow-hazards.md
@@ -107,6 +107,10 @@ Severity: low-medium. Largest workflow, generally well-structured.
 
 ### `coverage.yml`
 
+Superseded: hazard 1 below was never fixed and the workflow was deleted in
+`4cf315af9` for exactly that reason - the 45-minute job kept timing out on
+`master`. No workflow computes coverage now. Findings retained as a record.
+
 | # | Finding | Severity | Recommended fix |
 |---|---|---|---|
 | 1 | Single 45-min job runs `cargo llvm-cov nextest --workspace --all-features`. nextest partitioning is not used. | medium | Coverage tools like `cargo-llvm-cov` support `--no-report` per partition with a final `--no-run --report` merge step. Worth investigating; saves ~30-50% wall time on a cold run. |

--- a/docs/audits/cross-platform-ci-coverage.md
+++ b/docs/audits/cross-platform-ci-coverage.md
@@ -78,7 +78,7 @@ The macOS/Windows runners ignore this workflow entirely.
 |--------------------------------|-----------------|------------------------------------|--------------------------------------|
 | `parallel_determinism.yml`     | ubuntu-latest   | push/PR on `crates/`               | sequential vs parallel output diff   |
 | `interop-validation.yml`       | ubuntu-latest (x8 jobs) | push/PR/schedule           | exit codes, batch, daemon scenarios  |
-| `coverage.yml`                 | ubuntu-latest   | push/PR/schedule (nightly)         | `cargo llvm-cov`, informational      |
+| `coverage.yml`                 | ubuntu-latest   | push/PR/schedule (nightly)         | `cargo llvm-cov`, informational - **since deleted in `4cf315af9`; no workflow computes coverage** |
 | `msrv.yml`                     | ubuntu-latest   | push/PR                            | `cargo check` workspace on 1.88      |
 | `security.yml`                 | ubuntu-latest   | push/PR/schedule                   | `cargo audit`/dep-review             |
 | `known-failures.yml`           | ubuntu-latest   | weekly                             | upstream-rsync known-failure list    |

--- a/docs/audits/windows-acl-xattr-ci-matrix.md
+++ b/docs/audits/windows-acl-xattr-ci-matrix.md
@@ -28,7 +28,8 @@ Source of truth: `.github/workflows/`. Of 16 workflow files, only two run on
 for `x86_64-pc-windows-gnu` on `ubuntu-latest`. This catches compile errors
 but executes nothing.
 
-`coverage.yml:40` runs only on `ubuntu-latest`. The `_test-features.yml`
+`coverage.yml:40` ran only on `ubuntu-latest` (the workflow was since deleted
+in `4cf315af9`; no workflow computes coverage). The `_test-features.yml`
 reusable workflow (`ci.yml:141-147`) hard-codes `runs-on: ubuntu-latest`
 (`_test-features.yml:25`) and gates `io_uring` and `copy_file_range` to Linux
 via `linux_only: true`, but no entry currently isolates `acl` or `xattr` as
@@ -108,7 +109,7 @@ cross-OS strategy with a parallel `windows-latest` runner.
 
 - Workflows: `.github/workflows/ci.yml:151-227`,
   `.github/workflows/_test-features.yml:22-86`,
-  `.github/workflows/coverage.yml:40-69`,
+  `.github/workflows/coverage.yml:40-69` (deleted in `4cf315af9`),
   `.github/workflows/release-cross.yml:599`.
 - Code: `crates/metadata/Cargo.toml:26-39`,
   `crates/metadata/src/lib.rs:71-170`,

--- a/docs/contributing/TESTING.md
+++ b/docs/contributing/TESTING.md
@@ -15,8 +15,25 @@ Tests are layered by scope and purpose:
 5. **Fuzz targets** - find parser crashes and logic errors via cargo-fuzz.
 6. **SIMD parity tests** - ensure scalar and SIMD implementations produce identical output.
 
-Every change must include tests. The project targets greater than 95% line coverage
-(`cargo llvm-cov`), measured locally.
+Every change must include tests.
+
+The project *targets* greater than 95% line coverage, but that number is an
+aspiration, not a gate. **No workflow computes coverage.** The `Coverage`
+workflow was removed in `4cf315af9` after repeated 45-minute timeouts on
+`master`; even while it existed its threshold step carried
+`continue-on-error: true`, was pinned at 84% rather than 95%, and was never a
+required check. Nothing has replaced it, so no CI job can fail on a coverage
+drop.
+
+The last recorded workspace measurement is **85.52% line coverage**
+(`docs/audits/br-4a-workspace-coverage-2026-05-20.md`, 2026-05-20), with 13 of
+27 members below 95%. Treat that as the working baseline until someone
+re-measures. To measure locally, scope it to the crate you touched - a
+full-workspace run compiles everything and takes well over half an hour:
+
+```sh
+cargo llvm-cov nextest -p <crate> --all-features
+```
 
 ## Per-Crate Expectations
 

--- a/docs/user/platform-support.md
+++ b/docs/user/platform-support.md
@@ -18,7 +18,7 @@ generation. Regressions block merge.
 
 | Target | Runner | Notes |
 |--------|--------|-------|
-| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | Full workspace nextest (stable/beta/nightly), SSH integration tests, interop against upstream rsync 3.0.9 - 3.4.3, coverage via `cargo-llvm-cov`, benchmarks, fuzzing |
+| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | Full workspace nextest (stable/beta/nightly), SSH integration tests, interop against upstream rsync 3.0.9 - 3.4.3, benchmarks, fuzzing |
 
 ### Tier 2 - first-class platforms
 
@@ -144,7 +144,11 @@ reference to guarantee correctness across code paths.
 | interop (Windows) | Windows | Best-effort smoke against MSYS2 rsync |
 | io_uring kernel compat | Linux | Fallback behaviour on 5.15 and 6.8 kernels |
 | DG-3 stress | Linux, Windows, macOS | 1000-thread concurrency stress |
-| coverage | Linux | `cargo-llvm-cov`, informational threshold |
+
+Line coverage is not one of these. No workflow runs `cargo llvm-cov`; the
+`Coverage` workflow was removed in `4cf315af9` after repeated 45-minute
+timeouts on `master`. Coverage is measured on demand locally - see
+`docs/contributing/TESTING.md`.
 
 ---
 

--- a/scripts/COVERAGE_QUICK_REFERENCE.md
+++ b/scripts/COVERAGE_QUICK_REFERENCE.md
@@ -95,6 +95,10 @@ CARGO_LLVM_COV_EXTRA_ARGS="--ignore-filename-regex tests/" ./scripts/coverage.sh
 
 ## CI Integration
 
+Not wired up in this repository - no workflow computes coverage, and the
+`Coverage` workflow was deleted in `4cf315af9`. The snippet below is a
+template for anyone who wants to add one.
+
 ```yaml
 # GitHub Actions
 - run: ./scripts/coverage.sh --lcov-only

--- a/scripts/coverage-README.md
+++ b/scripts/coverage-README.md
@@ -140,6 +140,10 @@ The script displays a summary including:
 
 ## CI/CD Integration
 
+None of the pipelines below are configured for this repository. No workflow
+computes coverage; the `Coverage` workflow was deleted in `4cf315af9` after
+repeated timeouts. These are templates, not a description of current CI.
+
 ### GitHub Actions
 
 ```yaml


### PR DESCRIPTION
## The hole

The project's stated ">95% line coverage" success metric runs in **no workflow at all**, while several docs still describe it as a live CI check.

`.github/workflows/coverage.yml` was deleted in `4cf315af9` ("ci: remove llvm-cov coverage workflow", 2026-06-14). Nothing replaced it:

```
$ grep -rl "llvm-cov" .github/workflows/
.github/workflows/locked-gate.yml   # a comment listing cargo subcommand names
```

`fuzz-coverage.yml` and `bin-build-coverage.yml` are unrelated - the first is cargo-fuzz corpus coverage, the second is a guard against test cells that never build the binary.

## Why it was deleted

From the commit message: the workflow "has been hitting timeouts on master (#4351) and is informational only." It was a single 45-minute `cargo llvm-cov nextest --workspace --all-features` job. `docs/audits/ci-workflow-hazards.md` had already flagged the wall time as the top hazard for that workflow, and the recommended partition fix was never applied.

## Why restoring it was rejected

Restoring it verbatim cannot produce a real pass/fail:

1. **It could not fail, by construction.** The threshold step carried `continue-on-error: true`. A restored copy would report green regardless of the number - the vacuous-green failure mode.
2. **It never enforced 95%.** The gate was `--fail-under-lines 84`. The 95% figure appeared only in a step-summary string.
3. **It was never required.** The repository ruleset requires 10 contexts; `llvm-cov` is not among them, and PR runs were additionally gated behind a `coverage-required` label, so most PRs skipped it entirely.
4. **A real 95% gate would fail immediately.** The last recorded workspace measurement is 85.52% (145 055 / 169 620 lines), 13 of 27 members below 95%, needing 16 058 more covered lines - `docs/audits/br-4a-workspace-coverage-2026-05-20.md`.
5. **It is still unaffordable.** The timeout cause is unchanged, and the workflow pinned `nightly-2026-04-20` (needed for `--branch`, chosen to dodge an llvm-cov SIGSEGV), now several months stale.

So the honest fix is to correct the documentation rather than re-add a job that either cannot fail or fails on every run.

## Doc sites corrected

Current-state claims:

| File | Claim |
|---|---|
| `docs/contributing/TESTING.md` | said "measured locally" but did not say the gate is absent; now states it outright, with the recorded baseline and a crate-scoped command |
| `docs/user/platform-support.md` | listed a `coverage / Linux / cargo-llvm-cov, informational threshold` row in the informational-checks table, plus `coverage via cargo-llvm-cov` in the Tier 1 blurb - both for a workflow that no longer exists |
| `.github/RELEASE_NOTES_BETA.md` | release acceptance criterion required "`cargo llvm-cov` line coverage at or above 95%"; the Coverage section still read "TBD% (BR-4a baseline once recorded)" although BR-4a was recorded in May |

Historical records, annotated rather than rewritten:

- `docs/audits/br-4a-workspace-coverage-2026-05-20.md` - superseded banner; "the current informational gate enforced in CI is 84%" moved to past tense
- `docs/audits/ci-workflow-hazards.md`, `docs/audits/br-5b-non-required-ci-triage.md`, `docs/audits/cross-platform-ci-coverage.md`, `docs/audits/windows-acl-xattr-ci-matrix.md` - noted the workflow is gone at each reference
- `scripts/COVERAGE_QUICK_REFERENCE.md`, `scripts/coverage-README.md` - their "CI Integration" sections are generic templates (one is a GitLab pipeline); labelled as such so they are not read as this repo's setup

Left alone: `docs/contributing/ONBOARDING.md` ("Aim for >95% line coverage of new code") and `docs/design/filter-perishable.md` already phrase the target as policy rather than a gate.

Docs only - no code or workflow changes.
