### PR TITLE
fix(engine): answer am_root from the process identity

### DIFF
--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -184,7 +184,7 @@ pub(super) fn effective_am_root(super_mode: Option<bool>, fake_super: bool) -> b
 /// privilege drop. It is `false` on Windows, matching upstream's `am_root = 0`
 /// on platforms without POSIX uid semantics.
 ///
-/// upstream: `main.c:1764` `our_uid = MY_UID()` - the libc `geteuid()`
+/// upstream: `main.c:1844` `our_uid = MY_UID()` - the libc `geteuid()`
 /// (`rsync.h:1455`), re-sampled by `become_copy_as_user()` after the
 /// `--copy-as` drop. A raw `geteuid` syscall answers neither: `fakeroot`
 /// interposes the libc symbol and not the syscall, so it reports the real

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -177,15 +177,20 @@ pub(super) fn effective_am_root(super_mode: Option<bool>, fake_super: bool) -> b
 }
 
 /// Returns whether the current process is running as the effective root user.
-#[cfg(unix)]
+///
+/// Delegates to [`metadata::am_root`], the single answer to this question
+/// (also used by `may_attempt_node_creation` and the metadata-sync options),
+/// which reads the cached **libc** `geteuid` and honours the `--copy-as`
+/// privilege drop. It is `false` on Windows, matching upstream's `am_root = 0`
+/// on platforms without POSIX uid semantics.
+///
+/// upstream: `main.c:1764` `our_uid = MY_UID()` - the libc `geteuid()`
+/// (`rsync.h:1455`), re-sampled by `become_copy_as_user()` after the
+/// `--copy-as` drop. A raw `geteuid` syscall answers neither: `fakeroot`
+/// interposes the libc symbol and not the syscall, so it reports the real
+/// unprivileged uid in exactly the runs where upstream believes it is root.
 pub(super) fn is_effective_root() -> bool {
-    rustix::process::geteuid().is_root()
-}
-
-/// On non-Unix platforms, there is no concept of a root user.
-#[cfg(not(unix))]
-pub(super) fn is_effective_root() -> bool {
-    false
+    ::metadata::am_root()
 }
 
 #[cfg(all(any(unix, windows), feature = "xattr"))]

--- a/crates/engine/src/local_copy/options/metadata/tests.rs
+++ b/crates/engine/src/local_copy/options/metadata/tests.rs
@@ -242,7 +242,7 @@ fn copy_as_clear() {
 /// The `am_root` gate must read the identity oc-rsync believes it has, not the
 /// kernel's raw answer.
 ///
-/// upstream: `main.c:1764` `our_uid = MY_UID()` - the **libc** `geteuid()`
+/// upstream: `main.c:1844` `our_uid = MY_UID()` - the **libc** `geteuid()`
 /// (`rsync.h:1455`) - and `become_copy_as_user()`, which re-samples it after
 /// the permanent `--copy-as` drop. Two consequences a raw `geteuid` syscall
 /// cannot reproduce: `fakeroot` interposes the libc symbol and not the

--- a/crates/engine/src/local_copy/options/metadata/tests.rs
+++ b/crates/engine/src/local_copy/options/metadata/tests.rs
@@ -238,3 +238,44 @@ fn copy_as_clear() {
         .with_copy_as(None);
     assert!(options.copy_as_ids().is_none());
 }
+
+/// The `am_root` gate must read the identity oc-rsync believes it has, not the
+/// kernel's raw answer.
+///
+/// upstream: `main.c:1764` `our_uid = MY_UID()` - the **libc** `geteuid()`
+/// (`rsync.h:1455`) - and `become_copy_as_user()`, which re-samples it after
+/// the permanent `--copy-as` drop. Two consequences a raw `geteuid` syscall
+/// cannot reproduce: `fakeroot` interposes the libc symbol and not the
+/// syscall, so on the upstream testsuite's fakeroot legs a raw answer reports
+/// the real unprivileged uid while upstream believes it is root; and after the
+/// `--copy-as` drop the dropped identity has to be observed. Either way the
+/// local-copy privileged paths (`--super`, device creation, the fake-super
+/// placeholder branch) are gated on the wrong answer.
+///
+/// `set_process_identity` is that identity source, so driving it in both
+/// directions keeps this test non-vacuous whatever uid the test process
+/// actually runs at.
+#[cfg(unix)]
+#[test]
+fn am_root_follows_the_process_identity_not_the_raw_euid() {
+    ::metadata::identity::set_process_identity(0, 0);
+    assert!(
+        is_effective_root(),
+        "a process identity of uid 0 is upstream's am_root"
+    );
+    assert!(
+        effective_am_root(None, false),
+        "with no --super/--fake-super the gate defers to that same identity"
+    );
+
+    const NON_ROOT_UID: u32 = 65534;
+    ::metadata::identity::set_process_identity(NON_ROOT_UID, NON_ROOT_UID);
+    assert!(
+        !is_effective_root(),
+        "a dropped, non-root identity is not am_root"
+    );
+    assert!(
+        !effective_am_root(None, false),
+        "the gate must follow the drop, as upstream re-samples our_uid after it"
+    );
+}


### PR DESCRIPTION
## Problem

`crates/engine/src/local_copy/options/metadata/accessors.rs` resolved the
local-copy `am_root` gate with `rustix::process::geteuid().is_root()`. Two
other consumers of the same question in the same crate already call
`metadata::am_root()`:

- `crates/engine/src/local_copy/options/path_behavior.rs:450`
  (`may_attempt_node_creation`)
- `crates/engine/src/local_copy/metadata_sync.rs:137`

So the crate had two ways to answer one question, and they do not agree.

## Why they do not agree

On Linux, rustix's default backend emits the bare syscall instruction instead
of calling the libc symbol. Compiled for `aarch64-unknown-linux-gnu`:

```asm
via_rustix:                    via_libc:
    mov  w8, #175                  b  geteuid
    svc  #0
```

`fakeroot` works by `LD_PRELOAD`-interposing the libc symbol, so it can see
`b geteuid` and cannot see `svc #0`. Under fakeroot the raw form reports the
real unprivileged uid while upstream rsync - which samples the libc
`geteuid()` (`main.c:1764` `our_uid = MY_UID()`, `rsync.h:1455`) - believes it
is root. That silently flips the `--super`, device-creation and fake-super
placeholder gates in exactly the runs meant to validate them: the upstream
testsuite's fakeroot legs and packaging builds.

The same call is also blind to the permanent `--copy-as` privilege drop.
Upstream re-samples `our_uid`/`am_root` in `become_copy_as_user()`;
`metadata::am_root()` reproduces that through the identity override installed
by `metadata::copy_as::become_copy_as_user`, a raw syscall does not.

## Change

`is_effective_root()` delegates to `metadata::am_root()`. The `#[cfg(unix)]` /
`#[cfg(not(unix))]` pair goes away because `metadata::am_root()` is already
`false` on non-POSIX platforms, matching upstream's `am_root = 0` there. No
behaviour change on a plain unprivileged or plain root run; the two now agree
under fakeroot and after `--copy-as`.

## Test

`am_root_follows_the_process_identity_not_the_raw_euid` drives the identity
source in both directions, so it is non-vacuous whatever uid the test process
runs at. Reverting the one-line fix to `rustix::process::geteuid().is_root()`
turns it red and nothing else:

```
FAIL [0.018s] engine local_copy::options::metadata::tests::am_root_follows_the_process_identity_not_the_raw_euid
  panicked at crates/engine/src/local_copy/options/metadata/tests.rs:262:5:
  a process identity of uid 0 is upstream's am_root
Summary [0.091s] 45 tests run: 44 passed, 1 failed
```

With the fix in place: `324 tests run: 324 passed` for
`test(local_copy::options) or test(execute_super)`.

`cargo fmt --all -- --check` and
`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
are clean. `cargo check -p engine --all-features --tests` also passes for
`x86_64-pc-windows-gnu`.
