### PR TITLE
fix: report a failed source unlink at FERROR_XFER

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5739,6 +5739,87 @@ fn source_base_interning_round_trips_and_shares() {
     );
 }
 
+/// A failed source unlink must hand the caller upstream's `FERROR_XFER` text,
+/// naming the file-list entry rather than the sender's real path.
+///
+/// WHY THIS MATTERS, and why an `io_error` bit is not a substitute.
+///
+/// Upstream's `successful_send()` sets no `io_error` bit at all: every failing
+/// arm ends at `rsyserr(FERROR_XFER, ...)` (`sender.c:455-462`), and it is that
+/// log code that decides the exit status. `rwrite()` sets `got_xfer_error = 1`
+/// on `FERROR_XFER` (`log.c:337-338`) and, on a server, forwards the same text
+/// to the client as `MSG_ERROR_XFER` (`log.c:357-367`), which sets
+/// `got_xfer_error` on the client too; `cleanup.c:217-218` then lifts a zero
+/// exit to `RERR_PARTIAL` (23) at BOTH ends. A sender that writes the failure
+/// to its own stderr therefore tells a pulling client nothing - not the
+/// message, and not the exit code - which is exactly how a destructive-intent
+/// option came to report success while having silently not removed anything.
+///
+/// The name is asserted as well because routing the text to the peer puts it on
+/// the wire: upstream prints `f_name(file, fname)` after `change_pathname()`
+/// (`sender.c:412-414`), i.e. the file-list name, so a daemon module never
+/// leaks its server-side prefix to the client.
+#[cfg(unix)]
+#[test]
+fn remove_source_files_failure_yields_ferror_xfer_text() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let temp = create_test_files(&[("keep.txt", b"payload")]);
+    let src = temp.path().join("keep.txt");
+    let (_h, mut ctx) = test_generator_for_path(&src, false);
+    ctx.config.flags.remove_source_files = true;
+    build_file_list_for(&mut ctx, &src);
+
+    let flat = (0..ctx.file_list.len())
+        .find(|&i| ctx.file_list[i].is_file())
+        .expect("the single-file source produces one file entry");
+    let wire = ctx.flat_to_wire_ndx(flat);
+    let flist_name = ctx.file_list[flat].path().to_path_buf();
+    ctx.pending_source_removals.mark_pending(flat);
+
+    // Deny write on the parent so the unlink fails with EACCES - a real
+    // permission refusal, not a vanished source (which is upstream's benign
+    // FINFO arm) and not a refused syscall.
+    let mut perms = std::fs::metadata(temp.path())
+        .expect("stat the source directory")
+        .permissions();
+    let restore = perms.clone();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(temp.path(), perms).expect("make the parent read-only");
+
+    let outcome = ctx.confirm_source_removal(wire);
+
+    std::fs::set_permissions(temp.path(), restore).expect("restore the parent");
+
+    assert!(
+        src.exists(),
+        "the fixture must exercise a FAILED unlink: the source is still there"
+    );
+    assert_ne!(
+        outcome.io_error, 0,
+        "a failed unlink is an error, not a silent no-op"
+    );
+    let text = outcome.error_xfer.as_deref().expect(
+        "a failed unlink must hand back upstream's FERROR_XFER text; \
+                 without it the caller has nothing to set got_xfer_error with, \
+                 and a pulling client exits 0 (sender.c:455-459, log.c:337-338)",
+    );
+    assert!(
+        text.contains("sender failed to remove"),
+        "the text must be upstream's, got: {text:?}"
+    );
+    assert!(
+        text.contains(&*flist_name.to_string_lossy()),
+        "the diagnostic must name the file-list entry {flist_name:?}, got: {text:?}"
+    );
+    assert!(
+        !text.contains(&*temp.path().to_string_lossy()),
+        "the diagnostic is forwarded to the peer, so it must not carry the \
+         sender's real path prefix (sender.c:412-414 f_name after \
+         change_pathname), got: {text:?}"
+    );
+}
+
 /// A source is removed only after its commit is confirmed by `MSG_SUCCESS`.
 ///
 /// Encodes the crash-safety contract of upstream `successful_send()`
@@ -5767,8 +5848,12 @@ fn remove_source_files_unlinks_after_msg_success() {
     );
 
     // MSG_SUCCESS(ndx) confirms the commit and drives the deferred unlink.
-    let io_error = ctx.confirm_source_removal(wire);
-    assert_eq!(io_error, 0, "a clean removal sets no io_error bits");
+    let outcome = ctx.confirm_source_removal(wire);
+    assert_eq!(outcome.io_error, 0, "a clean removal sets no io_error bits");
+    assert!(
+        outcome.error_xfer.is_none(),
+        "a clean removal queues no FERROR_XFER diagnostic"
+    );
     assert!(!src.exists(), "a confirmed source must be removed");
     assert!(
         ctx.pending_source_removals.is_empty(),
@@ -5804,7 +5889,7 @@ fn remove_source_files_defers_until_msg_success() {
     // A confirmation for an index the sender never marked pending must not
     // trigger a spurious deletion.
     let bogus_wire = ctx.flat_to_wire_ndx(flat) + 100;
-    assert_eq!(ctx.confirm_source_removal(bogus_wire), 0);
+    assert_eq!(ctx.confirm_source_removal(bogus_wire).io_error, 0);
     assert!(
         src.exists(),
         "a stray MSG_SUCCESS must never delete an unrelated source"
@@ -5877,7 +5962,7 @@ fn remove_source_files_mid_commit_teardown_retains_unconfirmed_sources() {
     // dropped: exactly one MSG_SUCCESS is consumed.
     let wire_first = ctx.flat_to_wire_ndx(file_flats[0]);
     assert_eq!(
-        ctx.confirm_source_removal(wire_first),
+        ctx.confirm_source_removal(wire_first).io_error,
         0,
         "a clean removal sets no io_error bits"
     );

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -299,8 +299,26 @@ impl GeneratorContext {
         // failed transfer returns via `?` above and never reaches this point,
         // so its source is intentionally left in place. This is the crash-safe
         // ordering the inline unlink violated.
+        // upstream: sender.c:455-462 - every failing arm of successful_send()
+        // ends at FERROR_XFER, and it is the LOG CODE that carries the exit
+        // status, not an io_error bit: rwrite() sets got_xfer_error (log.c:338)
+        // and, on a server, forwards the text as MSG_ERROR_XFER (log.c:357-367)
+        // so the client sets got_xfer_error too. cleanup.c:217-218 then lifts a
+        // zero exit to RERR_PARTIAL (23) on BOTH ends. Routing the failure
+        // through `emit_sender_diagnostic` is therefore what makes a pulling
+        // client exit 23; the io_error bit alone only reaches a client that is
+        // itself the sender, because this drain runs after the sender has
+        // already sent its MSG_IO_ERROR.
         for wire_ndx in reader.take_success_indices() {
-            self.io_error |= self.confirm_source_removal(wire_ndx);
+            let outcome = self.confirm_source_removal(wire_ndx);
+            self.io_error |= outcome.io_error;
+            if let Some(text) = outcome.error_xfer {
+                self.emit_sender_diagnostic(
+                    writer,
+                    super::super::protocol_io::SenderDiagnostic::ErrorXfer,
+                    &text,
+                )?;
+            }
         }
 
         // UTS-V3.A drain barrier: explicit user-space drain after

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -192,6 +192,58 @@ fn sender_op_failure(op: &str, path: &Path, error: &io::Error) -> String {
     )
 }
 
+/// What a `--remove-source-files` removal attempt owes its caller: the
+/// `io_error` bits to accumulate, and the `FERROR_XFER` diagnostic to report.
+///
+/// The two travel together because upstream produces them together: every
+/// failing arm of `successful_send()` ends at `rsyserr(FERROR_XFER, ...)` /
+/// `rprintf(FERROR_XFER, ...)`, and it is that log code - not an `io_error`
+/// bit - that upstream turns into the exit status. `rwrite()` sets
+/// `got_xfer_error = 1` on `FERROR_XFER`, and on a server it *also* forwards
+/// the text to the client as `MSG_ERROR_XFER`, which sets `got_xfer_error` over
+/// there too; `exit_cleanup()` then lifts a zero exit to `RERR_PARTIAL` (23).
+/// `successful_send()` sets no `io_error` bit at all, so a sender that only
+/// records bits leaves a pulling client at exit 0.
+///
+/// The `io_error` bit is kept as well because oc's client-side sender drains it
+/// into its own exit code; it is redundant with the diagnostic, never a
+/// substitute for it.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/sender.c:455-462` - the shared `failed:` label
+/// - `rsync-3.5.0/log.c:337-338` - `case FERROR_XFER: got_xfer_error = 1;`
+/// - `rsync-3.5.0/log.c:357-367` - `am_server` forwards it as `MSG_ERROR_XFER`
+/// - `rsync-3.5.0/cleanup.c:217-218` - `got_xfer_error` -> `RERR_PARTIAL`
+#[must_use]
+pub(crate) struct SourceRemovalOutcome {
+    /// `io_error` bits to OR into the transfer's accumulated state.
+    pub(crate) io_error: i32,
+    /// Upstream's `FERROR_XFER` text, newline-terminated, when the removal
+    /// failed or a guard refused it.
+    pub(crate) error_xfer: Option<String>,
+}
+
+impl SourceRemovalOutcome {
+    /// The removal succeeded, was not requested, or hit upstream's benign
+    /// `ENOENT` "already removed" arm.
+    const fn clean() -> Self {
+        Self {
+            io_error: 0,
+            error_xfer: None,
+        }
+    }
+
+    /// The removal failed or a guard refused it: upstream reports `text` at
+    /// `FERROR_XFER` and finishes `RERR_PARTIAL` (23).
+    fn error_xfer(text: String) -> Self {
+        Self {
+            io_error: super::super::io_error_flags::IOERR_GENERAL,
+            error_xfer: Some(text),
+        }
+    }
+}
+
 impl GeneratorContext {
     /// Writes one file's NDX + iflags (+ optional xattr response) header and the
     /// sum head that follows it.
@@ -1367,9 +1419,10 @@ impl GeneratorContext {
     /// removed" notice (`FINFO`); a re-stat failure, a source that changed since
     /// it entered the file list, or an unlink failure is an `FERROR_XFER`, which
     /// upstream turns into `got_xfer_error` -> exit 23 (`RERR_PARTIAL`) without
-    /// aborting the run. We mirror the exit code by returning
-    /// [`IOERR_GENERAL`](super::super::io_error_flags::IOERR_GENERAL); the send
-    /// loop reports it via `MSG_IO_ERROR` after the final file.
+    /// aborting the run. We mirror that by returning the diagnostic in
+    /// [`SourceRemovalOutcome::error_xfer`] for the caller to route through
+    /// `emit_sender_diagnostic`, which is where the `got_xfer_error` flag and
+    /// the `MSG_ERROR_XFER` frame to the client both come from.
     ///
     /// The dev/ino "destination file" guard (sender.c:433-440) is gated on
     /// `local_server` upstream. The network generator is never `local_server`
@@ -1380,28 +1433,33 @@ impl GeneratorContext {
     ///
     /// - `sender.c:395` `successful_send()`
     /// - `options.c:765` `remove_source_files` global
-    #[must_use]
     fn remove_source_file_if_requested(
         &self,
         source_path: &Path,
+        display_name: &Path,
         recorded: RecordedSourceIdentity,
-    ) -> i32 {
+    ) -> SourceRemovalOutcome {
         // upstream: sender.c:405-406 - bail before any FS calls when the flag is off.
         if !self.config.flags.remove_source_files {
-            return 0;
+            return SourceRemovalOutcome::clean();
         }
         // upstream: sender.c:405-406 - successful_send() is a no-op when
         // do_xfers is false (dry-run). Mirror that early return so --dry-run
         // never touches the filesystem.
         if self.config.flags.dry_run {
-            return 0;
+            return SourceRemovalOutcome::clean();
         }
 
         // upstream: sender.c:408-455 - the parent resolve, the fd-relative
         // re-stat and the unlink are ONE decision about ONE directory entry,
         // so they live together in a free function the guard tests drive
         // directly.
-        remove_confirmed_source(source_path, recorded, self.config.flags.copy_links)
+        remove_confirmed_source(
+            source_path,
+            display_name,
+            recorded,
+            self.config.flags.copy_links,
+        )
     }
 
     /// Runs the deferred `--remove-source-files` unlink for a file the peer has
@@ -1417,33 +1475,40 @@ impl GeneratorContext {
     /// The re-stat and changed-file guards in
     /// [`remove_source_file_if_requested`](Self::remove_source_file_if_requested)
     /// still gate the unlink, so a source that vanished or changed since it
-    /// entered the file list is never removed. Returns the `io_error` bits the
-    /// caller must OR into the transfer's accumulated error state.
+    /// entered the file list is never removed. Returns the `io_error` bits and
+    /// the `FERROR_XFER` diagnostic the caller must drain.
+    ///
+    /// Diagnostics name the file-list entry, not the reconstructed absolute
+    /// path: upstream reports `f_name(file, fname)` after `change_pathname()`
+    /// has moved it to the file's own directory root, so the text a daemon
+    /// module forwards to its client never carries the server's real prefix.
     ///
     /// # Upstream Reference
     ///
     /// - `io.c:1623-1637` - `MSG_SUCCESS` receipt drives `successful_send(val)`.
     /// - `sender.c:395` - `successful_send()` unlink + guards.
-    #[must_use]
-    pub(crate) fn confirm_source_removal(&mut self, wire_ndx: i32) -> i32 {
+    /// - `sender.c:412-414` - `change_pathname(file, NULL, 0)` then
+    ///   `f_name(file, fname)` is the name every diagnostic below prints.
+    pub(crate) fn confirm_source_removal(&mut self, wire_ndx: i32) -> SourceRemovalOutcome {
         if wire_ndx < 0 {
-            return 0;
+            return SourceRemovalOutcome::clean();
         }
         let flat_ndx = self.wire_to_flat_ndx(wire_ndx);
         if flat_ndx >= self.file_list.len() {
-            return 0;
+            return SourceRemovalOutcome::clean();
         }
         if !self.pending_source_removals.confirm(flat_ndx) {
-            return 0;
+            return SourceRemovalOutcome::clean();
         }
         let source_path = self.reconstruct_source_path(flat_ndx);
         let entry = &self.file_list[flat_ndx];
+        let display_name = entry.path().to_path_buf();
         let recorded = RecordedSourceIdentity {
             size: entry.size(),
             mtime: entry.mtime(),
             mtime_nsec: entry.mtime_nsec(),
         };
-        self.remove_source_file_if_requested(&source_path, recorded)
+        self.remove_source_file_if_requested(&source_path, &display_name, recorded)
     }
 }
 
@@ -1570,15 +1635,13 @@ fn source_diminished_below_flist(source_path: &Path, flist_len: u64) -> bool {
 /// - `rsync-3.5.0/sender.c:455-459` - the shared `failed:` label, where `ENOENT`
 ///   from ANY of the three operations is the benign "already removed" notice
 #[cfg(unix)]
-#[must_use]
 fn remove_confirmed_source(
     source_path: &Path,
+    display_name: &Path,
     recorded: RecordedSourceIdentity,
     copy_links: bool,
-) -> i32 {
+) -> SourceRemovalOutcome {
     use std::os::fd::AsFd as _;
-
-    use super::super::io_error_flags::IOERR_GENERAL;
 
     // upstream: sender.c:416 - resolve the parent ONCE. Both the re-stat and
     // the unlink below run against this one descriptor.
@@ -1587,7 +1650,7 @@ fn remove_confirmed_source(
         // upstream: sender.c:421-425 + 455-459 - a refused parent is
         // failed_op = "secure-open-parent", which shares the `failed:` label,
         // and therefore the ENOENT-is-benign arm, with the other two failures.
-        Err(error) => return report_removal_failure("secure-open-parent", source_path, &error),
+        Err(error) => return report_removal_failure("secure-open-parent", display_name, &error),
     };
 
     // upstream: sender.c:426-428 - do_stat_atfd under --copy-links, else
@@ -1612,17 +1675,17 @@ fn remove_confirmed_source(
         Ok(identity) => identity,
         // upstream: sender.c:429-430,455-459 - ENOENT is the benign FINFO
         // notice, anything else is rsyserr(FERROR_XFER) -> exit 23.
-        Err(error) => return report_removal_failure("re-lstat", source_path, &error),
+        Err(error) => return report_removal_failure("re-lstat", display_name, &error),
     };
 
     // upstream: sender.c:442-451 - refuse to remove a source that changed size
-    // or modification time since it entered the file list.
+    // or modification time since it entered the file list. Upstream reports
+    // this at FERROR_XFER, exactly like the three failed_op arms.
     if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
-        eprintln!(
-            "ERROR: Skipping sender remove for changed file: {}",
-            source_path.display()
-        );
-        return IOERR_GENERAL;
+        return SourceRemovalOutcome::error_xfer(format!(
+            "ERROR: Skipping sender remove for changed file: {}\n",
+            display_name.display()
+        ));
     }
 
     // upstream: sender.c:453 - secure_remove_source_file(dfd, bname) through the
@@ -1634,24 +1697,22 @@ fn remove_confirmed_source(
     match removal {
         Ok(()) => {
             // upstream: sender.c:461-462 - INFO_GTE(REMOVE,1) success notice.
-            info_log!(Remove, 1, "removing source {}", source_path.display());
-            0
+            info_log!(Remove, 1, "removing source {}", display_name.display());
+            SourceRemovalOutcome::clean()
         }
-        Err(error) => report_removal_failure("remove", source_path, &error),
+        Err(error) => report_removal_failure("remove", display_name, &error),
     }
 }
 
 /// Windows has neither the `*at` family nor the ownership walk, so the removal
 /// stays the path-based pair upstream itself uses on its declined arm.
 #[cfg(not(unix))]
-#[must_use]
 fn remove_confirmed_source(
     source_path: &Path,
+    display_name: &Path,
     recorded: RecordedSourceIdentity,
     copy_links: bool,
-) -> i32 {
-    use super::super::io_error_flags::IOERR_GENERAL;
-
+) -> SourceRemovalOutcome {
     let restat = if copy_links {
         std::fs::metadata(source_path)
     } else {
@@ -1659,24 +1720,23 @@ fn remove_confirmed_source(
     };
     let current = match restat {
         Ok(meta) => meta,
-        Err(error) => return report_removal_failure("re-lstat", source_path, &error),
+        Err(error) => return report_removal_failure("re-lstat", display_name, &error),
     };
 
     let (size, mtime, mtime_nsec) = stat_identity(&current);
     if source_changed_since_flist(recorded, size, mtime, mtime_nsec) {
-        eprintln!(
-            "ERROR: Skipping sender remove for changed file: {}",
-            source_path.display()
-        );
-        return IOERR_GENERAL;
+        return SourceRemovalOutcome::error_xfer(format!(
+            "ERROR: Skipping sender remove for changed file: {}\n",
+            display_name.display()
+        ));
     }
 
     match std::fs::remove_file(source_path) {
         Ok(()) => {
-            info_log!(Remove, 1, "removing source {}", source_path.display());
-            0
+            info_log!(Remove, 1, "removing source {}", display_name.display());
+            SourceRemovalOutcome::clean()
         }
-        Err(error) => report_removal_failure("remove", source_path, &error),
+        Err(error) => report_removal_failure("remove", display_name, &error),
     }
 }
 
@@ -1686,19 +1746,21 @@ fn remove_confirmed_source(
 /// turns into `got_xfer_error` -> exit 23.
 ///
 /// upstream: `rsync-3.5.0/sender.c:455-459`
-#[must_use]
-fn report_removal_failure(op: &str, source_path: &Path, error: &io::Error) -> i32 {
+fn report_removal_failure(
+    op: &str,
+    display_name: &Path,
+    error: &io::Error,
+) -> SourceRemovalOutcome {
     if error.kind() == io::ErrorKind::NotFound {
         info_log!(
             Remove,
             1,
             "sender file already removed: {}",
-            source_path.display()
+            display_name.display()
         );
-        return 0;
+        return SourceRemovalOutcome::clean();
     }
-    eprintln!("{}", sender_op_failure(op, source_path, error));
-    super::super::io_error_flags::IOERR_GENERAL
+    SourceRemovalOutcome::error_xfer(format!("{}\n", sender_op_failure(op, display_name, error)))
 }
 
 /// Extracts `(size, mtime_seconds, mtime_nanoseconds)` from a re-stat result in
@@ -2018,15 +2080,23 @@ mod sender_remove_confinement_tests {
         let recorded = recorded_for(&spelled);
 
         confine_to(&root);
-        let io_error = remove_confirmed_source(&spelled, recorded, false);
+        let outcome = remove_confirmed_source(&spelled, &spelled, recorded, false);
 
         assert!(
             victim.exists(),
             "the out-of-root file was removed: the unlink followed the planted parent symlink"
         );
         assert_ne!(
-            io_error, 0,
+            outcome.io_error, 0,
             "a refused parent is upstream's secure-open-parent failure (FERROR_XFER -> exit 23)"
+        );
+        assert!(
+            outcome
+                .error_xfer
+                .as_deref()
+                .is_some_and(|text| text.contains("secure-open-parent")),
+            "the refusal must carry upstream's failed_op text so the caller can \
+             emit it at FERROR_XFER (sender.c:421-425,455-459)"
         );
     }
 
@@ -2046,9 +2116,16 @@ mod sender_remove_confinement_tests {
         let recorded = recorded_for(&source);
 
         confine_to(&root);
-        let io_error = remove_confirmed_source(&source, recorded, false);
+        let outcome = remove_confirmed_source(&source, &source, recorded, false);
 
-        assert_eq!(io_error, 0, "an in-root removal must report no error");
+        assert_eq!(
+            outcome.io_error, 0,
+            "an in-root removal must report no error"
+        );
+        assert!(
+            outcome.error_xfer.is_none(),
+            "a clean removal must not queue an FERROR_XFER diagnostic"
+        );
         assert!(!source.exists(), "the confirmed source was not removed");
     }
 
@@ -2067,9 +2144,20 @@ mod sender_remove_confinement_tests {
         recorded.size += 4096;
 
         confine_to(&root);
-        let io_error = remove_confirmed_source(&source, recorded, false);
+        let outcome = remove_confirmed_source(&source, &source, recorded, false);
 
-        assert_ne!(io_error, 0, "a changed source is FERROR_XFER -> exit 23");
+        assert_ne!(
+            outcome.io_error, 0,
+            "a changed source is FERROR_XFER -> exit 23"
+        );
+        assert!(
+            outcome
+                .error_xfer
+                .as_deref()
+                .is_some_and(|text| text.contains("Skipping sender remove for changed file")),
+            "upstream reports the changed-file refusal at FERROR_XFER, not on \
+             local stderr (sender.c:442-451)"
+        );
         assert!(source.exists(), "a changed source must not be removed");
     }
 
@@ -2089,10 +2177,14 @@ mod sender_remove_confinement_tests {
 
         confine_to(&root);
 
+        let outcome = remove_confirmed_source(&source, &source, recorded, false);
         assert_eq!(
-            remove_confirmed_source(&source, recorded, false),
-            0,
+            outcome.io_error, 0,
             "ENOENT is the benign FINFO notice, never an error bit"
+        );
+        assert!(
+            outcome.error_xfer.is_none(),
+            "the benign already-removed notice is FINFO, never FERROR_XFER"
         );
     }
 }


### PR DESCRIPTION
## What upstream actually does

Verified against `rsync-3.5.0` (the version the citation gate pins, `tools/ci/citation_drift_audit.py:40 VER = "3.5.0"`).

`successful_send()` sets **no `io_error` bit at all**. Every failing arm ends at
`FERROR_XFER`:

| upstream | arm |
|---|---|
| `sender.c:421-425,455-459` | `secure-open-parent` refusal |
| `sender.c:429-430,455-459` | re-stat failure |
| `sender.c:442-451` | changed-file guard (`rprintf(FERROR_XFER, ...)` at 447) |
| `sender.c:453-459` | the unlink itself (`rsyserr(FERROR_XFER, ...)` at 459) |

It is the **log code**, not a bit, that carries the exit status:

- `log.c:337-338` - `case FERROR_XFER: got_xfer_error = 1;`
- `log.c:357-367` - `if (am_server ...) send_msg(msg, ...)` forwards the same
  text as `MSG_ERROR_XFER`; the client's `io.c:1830` re-enters `rwrite()`, which
  sets `got_xfer_error` on the **client** too
- `cleanup.c:210-218` - `if (exit_code == 0) { ... if (io_error & IOERR_GENERAL
  || got_xfer_error) exit_code = RERR_PARTIAL; }` (23), and `main.c:1683`
  `if (got_xfer_error) _exit(RERR_PARTIAL);`

Precedence: only when `exit_code == 0`; within that, `RERR_PARTIAL` is assigned
last, so it wins over `RERR_VANISHED` (24) and `RERR_DEL_LIMIT` (25).

## The bug

oc's network sender wrote the failure with `eprintln!` and handed back only
`IOERR_GENERAL`. Measured, `--remove-source-files` with an unlinkable source
(parent `chmod 555`, EACCES - not the seccomp EPERM path, the daemon log
confirms `seccomp BPF unavailable in this build`):

| topology | before |
|---|---|
| local copy | 23 |
| push over `-e` wrapper (client is sender) | 23 |
| pull over `-e` wrapper (server child's exit status reaches the client) | 23 |
| **daemon pull** | **0, and the client sees no message at all** |

The diagnostic went to the daemon log and nowhere else. A destructive-intent
option reported success while having silently not removed anything.

## What this PR changes

`remove_confirmed_source` no longer prints; it returns a `SourceRemovalOutcome`
carrying the bits **and** upstream's `FERROR_XFER` text. The caller routes that
text through `emit_sender_diagnostic`, the shared drain `record_open_failure`
and `record_read_errors` already use - the single place `got_xfer_error` is set
and the `MSG_ERROR_XFER` frame is framed. No sixth special case.

Because the text now travels to the peer it names the file-list entry, not the
reconstructed server path, matching `f_name(file, fname)` after
`change_pathname()` (`sender.c:412-414`). A daemon module has no absolute-path
prefix to leak; the message is now `sender failed to remove sub/f.txt:
Permission denied (13)`.

## Scope: this is the routing half

On a daemon pull the client **still exits 0** after this PR. The drain
(`for wire_ndx in reader.take_success_indices()`) runs after
`handle_goodbye_with_finalizer`, so the frame is written when the client has
already stopped reading. Measured by moving the drain ahead of the goodbye as a
throwaway probe: the client then prints the diagnostic and exits 23. The routing
is correct; the write window is not.

Moving the drain is not a free change - the drain sits after the goodbye
precisely because `MSG_SUCCESS` frames keep arriving through the handshake, so
an earlier drain would silently stop removing sources confirmed during it. That
trade-off (observability of failures vs. completeness of removals) is a separate,
still-open question and is deliberately not settled here.

## Tests

- `remove_source_files_failure_yields_ferror_xfer_text` (new) - a real EACCES
  unlink failure must hand back upstream's `FERROR_XFER` text, must name the
  file-list entry, and must **not** contain the sender's path prefix. The doc
  comment states why an `io_error` bit is not a substitute.
- The four `sender_remove_confinement_tests` now also assert the diagnostic is
  handed back (or, for the benign `ENOENT` arm, that it is not).

Non-vacuity, proved by restoring the pre-fix routing (`eprintln!` +
`error_xfer: None`) while keeping the type:

```
FAIL transfer generator::tests::remove_source_files_failure_yields_ferror_xfer_text
  a failed unlink must hand back upstream's FERROR_XFER text; without it the
  caller has nothing to set got_xfer_error with, and a pulling client exits 0
  (sender.c:455-459, log.c:337-338)

FAIL transfer generator::transfer::transfer_loop::sender_remove_confinement_tests::
       a_parent_symlink_out_of_the_root_cannot_steer_the_removal
  the refusal must carry upstream's failed_op text so the caller can emit it at
  FERROR_XFER (sender.c:421-425,455-459)

Summary 10/11 tests run: 8 passed, 2 failed
```

Restored: `11 tests run: 11 passed`.

Gates: `cargo fmt --all -- --check` clean; `cargo clippy --workspace
--all-targets --all-features --no-deps -- -D warnings` clean; `cargo nextest run
-p transfer --all-features` 2776 passed; the root-level
`daemon_sender_removes_sources_for_both_spellings` passes; the three topologies
that already exited 23 still do.
