### PR TITLE
fix(daemon): keep a relative --backup-dir relative per upstream

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -628,10 +628,10 @@ fn collapse_relative_within_depth(path: &std::path::Path, depth: usize) -> std::
 /// differs is the CONSUMER, and that is why this cannot simply reuse
 /// [`clamp_basis_to_module`]:
 ///
-/// - an alt-basis dir and `--backup-dir` are anchored ONCE, at the destination,
-///   so pre-joining the destination onto a relative value (what
-///   `clamp_basis_to_module` does) reaches the same place upstream reaches when
-///   its consumer resolves the still-relative value against `curr_dir`;
+/// - an alt-basis dir is anchored ONCE, at the destination, so pre-joining the
+///   destination onto a relative value (what `clamp_basis_to_module` does)
+///   reaches the same place upstream reaches when its consumer resolves the
+///   still-relative value against `curr_dir`;
 /// - `--partial-dir` is anchored PER FILE at `dirname(fname)`
 ///   (`util1.c` `partial_dir_fname()`, mirrored by `temp_guard.rs`
 ///   `partial_dir_fname`). Pre-joining the destination would pin every entry's
@@ -667,6 +667,56 @@ fn sanitize_partial_dir(
         .components()
         .count();
     collapse_relative_within_depth(ref_path, depth)
+}
+
+/// Sanitises a client-supplied `--backup-dir` for a daemon receiver.
+///
+/// upstream: `options.c:2408-2409` -
+/// `backup_dir = sanitize_path(NULL, backup_dir, NULL, 0, SP_DEFAULT)`. That
+/// call has two arms and only the first re-roots: `util1.c:1145-1151` prefixes
+/// the rootdir (`module_dir`, because `rootdir` is `NULL`) **only** inside
+/// `if (*p == '/')`. An ABSOLUTE value therefore becomes module-anchored, while
+/// a RELATIVE one stays relative with its `..` collapsed at depth 0
+/// (`util1.c:1184-1197`: with `depth <= 0` every `..` is dropped rather than
+/// kept at the start).
+///
+/// The relative arm is why this cannot reuse [`clamp_basis_to_module`], for the
+/// same reason [`sanitize_partial_dir`] cannot: the clamp folds the DESTINATION
+/// OPERAND into a relative value and hands back an absolute path. That reaches
+/// upstream's answer only while the operand names a directory. Upstream anchors
+/// the still-relative value at the receiver's cwd, and `get_local_name()`
+/// (`main.c:832-859`) sets that cwd to the operand's PARENT when the
+/// destination names a single file - it returns `cp + 1`, the basename, after
+/// `change_dir()` on everything before the last slash. So
+/// `--backup-dir=bak` pushed to `rsync://host/mod/payload` backs up to
+/// `<module>/bak/payload` upstream, where the clamp produced
+/// `<module>/payload/bak` and the backup `mkdir` failed `ENOTDIR` on the
+/// destination file itself.
+///
+/// oc's receiver already anchors a relative value at its `dest_dir`
+/// (`engine::compute_backup_path`, `engine::create_backup_dir_parents`), and
+/// that `dest_dir` is upstream's post-`get_local_name()` cwd - the parent for a
+/// single-file operand, the operand itself for a directory one. Leaving the
+/// value relative therefore performs the join where the transfer knows what the
+/// operand turned out to name, instead of guessing before the file list has
+/// been received.
+fn sanitize_backup_dir(
+    ref_path: &std::path::Path,
+    resolve_base: &std::path::Path,
+    module_root_canonical: &std::path::Path,
+) -> std::path::PathBuf {
+    if ref_path.has_root() {
+        // upstream: util1.c:1145-1151 - the test is `*p == '/'` on the
+        // peer-supplied bytes, so `has_root()` not `is_absolute()`: the latter
+        // is FALSE on Windows for a leading-slash path and would skip the
+        // re-root. The rootdir replaces the leading slash and `depth` is forced
+        // to 0, which is exactly the absolute arm of `clamp_basis_to_module`.
+        return clamp_basis_to_module(ref_path, resolve_base, module_root_canonical);
+    }
+    // upstream: options.c:2409 passes the literal depth 0, unlike the
+    // `curr_dir_depth` that main.c:1239 passes for `--partial-dir`, so no
+    // leading `..` survives here at all.
+    collapse_relative_within_depth(ref_path, 0)
 }
 
 /// Whether an already-clamped basis directory resolves out of the module tree

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -334,26 +334,26 @@ fn build_server_config(
             // block that sanitises the alt-dest dirs also runs `backup_dir`
             // through `sanitize_path(NULL, backup_dir, NULL, 0, SP_DEFAULT)`.
             // An ABSOLUTE --backup-dir therefore re-roots at `module_dir`
-            // (util1.c:1145-1152, the `if (!rootdir) rootdir = module_dir`
-            // arm), while a relative one stays relative to the destination -
-            // the same two arms `clamp_basis_to_module` already implements for
-            // a basis directory, so it is reused rather than reimplemented.
+            // (util1.c:1145-1151, the `if (!rootdir) rootdir = module_dir`
+            // arm), while a RELATIVE one stays relative for the receiver to
+            // anchor at its own destination - see `sanitize_backup_dir` for why
+            // the relative arm must not go through `clamp_basis_to_module`.
             //
-            // Without this the daemon resolved `/backup/` against the
-            // filesystem root and the backup silently failed. That is not a
+            // Without the absolute arm the daemon resolved `/backup/` against
+            // the filesystem root and the backup silently failed. That is not a
             // cosmetic loss: `atomic_create()` makes the backup a PRECONDITION
             // (generator.c:2477-2479 `if (!make_backup(...)) return 0`), so the
             // failure SKIPPED the entry entirely, leaving the destination stale
             // while still exiting 0.
             if let Some(dir) = cfg.backup_dir.as_deref() {
-                let clamped = clamp_basis_to_module(
+                let sanitized = sanitize_backup_dir(
                     std::path::Path::new(dir),
                     &resolve_base,
                     &module_root_canonical,
                 );
-                // Lossless: `dir` is a String, and the clamp only joins and
+                // Lossless: `dir` is a String, and the sanitize only joins and
                 // drops whole components, so every retained byte stays UTF-8.
-                cfg.backup_dir = Some(clamped.to_string_lossy().into_owned());
+                cfg.backup_dir = Some(sanitized.to_string_lossy().into_owned());
             }
             // upstream: main.c:1233-1240 - the server receiver runs the very
             // same `if (sanitize_paths)` block over `partial_dir`

--- a/crates/transfer/tests/daemon_backup_dir_file_shaped_dest.rs
+++ b/crates/transfer/tests/daemon_backup_dir_file_shaped_dest.rs
@@ -1,0 +1,260 @@
+//! A daemon push whose destination operand names a FILE must honour a relative
+//! `--backup-dir`, not fold the operand into it.
+//!
+//! # The defect
+//!
+//! The daemon resolved a client's relative `--backup-dir` eagerly, at
+//! argument-parse time, by joining it onto the destination OPERAND. That agrees
+//! with upstream only while the operand names a directory. Push a single file at
+//! `rsync://host/mod/payload` and the operand names the destination FILE, so
+//! `bak` became `<module>/payload/bak` and the backup `mkdir` failed `ENOTDIR`
+//! on `payload` itself - an ordinary non-directory component, not a refusal.
+//! The whole session died with the daemon reporting
+//! `Not a directory (os error 20)` and the client exiting 23, leaving the
+//! destination unmodified. Dropping `--backup-dir` from the same push made it
+//! succeed.
+//!
+//! # What upstream does
+//!
+//! Upstream never anchors the value early. `sanitize_path(NULL, backup_dir,
+//! NULL, 0, SP_DEFAULT)` re-roots only an ABSOLUTE value at `module_dir`
+//! (`util1.c:1145-1151`, reached only inside `if (*p == '/')`); a relative one
+//! is merely `..`-collapsed and stays relative. It is then resolved against the
+//! receiver's cwd at backup time, and `get_local_name()` sets that cwd to the
+//! operand's PARENT when the destination names a single file
+//! (`main.c:832-859`: `change_dir()` on everything before the last slash,
+//! return the basename). So `--backup-dir=bak` lands at `<module>/bak/payload`
+//! for BOTH operand shapes.
+//!
+//! Measured against the real rsync 3.5.0 binary: all three cells below produce
+//! exactly the state asserted here.
+//!
+//! # Why the `..` cell is here
+//!
+//! Leaving the value relative moves the join to the receiver, so the daemon's
+//! `..`-collapse is the only thing left standing between a peer-supplied
+//! `--backup-dir=../bak` and a write above the module root. Upstream passes the
+//! literal depth `0` for this option (`options.c:2409`, unlike the
+//! `curr_dir_depth` at `main.c:1239` for `--partial-dir`), so no leading `..`
+//! survives at all and the backup stays in the module.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/options.c:2408-2409` - `backup_dir = sanitize_path(NULL,
+//!   backup_dir, NULL, 0, SP_DEFAULT)` for a sanitizing (daemon) receiver.
+//! - `rsync-3.5.0/util1.c:1145-1151` - the rootdir prefix is applied only when
+//!   the value starts with `/`; a relative value keeps no prefix.
+//! - `rsync-3.5.0/util1.c:1184-1197` - with `depth <= 0` every `..` component is
+//!   collapsed away rather than kept at the start.
+//! - `rsync-3.5.0/main.c:832-859` - `get_local_name()` mode 2: a single-file
+//!   destination chdirs to the operand's parent and returns its basename.
+
+#![cfg(unix)]
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+/// The destination's pre-transfer contents - what the backup must preserve.
+const PRE_IMAGE: &str = "PRE-IMAGE-IN-MODULE";
+/// What the client pushes over the destination.
+const NEW_CONTENT: &str = "NEW-CONTENT-FROM-THE-PEER";
+
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// The shape of the destination operand the client writes.
+#[derive(Clone, Copy)]
+enum DestOperand {
+    /// `rsync://host:port/data/payload` - names the destination FILE.
+    File,
+    /// `rsync://host:port/data/` - names the module directory.
+    Directory,
+}
+
+/// The filesystem state the assertions are made against.
+struct Outcome {
+    /// Contents at `<module>/bak/payload`, where upstream places the backup.
+    backup: io::Result<String>,
+    /// Contents of the destination after the push.
+    destination: io::Result<String>,
+    /// Whether anything at all was created above the module root, which is what
+    /// an uncollapsed `..` would produce.
+    escaped_backup_exists: bool,
+    /// The client's exit code, recorded beside every measurement so a
+    /// "nothing moved" run cannot be mistaken for a success.
+    client_exit: Option<i32>,
+    /// The client's stderr, for the failure messages.
+    client_stderr: String,
+}
+
+fn write_config(config: &Path, module_root: &Path, log_root: &Path) -> io::Result<()> {
+    fs::write(
+        config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [data]\n\
+             path = {root}\n\
+             read only = false\n",
+            pid = log_root.join("rsyncd.pid").display(),
+            log = log_root.join("rsyncd.log").display(),
+            root = module_root.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(oc_bin: &Path, config: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard(child), port))
+}
+
+/// Stages a module holding one destination file, pushes a replacement over it
+/// with `--backup --backup-dir=<backup_dir>`, and reports the resulting state.
+///
+/// Returns `None` when the daemon could not be started, so a harness failure is
+/// reported by the caller rather than passing vacuously.
+fn push_over_destination(operand: DestOperand, backup_dir: &str) -> Option<Outcome> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let tmp = test_support::create_tempdir();
+    let root = tmp.path();
+
+    let source_dir = root.join("src");
+    let module_root = root.join("module");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::create_dir_all(&module_root).expect("create module root");
+
+    let source = source_dir.join("payload");
+    fs::write(&source, NEW_CONTENT).expect("seed source");
+
+    let destination = module_root.join("payload");
+    fs::write(&destination, PRE_IMAGE).expect("seed destination");
+
+    let config = root.join("rsyncd.conf");
+    write_config(&config, &module_root, root).expect("write daemon config");
+    let (_daemon, port) = spawn_daemon(&oc_bin, &config).ok()?;
+
+    let url = match operand {
+        DestOperand::File => format!("rsync://127.0.0.1:{port}/data/payload"),
+        DestOperand::Directory => format!("rsync://127.0.0.1:{port}/data/"),
+    };
+    let output = Command::new(&oc_bin)
+        .args([
+            OsStr::new("--backup"),
+            OsStr::new(&format!("--backup-dir={backup_dir}")),
+            OsStr::new("--ignore-times"),
+            source.as_os_str(),
+            OsStr::new(&url),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run oc-rsync client");
+
+    Some(Outcome {
+        backup: fs::read_to_string(module_root.join("bak/payload")),
+        destination: fs::read_to_string(&destination),
+        escaped_backup_exists: root.join("bak").exists(),
+        client_exit: output.status.code(),
+        client_stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+fn measured(operand: DestOperand, backup_dir: &str, what: &str) -> Outcome {
+    push_over_destination(operand, backup_dir)
+        .unwrap_or_else(|| panic!("{what}: could not start the daemon, so nothing was measured"))
+}
+
+/// Asserts the one state upstream produces: the pre-image sits at
+/// `<module>/bak/payload`, the destination carries the new bytes, and nothing
+/// was written above the module root.
+fn assert_backed_up_inside_the_module(outcome: &Outcome, what: &str) {
+    assert_eq!(
+        outcome.client_exit,
+        Some(0),
+        "{what}: the push must succeed\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.backup.as_deref().ok(),
+        Some(PRE_IMAGE),
+        "{what}: the backup must hold the destination's pre-transfer bytes at \
+         <module>/bak/payload\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert_eq!(
+        outcome.destination.as_deref().ok(),
+        Some(NEW_CONTENT),
+        "{what}: the destination must carry the pushed bytes\nstderr:\n{}",
+        outcome.client_stderr,
+    );
+    assert!(
+        !outcome.escaped_backup_exists,
+        "{what}: nothing may be created above the module root",
+    );
+}
+
+/// THE PIN. The destination operand names a FILE. A relative `--backup-dir` is
+/// the client's, so it must be anchored where upstream anchors it - the
+/// operand's parent directory, which for this push is the module root - not
+/// joined onto the destination file, which cannot hold a directory.
+///
+/// Before the fix this cell observes the client exiting 23 with the daemon
+/// reporting `Not a directory (os error 20)`, no backup, and the destination
+/// still holding [`PRE_IMAGE`].
+#[test]
+fn a_file_shaped_destination_honours_a_relative_backup_dir() {
+    let outcome = measured(DestOperand::File, "bak", "file-shaped destination operand");
+    assert_backed_up_inside_the_module(&outcome, "file-shaped destination operand");
+}
+
+/// POSITIVE CONTROL. The identical `--backup-dir` against a DIRECTORY-shaped
+/// operand already worked and must keep working: this is the shape the existing
+/// `--backup-dir` fixtures push into, and moving the anchor to the receiver
+/// must not disturb it.
+#[test]
+fn a_directory_shaped_destination_still_honours_the_same_backup_dir() {
+    let outcome = measured(
+        DestOperand::Directory,
+        "bak",
+        "directory-shaped destination operand",
+    );
+    assert_backed_up_inside_the_module(&outcome, "directory-shaped destination operand");
+}
+
+/// CONTAINMENT. A relative value now reaches the receiver un-anchored, so the
+/// daemon's `..`-collapse is what keeps a peer-supplied `--backup-dir=../bak`
+/// from writing above the module root. Upstream collapses it to `bak` at depth
+/// `0` and lands in the module; so must oc.
+#[test]
+fn a_relative_backup_dir_climbing_out_is_collapsed_into_the_module() {
+    let outcome = measured(
+        DestOperand::File,
+        "../bak",
+        "escaping relative --backup-dir",
+    );
+    assert_backed_up_inside_the_module(&outcome, "escaping relative --backup-dir");
+}


### PR DESCRIPTION
A daemon push whose destination operand names a FILE died with `ENOTDIR` as soon as `--backup-dir` was present. Reproduced end-to-end against a real daemon on current master:

```
oc-rsync --backup --backup-dir=bak src/payload rsync://127.0.0.1:PORT/data/payload
client exit 23
daemon log: error=Not a directory (os error 20) (code 1) at streams.rs(420)
destination unmodified, no backup written
```

Dropping `--backup-dir` from the same push made it succeed (exit 0, `payload~` written), and the same option against a directory-shaped operand (`.../data/`) succeeded too. `--inplace` is irrelevant to the failure.

## Attribution

Not the ownership walk. Instrumented, the failing syscall is a plain `mkdir("<module>/payload/bak")` returning errno 20 because `payload` is an ordinary regular file - an interior non-directory component, not a confinement refusal:

```
PROBE backup_dir: in="bak" resolve_base=".../module/payload" out=".../module/payload/bak"
PROBE mkdir(backup_root=".../module/payload/bak") failed:
      Os { code: 20, kind: NotADirectory } raw_os_error=Some(20)
      (destination_root=".../module" backup_dir=".../module/payload/bak")
```

`build_server_config` anchored the client's relative `--backup-dir` eagerly, at argument-parse time, by running it through `clamp_basis_to_module` with `resolve_base = cfg.args.first()` - the destination OPERAND. Note `destination_root` at the receiver was already correct (`<module>`); only the daemon's pre-join was wrong.

The mechanism is confirmed by a falsifiable prediction rather than inferred from the errno: `--backup-dir=../bak` on the *same* file-shaped push **succeeded** and landed at `<module>/bak/payload`, because the spurious `payload` component was exactly what the `..` cancelled.

## Upstream

Upstream never anchors the value early.

- `options.c:2408-2409` - `backup_dir = sanitize_path(NULL, backup_dir, NULL, 0, SP_DEFAULT)`.
- `util1.c:1145-1151` - the rootdir prefix (`module_dir`, since `rootdir` is `NULL`) is applied **only** inside `if (*p == '/')`, so an absolute value re-roots and a relative one keeps no prefix.
- `util1.c:1184-1197` - with `depth <= 0` every `..` is collapsed away rather than kept at the start.
- `main.c:832-859` - `get_local_name()` mode 2: a single-file destination `change_dir()`s to the operand's parent and returns its basename, so the relative value is later resolved against that parent.

So `--backup-dir=bak` lands at `<module>/bak/payload` for both operand shapes.

Measured against the real rsync 3.5.0 binary on this host, all three shapes (file operand, directory operand, `../bak`) produce exactly that state. Post-fix oc matches upstream on all three.

## The fix

`sanitize_backup_dir` splits the two arms the way upstream does: absolute still re-roots at the module root, relative stays relative with `..` collapsed at depth `0`. The receiver already anchors a relative value at its own `dest_dir` (`engine::compute_backup_path`, `engine::create_backup_dir_parents`), and that `dest_dir` is upstream's post-`get_local_name()` cwd - the parent for a single-file operand, the operand itself for a directory one. The join now happens where the transfer knows what the operand turned out to name, instead of guessing before the file list has been received.

This is the same split `--partial-dir` already required (#7501). Its doc comment asserted `--backup-dir` was safe inside the clamp; that claim is corrected here.

Confinement is unchanged: depth `0` means no leading `..` survives, and the receiver joins under a module-confined `dest_dir`.

## Cells

`crates/transfer/tests/daemon_backup_dir_file_shaped_dest.rs`:

- THE PIN - file-shaped operand honours a relative `--backup-dir`.
- POSITIVE CONTROL - directory-shaped operand, the shape that already worked, still does.
- CONTAINMENT - `--backup-dir=../bak` still lands inside the module.

**Mutation-proven.** Restoring `clamp_basis_to_module` at the call site:

```
Summary [ 14.590s] 3 tests run: 2 passed, 1 failed, 0 skipped
  FAIL transfer::daemon_backup_dir_file_shaped_dest a_file_shaped_destination_honours_a_relative_backup_dir
  assertion `left == right` failed: file-shaped destination operand: the push must succeed
    left: Some(23)
   right: Some(0)
```

Both controls stay green, so the pin is the only cell the change moves.

## Gates run locally

- `cargo fmt --all -- --check` clean, plus explicit `rustfmt --check` on the two `include!`d files (`cargo fmt` is blind to those).
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p daemon --all-features` - 1896 passed.
- `cargo nextest run -p transfer --all-features` for `daemon_backup_dir_symlink_confinement`, `daemon_inplace_backup_dir_confinement`, `uts_backup_suffix_and_dir`, `uts_inplace_backup` - 15 passed.
- `tools/ci/citation_drift_audit.py` - no new drift or unresolved entries from the touched files.
