### PR TITLE
fix(daemon): make the connection close edge total

### DIFF
--- a/crates/daemon/src/connection/mod.rs
+++ b/crates/daemon/src/connection/mod.rs
@@ -2,12 +2,13 @@
 //!
 //! Provides `ConnectionState` and transition validation for the daemon
 //! connection lifecycle: `Greeting -> ModuleSelect -> Authenticating ->
-//! Transferring -> Closing`. Every state can also transition directly to
-//! `Closing`.
+//! Transferring`, with teardown to `Closing` available at any point.
 //!
-//! The state machine enforces forward-only progression through the
-//! non-terminal states. `Closing` is absorbing - once entered, no further
-//! transitions are permitted.
+//! The two edge kinds are separate operations so that neither hides the
+//! other. `transition` enforces forward-only progression and returns a
+//! `Result` a caller must handle; `close` is total - reachable from every
+//! state - so it returns the state directly and leaves no error to discard.
+//! `Closing` is terminal.
 //!
 //! # Usage
 //!
@@ -17,7 +18,7 @@
 //! let state = ConnectionState::Greeting;
 //! let state = state.transition(ConnectionState::ModuleSelect).unwrap();
 //! let state = state.transition(ConnectionState::Transferring).unwrap();
-//! let state = state.transition(ConnectionState::Closing).unwrap();
+//! let state = state.close();
 //! assert!(state.is_terminal());
 //! ```
 

--- a/crates/daemon/src/connection/state.rs
+++ b/crates/daemon/src/connection/state.rs
@@ -11,9 +11,14 @@ use std::fmt;
 
 /// Lifecycle state of a daemon connection.
 ///
-/// Connections progress forward through the states in order. Every state
-/// can transition to [`Closing`](Self::Closing), and `Closing` is terminal
-/// - no further transitions are permitted.
+/// The lifecycle has two kinds of edge, and they are separate operations:
+///
+/// - **Progression** - [`transition`](Self::transition) moves the handshake
+///   forward and is order-checked, so an out-of-order phase is rejected.
+///   [`Closing`](Self::Closing) is never a progression target.
+/// - **Teardown** - [`close`](Self::close) ends the session. It is reachable
+///   from every state, so it is total: it returns the new state directly and
+///   there is no error for a caller to discard.
 ///
 /// # States
 ///
@@ -26,7 +31,8 @@ use std::fmt;
 ///   response.
 /// - **Transferring** - Authentication passed (or was not required) and
 ///   the transfer engine is running.
-/// - **Closing** - The session is ending. Terminal state.
+/// - **Closing** - The session is ending. Terminal state, reached only
+///   through [`close`](Self::close).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ConnectionState {
     /// Server sent `@RSYNCD: <ver>.<sub> <digests>\n`, awaiting client version.
@@ -66,32 +72,52 @@ impl fmt::Display for InvalidTransition {
 impl Error for InvalidTransition {}
 
 impl ConnectionState {
-    /// Returns `true` if this is a terminal state with no outgoing transitions.
+    /// Returns `true` if the session has ended and no further progression or
+    /// teardown edge changes the state.
     #[must_use]
     pub const fn is_terminal(self) -> bool {
         matches!(self, Self::Closing)
     }
 
-    /// Returns all states reachable from the current state.
+    /// Returns the states this one can *progress* to.
     ///
-    /// The returned slice is static and ordered by the natural progression
-    /// of the protocol. `Closing` always appears last when present.
+    /// The returned slice is static and ordered by the natural progression of
+    /// the protocol. `Closing` is not a progression target - teardown is
+    /// always available and is expressed by [`close`](Self::close) instead.
     #[must_use]
     pub const fn valid_transitions(self) -> &'static [ConnectionState] {
         match self {
-            Self::Greeting => &[Self::ModuleSelect, Self::Closing],
-            Self::ModuleSelect => &[Self::Authenticating, Self::Transferring, Self::Closing],
-            Self::Authenticating => &[Self::Transferring, Self::Closing],
-            Self::Transferring => &[Self::Closing],
-            Self::Closing => &[],
+            Self::Greeting => &[Self::ModuleSelect],
+            Self::ModuleSelect => &[Self::Authenticating, Self::Transferring],
+            Self::Authenticating => &[Self::Transferring],
+            Self::Transferring | Self::Closing => &[],
         }
     }
 
-    /// Attempts to transition to `next`.
+    /// Ends the session, returning [`Closing`](Self::Closing).
+    ///
+    /// A connection can be torn down at any point in the handshake, so this
+    /// edge is total from every state and has no failure case. Keeping it out
+    /// of [`transition`](Self::transition) is what makes every remaining
+    /// `transition` call site a genuine, checkable ordering constraint rather
+    /// than a `Result` that can never be `Err`.
+    ///
+    /// Closing an already-closing connection is a no-op, matching upstream:
+    /// `_exit_cleanup()` (cleanup.c:103) is deliberately re-entrant, stepping
+    /// through `switch_step` and preserving the first exit code when a cleanup
+    /// action calls back into it.
+    #[must_use]
+    pub const fn close(self) -> ConnectionState {
+        Self::Closing
+    }
+
+    /// Attempts to progress to `next`.
     ///
     /// Returns `Ok(next)` when the transition is valid, or
     /// `Err(InvalidTransition)` when it is not. A transition is valid if
     /// `next` appears in [`valid_transitions`](Self::valid_transitions).
+    /// Use [`close`](Self::close) for teardown; `Closing` is always rejected
+    /// here.
     ///
     /// # Examples
     ///
@@ -101,6 +127,7 @@ impl ConnectionState {
     /// let state = ConnectionState::Greeting;
     /// assert!(state.transition(ConnectionState::ModuleSelect).is_ok());
     /// assert!(state.transition(ConnectionState::Transferring).is_err());
+    /// assert!(state.transition(ConnectionState::Closing).is_err());
     /// ```
     pub const fn transition(
         self,
@@ -135,12 +162,6 @@ mod tests {
     }
 
     #[test]
-    fn greeting_to_closing() {
-        let result = ConnectionState::Greeting.transition(ConnectionState::Closing);
-        assert_eq!(result, Ok(ConnectionState::Closing));
-    }
-
-    #[test]
     fn module_select_to_authenticating() {
         let result = ConnectionState::ModuleSelect.transition(ConnectionState::Authenticating);
         assert_eq!(result, Ok(ConnectionState::Authenticating));
@@ -153,27 +174,9 @@ mod tests {
     }
 
     #[test]
-    fn module_select_to_closing() {
-        let result = ConnectionState::ModuleSelect.transition(ConnectionState::Closing);
-        assert_eq!(result, Ok(ConnectionState::Closing));
-    }
-
-    #[test]
     fn authenticating_to_transferring() {
         let result = ConnectionState::Authenticating.transition(ConnectionState::Transferring);
         assert_eq!(result, Ok(ConnectionState::Transferring));
-    }
-
-    #[test]
-    fn authenticating_to_closing() {
-        let result = ConnectionState::Authenticating.transition(ConnectionState::Closing);
-        assert_eq!(result, Ok(ConnectionState::Closing));
-    }
-
-    #[test]
-    fn transferring_to_closing() {
-        let result = ConnectionState::Transferring.transition(ConnectionState::Closing);
-        assert_eq!(result, Ok(ConnectionState::Closing));
     }
 
     #[test]
@@ -278,10 +281,49 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Teardown is not a progression, so `Closing` is never a `transition`
+    /// target. Every close goes through `close()`, which cannot fail - there
+    /// is no `Result` at a close site for a caller to discard.
     #[test]
-    fn closing_to_closing() {
-        let result = ConnectionState::Closing.transition(ConnectionState::Closing);
-        assert!(result.is_err());
+    fn transition_never_targets_closing() {
+        for from in [
+            ConnectionState::Greeting,
+            ConnectionState::ModuleSelect,
+            ConnectionState::Authenticating,
+            ConnectionState::Transferring,
+            ConnectionState::Closing,
+        ] {
+            assert_eq!(
+                from.transition(ConnectionState::Closing),
+                Err(InvalidTransition {
+                    from,
+                    to: ConnectionState::Closing,
+                }),
+                "transition({from:?} -> Closing) must be rejected"
+            );
+            assert!(
+                !from.valid_transitions().contains(&ConnectionState::Closing),
+                "{from:?} must not list Closing as a progression target"
+            );
+        }
+    }
+
+    /// The close edge is total: reachable from every state, including
+    /// `Closing` itself. upstream: cleanup.c:103 `_exit_cleanup()` is
+    /// re-entrant, so a redundant close is a no-op rather than an error.
+    #[test]
+    fn close_is_total_from_every_state() {
+        for from in [
+            ConnectionState::Greeting,
+            ConnectionState::ModuleSelect,
+            ConnectionState::Authenticating,
+            ConnectionState::Transferring,
+            ConnectionState::Closing,
+        ] {
+            let closed = from.close();
+            assert_eq!(closed, ConnectionState::Closing, "close({from:?})");
+            assert!(closed.is_terminal(), "close({from:?}) must be terminal");
+        }
     }
 
     #[test]
@@ -290,7 +332,7 @@ mod tests {
         let state = state.transition(ConnectionState::ModuleSelect).unwrap();
         let state = state.transition(ConnectionState::Authenticating).unwrap();
         let state = state.transition(ConnectionState::Transferring).unwrap();
-        let state = state.transition(ConnectionState::Closing).unwrap();
+        let state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -299,29 +341,21 @@ mod tests {
         let state = ConnectionState::Greeting;
         let state = state.transition(ConnectionState::ModuleSelect).unwrap();
         let state = state.transition(ConnectionState::Transferring).unwrap();
-        let state = state.transition(ConnectionState::Closing).unwrap();
+        let state = state.close();
         assert!(state.is_terminal());
     }
 
     #[test]
     fn early_close_from_greeting() {
-        let state = ConnectionState::Greeting;
-        let state = state.transition(ConnectionState::Closing).unwrap();
+        let state = ConnectionState::Greeting.close();
         assert!(state.is_terminal());
         assert!(state.transition(ConnectionState::Greeting).is_err());
     }
 
     #[test]
     fn early_close_from_module_select() {
-        let state = ConnectionState::ModuleSelect;
-        let state = state.transition(ConnectionState::Closing).unwrap();
+        let state = ConnectionState::ModuleSelect.close();
         assert!(state.is_terminal());
-    }
-
-    #[test]
-    fn double_close_is_invalid() {
-        let state = ConnectionState::Closing;
-        assert!(state.transition(ConnectionState::Closing).is_err());
     }
 
     #[test]
@@ -342,10 +376,7 @@ mod tests {
     #[test]
     fn valid_transitions_greeting() {
         let valid = ConnectionState::Greeting.valid_transitions();
-        assert_eq!(
-            valid,
-            &[ConnectionState::ModuleSelect, ConnectionState::Closing]
-        );
+        assert_eq!(valid, &[ConnectionState::ModuleSelect]);
     }
 
     #[test]
@@ -356,7 +387,6 @@ mod tests {
             &[
                 ConnectionState::Authenticating,
                 ConnectionState::Transferring,
-                ConnectionState::Closing,
             ]
         );
     }
@@ -364,16 +394,13 @@ mod tests {
     #[test]
     fn valid_transitions_authenticating() {
         let valid = ConnectionState::Authenticating.valid_transitions();
-        assert_eq!(
-            valid,
-            &[ConnectionState::Transferring, ConnectionState::Closing]
-        );
+        assert_eq!(valid, &[ConnectionState::Transferring]);
     }
 
     #[test]
     fn valid_transitions_transferring() {
         let valid = ConnectionState::Transferring.valid_transitions();
-        assert_eq!(valid, &[ConnectionState::Closing]);
+        assert!(valid.is_empty());
     }
 
     #[test]
@@ -499,29 +526,27 @@ mod tests {
         ];
         assert_eq!(all_phases.len(), 5, "FSM must cover all 5 lifecycle phases");
 
-        // Every non-terminal phase has at least one valid forward transition.
+        // Progression stops at Transferring: the handshake has no phase after
+        // it, and teardown is a separate, total edge.
         for &phase in &all_phases {
-            if phase.is_terminal() {
-                assert!(
-                    phase.valid_transitions().is_empty(),
-                    "terminal state must have no outgoing transitions"
-                );
-            } else {
-                assert!(
-                    !phase.valid_transitions().is_empty(),
-                    "{phase:?} must have at least one forward transition"
-                );
-            }
+            let progresses = !matches!(
+                phase,
+                ConnectionState::Transferring | ConnectionState::Closing
+            );
+            assert_eq!(
+                !phase.valid_transitions().is_empty(),
+                progresses,
+                "{phase:?} progression targets"
+            );
         }
 
-        // Every non-terminal phase can reach Closing (error/abort path).
+        // Every phase can reach Closing (error/abort path), and the edge is
+        // total, so it is `close()` rather than a checked `transition`.
         for &phase in &all_phases {
-            if !phase.is_terminal() {
-                assert!(
-                    phase.transition(ConnectionState::Closing).is_ok(),
-                    "{phase:?} must be able to transition to Closing"
-                );
-            }
+            assert!(
+                phase.close().is_terminal(),
+                "{phase:?} must be able to close"
+            );
         }
     }
 
@@ -538,16 +563,13 @@ mod tests {
             Closing,
         ];
 
-        // Expected valid transitions encoded as (from, to) pairs.
+        // Expected valid progressions encoded as (from, to) pairs. Closing is
+        // absent by construction: teardown is `close()`, not a progression.
         let valid_pairs: &[(ConnectionState, ConnectionState)] = &[
             (Greeting, ModuleSelect),
-            (Greeting, Closing),
             (ModuleSelect, Authenticating),
             (ModuleSelect, Transferring),
-            (ModuleSelect, Closing),
             (Authenticating, Transferring),
-            (Authenticating, Closing),
-            (Transferring, Closing),
         ];
 
         for &from in &all {

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -575,10 +575,7 @@ fn handle_authentication(
             // upstream: compat.c:875 - `exit_cleanup(RERR_UNSUPPORTED)` right
             // after the refusal line, with no challenge and no auth-failure log.
             *ctx.session_exit_code = Some(UNSUPPORTED_AUTH_DIGEST_EXIT_CODE);
-            ctx.conn_state = ctx
-                .conn_state
-                .transition(ConnectionState::Closing)
-                .map_err(transition_error)?;
+            ctx.conn_state = ctx.conn_state.close();
             Ok(None)
         }
         AuthenticationStatus::Denied(denial) => {
@@ -604,10 +601,7 @@ fn handle_authentication(
             };
             send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             // FSM: -> Closing on auth failure (session ends).
-            ctx.conn_state = ctx
-                .conn_state
-                .transition(ConnectionState::Closing)
-                .map_err(transition_error)?;
+            ctx.conn_state = ctx.conn_state.close();
             Ok(None)
         }
         AuthenticationStatus::Granted {

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -968,10 +968,7 @@ fn process_approved_module(
     }
 
     // FSM: Transferring -> Closing - transfer and post-xfer hooks complete.
-    ctx.conn_state = ctx
-        .conn_state
-        .transition(ConnectionState::Closing)
-        .map_err(transition_error)?;
+    ctx.conn_state = ctx.conn_state.close();
 
     Ok(())
 }

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -239,6 +239,23 @@ pub(crate) fn single_session_exit(
     }
 }
 
+/// Takes the FSM's teardown edge as the session handler returns, forwarding
+/// `exit_code` unchanged.
+///
+/// The edge is total, since a connection can be torn down from any lifecycle
+/// state, so there is no error to propagate and none for a caller to discard.
+/// Nothing reads the state once the handler returns, so what is worth
+/// recording is the invariant rather than the value: a handler must not reach
+/// a second teardown after already closing.
+fn end_session(state: ConnectionState, exit_code: Option<ExitCode>) -> Option<ExitCode> {
+    debug_assert!(
+        !state.is_terminal(),
+        "daemon session torn down twice, from {state:?}"
+    );
+    let _closed: ConnectionState = state.close();
+    exit_code
+}
+
 /// Runs the legacy `@RSYNCD:` session protocol for a single connection.
 ///
 /// Sends the greeting with the protocol version and supported digest list,
@@ -328,11 +345,19 @@ fn handle_legacy_session(
             write_limited(reader.get_mut(), &mut limiter, b"\n")?;
             reader.get_mut().flush()?;
             // FSM: -> Closing after the fatal @ERROR refusal.
-            let _ = conn_state.transition(ConnectionState::Closing);
-            return Ok(None);
+            return Ok(end_session(conn_state, None));
         }
         match parse_legacy_daemon_message(&line) {
-            Ok(LegacyDaemonMessage::Version(version)) => {
+            // upstream: clientserver.c:1534-1538 start_daemon() - the version
+            // line is read exactly once, by exchange_protocols(); the very next
+            // read_line_old() is the request line whatever it contains. A
+            // second `@RSYNCD:` banner is therefore a module name, not a
+            // re-greeting, and falls through to the unknown-module refusal.
+            // Taking the Greeting -> ModuleSelect edge again instead would fail
+            // the FSM's ordering check, and a session error is fatal to the
+            // whole listener (workers.rs join_worker), so a peer could end the
+            // daemon with two greeting lines.
+            Ok(LegacyDaemonMessage::Version(version)) if negotiated_protocol.is_none() => {
                 // upstream: clientserver.c:199-203 exchange_protocols() -
                 // `daemon_auth_choices = strchr(buf + 9, ' ')` keeps the client's
                 // digest name list for negotiate_daemon_auth(). The Version
@@ -358,6 +383,8 @@ fn handle_legacy_session(
                     .map_err(transition_error)?;
                 continue;
             }
+            // A banner arriving after the version exchange is the request line.
+            Ok(LegacyDaemonMessage::Version(_)) => {}
             Ok(LegacyDaemonMessage::Other(payload)) => {
                 if let Some(option) = parse_daemon_option(payload) {
                     refused_options.push(option.to_owned());
@@ -366,8 +393,7 @@ fn handle_legacy_session(
             }
             Ok(LegacyDaemonMessage::Exit) => {
                 // FSM: -> Closing on client-initiated exit.
-                let _ = conn_state.transition(ConnectionState::Closing);
-                return Ok(None);
+                return Ok(end_session(conn_state, None));
             }
             Ok(
                 LegacyDaemonMessage::Ok
@@ -411,10 +437,6 @@ fn handle_legacy_session(
             );
         }
         respond_with_module_list(reader.get_mut(), &mut limiter, modules, messages)?;
-        // FSM: -> Closing after sending the module list and EXIT.
-        _ = conn_state
-            .transition(ConnectionState::Closing)
-            .map_err(transition_error)?;
     } else if request.starts_with('#') {
         // upstream: clientserver.c:1427-1431 - `if (*line == '#') { io_printf(
         // f_out, "@ERROR: Unknown command '%s'\n", line); return -1; }`. A
@@ -426,10 +448,6 @@ fn handle_legacy_session(
         // treats `@ERROR` as fatal and closes without reading further.
         let error = AtError::UnknownCommand(sanitize_module_identifier(&request).into_owned());
         send_error(reader.get_mut(), &mut limiter, &error)?;
-        // FSM: -> Closing after rejecting the unknown command.
-        _ = conn_state
-            .transition(ConnectionState::Closing)
-            .map_err(transition_error)?;
     } else {
         respond_with_module_request(
             &mut reader,
@@ -450,7 +468,10 @@ fn handle_legacy_session(
         )?;
     }
 
-    Ok(session_exit_code)
+    // FSM: -> Closing. Every branch above has finished with the client: the
+    // module list was sent, the unknown command was refused, or the module
+    // request ran to completion.
+    Ok(end_session(conn_state, session_exit_code))
 }
 
 /// Checks whether `line` is an `#early_input=<len>` command and, if so, reads
@@ -757,7 +778,7 @@ mod session_runtime_tests {
     #[test]
     fn fsm_module_select_to_closing_on_list() {
         let state = ConnectionState::ModuleSelect;
-        let state = state.transition(ConnectionState::Closing).unwrap();
+        let state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -766,7 +787,7 @@ mod session_runtime_tests {
         let mut state = ConnectionState::Greeting;
         state = state.transition(ConnectionState::ModuleSelect).unwrap();
         state = state.transition(ConnectionState::Transferring).unwrap();
-        state = state.transition(ConnectionState::Closing).unwrap();
+        state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -776,7 +797,7 @@ mod session_runtime_tests {
         state = state.transition(ConnectionState::ModuleSelect).unwrap();
         state = state.transition(ConnectionState::Authenticating).unwrap();
         state = state.transition(ConnectionState::Transferring).unwrap();
-        state = state.transition(ConnectionState::Closing).unwrap();
+        state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -784,7 +805,7 @@ mod session_runtime_tests {
     fn fsm_early_close_from_module_select() {
         let mut state = ConnectionState::Greeting;
         state = state.transition(ConnectionState::ModuleSelect).unwrap();
-        state = state.transition(ConnectionState::Closing).unwrap();
+        state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -793,7 +814,7 @@ mod session_runtime_tests {
         let mut state = ConnectionState::Greeting;
         state = state.transition(ConnectionState::ModuleSelect).unwrap();
         state = state.transition(ConnectionState::Authenticating).unwrap();
-        state = state.transition(ConnectionState::Closing).unwrap();
+        state = state.close();
         assert!(state.is_terminal());
     }
 
@@ -813,11 +834,27 @@ mod session_runtime_tests {
         assert!(result.is_err());
     }
 
+    /// Teardown is not a progression, so the handler cannot reach `Closing`
+    /// through `transition` at all - `end_session` owns the edge.
     #[test]
-    fn fsm_no_double_close() {
-        let state = ConnectionState::Closing;
-        let result = state.transition(ConnectionState::Closing);
-        assert!(result.is_err());
+    fn fsm_closing_is_not_a_transition_target() {
+        let state = ConnectionState::ModuleSelect;
+        assert!(state.transition(ConnectionState::Closing).is_err());
+    }
+
+    /// `end_session` forwards the session exit code untouched: the teardown
+    /// edge must not swallow the code the caller has to surface as the process
+    /// exit status in the stdio and inetd modes.
+    #[test]
+    fn end_session_forwards_exit_code() {
+        assert_eq!(end_session(ConnectionState::ModuleSelect, None), None);
+        assert_eq!(
+            end_session(
+                ConnectionState::Authenticating,
+                Some(UNSUPPORTED_AUTH_DIGEST_EXIT_CODE)
+            ),
+            Some(UNSUPPORTED_AUTH_DIGEST_EXIT_CODE)
+        );
     }
 
     #[test]

--- a/crates/daemon/tests/connection_lifecycle_fsm.rs
+++ b/crates/daemon/tests/connection_lifecycle_fsm.rs
@@ -406,6 +406,64 @@ fn lifecycle_max_connections_sequential_no_leak() {
     );
 }
 
+/// A second `@RSYNCD:` banner is the request line, not a re-greeting.
+///
+/// upstream reads the version line exactly once, in `exchange_protocols()`,
+/// and the very next `read_line_old()` is the request whatever it contains
+/// (clientserver.c:1534-1538). A repeated banner is therefore a module name
+/// and draws `@ERROR: Unknown module` (:1563-1567), not a second version
+/// exchange.
+///
+/// This is the only lifecycle edge a peer can aim at the FSM: taking
+/// Greeting -> ModuleSelect twice asks for ModuleSelect -> ModuleSelect,
+/// which the ordering check rejects. That refusal is not survivable - a
+/// session error that is not a connection close is fatal to the whole
+/// listener (`join_worker`) - so accepting the repeat as a re-greeting let a
+/// peer end the daemon with two lines. Both halves are asserted: the request
+/// is refused the way upstream refuses it, and the accept loop lives.
+#[test]
+fn lifecycle_repeated_version_line_is_a_module_name() {
+    let (port, listener) = allocate_listener();
+    let (handle, flags) = spawn_daemon(listener, port);
+
+    let stream = connect_with_timeout(port);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone"));
+    let mut writer = stream;
+
+    read_greeting(&mut reader);
+    send_version(&mut writer);
+    send_version(&mut writer);
+    writer.write_all(b"#list\n").expect("send #list");
+    writer.flush().expect("flush #list");
+
+    let mut response = String::new();
+    loop {
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => response.push_str(&line),
+        }
+    }
+    assert!(
+        response.contains("@ERROR: Unknown module"),
+        "a repeated banner is a module name (clientserver.c:1563), got: {response:?}"
+    );
+    assert!(
+        !response.contains("@RSYNCD: EXIT"),
+        "the trailing #list must never be served, got: {response:?}"
+    );
+
+    drop(writer);
+    drop(reader);
+
+    flags.shutdown.store(true, Ordering::Relaxed);
+    let result = handle.join().expect("daemon thread");
+    assert!(
+        result.is_ok(),
+        "a refused session must not tear down the accept loop: {result:?}"
+    );
+}
+
 /// Greeting -> ModuleSelect -> Closing: version only, then disconnect.
 ///
 /// The client sends its version (triggering Greeting -> ModuleSelect)


### PR DESCRIPTION
## What

The daemon's `ConnectionState` FSM validated each transition and then discarded the result at four of its ten production call sites. This makes the close edge total so there is nothing left to discard, and fixes the one peer-reachable failure the audit uncovered.

## Call-site inventory (10 production sites)

| Site | Edge | Before |
|---|---|---|
| `session_runtime.rs:331` | `-> Closing` (malformed greeting refusal) | **discarded** (`let _ =`) |
| `session_runtime.rs:369` | `-> Closing` (client `@RSYNCD: EXIT`) | **discarded** (`let _ =`) |
| `session_runtime.rs:415` | `-> Closing` (after `#list`) | error propagated, **new state dropped** (`_ = ...?`) |
| `session_runtime.rs:430` | `-> Closing` (unknown command) | error propagated, **new state dropped** (`_ = ...?`) |
| `session_runtime.rs:356` | `Greeting -> ModuleSelect` | propagated |
| `request.rs:560` | `-> Authenticating` | propagated |
| `request.rs:578` | `-> Closing` (unsupported auth digest) | propagated |
| `request.rs:607` | `-> Closing` (auth failure) | propagated |
| `orchestration.rs:774` | `-> Transferring` | propagated |
| `orchestration.rs:971` | `Transferring -> Closing` | propagated |

Every discarded site targeted `Closing`. `Closing` was reachable from every non-terminal state, and none of these paths could already be closing, so the discarded `Result` could never have been `Err`. Discarding was harmless and the check was inert - the guard existed and could not run.

## Change

Separate the two kinds of edge instead of expressing one through the other:

- `transition` now covers only the handshake progression - `Greeting -> ModuleSelect -> Authenticating -> Transferring` - and rejects `Closing` as a target. Every remaining call site is a genuine ordering constraint whose error is propagated.
- `close()` is the teardown edge. It is total from every state, returns `ConnectionState` rather than `Result`, and is a no-op on an already-closing connection, matching upstream's deliberately re-entrant `_exit_cleanup()` (cleanup.c:103).
- In `handle_legacy_session` the four teardown points collapse into one `end_session`, which forwards the session exit code and asserts the handler had not already closed.

## The bug this exposed

`session_runtime.rs:356` is the only edge a peer can aim at the FSM. A second `@RSYNCD:` banner made the handler take `Greeting -> ModuleSelect` twice; the ordering check rejected it and the resulting `io::Error` is **not survivable** - `join_worker` (`server_runtime/workers.rs`) treats any session error that is not a connection close as fatal to the accept loop. Two greeting lines ended the daemon:

```
Err(DaemonError { exit_code: SocketIo, message: "failed to serve legacy handshake
127.0.0.1:54215: invalid daemon connection transition: ModuleSelect -> ModuleSelect" })
```

Upstream reads the version line exactly once, in `exchange_protocols()`, and takes the very next `read_line_old()` as the request whatever it contains (clientserver.c:1534-1538). A repeated banner is therefore a module name and draws `@ERROR: Unknown module` (:1563-1567). The version arm is now guarded on `negotiated_protocol.is_none()` and a later banner falls through to the request, which fixes both the refusal shape and the listener teardown.

## Tests

`crates/daemon/tests/connection_lifecycle_fsm.rs::lifecycle_repeated_version_line_is_a_module_name` drives a real daemon, sends two banners and a `#list`, and asserts the upstream refusal, that the `#list` is never served, and that the accept loop survives.

Unit level: `transition_never_targets_closing` and `close_is_total_from_every_state` pin the split; `exhaustive_transition_matrix` and `connection_state_is_sole_lifecycle_authority` are updated to the progression-only table.

### Mutation proof

| Mutation | Result |
|---|---|
| Drop the `negotiated_protocol.is_none()` guard | `lifecycle_repeated_version_line_is_a_module_name` **FAILS** (`got: ""` - the daemon died); other 7 tests in the binary stay green |
| `close()` returns `self` instead of `Closing` | 11 unit tests **FAIL**, `close_is_total_from_every_state` among them; all 8 protocol-level lifecycle tests stay green, confirming the FSM writes are unobservable on the wire |
| Restore `Closing` to `valid_transitions(Greeting)` | `transition_never_targets_closing`, `exhaustive_transition_matrix`, `valid_transitions_greeting` **FAIL**; other 60 stay green |

## Verification

- `cargo nextest run -p daemon --all-features` - 1894 passed, 6 skipped
- `cargo nextest run -p bin --all-features -E 'binary(/daemon/)'` - 77 passed
- `cargo test -p daemon --doc` - 10 passed
- `cargo fmt --all -- --check` and `rustfmt --check` directly on all six touched files - clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - clean

## Follow-ups, not fixed here

- `join_worker` making any non-connection-close session error fatal to the listener is a general availability hazard well beyond the FSM; it deserves its own change and tests.
- `handle_unknown_module` and `handle_module_denied` return before any teardown edge is taken, so those paths never record `Closing`. Harmless today because nothing reads the state, but it is a gap in the model.
- The pre-request read loop accepts `OPTION --xxx` lines that upstream's `start_daemon` never reads, an oc-only extension to the handshake.
