### PR TITLE
fix: print the non-incremental file-list banner

### DIFF
--- a/crates/cli/src/frontend/execution/drive/summary.rs
+++ b/crates/cli/src/frontend/execution/drive/summary.rs
@@ -18,9 +18,9 @@ use crate::frontend::escape::EscapeStyle;
 use crate::frontend::{
     out_format::{OutFormat, OutFormatContext},
     progress::{
-        DeltaTransmissionState, DeltaTransmissionSummary, LiveProgress, NameOutputLevel,
-        PendingDiagnostics, ProgressMode, ProgressOutputConfig, StderrMode, emit_transfer_summary,
-        partition_by_summary_stream, render_diagnostic_events,
+        DeltaTransmissionState, DeltaTransmissionSummary, FlistBanner, LiveProgress,
+        NameOutputLevel, PendingDiagnostics, ProgressMode, ProgressOutputConfig, StderrMode,
+        emit_transfer_summary, partition_by_summary_stream, render_diagnostic_events,
     },
 };
 
@@ -153,8 +153,30 @@ where
     // rendering it here again would both duplicate it and print it dead last.
     // Only a local copy - whose per-file rows are all rendered post-hoc from
     // the collected events - still gets the banner from this deferred path.
-    let emit_flist_banner =
-        config.recursive() && info_gte(InfoFlag::Flist, 1) && !config.is_pull() && !is_sender;
+    //
+    // upstream: flist.c:170 - the sibling non-incremental banner is selected by
+    // `show_filelist_progress = INFO_GTE(FLIST, 1) && xfer_dirs && !am_server
+    // && !inc_recurse`, and flist.c:2521-2524 makes the two mutually exclusive.
+    // `xfer_dirs` is `recurse || dirs || list_only` (options.c:2317-2320); the
+    // `!inc_recurse` term already rules out the `recurse` disjunct here.
+    // upstream: flist.c:175 - `start_filelist_progress()` returns early under
+    // `quiet`, which `info_gte` does not model, so it needs its own term.
+    let flist_banner = if config.recursive() {
+        if info_gte(InfoFlag::Flist, 1) && verbosity > 0 && !config.is_pull() && !is_sender {
+            FlistBanner::Incremental
+        } else {
+            FlistBanner::None
+        }
+    } else if (config.dirs() || config.list_only())
+        && info_gte(InfoFlag::Flist, 1)
+        && !config.quiet()
+        && !config.is_pull()
+        && !is_sender
+    {
+        FlistBanner::Building
+    } else {
+        FlistBanner::None
+    };
     // A pure-local copy (no remote operand): `is_local_sender()` reports false
     // for the local `local_server` case and `is_pull()` is false, so their
     // conjunction uniquely identifies the in-process local-copy path whose
@@ -267,7 +289,7 @@ where
                     name_overridden,
                     human_readable_mode,
                     suppress_updated_only_totals,
-                    emit_flist_banner,
+                    flist_banner,
                     delta_notice,
                     show_copy_method,
                     show_atimes,
@@ -441,7 +463,10 @@ fn emit_log_output(params: EmitLogOutputParams<'_>) -> io::Result<()> {
         name_overridden,
         human_readable_mode,
         false,
-        false,
+        // Both client banners are stdout-only (upstream FCLIENT/FINFO); the
+        // log file's own "building file list" line (flist.c:2520, FLOG) is
+        // replayed from the FLOG queue above.
+        FlistBanner::None,
         // The delta-transmission notice and match_report `total:` line are
         // stdout-only diagnostics (upstream FINFO); the log file is fed from the
         // FLOG queue above, so suppress them here.

--- a/crates/cli/src/frontend/progress/mod.rs
+++ b/crates/cli/src/frontend/progress/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use self::live::{LiveProgress, ProgressOutputConfig};
 pub(crate) use self::mode::ProgressMode;
 pub use self::mode::{NameOutputLevel, ProgressSetting, StderrMode}; // Changed to pub for test_utils
 pub(crate) use self::render::{
-    DeltaTransmissionState, DeltaTransmissionSummary, emit_transfer_summary,
+    DeltaTransmissionState, DeltaTransmissionSummary, FlistBanner, emit_transfer_summary,
 };
 #[cfg(test)]
 pub(crate) use self::render::{emit_list_only, emit_stats};

--- a/crates/cli/src/frontend/progress/render.rs
+++ b/crates/cli/src/frontend/progress/render.rs
@@ -55,6 +55,62 @@ use super::mode::{NameOutputLevel, ProgressMode};
 use crate::{OutFormat, OutFormatContext, emit_out_format};
 use logging::{InfoFlag, info_gte};
 
+/// Which file-list banner the sender prints before the per-file name list.
+///
+/// upstream: flist.c:2521-2524 - `send_file_list()` picks exactly one of the
+/// two client-facing banners:
+///
+/// ```c
+/// if (show_filelist_progress)
+///         start_filelist_progress("building file list");
+/// else if (inc_recurse && INFO_GTE(FLIST, 1) && !am_server)
+///         rprintf(FCLIENT, "sending incremental file list\n");
+/// ```
+///
+/// with `show_filelist_progress = INFO_GTE(FLIST, 1) && xfer_dirs && !am_server
+/// && !inc_recurse` (flist.c:170). Modelling the choice as one enum keeps the
+/// two banners mutually exclusive by construction, as upstream's `if`/`else if`
+/// makes them.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub(crate) enum FlistBanner {
+    /// No banner: the gate is off (quiet, `--info=flist0`, a server role, or
+    /// neither recursion nor `xfer_dirs`).
+    #[default]
+    None,
+    /// `building file list ... done` - the non-incremental banner.
+    /// upstream: flist.c:177 + flist.c:206.
+    Building,
+    /// `sending incremental file list` - upstream: flist.c:2524.
+    Incremental,
+}
+
+impl FlistBanner {
+    /// Writes the banner this variant selects.
+    ///
+    /// upstream splits the `Building` banner across two writes on two log
+    /// codes: `start_filelist_progress()` emits `"%s ... "` on `FCLIENT` with
+    /// no trailing newline (flist.c:177) and, once the list is complete,
+    /// `finish_filelist_progress()` emits `"done\n"` on `FINFO` (flist.c:206).
+    /// Both halves land on the client's stdout, so the concatenation is
+    /// byte-identical to upstream's stream.
+    fn emit(self, writer: &mut dyn Write) -> io::Result<()> {
+        match self {
+            Self::None => Ok(()),
+            Self::Building => {
+                // upstream: flist.c:177 - rprintf(FCLIENT, "%s ... ", kind),
+                // no newline; `output_needs_newline` is set instead.
+                write!(writer, "building file list ... ")?;
+                // upstream: flist.c:206 - rprintf(FINFO, "done\n") from
+                // finish_filelist_progress(), called at flist.c:2797 (sender)
+                // and flist.c:3023 (receiver).
+                writeln!(writer, "done")
+            }
+            // upstream: flist.c:2524.
+            Self::Incremental => writeln!(writer, "sending incremental file list"),
+        }
+    }
+}
+
 /// Which `delta-transmission %s` notice the generator would print.
 ///
 /// upstream: generator.c:2291-2294 - the generator emits this line once at
@@ -117,7 +173,7 @@ pub(crate) fn emit_transfer_summary(
     name_overridden: bool,
     human_readable_mode: HumanReadableMode,
     suppress_updated_only_totals: bool,
-    emit_flist_banner: bool,
+    flist_banner: FlistBanner,
     delta_notice: DeltaTransmissionSummary,
     show_copy_method: bool,
     show_atimes: bool,
@@ -133,6 +189,13 @@ pub(crate) fn emit_transfer_summary(
 ) -> io::Result<()> {
     let events = summary.events();
     let stats_on = stats_level > 0;
+
+    // upstream: flist.c:2520-2524 - both banners are written at the *start* of
+    // `send_file_list()`, before any entry is listed, so this has to precede the
+    // `--list-only` branch below. `--list-only` resolves `xfer_dirs` to 1
+    // (options.c:2320) without turning on `inc_recurse`, so it is one of the
+    // cells that selects the `building file list ... done` banner.
+    flist_banner.emit(writer)?;
 
     if list_only {
         let mut wrote_listing = false;
@@ -179,17 +242,6 @@ pub(crate) fn emit_transfer_summary(
         }
 
         return Ok(());
-    }
-
-    // upstream: flist.c:2524 - rprintf(FCLIENT, "sending incremental file list\n")
-    // is gated on inc_recurse && INFO_GTE(FLIST, 1) && !am_server. This banner is
-    // stdout-only. Upstream's parallel `rprintf(FLOG, "building file list\n")`
-    // (flist.c:2248) targets the log file, which a plain client without
-    // --log-file discards, so it never reaches stdout. Local-copy mode is treated
-    // as inc_recurse-equivalent because the source enumeration is interleaved with
-    // per-file dispatch.
-    if emit_flist_banner && verbosity > 0 {
-        writeln!(writer, "sending incremental file list")?;
     }
 
     // upstream: main.c:787-808 - when the receiver pre-flight-mkdirs the
@@ -1583,7 +1635,7 @@ mod tests {
             false, // name_overridden
             HumanReadableMode::Grouped,
             false,                               // suppress_updated_only_totals
-            false,                               // emit_flist_banner
+            FlistBanner::None,                   // flist_banner
             DeltaTransmissionSummary::default(), // delta_notice
             false,                               // show_copy_method
             false,                               // show_atimes

--- a/crates/cli/src/frontend/tests/out/upstream_compat.rs
+++ b/crates/cli/src/frontend/tests/out/upstream_compat.rs
@@ -12,6 +12,7 @@
 
 use super::*;
 use crate::frontend::escape::EscapeStyle;
+use crate::frontend::progress::FlistBanner;
 use core::client::run_client;
 
 #[test]
@@ -241,7 +242,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false,                               // emit_flist_banner
+        FlistBanner::None,                   // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -268,7 +269,7 @@ fn out_format_suppresses_verbose_listing_in_summary() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false,                               // emit_flist_banner
+        FlistBanner::None,                   // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes

--- a/crates/cli/src/frontend/tests/output_parity.rs
+++ b/crates/cli/src/frontend/tests/output_parity.rs
@@ -10,6 +10,7 @@ use super::{
     NameOutputLevel, OutFormatContext, ProgressSetting, emit_transfer_summary, parse_out_format,
 };
 use crate::frontend::escape::EscapeStyle;
+use crate::frontend::progress::FlistBanner;
 use core::client::{
     ClientConfig, ClientEntryKind, ClientEvent, ClientEventKind, ClientSummary, HumanReadableMode,
     run_client,
@@ -72,7 +73,7 @@ fn render_stats_at_level(
         false,
         human_readable,
         false,
-        false,                               // emit_flist_banner
+        FlistBanner::None,                   // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -102,7 +103,7 @@ fn render_verbose(summary: &ClientSummary, verbosity: u8) -> String {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,                                // emit_flist_banner
+        FlistBanner::Incremental,            // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -148,7 +149,7 @@ fn info_name_only_suppresses_stats_footer() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false,                               // emit_flist_banner
+        FlistBanner::None,                   // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -547,7 +548,7 @@ fn parity_totals_only_without_stats_flag() {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,                                // emit_flist_banner
+        FlistBanner::Incremental,            // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -829,7 +830,7 @@ fn parity_verbose_v2_emits_bare_name_per_upstream() {
         false,
         HumanReadableMode::Grouped,
         false,
-        true,                                // emit_flist_banner
+        FlistBanner::Incremental,            // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes

--- a/crates/cli/src/frontend/tests/progress_render.rs
+++ b/crates/cli/src/frontend/tests/progress_render.rs
@@ -3,6 +3,7 @@ use super::{
     NameOutputLevel, OutFormatContext, ProgressSetting, emit_transfer_summary, parse_out_format,
 };
 use crate::frontend::escape::EscapeStyle;
+use crate::frontend::progress::FlistBanner;
 use core::client::{ClientConfig, ClientSummary, HumanReadableMode, run_client};
 use tempfile::TempDir;
 
@@ -56,7 +57,7 @@ fn emit_transfer_summary_list_only_emits_listing_and_stats() {
         false,
         HumanReadableMode::DecimalUnits,
         false,
-        false,                               // emit_flist_banner (list_only path)
+        FlistBanner::None,                   // flist_banner (list_only path)
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -94,7 +95,7 @@ fn emit_transfer_summary_with_progress_and_verbose_listing() {
         false,
         HumanReadableMode::DecimalUnits,
         false,
-        true,                                // emit_flist_banner
+        FlistBanner::Incremental,            // flist_banner
         DeltaTransmissionSummary::default(), // delta_notice
         false,                               // show_copy_method
         false,                               // show_atimes
@@ -140,11 +141,11 @@ fn emit_transfer_summary_out_format_adds_separator_before_stats() {
         false,
         HumanReadableMode::Grouped,
         false,
-        false, // emit_flist_banner (out_format path: starts_with assertion)
+        FlistBanner::None, // flist_banner (out_format path: starts_with assertion)
         DeltaTransmissionSummary::default(), // delta_notice
-        false, // show_copy_method
-        false, // show_atimes
-        false, // show_crtimes
+        false,             // show_copy_method
+        false,             // show_atimes
+        false,             // show_crtimes
         EscapeStyle::terminal(false), // escape style
         &mut rendered,
         &mut PendingDiagnostics::empty(),

--- a/crates/cli/src/frontend/tests/verbose.rs
+++ b/crates/cli/src/frontend/tests/verbose.rs
@@ -1843,3 +1843,192 @@ fn quiet_suppresses_info_regardless_of_verbose_order() {
          quiet assertions above vacuous"
     );
 }
+
+/// Builds `<tmp>/from/{a.txt,sub/f.txt}` plus an empty `<tmp>/to`, and returns
+/// `(tmp, "<from>/", "<to>")` ready to hand to [`run_with_args`].
+///
+/// Shared by the file-list-banner cells below so each one differs only in the
+/// flags under test.
+fn banner_fixture() -> (tempfile::TempDir, OsString, OsString) {
+    use tempfile::tempdir;
+
+    let tmp = tempdir().expect("tempdir");
+    let from = tmp.path().join("from");
+    let to = tmp.path().join("to");
+    std::fs::create_dir_all(from.join("sub")).expect("mkdir from/sub");
+    std::fs::write(from.join("a.txt"), b"alpha").expect("write a.txt");
+    std::fs::write(from.join("sub").join("f.txt"), b"foxtrot").expect("write sub/f.txt");
+    std::fs::create_dir_all(&to).expect("mkdir to");
+
+    let mut from_slash = from.into_os_string();
+    from_slash.push("/");
+    (tmp, from_slash, to.into_os_string())
+}
+
+/// Runs the front-end with `flags` against [`banner_fixture`] and returns the
+/// decoded stdout, asserting a clean exit and an empty stderr.
+///
+/// Asserting stderr is empty is what pins the banner to the *stdout* stream:
+/// upstream writes both halves on `FCLIENT`/`FINFO`, which are client-stdout
+/// codes, so a producer wired to an error code would surface here rather than
+/// silently satisfying a substring check.
+fn banner_stdout(flags: &[&str]) -> String {
+    let (_tmp, from, to) = banner_fixture();
+    let mut argv = vec![OsString::from(RSYNC)];
+    argv.extend(flags.iter().map(OsString::from));
+    argv.push(from);
+    argv.push(to);
+
+    let (code, stdout, stderr) = run_with_args(argv);
+    assert_eq!(code, 0, "{flags:?} must exit 0");
+    assert!(
+        stderr.is_empty(),
+        "{flags:?} must print nothing on stderr, got: {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+    String::from_utf8(stdout).expect("stdout is valid UTF-8")
+}
+
+/// Pins the FIRST of upstream's two banner writes: `start_filelist_progress()`
+/// emits `"%s ... "` on `FCLIENT` with no trailing newline (flist.c:177), so a
+/// non-recursive `-dv` run opens with that exact prefix.
+///
+/// Kept separate from [`dirs_verbose_banner_terminates_with_done`] on purpose:
+/// each test fails for exactly one of the two writes, so dropping either half
+/// is caught on its own rather than by a single conflated assertion.
+#[test]
+fn dirs_verbose_banner_starts_with_flist_progress_prefix() {
+    let rendered = banner_stdout(&["-dv"]);
+    assert!(
+        rendered.starts_with("building file list ... "),
+        "stdout must open with the flist.c:177 FCLIENT prefix, got: {rendered:?}"
+    );
+}
+
+/// Pins the SECOND banner write: `finish_filelist_progress()` emits `"done\n"`
+/// on `FINFO` (flist.c:206) once the list is complete, terminating the line the
+/// first write left open.
+#[test]
+fn dirs_verbose_banner_terminates_with_done() {
+    let rendered = banner_stdout(&["-dv"]);
+    let first = rendered.lines().next().unwrap_or_default();
+    assert!(
+        first.ends_with("done"),
+        "the banner line must be terminated by the flist.c:206 FINFO write, got: {rendered:?}"
+    );
+}
+
+/// The two writes concatenate into one line, emitted exactly once and ahead of
+/// the per-file names - upstream: flist.c:2521-2522, which runs at the top of
+/// `send_file_list()` before any entry is listed.
+#[test]
+fn dirs_verbose_prints_building_banner_once_and_first() {
+    let rendered = banner_stdout(&["-dv"]);
+    let lines: Vec<&str> = rendered.lines().collect();
+
+    assert_eq!(
+        lines.first().copied(),
+        Some("building file list ... done"),
+        "got: {rendered:?}"
+    );
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line.starts_with("building file list"))
+            .count(),
+        1,
+        "the banner must be emitted exactly once, got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("sending incremental file list"),
+        "the incremental banner is the mutually exclusive `else if` arm \
+         (flist.c:2523-2524) and must not also appear, got: {rendered:?}"
+    );
+}
+
+/// `--list-only` resolves `xfer_dirs` to 1 without enabling `inc_recurse`
+/// (options.c:2317-2320), so it selects the same non-incremental banner. This
+/// is the cell a fix placed at the incremental banner's own emission site would
+/// miss entirely, because the listing renderer returns before reaching it.
+#[test]
+fn list_only_verbose_prints_building_banner_before_the_listing() {
+    let (_tmp, from, _to) = banner_fixture();
+    let (code, stdout, stderr) = run_with_args([OsString::from(RSYNC), OsString::from("-v"), from]);
+
+    assert_eq!(code, 0);
+    assert!(
+        stderr.is_empty(),
+        "stderr: {:?}",
+        String::from_utf8_lossy(&stderr)
+    );
+
+    let rendered = String::from_utf8(stdout).expect("stdout is valid UTF-8");
+    let lines: Vec<&str> = rendered.lines().collect();
+    assert_eq!(
+        lines.first().copied(),
+        Some("building file list ... done"),
+        "got: {rendered:?}"
+    );
+    assert!(
+        lines.iter().skip(1).any(|line| line.ends_with(" a.txt")),
+        "the banner must precede the listing rows, got: {rendered:?}"
+    );
+}
+
+/// Recursion keeps the *incremental* banner: `inc_recurse` clears
+/// `show_filelist_progress` (flist.c:170), routing `send_file_list()` to the
+/// `else if` arm at flist.c:2523-2524.
+///
+/// This is the cell that catches an unconditional or wrongly-negated banner: a
+/// fix that ignores `!inc_recurse` prints the `building` text here, or prints
+/// both banners.
+#[test]
+fn recursive_verbose_keeps_incremental_banner() {
+    let rendered = banner_stdout(&["-rv"]);
+    let lines: Vec<&str> = rendered.lines().collect();
+
+    assert_eq!(
+        lines.first().copied(),
+        Some("sending incremental file list"),
+        "got: {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("building file list"),
+        "the non-incremental banner must not appear under -r, got: {rendered:?}"
+    );
+}
+
+/// Without `-v` the `INFO_GTE(FLIST, 1)` term of flist.c:170 is false, so no
+/// banner is printed - and nothing else is either.
+#[test]
+fn dirs_without_verbose_prints_no_banner() {
+    let rendered = banner_stdout(&["-d"]);
+    assert!(rendered.is_empty(), "got: {rendered:?}");
+}
+
+/// `--info=flist0` clears the FLIST category while leaving verbosity at 1,
+/// proving the gate is the info category (flist.c:170) rather than raw `-v`.
+#[test]
+fn dirs_verbose_info_flist0_suppresses_banner() {
+    let rendered = banner_stdout(&["-dv", "--info=flist0"]);
+    assert!(
+        !rendered.contains("building file list"),
+        "got: {rendered:?}"
+    );
+    assert!(
+        rendered.contains("a.txt"),
+        "only the banner is suppressed; the name list still prints, got: {rendered:?}"
+    );
+}
+
+/// `start_filelist_progress()` returns early under `quiet` (flist.c:175) - a
+/// term the info-level gate does not model, so it needs its own check now that
+/// `-q` and `-v` are independent.
+#[test]
+fn dirs_quiet_verbose_suppresses_banner() {
+    let rendered = banner_stdout(&["-d", "-q", "-v"]);
+    assert!(
+        !rendered.contains("building file list"),
+        "got: {rendered:?}"
+    );
+}


### PR DESCRIPTION
## Problem

Upstream `send_file_list()` picks exactly one of two client-facing banners at the top of the function, before a single entry is listed (flist.c:2521-2524):

```c
if (show_filelist_progress)
        start_filelist_progress("building file list");
else if (inc_recurse && INFO_GTE(FLIST, 1) && !am_server)
        rprintf(FCLIENT, "sending incremental file list\n");
```

with `show_filelist_progress = INFO_GTE(FLIST, 1) && xfer_dirs && !am_server && !inc_recurse` (flist.c:170).

oc only ever produced the *incremental* arm. The `building file list ... done` line had no producer anywhere in `crates/` - the only three matches for the string were comments. Every non-recursive verbose run therefore opened with no banner: `-dv`, and `--list-only`, which resolves `xfer_dirs` to 1 without enabling `inc_recurse` (options.c:2317-2320).

## Upstream: two writes, two log codes

The `building` line is not one write. It is assembled from two, on two different log codes, separated in time by the whole file-list build:

| upstream | code | text |
|---|---|---|
| flist.c:177 `start_filelist_progress()` | `FCLIENT` | `"%s ... "` - **no newline**; sets `output_needs_newline` |
| flist.c:206 `finish_filelist_progress()` | `FINFO` | `"done\n"` |

`finish_filelist_progress()` is called from flist.c:2797 (sender) and flist.c:3023 (receiver), both under `if (show_filelist_progress)`. Both codes resolve to the client's stdout, so the concatenation is byte-identical in a captured stream. The `quiet` suppression is on **both** halves: the start checks it explicitly at flist.c:175, the finish inherits it through `rwrite`.

## Measured, oc vs rsync 3.5.0

Same fixture (`from/{a.txt,sub/f.txt}` -> empty `to/`), same host, first stdout line:

| cell | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|
| `-dv src/ dst/` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-Rv --list-only ./src/sub/f.txt` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-v src/` (implicit list-only) | `building file list ... done` | *(absent)* | `building file list ... done` |
| `--list-only --info=flist1 src/` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-d --info=flist1 src/ dst/` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-dv -n src/ dst/` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-dvv src/ dst/` | `building file list ... done` | *(absent)* | `building file list ... done` |
| `-rv src/ dst/` | `sending incremental file list` | same | same |
| `-av --list-only src/` | `sending incremental file list` | same | same |
| `-d src/ dst/` | *(silent)* | same | same |
| `-dv --info=flist0` | *(no banner)* | same | same |
| `-dqv src/ dst/` | *(silent)* | same | same |
| `--list-only src/` (no `-v`) | *(no banner)* | same | same |
| `-d --list-only src/` (no `-v`) | *(no banner)* | same | same |
| `-v src/a.txt dst/` (single file) | *(no banner)* | same | same |

## Change

`FlistBanner` (`crates/cli/src/frontend/progress/render.rs`) replaces the previous `emit_flist_banner: bool` parameter with a three-state enum - `None` / `Building` / `Incremental` - so the two banners stay mutually exclusive by construction, as upstream's `if`/`else if` makes them. Its `emit()` performs the two writes as two statements, each carrying its own upstream citation.

The banner is emitted **above** the `--list-only` early return in `emit_transfer_summary`, matching upstream's placement at the top of `send_file_list()`. The previous emission site sat *after* that return, so a fix placed there would have looked correct and done nothing for the `--list-only` cell.

Gate, in `execution/drive/summary.rs` alongside the existing one:

```rust
let flist_banner = if config.recursive() {
    if info_gte(InfoFlag::Flist, 1) && verbosity > 0 && !config.is_pull() && !is_sender {
        FlistBanner::Incremental
    } else { FlistBanner::None }
} else if (config.dirs() || config.list_only())
    && info_gte(InfoFlag::Flist, 1)
    && !config.quiet()
    && !config.is_pull()
    && !is_sender
{ FlistBanner::Building } else { FlistBanner::None };
```

## Two approximations, stated rather than papered over

1. `config.dirs()` folds in `--files-from` (matching upstream options.c:2190-2191) but not `--list-only`, hence the explicit `|| config.list_only()`. The same disjunction is already used in-tree at `engine/.../sources/orchestration.rs:919-921`.
2. Upstream's `xfer_dirs` is a tri-state whose `< 0` sentinel means an explicit `--no-dirs` keeps it at 0 even under `--list-only`. oc's `dirs` is a plain bool, so the disjunction cannot express that. **Measured**: `-v --no-dirs --list-only src/` prints `skipping directory .` upstream and now also prints the banner in oc. That cell was already divergent before this change (oc emits no `skipping directory` line there at all); this change adds one more line to it. Same approximation the existing `orchestration.rs` site makes.

## Scope

Local-copy path only. **Network cells were not measured** - the claim that the network sender also lacks this producer would be source-level only, so this change deliberately does not touch it.

Two further upstream behaviours are read but not implemented, and remain gaps:

- At `INFO_GTE(FLIST, 2)` (`--info=flist2`, *not* `-vv`) `finish_filelist_progress()` prints `"%d file%sto consider"` instead of `done`, and `emit_filelist_progress()` interleaves `" %d files...\r"` ticks. **Measured**: `-dvv` prints `building file list ... done` on both binaries, so the common verbose path is correct; `-d --info=flist2` still differs.
- The receiver-side `receiving file list` banner (flist.c:2876-2877) is not exercised.

## Non-vacuity

Each half is pinned by its own test, so removing either write reddens exactly one and leaves the other green.

**Mutation A** - delete the FCLIENT half (`write!(writer, "building file list ... ")`):

```
PASS  dirs_verbose_banner_terminates_with_done
FAIL  dirs_verbose_banner_starts_with_flist_progress_prefix
Summary  2 tests run: 1 passed, 1 failed
```

**Mutation B** - delete the FINFO half (`writeln!(writer, "done")` -> `Ok(())`):

```
PASS  dirs_verbose_banner_starts_with_flist_progress_prefix
FAIL  dirs_verbose_banner_terminates_with_done
  the banner line must be terminated by the flist.c:206 FINFO write, got:
  "building file list ... a.txt\nsub/\n\nsent 5 bytes  received 0 bytes ..."
Summary  2 tests run: 1 passed, 1 failed
```

## Tests

Nine cells in `crates/cli/src/frontend/tests/verbose.rs`, all through the in-process `run_with_args` harness. Each asserts stderr is empty, which is what pins the banner to *stdout*: a producer wired to an error code would surface there rather than silently satisfying a substring check.

- `dirs_verbose_banner_starts_with_flist_progress_prefix` - write 1
- `dirs_verbose_banner_terminates_with_done` - write 2
- `dirs_verbose_prints_building_banner_once_and_first` - **counts** the occurrences (exactly 1), pins position (line 0), and asserts the incremental arm does not also appear
- `list_only_verbose_prints_building_banner_before_the_listing` - the cell the old insertion point misses
- `recursive_verbose_keeps_incremental_banner` - **the cell that catches a wrong fix**: an unconditional or wrongly-negated banner prints the `building` text here, or prints both
- `dirs_without_verbose_prints_no_banner` - the `INFO_GTE(FLIST, 1)` term
- `dirs_verbose_info_flist0_suppresses_banner` - proves the gate is the FLIST category, not raw verbosity
- `dirs_quiet_verbose_suppresses_banner` - the flist.c:175 `quiet` early return

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `cargo nextest run -p cli --all-features` - 3855 passed, 3 skipped
- `cargo nextest run -p flist -p logging --all-features` - 905 passed
- root-level `flist_banner_before_names`, `upstream_compat_inc_recurse_receiver_oracle`, `filter_nested_rsync_filter_stress` - 10 passed
- `transfer` `files_from_lsh_repeated`, `itemize_fidelity_golden` - 4 passed
- `tools/ci/citation_drift_audit.py` - no new drift or unresolved entries attributable to this change
- `tools/no_placeholders.sh` - exit 0
