### PR TITLE
fix: drain confirmed source removals in two phases

### DIFF
--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -5986,6 +5986,144 @@ fn remove_source_files_mid_commit_teardown_retains_unconfirmed_sources() {
     );
 }
 
+/// A `MSG_SUCCESS` that only arrives DURING the goodbye handshake must still
+/// remove its source.
+///
+/// WHY A SECOND DRAIN PHASE EXISTS AT ALL.
+///
+/// Upstream never batches: `read_a_msg()` calls `successful_send(val)` the
+/// instant it demultiplexes a `MSG_SUCCESS` frame (`io.c:1793-1807`), so the
+/// unlink happens wherever the sender is doing I/O - inside `send_files()` and
+/// again inside `read_final_goodbye()` (`main.c:997`), because the receiver
+/// commits and acknowledges its last files after its generator has already sent
+/// `NDX_DONE`. oc's reader accumulates the indices instead of dispatching them,
+/// so that eagerness has to be reproduced by draining at each point upstream
+/// would have reacted: once before the sender answers the goodbye (so a failure
+/// diagnostic still reaches a peer that is reading - see
+/// `refused_source_unlink_exits_23_in_every_topology`), and once after it (so
+/// the confirmations that arrived during the handshake are not dropped).
+///
+/// THIS TEST IS THE GUARD ON THE SECOND PHASE. Deleting it turns the two-phase
+/// drain into "the drain moved earlier", and a source the peer safely committed
+/// is silently left behind - the failure mode is invisible in the exit code and
+/// invisible in a fixture whose confirmations all arrive early.
+///
+/// The fixture is scripted at the byte level so neither phase can be empty by
+/// accident: `early.txt`'s confirmation precedes the receiver's goodbye
+/// `NDX_DONE` and `late.txt`'s follows it, and the test asserts BOTH drained
+/// counts are exactly 1. A vacuous fixture - one whose phase-2 set is empty -
+/// would pass under either shape and prove nothing.
+#[test]
+fn handshake_confirmed_source_is_still_removed_by_the_second_drain() {
+    let temp = create_test_files(&[("early.txt", b"alpha"), ("late.txt", b"bravo")]);
+    let early = temp.path().join("early.txt");
+    let late = temp.path().join("late.txt");
+
+    let handshake = test_handshake_with_protocol(31);
+    let mut config = test_config();
+    config.protocol = ProtocolVersion::try_from(31u8).unwrap();
+    // Skip del_stats so the receiver's wire is exactly the two NDX_DONE frames.
+    config.do_stats = false;
+    config.args = vec![OsString::from(&early), OsString::from(&late)];
+    config.flags.remove_source_files = true;
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+    ctx.build_file_list(&[early.clone(), late.clone()])
+        .expect("building the file list for two real files must succeed");
+
+    let flats: Vec<usize> = (0..ctx.file_list.len())
+        .filter(|&i| ctx.file_list[i].is_file())
+        .collect();
+    assert_eq!(
+        flats.len(),
+        2,
+        "two positional file sources produce two file entries"
+    );
+    let sources: Vec<PathBuf> = flats
+        .iter()
+        .map(|&flat| ctx.reconstruct_source_path(flat))
+        .collect();
+    for src in &sources {
+        assert!(src.exists(), "each source must exist before the drain");
+    }
+    // The sender finished transmitting both: every unlink is deferred.
+    for &flat in &flats {
+        ctx.pending_source_removals.mark_pending(flat);
+    }
+    let wire_early = ctx.flat_to_wire_ndx(flats[0]);
+    let wire_late = ctx.flat_to_wire_ndx(flats[1]);
+
+    // The receiver's wire, in arrival order. The MSG_SUCCESS payload is the
+    // bare 4-byte LE ndx (io.c:1202 send_msg_int(MSG_SUCCESS, ndx)); the two
+    // NDX_DONE markers ride MSG_DATA in the modern (protocol >= 30) single-byte
+    // encoding.
+    const NDX_DONE_BYTE: [u8; 1] = [0x00];
+    let mut wire = Vec::new();
+    protocol::send_msg(
+        &mut wire,
+        protocol::MessageCode::Success,
+        &wire_early.to_le_bytes(),
+    )
+    .expect("frame the pre-goodbye confirmation");
+    protocol::send_msg(&mut wire, protocol::MessageCode::Data, &NDX_DONE_BYTE)
+        .expect("frame the receiver's goodbye NDX_DONE");
+    protocol::send_msg(
+        &mut wire,
+        protocol::MessageCode::Success,
+        &wire_late.to_le_bytes(),
+    )
+    .expect("frame the in-handshake confirmation");
+    protocol::send_msg(&mut wire, protocol::MessageCode::Data, &NDX_DONE_BYTE)
+        .expect("frame the receiver's final NDX_DONE");
+
+    let mut reader = crate::reader::ServerReader::new_plain(Cursor::new(wire))
+        .activate_multiplex()
+        .expect("activate input multiplex");
+    let mut out = Vec::new();
+    let mut writer = crate::writer::ServerWriter::new_plain(&mut out)
+        .activate_multiplex()
+        .expect("activate output multiplex");
+    let mut ndx_read = protocol::codec::create_ndx_codec(31);
+    let mut ndx_write = protocol::codec::MonotonicNdxWriter::new(31);
+
+    // The PRODUCTION sequence, not a copy of it: `orchestrator::run` calls this
+    // same method, so deleting a phase there fails this test.
+    let drains = ctx
+        .goodbye_draining_source_removals(
+            &mut reader,
+            &mut writer,
+            &mut ndx_read,
+            &mut ndx_write,
+            |_w| Ok(()),
+        )
+        .expect("the goodbye plus both drains must complete");
+
+    // The consequence first, so a regression names the file it leaked.
+    assert!(
+        !sources[0].exists(),
+        "the pre-goodbye confirmation must remove its source"
+    );
+    assert!(
+        !sources[1].exists(),
+        "a source confirmed DURING the goodbye handshake must still be removed; \
+         dropping the post-goodbye drain leaks exactly this file (sender.c:395 \
+         successful_send(), dispatched inline by io.c:1793-1807)"
+    );
+    assert!(
+        ctx.pending_source_removals.is_empty(),
+        "both deferred removals must be consumed across the two phases"
+    );
+    // Then the guard that keeps the assertions above honest.
+    assert_eq!(
+        drains.before_goodbye, 1,
+        "the confirmation that preceded the goodbye belongs to the first phase"
+    );
+    assert_eq!(
+        drains.during_goodbye, 1,
+        "NON-VACUITY: the second phase must have real work, otherwise deleting \
+         it would change nothing and this test would prove nothing"
+    );
+}
+
 /// Splits the bytes a multiplexed `ServerWriter` produced into `(code, payload)`
 /// pairs so a test can pin both the frame tag and its exact text.
 fn decode_mux_frames(buf: &[u8]) -> Vec<(protocol::MessageCode, Vec<u8>)> {

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -1,6 +1,9 @@
 //! Goodbye handshake handling for the generator role.
 //!
-//! Contains `handle_goodbye` plus its helpers `should_send_del_stats`,
+//! The handshake is split into `read_receiver_goodbye` and
+//! `answer_goodbye_with_finalizer` so a caller can act in the gap between the
+//! two - the last point at which the sender can still write a diagnostic the
+//! peer will read. Helpers: `should_send_del_stats`,
 //! `read_ndx_skipping_del_stats`, and `accumulate_delete_stats`.
 //!
 //! # Upstream Reference
@@ -16,6 +19,21 @@ use protocol::stats::DeleteStats;
 use super::super::{GeneratorContext, is_early_close_error};
 use crate::receiver::ndx_stream::{FlistMarkerSink, NdxFrame, StreamRole, read_marker_aware_ndx};
 use crate::role_trailer::error_location;
+
+/// What the receiver's half of the goodbye handshake delivered.
+///
+/// Distinguishes "the peer said goodbye, answer it" from "there is nothing to
+/// answer" so the caller can run work in the gap between the two halves without
+/// having to re-derive whether the exchange is still live.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::generator) enum GoodbyeArrival {
+    /// The receiver's goodbye `NDX_DONE` arrived and is waiting for the
+    /// sender's reply (upstream: `main.c:919-922` - the sender echoes it back).
+    Done,
+    /// This protocol version exchanges no goodbye, or the peer closed the
+    /// connection before sending one. Nothing is owed to the peer.
+    None,
+}
 
 /// The sender's view of the goodbye NDX stream.
 ///
@@ -128,21 +146,50 @@ impl GeneratorContext {
     /// `Z_FINISH` (`token.c:367 send_deflated_token()` performs the matching
     /// `deflateEnd()` at end of transfer) before the receiver tries to
     /// decompress past the in-flight block.
+    #[cfg(test)]
     pub(in crate::generator) fn handle_goodbye_with_finalizer<R, W, F>(
         &mut self,
         reader: &mut R,
         writer: &mut W,
         ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
         ndx_write_codec: &mut MonotonicNdxWriter,
-        mut finalize_between_write_and_read: F,
+        finalize_between_write_and_read: F,
     ) -> io::Result<()>
     where
         R: Read,
         W: Write,
         F: FnMut(&mut W) -> io::Result<()>,
     {
+        if self.read_receiver_goodbye(reader, ndx_read_codec)? == GoodbyeArrival::Done {
+            self.answer_goodbye_with_finalizer(
+                reader,
+                writer,
+                ndx_read_codec,
+                ndx_write_codec,
+                finalize_between_write_and_read,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Reads the receiver's goodbye `NDX_DONE`, the first half of the
+    /// handshake.
+    ///
+    /// Split from the answering half so the caller owns the gap between the
+    /// two, which is the last point in the run at which the sender can still
+    /// write a diagnostic the peer will read. The `--remove-source-files` drain
+    /// uses it (see `GeneratorContext::goodbye_draining_source_removals`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `main.c:916-919` - `read_final_goodbye()` reads the receiver's NDX first
+    pub(in crate::generator) fn read_receiver_goodbye<R: Read>(
+        &mut self,
+        reader: &mut R,
+        ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
+    ) -> io::Result<GoodbyeArrival> {
         if !self.protocol.supports_goodbye_exchange() {
-            return Ok(());
+            return Ok(GoodbyeArrival::None);
         }
 
         // Read first NDX_DONE from receiver, skipping any NDX_DEL_STATS.
@@ -152,7 +199,7 @@ impl GeneratorContext {
         let ndx = match self.read_ndx_skipping_del_stats(reader, ndx_read_codec) {
             Ok(ndx) => ndx,
             Err(e) if is_early_close_error(&e) => {
-                return Ok(());
+                return Ok(GoodbyeArrival::None);
             }
             Err(e) => return Err(e),
         };
@@ -165,7 +212,28 @@ impl GeneratorContext {
                 crate::role_trailer::sender()
             )));
         }
+        Ok(GoodbyeArrival::Done)
+    }
 
+    /// Answers the receiver's goodbye, the second half of the handshake.
+    ///
+    /// Called only after [`read_receiver_goodbye`](Self::read_receiver_goodbye)
+    /// reported [`GoodbyeArrival::Done`]. Writing the sender's `NDX_DONE` here
+    /// is the point after which the peer stops reading, so anything the sender
+    /// still owes the peer must already be on the wire.
+    pub(in crate::generator) fn answer_goodbye_with_finalizer<R, W, F>(
+        &mut self,
+        reader: &mut R,
+        writer: &mut W,
+        ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
+        ndx_write_codec: &mut MonotonicNdxWriter,
+        mut finalize_between_write_and_read: F,
+    ) -> io::Result<()>
+    where
+        R: Read,
+        W: Write,
+        F: FnMut(&mut W) -> io::Result<()>,
+    {
         // For protocol 31+: conditionally send del_stats, echo NDX_DONE, read final NDX_DONE.
         //
         // Upstream gates del_stats sending on INFO_GTE(STATS, 2) (i.e. --stats was passed)

--- a/crates/transfer/src/generator/transfer/mod.rs
+++ b/crates/transfer/src/generator/transfer/mod.rs
@@ -19,6 +19,8 @@ mod orchestrator;
 mod stats;
 mod transfer_loop;
 
+pub(in crate::generator) use goodbye::GoodbyeArrival;
+
 #[cfg(test)]
 mod send_debug_emission_tests {
     //! Wording tests for `--debug=send` producer emissions.

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -21,6 +21,21 @@ use crate::generator::GeneratorStats;
 use crate::role_trailer::error_location;
 use crate::transfer_state::TransferPhase;
 
+/// How many `--remove-source-files` confirmations each half of the goodbye
+/// drain consumed, so a caller can tell the two phases apart.
+///
+/// A test that asserts only "the sources are gone" cannot distinguish a working
+/// two-phase drain from one that got all its work in the first phase, which is
+/// exactly the shape that silently degenerates into "the drain moved earlier".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SourceRemovalDrains {
+    /// Confirmations already demultiplexed when the sender still owed the peer
+    /// its goodbye reply - the ones whose diagnostics a pulling client reads.
+    pub(crate) before_goodbye: usize,
+    /// Confirmations that only arrived while the goodbye handshake ran.
+    pub(crate) during_goodbye: usize,
+}
+
 impl GeneratorContext {
     /// Prints the `sending incremental file list` banner on the client's own
     /// output at file-list-send time, ahead of any per-file rows.
@@ -50,6 +65,83 @@ impl GeneratorContext {
         self.config.connection.client_mode
             && self.config.flags.recursive
             && logging::info_gte(logging::InfoFlag::Flist, 1)
+    }
+
+    /// Runs the goodbye handshake with the deferred `--remove-source-files`
+    /// drain split across it, and reports how many confirmations each phase
+    /// consumed.
+    ///
+    /// Upstream has no batched drain: `read_a_msg()` calls
+    /// `successful_send(val)` the instant it demultiplexes a `MSG_SUCCESS`
+    /// frame (`io.c:1793-1807`), so the unlink - and the `FERROR_XFER` a
+    /// refused unlink raises - happens wherever the sender is doing I/O, inside
+    /// `send_files()` and again inside `read_final_goodbye()` (`main.c:997`).
+    /// Our reader accumulates the indices instead of dispatching them, so that
+    /// eagerness has to be reproduced by draining at each point upstream would
+    /// already have reacted.
+    ///
+    /// **Phase 1** runs before the sender answers the goodbye. That is the last
+    /// moment a diagnostic still reaches a pulling client: `sender.c:455-462`
+    /// ends every failing arm at `FERROR_XFER`, and it is the LOG CODE that
+    /// carries the exit status, not an `io_error` bit - `rwrite()` sets
+    /// `got_xfer_error` (`log.c:337-338`) and, on a server, forwards the text
+    /// as `MSG_ERROR_XFER` (`log.c:357-367`) so the client sets it too, which
+    /// `cleanup.c:217-218` lifts to `RERR_PARTIAL` (23) at BOTH ends. Once the
+    /// sender writes its `NDX_DONE` the client writes its own and stops
+    /// reading, so a frame written after that lands in a dead window and the
+    /// client exits 0 for a destructive-intent option that did not do its job.
+    ///
+    /// **Phase 2** runs after. `MSG_SUCCESS` frames keep arriving through the
+    /// handshake - the receiver commits and acknowledges its last files after
+    /// its generator has already sent `NDX_DONE` - and those confirmations are
+    /// only visible once the goodbye reads have demultiplexed them. Dropping
+    /// this phase would turn the split into "the drain moved earlier" and leak
+    /// exactly those sources.
+    ///
+    /// A file the peer never confirmed keeps its source: an interrupted or
+    /// failed transfer returns via `?` before reaching here, so nothing is
+    /// unlinked without a commit the peer acknowledged.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1793-1807` - `MSG_SUCCESS` dispatches `successful_send(val)` inline
+    /// - `sender.c:395` - `successful_send()` performs the guarded unlink
+    /// - `main.c:993-997` - `read_final_goodbye()` still drives `read_a_msg()`
+    pub(crate) fn goodbye_draining_source_removals<R, W, F>(
+        &mut self,
+        reader: &mut super::super::super::reader::ServerReader<R>,
+        writer: &mut super::super::super::writer::ServerWriter<W>,
+        ndx_read_codec: &mut protocol::codec::NdxCodecEnum,
+        ndx_write_codec: &mut protocol::codec::MonotonicNdxWriter,
+        finalize_between_write_and_read: F,
+    ) -> io::Result<SourceRemovalDrains>
+    where
+        R: Read,
+        W: Write,
+        F: FnMut(&mut super::super::super::writer::ServerWriter<W>) -> io::Result<()>,
+    {
+        let arrival = self.read_receiver_goodbye(reader, ndx_read_codec)?;
+
+        let before_goodbye =
+            self.drain_confirmed_source_removals(writer, reader.take_success_indices())?;
+
+        if arrival == super::GoodbyeArrival::Done {
+            self.answer_goodbye_with_finalizer(
+                reader,
+                writer,
+                ndx_read_codec,
+                ndx_write_codec,
+                finalize_between_write_and_read,
+            )?;
+        }
+
+        let during_goodbye =
+            self.drain_confirmed_source_removals(writer, reader.take_success_indices())?;
+
+        Ok(SourceRemovalDrains {
+            before_goodbye,
+            during_goodbye,
+        })
     }
 
     /// Runs the generator role to completion.
@@ -278,7 +370,11 @@ impl GeneratorContext {
         // already shut down. Early close during goodbye-shutdown is rare
         // and the transfer is over, so any other error is treated as a
         // real failure rather than swallowed.
-        self.handle_goodbye_with_finalizer(
+        //
+        // The goodbye is split in two so the deferred --remove-source-files
+        // drain can run in the gap between the halves; see
+        // `goodbye_draining_source_removals`.
+        self.goodbye_draining_source_removals(
             reader,
             writer,
             &mut ndx_read_codec,
@@ -289,37 +385,6 @@ impl GeneratorContext {
                 Err(e) => Err(e),
             },
         )?;
-
-        // upstream: io.c:1623-1637 - MSG_SUCCESS(ndx) frames arrive interleaved
-        // with the receiver's NDX requests and are demultiplexed as the sender
-        // drives the transfer loop and goodbye handshake. Now that the wire is
-        // drained, run the deferred --remove-source-files unlink for every file
-        // the peer confirmed committed (sender.c:395 successful_send()). A
-        // file the peer never confirmed keeps its source: an interrupted or
-        // failed transfer returns via `?` above and never reaches this point,
-        // so its source is intentionally left in place. This is the crash-safe
-        // ordering the inline unlink violated.
-        // upstream: sender.c:455-462 - every failing arm of successful_send()
-        // ends at FERROR_XFER, and it is the LOG CODE that carries the exit
-        // status, not an io_error bit: rwrite() sets got_xfer_error (log.c:338)
-        // and, on a server, forwards the text as MSG_ERROR_XFER (log.c:357-367)
-        // so the client sets got_xfer_error too. cleanup.c:217-218 then lifts a
-        // zero exit to RERR_PARTIAL (23) on BOTH ends. Routing the failure
-        // through `emit_sender_diagnostic` is therefore what makes a pulling
-        // client exit 23; the io_error bit alone only reaches a client that is
-        // itself the sender, because this drain runs after the sender has
-        // already sent its MSG_IO_ERROR.
-        for wire_ndx in reader.take_success_indices() {
-            let outcome = self.confirm_source_removal(wire_ndx);
-            self.io_error |= outcome.io_error;
-            if let Some(text) = outcome.error_xfer {
-                self.emit_sender_diagnostic(
-                    writer,
-                    super::super::protocol_io::SenderDiagnostic::ErrorXfer,
-                    &text,
-                )?;
-            }
-        }
 
         // UTS-V3.A drain barrier: explicit user-space drain after
         // `handle_goodbye_with_finalizer` returns and before the writer

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -1510,6 +1510,47 @@ impl GeneratorContext {
         };
         self.remove_source_file_if_requested(&source_path, &display_name, recorded)
     }
+
+    /// Runs the deferred `--remove-source-files` unlink for every confirmation
+    /// in `confirmed`, routing each failure through `emit_sender_diagnostic`.
+    ///
+    /// Returns how many confirmations were drained, which is what lets a test
+    /// assert that a given drain phase had real work to do rather than passing
+    /// on an empty set.
+    ///
+    /// Upstream has no batched drain to mirror: `read_a_msg()` calls
+    /// `successful_send(val)` the instant a `MSG_SUCCESS` frame is demultiplexed
+    /// (`io.c:1793-1807`), so the unlink and its `FERROR_XFER` happen wherever
+    /// the sender happened to be doing I/O - during `send_files()` and again
+    /// inside `read_final_goodbye()`. Our reader accumulates the indices instead
+    /// of dispatching them, so the eagerness upstream gets for free has to be
+    /// reproduced by calling this at each point upstream could have reacted.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `io.c:1793-1807` - `MSG_SUCCESS` dispatches `successful_send(val)` inline
+    /// - `sender.c:395` - `successful_send()` performs the guarded unlink
+    /// - `log.c:337-338`, `log.c:357-367` - `FERROR_XFER` sets `got_xfer_error`
+    ///   and, on a server, forwards the text as `MSG_ERROR_XFER`
+    pub(crate) fn drain_confirmed_source_removals<W: Write>(
+        &mut self,
+        writer: &mut crate::writer::ServerWriter<W>,
+        confirmed: Vec<i32>,
+    ) -> io::Result<usize> {
+        let drained = confirmed.len();
+        for wire_ndx in confirmed {
+            let outcome = self.confirm_source_removal(wire_ndx);
+            self.io_error |= outcome.io_error;
+            if let Some(text) = outcome.error_xfer {
+                self.emit_sender_diagnostic(
+                    writer,
+                    super::super::protocol_io::SenderDiagnostic::ErrorXfer,
+                    &text,
+                )?;
+            }
+        }
+        Ok(drained)
+    }
 }
 
 /// Per-index record of which file-list entries the sender has already

--- a/tests/remove_source_files_failure_exit_23.rs
+++ b/tests/remove_source_files_failure_exit_23.rs
@@ -1,0 +1,315 @@
+//! A failed `--remove-source-files` unlink must exit 23 in EVERY topology.
+//!
+//! ```c
+//! /* sender.c:455-462 - successful_send() */
+//!   failed:
+//!         rsyserr(FERROR_XFER, errno, "sender failed to remove %s", fname);
+//! /* log.c:337-338 - rwrite() */
+//!         case FERROR_XFER:
+//!                 got_xfer_error = 1;
+//! /* cleanup.c:217-218 - exit_cleanup() */
+//!         if (!code && got_xfer_error)
+//!                 code = RERR_PARTIAL;
+//! ```
+//!
+//! Upstream reacts to a `MSG_SUCCESS` frame the instant `read_a_msg()`
+//! demultiplexes it (`io.c:1793-1807` calls `successful_send(val)` inline), so
+//! the `FERROR_XFER` for a refused unlink is written wherever the sender
+//! happens to be doing I/O - always while the peer is still reading. oc's
+//! sender accumulates the confirmations and drains them in a batch instead, so
+//! the position of that batch relative to the goodbye handshake decides whether
+//! the client ever sees the message.
+//!
+//! With a single drain placed AFTER the goodbye, the two pulling topologies
+//! reported success for a destructive-intent option that had not done its job:
+//!
+//! | topology   | before | after |
+//! |------------|--------|-------|
+//! | local copy | 23     | 23    |
+//! | ssh push   | 23     | 23    |
+//! | ssh pull   | **0**  | 23    |
+//! | daemon pull| **0**  | 23    |
+//!
+//! Both zeros are the same defect: on a pull the sender is the remote, its
+//! diagnostic has to cross the wire as `MSG_ERROR_XFER`, and by the time the
+//! post-goodbye drain wrote it the client had already sent its final `NDX_DONE`
+//! and stopped reading. The push and local cells never noticed because there
+//! the failing sender IS the process whose exit code is observed.
+//!
+//! WHY THE FIXTURE IS EACCES AND NOT A REFUSED SYSCALL.
+//!
+//! The source's parent is `chmod 555`, so `unlinkat` fails `EACCES` on every
+//! platform and in every feature set. A seccomp-refused `unlink` would produce
+//! `EPERM` only on Linux `--all-features` builds, which would make a green run
+//! elsewhere say nothing about the behaviour under test.
+//!
+//! Skip conditions (the test passes with a printed reason):
+//! - Loopback TCP is unavailable (daemon cell only).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// What one topology reported for the same refused unlink.
+struct Attempt {
+    exit_code: Option<i32>,
+    stderr: String,
+    delivered: bool,
+    source_remains: bool,
+}
+
+/// Seeds `<root>/<cell>` with `src/sub/f.txt` under a write-denied parent plus
+/// an empty `dst/`, and returns that cell root.
+///
+/// The file itself stays writable: it is the PARENT's missing write bit that
+/// refuses the unlink, which is what makes the failure `EACCES` rather than a
+/// property of the file.
+fn seed(root: &Path, cell: &str) -> PathBuf {
+    let dir = root.join(cell);
+    let sub = dir.join("src/sub");
+    fs::create_dir_all(&sub).expect("create source dir");
+    fs::create_dir_all(dir.join("dst")).expect("create dest dir");
+    fs::write(sub.join("f.txt"), b"payload\n").expect("seed source file");
+    let mut perms = fs::metadata(&sub)
+        .expect("stat source parent")
+        .permissions();
+    perms.set_mode(0o555);
+    fs::set_permissions(&sub, perms).expect("deny write on the source parent");
+    dir
+}
+
+/// Restores the write bit so the temp dir can be torn down.
+fn unseal(dir: &Path) {
+    let sub = dir.join("src/sub");
+    if let Ok(meta) = fs::metadata(&sub) {
+        let mut perms = meta.permissions();
+        perms.set_mode(0o755);
+        let _ = fs::set_permissions(&sub, perms);
+    }
+}
+
+fn observe(dir: &Path, output: std::process::Output) -> Attempt {
+    Attempt {
+        exit_code: output.status.code(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        delivered: dir.join("dst/sub/f.txt").exists(),
+        source_remains: dir.join("src/sub/f.txt").exists(),
+    }
+}
+
+/// An SSH-shaped remote-shell shim: drop the options and the host placeholder,
+/// then exec the server command locally. Gives a genuine two-process transfer
+/// over a pipe pair without an SSH server.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    let body = "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         # $1 is the host placeholder; the server command follows it.\n\
+         shift || true\n\
+         exec \"$@\"\n";
+    fs::write(&script, body).expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+fn local_copy(root: &Path) -> Attempt {
+    let dir = seed(root, "local-copy");
+    let output = Command::new(oc_binary())
+        .args([
+            "-r",
+            "--remove-source-files",
+            &format!("{}/", dir.join("src").display()),
+            &format!("{}/", dir.join("dst").display()),
+        ])
+        .output()
+        .expect("run local copy");
+    let attempt = observe(&dir, output);
+    unseal(&dir);
+    attempt
+}
+
+/// `--rsync-path` forces a real external `--server` process, so the sender runs
+/// in its own process and its diagnostic has to cross the pipe.
+fn remote_shell(root: &Path, cell: &str, pull: bool) -> Attempt {
+    let dir = seed(root, cell);
+    let shim = write_rsh_shim(root);
+    let binary = oc_binary();
+    let src = format!("{}/", dir.join("src").display());
+    let dst = format!("{}/", dir.join("dst").display());
+    let (from, to) = if pull {
+        (format!("localhost:{src}"), dst)
+    } else {
+        (src, format!("localhost:{dst}"))
+    };
+    let output = Command::new(&binary)
+        .args(["-r", "--remove-source-files", "--rsh"])
+        .arg(&shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(&from)
+        .arg(&to)
+        .output()
+        .expect("run remote-shell transfer");
+    let attempt = observe(&dir, output);
+    unseal(&dir);
+    attempt
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// Starts a daemon and waits until its port answers.
+///
+/// `stdin` is `/dev/null` deliberately: with an inherited terminal or pipe the
+/// daemon takes its single-connection inetd path and never listens.
+fn spawn_daemon(conf: &Path, port: u16) -> Child {
+    let child = Command::new(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+/// The module is deliberately NOT `read only`: upstream refuses a source
+/// removal on a read-only module, so a read-only fixture would report the same
+/// "source still there" as the bug and prove nothing.
+fn daemon_pull(root: &Path) -> Option<Attempt> {
+    let dir = seed(root, "daemon-pull");
+    let port = free_port()?;
+    let conf_path = dir.join("rsyncd.conf");
+    fs::write(
+        &conf_path,
+        format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             log file = {log}\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = no\n",
+            log = dir.join("daemon.log").display(),
+            module = dir.join("src").display(),
+        ),
+    )
+    .expect("write daemon config");
+
+    let mut daemon = spawn_daemon(&conf_path, port);
+    let output = Command::new(oc_binary())
+        .args([
+            "-r",
+            "--remove-source-files",
+            &format!("rsync://127.0.0.1:{port}/m/"),
+            &format!("{}/", dir.join("dst").display()),
+        ])
+        .output()
+        .expect("run daemon pull");
+    // Observe BEFORE killing the daemon: it is the daemon that performs the
+    // removal, so tearing it down first would guarantee the very absence of
+    // work this test is trying to detect.
+    let attempt = observe(&dir, output);
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+    unseal(&dir);
+    Some(attempt)
+}
+
+/// Reports everything wrong with one cell, rather than stopping at the first
+/// problem: a caller that aborts on the earliest failing topology hides whether
+/// the rest of the table is intact, which is the whole point of running four.
+///
+/// The delivery and source-still-there checks come first because they are what
+/// keeps the cell honest - without them "exit 23" could be reporting a transfer
+/// that never ran, or an unlink the fixture failed to refuse.
+fn faults(topology: &str, attempt: &Attempt) -> Vec<String> {
+    let mut faults = Vec::new();
+    if !attempt.delivered {
+        faults.push(format!(
+            "{topology}: the file did not reach the destination, so the \
+             exit-code assertion would be meaningless"
+        ));
+    }
+    if !attempt.source_remains {
+        faults.push(format!(
+            "{topology}: the source was removed, so the fixture did not exercise \
+             a FAILED unlink and this cell proves nothing"
+        ));
+    }
+    if !attempt.stderr.contains("sender failed to remove") {
+        faults.push(format!(
+            "{topology}: upstream's sender.c:455-459 text never reached the \
+             observing process; on a pull that means it did not cross the wire \
+             as MSG_ERROR_XFER while the client was still reading"
+        ));
+    }
+    if attempt.exit_code != Some(23) {
+        faults.push(format!(
+            "{topology}: exit {:?}, want 23 - a refused source unlink is \
+             RERR_PARTIAL (sender.c:455-459 -> log.c:337-338 -> cleanup.c:217-218)",
+            attempt.exit_code
+        ));
+    }
+    for fault in &mut faults {
+        fault.push_str(&format!("\n    stderr: {:?}", attempt.stderr));
+    }
+    faults
+}
+
+/// All four topologies, one fixture, one assertion. Splitting them into
+/// separate tests would let the two pulling cells be quietly dropped, which is
+/// how the divergence survived: the local and push cells were green throughout.
+#[test]
+fn refused_source_unlink_exits_23_in_every_topology() {
+    let root = tempfile::tempdir().expect("temp dir");
+
+    let mut cells = vec![
+        ("local copy", local_copy(root.path())),
+        ("ssh push", remote_shell(root.path(), "ssh-push", false)),
+        ("ssh pull", remote_shell(root.path(), "ssh-pull", true)),
+    ];
+    match daemon_pull(root.path()) {
+        Some(attempt) => cells.push(("daemon pull", attempt)),
+        None => println!("SKIP daemon pull: no loopback port available"),
+    }
+
+    let faults: Vec<String> = cells
+        .iter()
+        .flat_map(|(topology, attempt)| faults(topology, attempt))
+        .collect();
+    assert!(
+        faults.is_empty(),
+        "a refused --remove-source-files unlink must exit 23 everywhere:\n  {}",
+        faults.join("\n  ")
+    );
+}


### PR DESCRIPTION
Builds on #7576, which has since landed on master (squashed as c19f0ba18). This branch is now rebased onto master and targets it directly. It depends on the `SourceRemovalOutcome` type and the `emit_sender_diagnostic` routing #7576 introduced.

## What upstream does about drain ordering

Upstream has no drain to order. `read_a_msg()` calls `successful_send(val)` the instant it demultiplexes a `MSG_SUCCESS` frame (`io.c:1793-1807`), so the unlink - and the `FERROR_XFER` a refused unlink raises (`sender.c:455-462`) - happens wherever the sender is doing I/O: inside `send_files()` (`main.c:993`) and again inside `read_final_goodbye()` (`main.c:997`), which still drives `read_a_msg()`. The reaction is always written while the peer is still reading.

Our reader accumulates the confirmations instead of dispatching them, so the single batched drain had a position, and it sat after the whole goodbye exchange - deliberately, because `MSG_SUCCESS` frames keep arriving through the handshake.

## The defect

By the time the post-goodbye drain wrote its `MSG_ERROR_XFER`, the client had written its final `NDX_DONE` and stopped reading. The frame landed in a dead read window:

| topology    | before | after |
|-------------|--------|-------|
| local copy  | 23     | 23    |
| ssh push    | 23     | 23    |
| ssh pull    | **0**  | 23    |
| daemon pull | **0**  | 23    |

Both zeros are the same defect. The issue was reported for daemon pull; ssh pull was measured to be equally affected - on a pull the sender is the remote either way. The push and local cells were green throughout because there the failing sender IS the process whose exit code is observed.

## The fix: a two-phase drain

Moving the drain earlier is not the fix - the confirmations that arrive during the handshake would stop being acted on and those sources would be silently left behind. Instead, reproduce upstream's eagerness by draining at each point upstream would already have reacted.

- `handle_goodbye_with_finalizer` splits into `read_receiver_goodbye` and `answer_goodbye_with_finalizer` (it survives as the `#[cfg(test)]` composition of the two, so the existing goodbye tests are unchanged).
- `goodbye_draining_source_removals` composes them around two drains:
  - **Phase 1**, before the sender answers the goodbye - the last moment a diagnostic still reaches a pulling client.
  - **Phase 2**, after - unlinks the sources confirmed while the handshake ran.
- Both phases go through the existing `emit_sender_diagnostic`, the single place `got_xfer_error` is set and `MSG_ERROR_XFER` is framed. No second special case.
- The method returns `SourceRemovalDrains { before_goodbye, during_goodbye }` so a test can tell the two phases apart.

## Mutation proofs

**Delete phase 1** -> `refused_source_unlink_exits_23_in_every_topology` goes RED on exactly the two pulling cells, reproducing the pre-fix table:

```
a refused --remove-source-files unlink must exit 23 everywhere:
  ssh pull: upstream's sender.c:455-459 text never reached the observing process; on a pull that means it did not cross the wire as MSG_ERROR_XFER while the client was still reading
    stderr: ""
  ssh pull: exit Some(0), want 23 - a refused source unlink is RERR_PARTIAL (sender.c:455-459 -> log.c:337-338 -> cleanup.c:217-218)
    stderr: ""
  daemon pull: upstream's sender.c:455-459 text never reached the observing process; ...
    stderr: ""
  daemon pull: exit Some(0), want 23 - a refused source unlink is RERR_PARTIAL ...
    stderr: ""
```

**Delete phase 2** -> `handshake_confirmed_source_is_still_removed_by_the_second_drain` goes RED:

```
a source confirmed DURING the goodbye handshake must still be removed; dropping
the post-goodbye drain leaks exactly this file (sender.c:395 successful_send(),
dispatched inline by io.c:1793-1807)
```

## Why the phase-2 fixture is not vacuous

Reported honestly, because it matters: with phase 2 deleted, both wire-level integration tests (`refused_source_unlink_exits_23_in_every_topology` and `daemon_sender_removes_sources_for_both_spellings`) still PASS. On their single-file fixtures every `MSG_SUCCESS` happens to land before the receiver's goodbye `NDX_DONE`, so they exercise phase 1 only and say nothing about phase 2. A real-transfer fixture is therefore not a sufficient guard - which is precisely how "move the drain earlier" would have shipped unnoticed.

So the phase-2 guard scripts the receiver's wire byte by byte: `MSG_SUCCESS(early)`, `MSG_DATA(NDX_DONE)`, `MSG_SUCCESS(late)`, `MSG_DATA(NDX_DONE)`. `late`'s confirmation is only demultiplexed by the reads inside the goodbye, so it can only be acted on by phase 2. The test asserts both sources are gone AND that `before_goodbye == 1` and `during_goodbye == 1` - an empty phase-2 set fails the assertion rather than passing quietly. It drives `goodbye_draining_source_removals`, the same method `orchestrator::run` calls, so deleting a phase in production fails the test.

## Verification

- Four-topology table after the change: local copy 23, ssh push 23, ssh pull 23, daemon pull 23. Every cell also asserts the file was delivered and the source is still present, so no cell can pass on a transfer that never ran or an unlink that was not refused.
- Fixture is EACCES (`chmod 555` on the source parent), not a seccomp `EPERM`, so the cells mean the same thing on every platform and feature set.
- `cargo fmt --all -- --check` clean (and `rustfmt --check` directly on the touched files).
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `cargo nextest run -p transfer --all-features`: 2777 passed.
- `cargo nextest run -p bin --all-features`: 516 passed.
- `cargo nextest run -p core -p daemon --all-features`: 4731 passed.
- `tools/ci/citation_drift_audit.py` exits 0; no new unresolved citations.

