### PR TITLE
fix(receiver): abort with 11 when a commit-path backup fails

### DIFF
--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -328,6 +328,9 @@ impl ExitCode {
     /// - `UnexpectedEof`, other `InvalidData` - `StreamIo`
     /// - `Unsupported` - `Unsupported`
     /// - `Interrupted` by signal - `Signal`
+    /// - A failed commit-path backup (tagged
+    ///   [`transfer::temp_guard::CommitOp::Backup`]) - `FileIo`, whatever the
+    ///   errno
     /// - All other I/O errors - `FileIo`
     ///
     /// A wire-protocol violation that upstream rsync exits with
@@ -358,6 +361,18 @@ impl ExitCode {
             .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>())
         {
             return Self::Syntax;
+        }
+
+        // upstream: rsync.c:900 - `finish_transfer()` answers a failed
+        // `make_backup()` with `exit_cleanup(RERR_FILEIO)` whatever the errno
+        // was, so a denied backup must not be graded by `ErrorKind` like the
+        // per-file open failures below. Without this arm the usual `EACCES`
+        // reaches the `PermissionDenied => FileSelect` arm and reports 3.
+        if matches!(
+            transfer::temp_guard::commit_op_failure(error),
+            Some((transfer::temp_guard::CommitOp::Backup, _))
+        ) {
+            return Self::FileIo;
         }
 
         match error.kind() {

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -398,12 +398,78 @@ impl PipelinedReceiver {
         });
     }
 
+    /// Decides whether a failed commit skips one file or stops the whole run,
+    /// and records the per-file diagnostic when it skips.
+    ///
+    /// Returns `None` when the file was skipped and the transfer may continue,
+    /// or `Some(error)` for the caller to propagate.
+    ///
+    /// Upstream answers the two commit failures differently, and the
+    /// discriminator is the operation, not the errno:
+    ///
+    /// - a denied `mkstemp()` is per-file. `receiver.c:452-455` reports it and
+    ///   `recv_files()` moves to the next file, so the run ends at
+    ///   `RERR_PARTIAL` (23) through `io_error`.
+    /// - a failed backup is fatal. `finish_transfer()` answers
+    ///   `!make_backup(fname, False)` with `exit_cleanup(RERR_FILEIO)`, which
+    ///   does not return. Continuing would let every later file overwrite the
+    ///   pre-image its own backup was asked to preserve, so the abort - not the
+    ///   exit code - is the data guarantee. The `FERROR` diagnostic
+    ///   `make_backup()` already printed is kept, matching upstream's two-line
+    ///   output (the per-file reason, then the fatal exit line).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/rsync.c:897-900` - `finish_transfer()`:
+    ///   `if (!ok) exit_cleanup(RERR_FILEIO);`
+    /// - `rsync-3.5.0/cleanup.c:103` - `_exit_cleanup()` is `NORETURN`.
+    /// - `rsync-3.5.0/cleanup.c:113-117` - the first code in wins, and
+    ///   `cleanup.c:210-218` only reaches for `RERR_PARTIAL` when no code has
+    ///   been claimed, so `RERR_FILEIO` (11) outranks the 23 the accumulated
+    ///   `got_xfer_error` would otherwise produce.
+    /// - `rsync-3.5.0/receiver.c:452-455` - the contrasting per-file `mkstemp`
+    ///   failure that does continue.
+    fn absorb_commit_error(
+        &mut self,
+        error: io::Error,
+        meta_errors: &mut Vec<(PathBuf, String)>,
+    ) -> Option<io::Error> {
+        let pending = self.expected_checksums.pop_front();
+        let path = pending.map(|p| p.file_path).unwrap_or_default();
+        let fatal_backup = matches!(
+            crate::temp_guard::commit_op_failure(&error),
+            Some((crate::temp_guard::CommitOp::Backup, _))
+        );
+
+        if fatal_backup {
+            self.warnings
+                .push((MessageCode::ErrorXfer, self.commit_failure(&path, &error)));
+            return Some(error);
+        }
+
+        if !is_permission_error(&error) {
+            return Some(error);
+        }
+
+        // upstream: receiver.c:452-453 - rsyserr(FERROR_XFER, errno,
+        // "mkstemp %s failed", full_fname(fnametmp)). Emitting this as
+        // FERROR_XFER (not FINFO) makes the peer's rwrite() set
+        // got_xfer_error, so the run exits 23 (RERR_PARTIAL) instead of 0
+        // when mkstemp() was denied.
+        let message = self.commit_failure(&path, &error);
+        self.warnings.push((MessageCode::ErrorXfer, message));
+        meta_errors.push((path, error.to_string()));
+        self.permission_error_count += 1;
+        None
+    }
+
     /// Non-blockingly drains all available commit results.
     ///
     /// Returns accumulated (bytes_written, metadata_errors).
     /// Permission-denied errors from the disk thread are treated as recoverable
     /// per-file errors - logged and added to `meta_errors` rather than aborting
-    /// the transfer. Other fatal disk errors are still propagated.
+    /// the transfer. A failed backup and every other disk error are propagated;
+    /// see [`Self::absorb_commit_error`] for the split.
     /// Verifies per-file checksums when the disk thread returns a computed digest.
     ///
     /// # Upstream Reference
@@ -429,20 +495,8 @@ impl PipelinedReceiver {
                 }
                 Ok(Err(e)) => {
                     self.pending_commits = self.pending_commits.saturating_sub(1);
-                    let pending = self.expected_checksums.pop_front();
-                    if is_permission_error(&e) {
-                        let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: receiver.c:452-453 - rsyserr(FERROR_XFER, errno,
-                        // "mkstemp %s failed", full_fname(fnametmp)). Emitting
-                        // this as FERROR_XFER (not FINFO) makes the peer's
-                        // rwrite() set got_xfer_error, so the run exits 23
-                        // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
-                        let message = self.commit_failure(&path, &e);
-                        self.warnings.push((MessageCode::ErrorXfer, message));
-                        meta_errors.push((path, e.to_string()));
-                        self.permission_error_count += 1;
-                    } else {
-                        return Err(e);
+                    if let Some(err) = self.absorb_commit_error(e, &mut meta_errors) {
+                        return Err(err);
                     }
                 }
                 Err(TryRecvError::Empty) => break,
@@ -466,7 +520,8 @@ impl PipelinedReceiver {
     /// Returns accumulated (bytes_written, metadata_errors).
     /// Permission-denied errors from the disk thread are treated as recoverable
     /// per-file errors - logged and added to `meta_errors` rather than aborting
-    /// the transfer. Other fatal disk errors are still propagated.
+    /// the transfer. A failed backup and every other disk error are propagated;
+    /// see [`Self::absorb_commit_error`] for the split.
     /// Verifies per-file checksums when the disk thread returns a computed digest.
     ///
     /// # Upstream Reference
@@ -492,20 +547,8 @@ impl PipelinedReceiver {
                 }
                 Ok(Err(e)) => {
                     self.pending_commits -= 1;
-                    let pending = self.expected_checksums.pop_front();
-                    if is_permission_error(&e) {
-                        let path = pending.map(|p| p.file_path).unwrap_or_default();
-                        // upstream: receiver.c:452-453 - rsyserr(FERROR_XFER, errno,
-                        // "mkstemp %s failed", full_fname(fnametmp)). Emitting
-                        // this as FERROR_XFER (not FINFO) makes the peer's
-                        // rwrite() set got_xfer_error, so the run exits 23
-                        // (RERR_PARTIAL) instead of 0 when mkstemp() was denied.
-                        let message = self.commit_failure(&path, &e);
-                        self.warnings.push((MessageCode::ErrorXfer, message));
-                        meta_errors.push((path, e.to_string()));
-                        self.permission_error_count += 1;
-                    } else {
-                        return Err(e);
+                    if let Some(err) = self.absorb_commit_error(e, &mut meta_errors) {
+                        return Err(err);
                     }
                 }
                 Err(_) => {

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -265,6 +265,42 @@ impl ReceiverContext {
         self.emit_pipeline_messages(writer, messages);
     }
 
+    /// Runs one commit drain, flushing whatever the drain queued for the peer
+    /// even when the drain itself is fatal.
+    ///
+    /// A bare `?` on the drain returns before `emit_peer_messages`, so the
+    /// per-file diagnostic that explains the abort - `keep_backup failed: ...`
+    /// for the commit-path backup that upstream answers with
+    /// `exit_cleanup(RERR_FILEIO)` - dies with the loop and the operator sees
+    /// only the exit line. Upstream loses nothing here: `_exit_cleanup()`
+    /// reaches `io_flush(MSG_FLUSH)` before the process ends, so the `FERROR`
+    /// the failed operation printed is already on its way out.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/cleanup.c:242-253` - `_exit_cleanup()` flushes queued
+    ///   messages on the fatal path.
+    /// - `rsync-3.5.0/rsync.c:897-900` - the backup failure that makes this
+    ///   path reachable.
+    fn drain_or_report<W, F>(
+        &self,
+        writer: &mut W,
+        pipelined_receiver: &mut crate::pipeline::receiver::PipelinedReceiver,
+        drain: F,
+    ) -> io::Result<(u64, Vec<(PathBuf, String)>)>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+        F: FnOnce(
+            &mut crate::pipeline::receiver::PipelinedReceiver,
+        ) -> io::Result<(u64, Vec<(PathBuf, String)>)>,
+    {
+        let outcome = drain(pipelined_receiver);
+        if outcome.is_err() {
+            self.emit_peer_messages(writer, pipelined_receiver);
+        }
+        outcome
+    }
+
     /// Pipelined transfer loop with decoupled network/disk I/O.
     ///
     /// Fills a sliding window of file requests, computes signatures in parallel
@@ -762,7 +798,10 @@ impl ReceiverContext {
                 );
 
                 // Non-blocking: collect any ready disk results.
-                let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_ready_results()?;
+                let (_disk_bytes, disk_meta_errors) =
+                    self.drain_or_report(writer, &mut pipelined_receiver, |pr| {
+                        pr.drain_ready_results()
+                    })?;
                 metadata_errors.extend(disk_meta_errors);
 
                 // upstream: receiver.c:1063-1069 - a committed file (recv_ok == 1)
@@ -848,7 +887,8 @@ impl ReceiverContext {
             }
 
             // Drain all remaining disk results
-            let (_disk_bytes, disk_meta_errors) = pipelined_receiver.drain_all_results()?;
+            let (_disk_bytes, disk_meta_errors) =
+                self.drain_or_report(writer, &mut pipelined_receiver, |pr| pr.drain_all_results())?;
             metadata_errors.extend(disk_meta_errors);
 
             // upstream: receiver.c:1063-1069 - flush MSG_SUCCESS for the final

--- a/tests/commit_backup_failure_is_fatal.rs
+++ b/tests/commit_backup_failure_is_fatal.rs
@@ -1,0 +1,251 @@
+//! A commit-path backup that cannot be placed must STOP the transfer with
+//! `RERR_FILEIO` (11), not skip the file and carry on.
+//!
+//! upstream `rsync.c:897-900`, `finish_transfer()`:
+//!
+//! ```text
+//! if (make_backups > 0 && overwriting_basis) {
+//!         int ok = make_backup(fname, False);
+//!         if (!ok)
+//!                 exit_cleanup(RERR_FILEIO);
+//! ```
+//!
+//! `_exit_cleanup()` is `NORETURN` (`cleanup.c:103`), so this is an abort, and
+//! the errno never enters the decision - `EACCES` is as fatal as anything else.
+//! The code is 11 rather than the 23 a per-file error would produce because
+//! `cleanup.c:113-117` keeps the first code handed to `exit_cleanup()`, and the
+//! `RERR_PARTIAL` fallback at `cleanup.c:210-218` is guarded on
+//! `exit_code == 0`. Contrast the per-file failure oc already matched: a denied
+//! `mkstemp()` (`receiver.c:452-455`) is reported and `recv_files()` moves on.
+//!
+//! Why the abort is the half that matters: `make_backup()` is what preserves
+//! the destination's pre-image. A receiver that treats "the backup could not be
+//! placed" as a per-file skip keeps walking a batch whose backup area is known
+//! to be unusable, so every later `-b` file is one lost pre-image away from the
+//! operator's only copy. Upstream refuses to make that trade even once.
+//!
+//! Measured against rsync 3.5.0 over this fixture (pull and push alike):
+//! `rc=11`, exactly ONE `backup mkdir bak/sub failed: Permission denied (13)`
+//! on stderr for a 20-file batch, and every destination file left at its
+//! pre-transfer contents. oc emitted a diagnostic for all 20 and exited 23.
+//!
+//! The cell is a PULL through a real `--server` process: the local side is then
+//! the receiver, so the commit path under test is the network receiver's
+//! (`crates/transfer/src/pipeline/receiver.rs`), not the engine's local-copy
+//! executor, which has its own backup path and would exercise none of this.
+//! A pull is also the only direction that can pin the code today: a push puts
+//! the receiver in the remote `--server` process, whose fatal exit is not
+//! carried back to the client - `crates/cli/src/frontend/server/run.rs` returns
+//! a flat 1 for every server error and oc emits no `MSG_ERROR_EXIT`, so the
+//! client grades the run by the truncated stream it observes instead. A push
+//! over this fixture does stop at the first file, which is the half with data
+//! consequences, but reports 12.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// Enough files that "stopped at the first failure" and "walked the whole
+/// batch" cannot be confused by however many commits the pipeline had in
+/// flight.
+const FILE_COUNT: usize = 20;
+
+const OLD: &str = "pre-transfer contents\n";
+const NEW: &str = "replacement contents that are longer\n";
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Root ignores the mode bits that make the backup `mkdir` fail, so the fixture
+/// would report the post-fix state on a broken binary. Skip instead of emitting
+/// a false pass on the root CI leg.
+fn running_as_root() -> bool {
+    std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
+        .unwrap_or(false)
+}
+
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+/// `src/sub/fNN` holds new content; `dst/sub/fNN` holds older, backdated
+/// content, so the quick check sees a genuine update and every file has a
+/// pre-image to back up.
+///
+/// The backup lives at `dst/bak/sub/fNN` (upstream clears the suffix when a
+/// `--backup-dir` is named, `options.c:2438-2439`). Nesting the files one level
+/// down is load-bearing: the step that fails is the leaf `mkdir` of
+/// `dst/bak/sub`, so top-level files would need no new backup subdirectory and
+/// the fixture would never fail.
+fn fixture() -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src/sub")).expect("create src");
+    fs::create_dir_all(root.join("dst/sub")).expect("create dst");
+    fs::create_dir_all(root.join("dst/bak")).expect("create backup root");
+    for name in file_names() {
+        fs::write(root.join("src/sub").join(&name), NEW).expect("write src");
+        let dest = root.join("dst/sub").join(&name);
+        fs::write(&dest, OLD).expect("write dst");
+        filetime::set_file_mtime(&dest, filetime::FileTime::from_unix_time(1_000_000, 0))
+            .expect("backdate dst");
+    }
+    let shim = write_rsh_shim(&root);
+    Fixture {
+        _temp: temp,
+        root,
+        shim,
+    }
+}
+
+/// Zero-padded so the flist sort order matches the numeric order, which is what
+/// makes `last_file()` genuinely the last file the receiver would reach.
+fn file_names() -> Vec<String> {
+    (0..FILE_COUNT).map(|i| format!("f{i:02}")).collect()
+}
+
+fn last_file() -> String {
+    file_names().pop().expect("FILE_COUNT is non-zero")
+}
+
+/// Pulls through the shim from an external `--server` sender, so the local
+/// process is the receiver that runs the commit path.
+fn pull(fx: &Fixture) -> (Option<i32>, String) {
+    let binary = oc_rsync_binary();
+    let out = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        .args(["-r", "--backup", "--backup-dir=bak"])
+        .arg("--rsh")
+        .arg(&fx.shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("bkhost:{}/src/", fx.root.display()))
+        .arg(format!("{}/dst/", fx.root.display()))
+        .run()
+        .expect("pull did not finish");
+    (
+        out.status,
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn backup_failures(stderr: &str) -> usize {
+    stderr
+        .lines()
+        .filter(|line| line.contains("keep_backup failed"))
+        .count()
+}
+
+/// The headline, asserting both halves of upstream's answer at once: the exit
+/// code is `RERR_FILEIO`, AND the run stopped instead of walking the rest of
+/// the batch.
+#[test]
+fn a_failed_commit_backup_aborts_with_file_io() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+    let bak = fx.root.join("dst/bak");
+    fs::set_permissions(&bak, fs::Permissions::from_mode(0o555)).expect("chmod backup root");
+
+    let (status, stderr) = pull(&fx);
+
+    fs::set_permissions(&bak, fs::Permissions::from_mode(0o755)).expect("restore backup root");
+
+    let failures = backup_failures(&stderr);
+    assert!(
+        failures >= 1,
+        "the fixture is only meaningful while the backup genuinely cannot be \
+         placed; stderr was: {stderr}"
+    );
+
+    // The abort half. Upstream stops at the FIRST unplaceable backup
+    // (rsync.c:900 -> NORETURN cleanup.c:103), so the last file in the batch is
+    // never reached. Treating the failure as a per-file skip instead reports
+    // one line per file and leaves the transfer running against a backup area
+    // already known to be unusable.
+    assert!(
+        !stderr.contains(&last_file()),
+        "the transfer must stop at the first unplaceable backup, but it \
+         reached {}, the last file of the batch ({failures} of {FILE_COUNT} \
+         files reported). stderr was: {stderr}",
+        last_file()
+    );
+    assert!(
+        failures < FILE_COUNT,
+        "{failures} of {FILE_COUNT} files reported a failed backup, so the run \
+         walked the whole batch instead of aborting. stderr was: {stderr}"
+    );
+
+    // The exit-code half. 11 (RERR_FILEIO), not the 23 (RERR_PARTIAL) a
+    // per-file error accumulates: upstream hands 11 straight to exit_cleanup()
+    // (rsync.c:900) and cleanup.c:210-218 only reaches for 23 when no code has
+    // been claimed. Measured identical against rsync 3.5.0 on this fixture.
+    assert_eq!(status, Some(11), "stderr was: {stderr}");
+
+    // Nothing may be committed on the way out: the destination still holds the
+    // pre-image the backup was asked to preserve.
+    for name in file_names() {
+        assert_eq!(
+            fs::read_to_string(fx.root.join("dst/sub").join(&name)).expect("read dst"),
+            OLD,
+            "{name} was overwritten even though its backup could not be placed"
+        );
+    }
+}
+
+/// Non-vacuity for the cell above: the SAME fixture with a writable
+/// `--backup-dir` transfers every file and exits 0, so "the run stopped" and
+/// "exit 11" cannot be passing because the transfer never moved anything.
+#[test]
+fn a_placeable_backup_transfers_the_whole_batch() {
+    if running_as_root() {
+        return;
+    }
+    let fx = fixture();
+
+    let (status, stderr) = pull(&fx);
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    for name in file_names() {
+        assert_eq!(
+            fs::read_to_string(fx.root.join("dst/sub").join(&name)).expect("read dst"),
+            NEW,
+            "{name} must be updated when its backup can be placed"
+        );
+        assert_eq!(
+            fs::read_to_string(fx.root.join("dst/bak/sub").join(&name)).expect("read backup"),
+            OLD,
+            "the pre-image of {name} belongs under the named backup dir"
+        );
+    }
+}


### PR DESCRIPTION
## What

A commit-path backup that cannot be placed is fatal upstream. oc treated it as a per-file skip.

## Upstream

`finish_transfer()`, `rsync.c:897-900`:

```c
if (make_backups > 0 && overwriting_basis) {
        int ok = make_backup(fname, False);
        if (!ok)
                exit_cleanup(RERR_FILEIO);
```

- `cleanup.c:103` - `_exit_cleanup()` is `NORETURN`, so this is an abort. The errno never enters the decision.
- `cleanup.c:113-117` - the first code handed to `exit_cleanup()` wins.
- `cleanup.c:210-218` - the `RERR_PARTIAL` fallback is guarded on `exit_code == 0`, so 11 outranks the 23 an accumulated `got_xfer_error` would otherwise produce.
- `receiver.c:452-455` - the contrasting per-file failure: a denied `mkstemp()` is reported and `recv_files()` moves on. oc already matched this one and still does.

## Measured

20-file batch, existing backdated destinations, `--backup-dir` whose leaf `mkdir` is denied (mode 555 parent).

| | exit | failures reported | destination |
|---|---|---|---|
| rsync 3.5.0 | 11 | 1 of 20 | all 20 unchanged |
| oc before | 23 | 20 of 20 | all 20 unchanged |
| oc after | 11 | 1 of 20 | all 20 unchanged |

The exit code is the visible half; the abort is the one with consequences. Skipping and continuing keeps the receiver walking a batch whose backup area is already known to be unusable, so every later `-b` file proceeds on a backup that cannot be placed.

## Change

`drain_ready_results` and `drain_all_results` held byte-identical copies of the continue-vs-abort decision. They now share one `absorb_commit_error`, which splits on the *operation* (the commit-op tag the error already carries) rather than on the errno.

The same tag selects `RERR_FILEIO` in `ExitCode::from_io_error`, so the usual `EACCES` no longer falls through the `PermissionDenied => FileSelect` arm and reports 3.

A fatal drain now flushes what it queued for the peer before returning. A bare `?` returned ahead of `emit_peer_messages`, dropping the `keep_backup failed: <path>` line that says *why* the run stopped; upstream loses nothing there because `_exit_cleanup()` reaches `io_flush(MSG_FLUSH)` on its way out (`cleanup.c:242-253`).

## Test

`tests/commit_backup_failure_is_fatal.rs` asserts both halves in one cell - the exit code **and** that the last file of the batch was never reached - plus a non-vacuity twin that transfers the whole batch through a writable `--backup-dir`.

Non-vacuity by mutation, each half reverted in turn:

- abort half disabled (`fatal_backup = false`): *"the transfer must stop at the first unplaceable backup, but it reached f19, the last file of the batch (20 of 20 files reported)"* - exactly the pre-fix behaviour.
- exit-code half disabled (mapper arm removed): `left: Some(3)`, `right: Some(11)`, while the abort still happens.

The cell is a pull through a real `--server` process, so the local side is the receiver and the path under test is the network receiver's, not the engine's local-copy executor.

## Known residuals, deliberately not in scope

- **Push direction reports 12, not 11.** It now stops at the first file (the half with data consequences), but the receiver lives in the remote `--server` process, whose fatal exit is not carried back: `crates/cli/src/frontend/server/run.rs` returns a flat `1` for every server error and no `MSG_ERROR_EXIT` is emitted anywhere, so the client grades the run by the truncated stream it observes. Fixing that is server-side exit propagation, not backup handling.
- **The local-copy executor exits 23 where upstream exits 11.** It already aborts, so only the code diverges, and it does so because `LocalCopyError::exit_code()` maps every `Io` kind to 23 generically - a separate change with a much wider surface.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p transfer --all-features` - 2775 passed
- `cargo nextest run -p core --all-features` - 2835 passed
- `cargo nextest run -p bin --all-features` - 517 passed
- `cargo nextest run -p engine -p cli -p daemon --all-features` - 10813 passed
- `tools/ci/citation_drift_audit.py` - exit 0
- `tools/no_placeholders.sh` - exit 0
