### PR TITLE
fix(receiver): key --write-devices on the destination, not the flist

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -34,6 +34,42 @@ use crate::transfer_ops::{
 /// base iflags.
 type InFlightFile = (usize, PathBuf, FileEntry, u32);
 
+/// Reports whether the transfer's DESTINATION is a block or character device,
+/// without following a final symlink.
+///
+/// This is the `--write-devices` predicate. It is keyed on the destination
+/// because that is the only end that can be a device: `--write-devices` streams
+/// a REGULAR source file's contents into an EXISTING device node, so the
+/// sender's file-list entry describes a regular file by construction and
+/// keying the predicate on it can never be true.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:1170` - `write_to_device = write_devices && IS_DEVICE(st.st_mode)`,
+///   where `st` is the `do_fstat()` of the opened destination/basis descriptor
+///   (`receiver.c:1143-1145`), never the file-list entry.
+/// - `receiver.c:1076` - that descriptor is opened via `do_open_atfd()`, which
+///   forces `O_NOFOLLOW` (`syscall.c:3835`), so a symlinked destination is not
+///   followed into a device; `symlink_metadata` is the same decision.
+/// - `rsync.h:1394` - `IS_DEVICE(mode)` is `S_ISCHR(mode) || S_ISBLK(mode)`. FIFOs
+///   and sockets are `IS_SPECIAL` (`rsync.h:1393`) and are NOT device targets.
+#[cfg(unix)]
+fn destination_is_device(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+
+    std::fs::symlink_metadata(path).is_ok_and(|meta| {
+        let file_type = meta.file_type();
+        file_type.is_block_device() || file_type.is_char_device()
+    })
+}
+
+/// Windows has no `S_ISBLK`/`S_ISCHR` destination a transfer can write through,
+/// so `--write-devices` never engages there.
+#[cfg(not(unix))]
+fn destination_is_device(_path: &std::path::Path) -> bool {
+    false
+}
+
 /// The receiver's in-flight request window - wire state and per-file state
 /// held as one unit.
 ///
@@ -696,7 +732,8 @@ impl ReceiverContext {
                 };
 
                 let xattr_list = self.resolve_xattr_list(&file_entry);
-                let is_device_target = self.config.write.write_devices && file_entry.is_device();
+                let is_device_target =
+                    self.config.write.write_devices && destination_is_device(&file_path);
                 let response = process_file_response_streaming(
                     reader,
                     &mut *ndx_read_codec,

--- a/crates/transfer/tests/write_devices_device_destination.rs
+++ b/crates/transfer/tests/write_devices_device_destination.rs
@@ -1,0 +1,145 @@
+//! `--write-devices` must stream a regular source into an existing DEVICE
+//! destination instead of truncating it.
+//!
+//! The receiver's device predicate is keyed on the DESTINATION, never on the
+//! sender's file-list entry: `--write-devices` writes a REGULAR file's contents
+//! into an EXISTING device node, so the flist entry describes a regular file by
+//! construction. Keying the predicate on the entry left it permanently false,
+//! which let the in-place commit run `ftruncate()` against the device and fail
+//! `EINVAL`, reporting exit 12 where upstream reports 0.
+//!
+//! upstream: `receiver.c:1170` - `write_to_device = write_devices && IS_DEVICE(st.st_mode)`,
+//! with `st` the `do_fstat()` of the opened destination (`receiver.c:1143-1145`).
+//! upstream: `receiver.c:652` - the in-place `do_ftruncate()` is gated on
+//! `!IS_DEVICE(file->mode)`, which is the truncate this predicate must suppress.
+//!
+//! Why this rides a REMOTE-SHELL push and not a local copy: the predicate lives
+//! on the receiver pipeline (`crates/transfer/src/receiver/transfer/pipeline.rs`),
+//! and a plain local `oc-rsync src /dev/null` never reaches it - that is the
+//! engine crate's local-copy executor, which has no `--write-devices` predicate
+//! at all. A local fixture passes on the unfixed tree and proves nothing.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::path::Path;
+
+use test_support::{
+    LSH_STUB_BIN, LshRunnerStub, OcRsyncCliRunner, create_tempdir, require_binaries,
+};
+
+/// A character device every Unix has, which `--write-devices` may be pointed at
+/// without destroying anything: the device branch opens it `O_WRONLY` and never
+/// unlinks or renames over it, at any privilege level.
+const DEVICE_DEST: &str = "/dev/null";
+
+/// Reports whether this platform rejects `ftruncate()` against a device node.
+///
+/// The defect is only OBSERVABLE where truncating a device fails. Linux returns
+/// `EINVAL`; macOS accepts the call silently, so the same transfer succeeds
+/// there whether or not the predicate is correct, and asserting on it would be
+/// a vacuous pass. Probing the behaviour beats hardcoding a target list: the
+/// test then runs exactly where it can discriminate.
+fn platform_rejects_truncating_a_device() -> bool {
+    let Ok(file) = fs::OpenOptions::new().write(true).open(DEVICE_DEST) else {
+        return false;
+    };
+    file.set_len(1).is_err()
+}
+
+fn device_dest_is_usable() -> Result<(), String> {
+    let meta = fs::metadata(DEVICE_DEST).map_err(|e| format!("cannot stat {DEVICE_DEST}: {e}"))?;
+    if !std::os::unix::fs::FileTypeExt::is_char_device(&meta.file_type()) {
+        return Err(format!("{DEVICE_DEST} is not a character device"));
+    }
+    if !platform_rejects_truncating_a_device() {
+        return Err(format!(
+            "this platform accepts ftruncate() on {DEVICE_DEST}, so the \
+             truncate-against-a-device defect is not observable here"
+        ));
+    }
+    Ok(())
+}
+
+fn write_source(dir: &Path) -> std::path::PathBuf {
+    let src = dir.join("payload");
+    fs::write(&src, b"write-devices payload 0123456789\n").expect("write source");
+    src
+}
+
+/// Regression: a `--write-devices` push to a device destination must exit 0.
+///
+/// On the unfixed tree the receiver's predicate read the sender's file-list
+/// entry (a regular file), so `is_device_target` stayed false, the in-place
+/// commit truncated the device and the server failed `EINVAL` - surfacing to the
+/// client as exit 12. Upstream 3.5.0 exits 0 on the same invocation.
+#[test]
+fn write_devices_push_to_a_device_destination_succeeds() {
+    require_binaries!("oc-rsync", LSH_STUB_BIN);
+    if let Err(reason) = device_dest_is_usable() {
+        eprintln!("SKIP write_devices_push_to_a_device_destination_succeeds: {reason}");
+        return;
+    }
+    let stub = LshRunnerStub::locate().expect("lsh-stub located");
+
+    let tmp = create_tempdir();
+    let src = write_source(tmp.path());
+
+    OcRsyncCliRunner::new()
+        .arg("--write-devices")
+        .arg(format!("--rsh={}", stub.path().display()))
+        .arg(format!(
+            "--rsync-path={}",
+            test_support::oc_rsync_bin().display()
+        ))
+        .arg(src.display().to_string())
+        .arg(format!("localhost:{DEVICE_DEST}"))
+        .run()
+        .expect("push run")
+        .assert_success();
+
+    // The device branch writes THROUGH the node; it must never have been
+    // replaced by a regular file: under `inplace` upstream names the output
+    // `fname` itself (receiver.c:1195-1196), so there is no temp file to rename
+    // over the device and no unlink of it.
+    let meta = fs::metadata(DEVICE_DEST).expect("stat device after transfer");
+    assert!(
+        std::os::unix::fs::FileTypeExt::is_char_device(&meta.file_type()),
+        "{DEVICE_DEST} must still be a character device after --write-devices"
+    );
+}
+
+/// Companion: the same push WITHOUT a device destination must stay correct.
+///
+/// Without this, the regression test above would still pass if `--write-devices`
+/// had been made to short-circuit every transfer. It pins that a regular-file
+/// destination is unaffected by the predicate change - the arm that must keep
+/// using temp-file staging and the closing `set_len`.
+#[test]
+fn write_devices_push_to_a_regular_file_still_transfers_content() {
+    require_binaries!("oc-rsync", LSH_STUB_BIN);
+    let stub = LshRunnerStub::locate().expect("lsh-stub located");
+
+    let tmp = create_tempdir();
+    let src = write_source(tmp.path());
+    let dst = tmp.path().join("regular-dest");
+
+    OcRsyncCliRunner::new()
+        .arg("--write-devices")
+        .arg(format!("--rsh={}", stub.path().display()))
+        .arg(format!(
+            "--rsync-path={}",
+            test_support::oc_rsync_bin().display()
+        ))
+        .arg(src.display().to_string())
+        .arg(format!("localhost:{}", dst.display()))
+        .run()
+        .expect("push run")
+        .assert_success();
+
+    assert_eq!(
+        fs::read(&src).expect("read source"),
+        fs::read(&dst).expect("read destination"),
+        "a regular-file destination must receive the source bytes verbatim"
+    );
+}


### PR DESCRIPTION
## Problem

`--write-devices` streams a REGULAR source file's contents into an EXISTING device
node, so the sender's file-list entry describes a regular file by construction.
The receiver keyed its device predicate on `file_entry.is_device()`, which is
therefore permanently false: the in-place commit ran `set_len()` against the
device, the server failed `EINVAL`, and the client saw **exit 12** where upstream
3.5.0 exits 0.

## Fix

One boolean moves. `is_device_target` is now computed from the DESTINATION's
`symlink_metadata`, matching upstream:

- `receiver.c:1170` - `write_to_device = write_devices && IS_DEVICE(st.st_mode)`,
  where `st` is the `do_fstat()` of the opened destination descriptor
  (`receiver.c:1143-1145`), never the file-list entry.
- `receiver.c:1076` / `syscall.c:3835` - that descriptor is opened via
  `do_open_atfd()`, which forces `O_NOFOLLOW`, so a symlinked destination is not
  followed; `symlink_metadata` is the matching decision.
- `rsync.h:1394` - `IS_DEVICE` is `S_ISCHR || S_ISBLK`; FIFOs and sockets are
  `IS_SPECIAL` (`rsync.h:1393`) and are NOT device targets.

All citations were re-read against the 3.5.0 pin.

## What is deliberately NOT ported

Upstream reaches its truncate suppression by rewriting `file->mode` to `S_IFBLK`
around `receive_data()` and restoring it immediately after
(`receiver.c:1256-1271`). That save/restore exists only because upstream's
`file_struct` is allocated with no `DEV_EXTRA_CNT`, so a lingering `S_IFBLK`
makes `set_stat_xattr`'s `F_RDEV_P()` read past the allocation.

oc carries the decision in a message field (`BeginMessage.is_device_target`)
rather than mutating shared file-list state, and already gates the in-place
`set_len` on `!is_device_target` (`disk_commit/process/commit.rs:180`, citing
`receiver.c:652` `!IS_DEVICE(file->mode)`). Porting the mode rewrite would import
upstream's allocation hazard for no gain.

## Tests

`crates/transfer/tests/write_devices_device_destination.rs` - a remote-shell push
through a fake rsh, because the predicate lives on the receiver pipeline and a
local copy never reaches it (that is the engine crate's local-copy executor,
which has no `--write-devices` predicate at all and would pass on the unfixed
tree). It self-gates on a runtime probe of whether the platform rejects
`ftruncate()` on a device - Linux returns `EINVAL`, macOS accepts it silently -
and emits a counted, reason-carrying SKIP rather than a silent pass.

Mutation-proven on Linux, each independently:

| mutation | result |
|---|---|
| none (the fix) | `2 tests run: 2 passed, 0 skipped` |
| predicate reverted to `file_entry.is_device()` | `2 tests run: 1 passed, 1 failed` - device cell `left: Some(12), right: Some(0)`; regular-file companion green |
| existing truncate gate `!begin.is_device_target` removed | `2 tests run: 1 passed, 1 failed` - same exit 12; companion green |

The second mutation is the non-vacuity proof: it shows the fixture genuinely
reaches the in-place truncate, so the passing cell is not passing by accident.

## Gates

- `cargo fmt --all -- --check`: exit 0
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`: exit 0
- `python3 tools/ci/citation_drift_audit.py`: exit 0
- targeted nextest: as tabled above (full workspace left to CI)

## Why the mode rewrite is a workaround for a constraint oc does not have

Upstream's own comment at `receiver.c:1252-1258` says why the save/restore exists:

> `--write-devices` writes a regular source file's content into an existing
> destination device.  Flip `file->mode` to `S_IFBLK` just for `receive_data()`'s
> ftruncate gate (`!IS_DEVICE`), then restore it right after -- the `file_struct`
> was built as a regular file with no `DEV_EXTRA_CNT`, so leaving it `S_IFBLK`
> would make `set_stat_xattr`'s `F_RDEV_P()` read past the allocation.

Upstream reuses `file->mode` as the signal channel because it has nowhere else to
put it, and then must undo the reuse before anything reads the mode again. oc
already carries the same signal as a first-class `BeginMessage.is_device_target`
field, which no other reader interprets and which cannot read past an
allocation. Porting the rewrite would import upstream's hazard to solve a
problem oc does not have. Not ported, deliberately.

## The two adjacent upstream rules, reported not dropped

Both are generator-side (`recv_generator`); this PR is receiver-side, so neither
is fixed here. Each is scoped out with a reason, and neither is silently dropped.

**Obstacle classification — `generator.c:2148`**
`if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE)))`
then `delete_item(... DEL_FOR_FILE)`. Upstream deletes a non-regular destination
as an obstacle, *exempting* a device under `--write-devices`.
Measured in oc: there is **no destination-type classification on the receiver
pipeline at all** — every obstacle-removal site (`remove_existing_destination`,
`clear_obstructing_non_directory`, `clear_partial_dir_obstruction`) lives in
`crates/engine` local-copy or the backup/partial-dir paths. So the exemption's
*effect* holds for free on this path (nothing can delete the device), and the
test asserts the device survives. The wider gap — oc not classifying a
non-regular destination on the receiver path at all — is real but is not
`--write-devices`-specific and belongs in its own task.

**Device size discovery — `generator.c:2226`**
`if (write_devices && IS_DEVICE(sx.st.st_mode) && sx.st.st_size == 0)` then
`get_device_size(fd, fnamecmp)`. A device reports `st_size == 0`, so without the
substitution the generator sees a zero-length basis.
Measured in oc: `get_device_size` **exists** (`generator/context.rs:1337`) but is
the *sender-side* `--copy-devices` path, citing `sender.c:404-419` and
`flist.c:1711`. `write_devices` appears nowhere under
`crates/transfer/src/generator/`. The receiver-side substitution is genuinely
ABSENT. Correctness is unaffected (the transfer completes and the payload lands);
the cost is delta efficiency — a device basis looks 0-length, so the generator
builds no signature and the whole file goes as literal. Scoped out of this PR
because it is an efficiency fix on a different path, needing its own measurement.

## Reusable finding: gate device assertions on a runtime probe, not `cfg`

`ftruncate()` on a device node returns `EINVAL` on Linux and succeeds silently on
macOS. Any test that asserts on this defect therefore passes **vacuously** on
macOS. This test probes the behaviour at runtime rather than keying on
`cfg(target_os = "linux")`: the probe states the actual precondition, keeps
working on a BSD that behaves either way, and needs no root — which removes the
root-fixture problem entirely.
