### PR TITLE
fix(daemon): honour a client's forwarded --timeout

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -42,6 +42,23 @@ fn landlock_root_for_dest(dest: &std::path::Path) -> Option<std::path::PathBuf> 
         .or_else(|| dest.parent().and_then(|parent| parent.canonicalize().ok()))
 }
 
+/// Converts the client's forwarded `--timeout=N` into this server process's
+/// effective I/O timeout in seconds, or `None` for "no timeout".
+///
+/// upstream: `options.c` - `server_options()` emits `--timeout=%d` from the
+/// client's `io_timeout`, and the server's own `parse_arguments()` over the
+/// received argv ends in `set_io_timeout(io_timeout)` (`options.c:2511`), so a
+/// client `--timeout` arms the server process too.
+///
+/// A non-positive or unparsable value is "no timeout": upstream parses
+/// `--timeout` as a plain `int`, and `io.c:1266-1271` `set_io_timeout()` clamps
+/// a negative to `0`, which every timeout check short-circuits on.
+pub(super) fn forwarded_io_timeout(raw: Option<&str>) -> Option<u32> {
+    raw.and_then(|value| value.parse::<i64>().ok())
+        .and_then(|secs| u32::try_from(secs).ok())
+        .filter(|secs| *secs > 0)
+}
+
 /// Runs the native server implementation when `--server` is requested.
 pub(crate) fn run_server_mode<Out, Err>(
     args: &[OsString],
@@ -231,6 +248,7 @@ where
     // (`GeneratorContext::source_open`), which prefers the module directory, so
     // a peer-supplied value cannot widen a module even if one arrives here.
     config.connection.confine_root = long_flags.confine_root.map(std::path::PathBuf::from);
+    config.connection.io_timeout = forwarded_io_timeout(long_flags.timeout.as_deref());
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
     // upstream: options.c:2400-2411 - append mode implies inplace. The promotion

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -3020,3 +3020,48 @@ fn fake_super_is_a_known_server_long_flag() {
     assert!(is_known_server_long_flag("--fake-super"));
     assert!(is_known_server_long_flag("--no-fake-super"));
 }
+
+/// The client's forwarded `--timeout=N` becomes this server process's
+/// `io_timeout`, and a non-positive or unparsable value is "no timeout".
+///
+/// Before the fix `ServerLongFlags::timeout` was parsed and never read, so a
+/// forwarded `--timeout` armed nothing on the SSH server side.
+///
+/// upstream: `options.c` `server_options()` emits `--timeout=%d`;
+/// `options.c:2511` `set_io_timeout(io_timeout)`; `io.c:1266-1271` clamps a
+/// negative to `0`.
+#[test]
+fn forwarded_timeout_becomes_the_server_io_timeout() {
+    use super::run::forwarded_io_timeout;
+
+    assert_eq!(forwarded_io_timeout(Some("30")), Some(30));
+    assert_eq!(forwarded_io_timeout(Some("1")), Some(1));
+    assert_eq!(forwarded_io_timeout(None), None);
+    for off in ["0", "-1", "", "abc"] {
+        assert_eq!(
+            forwarded_io_timeout(Some(off)),
+            None,
+            "--timeout={off} must read as no timeout"
+        );
+    }
+}
+
+/// The parse and the read are the same option: whatever
+/// `parse_server_long_flags` captures for `--timeout` is what
+/// `forwarded_io_timeout` converts.
+///
+/// This chains the two halves so a future rename on either side cannot leave
+/// the flag parsed-but-unread again.
+#[test]
+fn parsed_timeout_flag_feeds_the_server_io_timeout() {
+    let argv: Vec<OsString> = ["--server", "--sender", "--timeout=45", ".", "."]
+        .iter()
+        .map(OsString::from)
+        .collect();
+    let flags = parse_server_long_flags(&argv);
+    assert_eq!(
+        super::run::forwarded_io_timeout(flags.timeout.as_deref()),
+        Some(45),
+        "the parsed --timeout value must reach the server's io_timeout"
+    );
+}

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -782,8 +782,12 @@ fn process_approved_module(
         .transition(ConnectionState::Transferring)
         .map_err(transition_error)?;
 
-    let handshake =
-        build_handshake_result(ctx.reader, negotiated_protocol, client_args.clone(), io_timeout);
+    let handshake = build_handshake_result(
+        ctx.reader,
+        negotiated_protocol,
+        client_args.clone(),
+        io_timeout,
+    );
     let final_protocol = handshake.protocol;
 
     let supports_tcp_shutdown = streams.supports_tcp_shutdown;

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -340,6 +340,12 @@ fn process_approved_module(
         None => return Ok(()),
     };
 
+    // upstream: clientserver.c:1288-1289 - the client's forwarded `--timeout`
+    // has now been read, so the connection is re-armed with the minimum of it
+    // and the module's `timeout` directive (0 on either side meaning "no
+    // timeout"). Before this point only the module value is known.
+    let io_timeout = apply_effective_io_timeout(ctx.reader.get_mut(), module, &client_args)?;
+
     // upstream: clientserver.c:rsync_module() -> parse_arguments() applies the
     // module's `refuse options` list against the actual client argv after the
     // post-OK `read_args()` round-trip. The earlier check at the OPTION-line
@@ -777,7 +783,7 @@ fn process_approved_module(
         .map_err(transition_error)?;
 
     let handshake =
-        build_handshake_result(ctx.reader, negotiated_protocol, client_args.clone(), module);
+        build_handshake_result(ctx.reader, negotiated_protocol, client_args.clone(), io_timeout);
     let final_protocol = handshake.protocol;
 
     let supports_tcp_shutdown = streams.supports_tcp_shutdown;

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -258,7 +258,7 @@ fn build_handshake_result(
     reader: &BufReader<DaemonStream>,
     negotiated_protocol: Option<ProtocolVersion>,
     client_args: Vec<String>,
-    module: &ModuleRuntime,
+    io_timeout: Option<NonZeroU64>,
 ) -> HandshakeResult {
     let final_protocol = negotiated_protocol.unwrap_or(ProtocolVersion::V30);
     let buffered_data = reader.buffer().to_vec();
@@ -268,7 +268,10 @@ fn build_handshake_result(
         buffered: buffered_data,
         compat_exchanged: false,
         client_args: Some(client_args),
-        io_timeout: module.timeout.map(|t| t.get()),
+        // upstream: clientserver.c:1288-1289 - the reconciled minimum of the
+        // client's forwarded `--timeout` and the module's `timeout` directive,
+        // which is what `main.c:1295` then advertises as `MSG_IO_TIMEOUT`.
+        io_timeout: io_timeout.map(NonZeroU64::get),
         negotiated_algorithms: None,
         compat_flags: None,
         checksum_seed: 0,

--- a/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/module_spec.rs
@@ -6,8 +6,58 @@
 // TCP fast-open mode, bwlimit). Mirrors upstream `loadparm.c` /
 // `clientserver.c` per-module config handling.
 
-fn apply_module_timeout(stream: &DaemonStream, module: &ModuleDefinition) -> io::Result<()> {
-    if let Some(timeout) = module.timeout {
+/// Extracts the client's forwarded `--timeout=N` from the transfer argv.
+///
+/// upstream: `options.c` - `server_options()` emits `--timeout=%d` whenever the
+/// client has `io_timeout` set, and the daemon's own `parse_arguments()` run
+/// over the received argv lands it in the global `io_timeout`, which
+/// `options.c:2511 set_io_timeout(io_timeout)` then arms. oc's daemon has no
+/// such global, so the value is read back out of the argv here.
+///
+/// A non-positive or unparsable value yields `None`: upstream parses `--timeout`
+/// as a plain `int`, and `io.c:1266-1271 set_io_timeout()` clamps a negative to
+/// `0`, which is "no timeout" - the same thing `None` means here.
+fn client_io_timeout_from_args(client_args: &[String]) -> Option<NonZeroU64> {
+    client_args
+        .iter()
+        .rev()
+        .find_map(|arg| arg.strip_prefix("--timeout="))
+        .and_then(|value| value.parse::<i64>().ok())
+        .and_then(|secs| u64::try_from(secs).ok())
+        .and_then(NonZeroU64::new)
+}
+
+/// Reconciles the client's forwarded `--timeout` with the module's `timeout`.
+///
+/// upstream: `clientserver.c:1288-1289` in `rsync_module()`:
+///
+/// ```c
+/// if (lp_timeout(module_id) && (!io_timeout || lp_timeout(module_id) < io_timeout))
+///         set_io_timeout(lp_timeout(module_id));
+/// ```
+///
+/// `io_timeout` already holds the client's forwarded `--timeout` at that point,
+/// so the statement is a MINIMUM over the two values in which `0` - "no
+/// timeout", the default on both sides - reads as infinity: a module value of
+/// `0` leaves the client's setting alone, a client value of `0` adopts the
+/// module's, and two positive values resolve to the smaller. Taking the minimum
+/// rather than letting either side win is what stops a peer lengthening a short
+/// operator-set module timeout.
+fn effective_io_timeout(
+    client: Option<NonZeroU64>,
+    module: Option<NonZeroU64>,
+) -> Option<NonZeroU64> {
+    match (client, module) {
+        (Some(client), Some(module)) => Some(client.min(module)),
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (None, None) => None,
+    }
+}
+
+/// Arms the connection socket with `timeout`, or clears both deadlines when it
+/// is `None`.
+fn apply_io_timeout(stream: &DaemonStream, timeout: Option<NonZeroU64>) -> io::Result<()> {
+    if let Some(timeout) = timeout {
         let duration = Duration::from_secs(timeout.get());
         stream.set_read_timeout(Some(duration))?;
         stream.set_write_timeout(Some(duration))?;
@@ -23,6 +73,29 @@ fn apply_module_timeout(stream: &DaemonStream, module: &ModuleDefinition) -> io:
     }
 
     Ok(())
+}
+
+/// Arms the pre-argument phases with the module's own `timeout` directive.
+///
+/// The client's `--timeout` has not been read yet at this point; the data phase
+/// is re-armed with the reconciled value by `apply_effective_io_timeout` once
+/// the argv arrives.
+fn apply_module_timeout(stream: &DaemonStream, module: &ModuleDefinition) -> io::Result<()> {
+    apply_io_timeout(stream, module.timeout)
+}
+
+/// Re-arms the connection with `min(client --timeout, module timeout)` and
+/// returns the value, for the handshake's keep-alive and `MSG_IO_TIMEOUT`.
+///
+/// upstream: `clientserver.c:1288-1289` - see [`effective_io_timeout`].
+fn apply_effective_io_timeout(
+    stream: &DaemonStream,
+    module: &ModuleDefinition,
+    client_args: &[String],
+) -> io::Result<Option<NonZeroU64>> {
+    let timeout = effective_io_timeout(client_io_timeout_from_args(client_args), module.timeout);
+    apply_io_timeout(stream, timeout)?;
+    Ok(timeout)
 }
 
 fn missing_argument_value(option: &str) -> DaemonError {

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1352,3 +1352,180 @@ fn refuse_compress_message_mentions_compress() {
         "refusal payload must name the refused option literally, got: {payload}"
     );
 }
+
+/// Opens a connected loopback TCP pair and wraps the server end as a
+/// `DaemonStream`, so the socket deadlines `apply_io_timeout` sets are
+/// observable through `TcpStream::read_timeout`.
+#[cfg(unix)]
+fn connected_daemon_stream() -> (DaemonStream, std::net::TcpStream) {
+    use std::net::{TcpListener, TcpStream};
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+    let addr = listener.local_addr().expect("listener address");
+    let client = TcpStream::connect(addr).expect("connect to listener");
+    let (server, _) = listener.accept().expect("accept the loopback connection");
+    (DaemonStream::plain(server), client)
+}
+
+/// `--timeout=N` is read back out of the forwarded argv.
+///
+/// upstream: `options.c` - `server_options()` emits `--timeout=%d`, and the
+/// daemon's own `parse_arguments()` over that argv is what sets `io_timeout`.
+#[test]
+fn client_timeout_is_read_from_the_forwarded_argv() {
+    let args = vec![
+        "--server".to_owned(),
+        "--sender".to_owned(),
+        "-vlogDtpre.iLsfxCIvu".to_owned(),
+        "--timeout=17".to_owned(),
+        ".".to_owned(),
+    ];
+    assert_eq!(
+        client_io_timeout_from_args(&args).map(NonZeroU64::get),
+        Some(17)
+    );
+}
+
+/// A forwarded `--timeout=0` (upstream's "no timeout") and a negative or
+/// unparsable value all read as "no timeout".
+///
+/// upstream: `io.c:1266-1271` `set_io_timeout()` clamps a negative to `0`, and
+/// `0` short-circuits every timeout check.
+#[test]
+fn non_positive_client_timeout_reads_as_no_timeout() {
+    for value in ["--timeout=0", "--timeout=-5", "--timeout=x"] {
+        let args = vec![value.to_owned()];
+        assert_eq!(
+            client_io_timeout_from_args(&args),
+            None,
+            "{value} must read as no timeout"
+        );
+    }
+}
+
+/// Upstream's `clientserver.c:1288-1289` minimum, with `0` on either side
+/// meaning infinity. The table is exhaustive over the five shapes.
+#[test]
+fn effective_io_timeout_takes_the_minimum_treating_zero_as_infinite() {
+    let nz = NonZeroU64::new;
+    let rows = [
+        // (client, module, expected)
+        (nz(5), nz(9), nz(5)),
+        (nz(9), nz(5), nz(5)),
+        (nz(7), None, nz(7)),
+        (None, nz(7), nz(7)),
+        (None, None, None),
+    ];
+    for (client, module, expected) in rows {
+        assert_eq!(
+            effective_io_timeout(client, module),
+            expected,
+            "client={client:?} module={module:?}"
+        );
+    }
+}
+
+/// The daemon ARMS the connection with the client's forwarded `--timeout` even
+/// when the module carries no `timeout` directive.
+///
+/// This is the defect: before the fix the socket was armed from
+/// `module.timeout` alone, so a default `rsyncd.conf` left a wedged peer able
+/// to hold the connection indefinitely against a client `--timeout=N`.
+///
+/// upstream: `clientserver.c:1288-1289`.
+#[cfg(unix)]
+#[test]
+fn client_timeout_arms_the_socket_when_the_module_sets_none() {
+    let (stream, _client) = connected_daemon_stream();
+    let module = ModuleDefinition::default();
+    assert!(
+        module.timeout.is_none(),
+        "fixture precondition: the module must carry no `timeout` directive"
+    );
+    let args = vec!["--timeout=5".to_owned()];
+
+    let effective = apply_effective_io_timeout(&stream, &module, &args).expect("arm the socket");
+
+    assert_eq!(effective.map(NonZeroU64::get), Some(5));
+    let DaemonStream::Plain(socket) = &stream else {
+        panic!("fixture must produce a plain TCP stream");
+    };
+    assert_eq!(
+        socket.read_timeout().expect("read the socket deadline"),
+        Some(Duration::from_secs(5)),
+        "the forwarded --timeout must reach the socket"
+    );
+}
+
+/// A client `--timeout` LONGER than a short module `timeout` must not lengthen
+/// it: upstream takes the minimum, so the operator's value still governs.
+///
+/// Without this cell a "client wins" implementation would pass every other
+/// test here while letting a peer defeat a short operator-set timeout.
+///
+/// upstream: `clientserver.c:1288-1289`.
+#[cfg(unix)]
+#[test]
+fn a_longer_client_timeout_does_not_lengthen_a_short_module_timeout() {
+    let (stream, _client) = connected_daemon_stream();
+    let module = ModuleDefinition {
+        timeout: NonZeroU64::new(3),
+        ..Default::default()
+    };
+    let args = vec!["--timeout=600".to_owned()];
+
+    let effective = apply_effective_io_timeout(&stream, &module, &args).expect("arm the socket");
+
+    assert_eq!(effective.map(NonZeroU64::get), Some(3));
+    let DaemonStream::Plain(socket) = &stream else {
+        panic!("fixture must produce a plain TCP stream");
+    };
+    assert_eq!(
+        socket.read_timeout().expect("read the socket deadline"),
+        Some(Duration::from_secs(3)),
+        "the module's shorter timeout must still govern"
+    );
+}
+
+/// The module-only cell: with no forwarded `--timeout` the module directive
+/// must still arm the socket, so the fix cannot regress the operator's lever.
+#[cfg(unix)]
+#[test]
+fn a_module_timeout_still_arms_the_socket_without_a_client_timeout() {
+    let (stream, _client) = connected_daemon_stream();
+    let module = ModuleDefinition {
+        timeout: NonZeroU64::new(5),
+        ..Default::default()
+    };
+
+    let effective = apply_effective_io_timeout(&stream, &module, &[]).expect("arm the socket");
+
+    assert_eq!(effective.map(NonZeroU64::get), Some(5));
+    let DaemonStream::Plain(socket) = &stream else {
+        panic!("fixture must produce a plain TCP stream");
+    };
+    assert_eq!(
+        socket.read_timeout().expect("read the socket deadline"),
+        Some(Duration::from_secs(5))
+    );
+}
+
+/// Neither side sets a timeout: the connection carries no deadline, matching
+/// upstream's `io_timeout = 0` default.
+#[cfg(unix)]
+#[test]
+fn no_timeout_on_either_side_leaves_the_socket_untimed() {
+    let (stream, _client) = connected_daemon_stream();
+    let module = ModuleDefinition::default();
+
+    let effective = apply_effective_io_timeout(&stream, &module, &[]).expect("clear the deadlines");
+
+    assert_eq!(effective, None);
+    let DaemonStream::Plain(socket) = &stream else {
+        panic!("fixture must produce a plain TCP stream");
+    };
+    assert_eq!(
+        socket.read_timeout().expect("read the socket deadline"),
+        None
+    );
+}

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -158,6 +158,21 @@ pub struct ConnectionConfig {
     pub client_mode: bool,
     /// Indicates the transfer is over a daemon (rsync://) connection.
     pub is_daemon_connection: bool,
+    /// Effective I/O timeout in whole seconds; `None` means "no timeout".
+    ///
+    /// This is oc-rsync's `io_timeout` global for a server process started over
+    /// stdio: the CLI parses the client's forwarded `--timeout=N` into it, and
+    /// `run_server_stdio` hands it to the handshake so the generator/sender loop
+    /// derives its keep-alive half-interval from it. The daemon does not use
+    /// this field - it reconciles the module directive with the forwarded value
+    /// itself and puts the result straight on the `HandshakeResult`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:2511` - `set_io_timeout(io_timeout)` at the end of
+    ///   `parse_arguments()`, which the server runs over the received argv.
+    /// - `io.c:1266` - `set_io_timeout()` derives `allowed_lull` from it.
+    pub io_timeout: Option<u32>,
     /// Name of the daemon module this server process is serving, when any.
     ///
     /// Mirrors upstream's `module_id` global: it is set exactly once, when the

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -520,7 +520,15 @@ pub fn run_server_stdio(
     // pre-release subprotocol (carried in its `-e` capability string) before it
     // writes its protocol version. For a stock release peer this is a no-op and
     // the version exchange is byte-identical to a plain `perform_handshake`.
-    let handshake = perform_server_handshake(stdin, stdout, &config.flag_string)?;
+    let mut handshake = perform_server_handshake(stdin, stdout, &config.flag_string)?;
+    // upstream: options.c:2511 - the server's own `parse_arguments()` run over
+    // the argv the client forwarded ends in `set_io_timeout(io_timeout)`, so a
+    // `--timeout=N` on the client arms this process too. The CLI's server-mode
+    // parser lands the value in `connection.io_timeout`; carrying it onto the
+    // handshake is what makes the generator/sender emit keep-alives at
+    // `ceil(N/2)`. Without a forwarded `--timeout` this stays `None` and the
+    // wire is unchanged.
+    handshake.io_timeout = config.connection.io_timeout.map(u64::from);
     run_server_with_handshake(config, handshake, stdin, stdout, progress, None, None)
 }
 
@@ -987,8 +995,14 @@ pub fn run_server_with_handshake_adopting<W: Write>(
         }
     }
 
-    // upstream: main.c:1267-1268 - server sends MSG_IO_TIMEOUT to client.
+    // upstream: main.c:1294-1295 - `if (am_daemon && io_timeout &&
+    // protocol_version >= 31) send_msg_int(MSG_IO_TIMEOUT, io_timeout)`. The
+    // gate is `am_daemon`, not "server": an SSH server process has an
+    // `io_timeout` of its own once the client forwards `--timeout`, and it must
+    // still not advertise one. `daemon_module` is set exactly when this process
+    // is the daemon serving a module, so it is oc's `am_daemon`.
     if !config.connection.client_mode
+        && config.connection.daemon_module.is_some()
         && let Some(timeout_secs) = handshake.io_timeout
         && handshake.protocol.supports_extended_goodbye()
     {


### PR DESCRIPTION
## The defect

With a default `rsyncd.conf` (no `timeout` directive) the daemon armed nothing,
so a client's forwarded `--timeout=N` was inert and a wedged peer held the
connection indefinitely. An operator who sets `timeout` in the module was
covered; only the client's own lever did nothing.

The SSH server half had the same shape from the other direction:
`ServerLongFlags::timeout` was parsed and never read.

## Upstream

`clientserver.c:1288-1289` in `rsync_module()`, at the 3.5.0 pin:

```c
if (lp_timeout(module_id) && (!io_timeout || lp_timeout(module_id) < io_timeout))
        set_io_timeout(lp_timeout(module_id));
```

`io_timeout` already holds the client's forwarded `--timeout` when that line
runs: the daemon parses the received argv with `parse_arguments()`, which ends
in `set_io_timeout(io_timeout)` at `options.c:2511`. So the statement is a
**minimum over the two values**, not a replacement.

Zero semantics come from the C, not from us: `set_io_timeout()`
(`io.c:1266-1271`) clamps a negative to `0`, and `0` short-circuits every
timeout check - it means "no timeout", i.e. infinity. Upstream's guard reads
`lp_timeout(module_id) && !io_timeout` for exactly that reason. So the rule is
"minimum over the non-zero values; absent on both sides means no timeout",
which is what `effective_io_timeout` implements.

The daemon now reads `--timeout=N` back out of the client argv, reconciles it
with the module directive by that rule, arms the connection with the result,
and carries it onto the handshake - which is also what `main.c:1295`
advertises as `MSG_IO_TIMEOUT`. Taking the minimum rather than letting the
client win is what stops a peer *lengthening* a short operator-set timeout.

On the SSH half the parsed value now reaches `ConnectionConfig::io_timeout` and
`run_server_stdio` puts it on the handshake, so the generator derives its
keep-alive half-interval from it. `MSG_IO_TIMEOUT` emission is narrowed from
"any server" to upstream's `am_daemon` gate (`main.c:1294`) in the same change,
so wiring the SSH side adds no wire message upstream would not send. That is
behaviour-neutral today - the SSH path previously always had `io_timeout =
None` - and it keeps the SSH half from introducing a wire change.

## Measured (Linux aarch64, release build of this branch)

256 MiB pull from a loopback daemon. The peer is SIGSTOPped the moment the
transfer is provably mid-flight and held 18s. Every cell asserts its own
preconditions: the peer is sampled in state `T` at the start of the hold **and
again immediately before `SIGCONT`**, and the destination is checked strictly
mid-flight (`0 < bytes < 268435456`) so a no-op transfer cannot masquerade as a
pass.

| cell | module `timeout` | client `--timeout` | exit | fired | elapsed | mid-flight |
|------|------------------|--------------------|------|-------|---------|-----------|
| A control | 5 | - | 23 | yes | 5.18s | 22544384 |
| B measure | - | 5 | 23 | **yes** | 5.48s | 22282240 |
| C minimum | 3 | 30 | 23 | yes | **3.08s** | 13107200 |
| C2 minimum | 30 | 3 | 23 | yes | **3.09s** | 6815744 |
| D negative | - | - | 0 | no | 19.85s | 19136512 |

Cell B is the flip: it previously reported `client_exit=0`,
`268435456/268435456`, transfer COMPLETED. Cell A confirms the operator's lever
did not regress. C and C2 pin the minimum from both directions - whichever side
is smaller decides, so this is neither "client wins" nor "module wins". D is the
negative control: with no timeout on either side the same wedged peer is simply
waited out, which is what attributes the teardown in the other four cells to a
timeout rather than to something ambient.

Note the teardown surfaces as `(code 23)` with an errno rather than naming a
timeout; that is a separate, already-tracked reporting shape and is not changed
here.
