### PR TITLE
fix(daemon): resolve the module identity before the chroot

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -71,7 +71,50 @@ fn apply_privilege_restrictions_with_upstream_errors(
         }
     };
 
-    // upstream: clientserver.c:980-989 - chroot first, then privilege drop.
+    // Resolve the identity BEFORE the chroot, because resolving it is a name
+    // lookup and the chroot is what makes names unresolvable.
+    //
+    // upstream: clientserver.c:831-880 resolves the uid (`user_to_uid`, :833)
+    // and the whole group set (`want_all_groups` :849, `add_a_group` :698-707,
+    // the `NOBODY_GROUP` default :873) while still outside any jail; the
+    // `chroot()` does not happen until :1050. Every impure arm of
+    // `resolve_drop_target` goes through NSS - the `nobody` user, the
+    // `nobody`/`nogroup` group, and the `gid = *` supplementary-group
+    // enumeration - so a jail that does not contain `/etc/passwd`, `/etc/group`
+    // and the NSS modules cannot answer them. Resolving after the chroot turns
+    // the `nobody` default that a root daemon applies to every module without
+    // an explicit numeric `uid` into `@ERROR: invalid uid nobody`, and the
+    // module never serves.
+    //
+    // Only the `setgid`/`setgroups`/`setuid` SYSCALLS need to run after the
+    // chroot (they need the root privileges the chroot also needs); those stay
+    // below. upstream: clientserver.c:1024/1031/1053.
+    let drop_target = if needs_privdrop {
+        match resolve_drop_target(module, am_root) {
+            Ok(target) => Some(target),
+            Err(err) => {
+                // A uid/gid NAME that fails to resolve (here the `nobody`
+                // default) is a distinct failure point from the setgid/setuid
+                // SYSCALL failures handled below: it yields `@ERROR: invalid
+                // uid <name>` / `@ERROR: invalid gid <name>` with a matching
+                // FLOG `Invalid uid/gid <name>`.
+                // upstream: clientserver.c:836-838 (uid) / 702-703 (gid). This
+                // lookup runs before the post-xfer-exec fork point (908), so
+                // no `post-xfer exec` hook fires here.
+                let (flog, error) = err.upstream_reply();
+                let message = rsync_error!(1, flog).with_role(Role::Daemon);
+                log_message(log_sink, &message);
+                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
+                return Ok(None);
+            }
+        }
+    } else {
+        None
+    };
+
+    // upstream: clientserver.c:1040-1057 - chroot, then chdir into the served
+    // root. Only the privilege-drop SYSCALLS follow it; the identity they drop
+    // to was resolved above.
     // A rootless auto-fallback (unset `use chroot` + failing probe) yields
     // `Ok(false)`; an explicit `use chroot = yes` that fails is fatal.
     let mut chroot_applied = false;
@@ -109,28 +152,7 @@ fn apply_privilege_restrictions_with_upstream_errors(
         }
     }
 
-    if needs_privdrop {
-        // upstream: clientserver.c:783-824 - resolve the effective uid and full
-        // group set (nobody defaults, `gid = *` expansion) before dropping.
-        let target = match resolve_drop_target(module, am_root) {
-            Ok(target) => target,
-            Err(err) => {
-                // A uid/gid NAME that fails to resolve (here the `nobody`
-                // default) is a distinct failure point from the setgid/setuid
-                // SYSCALL failures handled below: it yields `@ERROR: invalid
-                // uid <name>` / `@ERROR: invalid gid <name>` with a matching
-                // FLOG `Invalid uid/gid <name>`.
-                // upstream: clientserver.c:784-786 (uid) / 657-659 (gid). This
-                // lookup runs before the post-xfer-exec fork point (908), so
-                // no `post-xfer exec` hook fires here.
-                let (flog, error) = err.upstream_reply();
-                let message = rsync_error!(1, flog).with_role(Role::Daemon);
-                log_message(log_sink, &message);
-                send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-                return Ok(None);
-            }
-        };
-
+    if let Some(target) = drop_target {
         if target.uid.is_some() || !target.gids.is_empty() {
             if let Err(err) = drop_privileges(target.uid, &target.gids, log_sink) {
                 // Distinguish upstream error messages based on the error text.

--- a/tests/daemon_chroot_identity_resolution.rs
+++ b/tests/daemon_chroot_identity_resolution.rs
@@ -1,0 +1,263 @@
+//! A chrooted module must still resolve the `nobody` uid/gid defaults.
+//!
+//! Upstream resolves the identity to drop to BEFORE it enters the jail:
+//!
+//! ```c
+//! /* clientserver.c:831-843 - rsync_module() */
+//! am_root = (uid == ROOT_UID);
+//! p = *lp_uid(module_id) ? lp_uid(module_id) : am_root ? NOBODY_USER : NULL;
+//! if (p) {
+//!         if (!user_to_uid(p, &uid, True)) {
+//!                 rprintf(FLOG, "Invalid uid %s\n", p);
+//!                 io_printf(f_out, "@ERROR: invalid uid %s\n", p);
+//! ...
+//! /* clientserver.c:873 - the NOBODY_GROUP default, same pre-chroot region */
+//!         if (add_a_group(f_out, NOBODY_GROUP) < 0)
+//! ...
+//! /* clientserver.c:1040-1050 - only now does the jail exist */
+//! if (use_chroot) {
+//!         ...
+//!         if (chroot(module_chdir)) {
+//! ```
+//!
+//! The order is load-bearing, not incidental. `user_to_uid` / `group_to_gid`
+//! are NSS lookups: they read `/etc/passwd`, `/etc/group` and the NSS shared
+//! objects. A module root is not a system root, so inside the jail none of
+//! those exist and the lookup cannot succeed. Resolving after the chroot turns
+//! the `nobody` default that a root daemon applies to EVERY module without an
+//! explicit numeric `uid` into `@ERROR: invalid uid nobody`, and the module
+//! serves nothing at all.
+//!
+//! Only the `setgid`/`setgroups`/`setuid` syscalls belong after the chroot -
+//! they and the chroot both need the root privileges being dropped.
+//!
+//! WHY THIS TEST NEEDS ROOT, AND WHY THE SKIP IS NOT A PASS IN DISGUISE.
+//!
+//! The defect needs three things at once: `am_root` (only a root daemon
+//! applies the `nobody` default), an effective `use chroot`, and a uid/gid left
+//! to that default. A non-root daemon reaches neither the default nor
+//! `chroot(2)`, so the cell is structurally unable to fail there and prints a
+//! reason instead of asserting. CI's `nextest` leg runs unprivileged, so this
+//! cell reports SKIP there; it is written to fire for anyone running the suite
+//! as root, which is the only configuration that can observe the behaviour.
+//!
+//! Skip conditions (the test prints a reason and returns):
+//! - not running as root;
+//! - no `nobody` account on the host (the lookup would fail for a real reason);
+//! - loopback TCP unavailable;
+//! - `chroot(2)` refused by the environment (a rootless container maps uid 0
+//!   without granting CAP_SYS_CHROOT).
+#![cfg(unix)]
+
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+fn running_as_root() -> bool {
+    id_of(&["-u"]).as_deref() == Some("0")
+}
+
+/// The uid the daemon will drop to, or `None` when the host has no such
+/// account. Reported as a skip rather than asserted: without `nobody` the
+/// lookup fails for a reason that has nothing to do with the chroot ordering.
+fn nobody_uid() -> Option<String> {
+    id_of(&["-u", "nobody"])
+}
+
+fn id_of(args: &[&str]) -> Option<String> {
+    let out = Command::new("id").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+    if value.is_empty() { None } else { Some(value) }
+}
+
+/// Starts a daemon and waits until its port answers.
+///
+/// `stdin` is `/dev/null` deliberately: with an inherited terminal or pipe the
+/// daemon takes its single-connection inetd path and never listens, and the
+/// client then reports "connection refused" instead of the behaviour under
+/// test.
+fn spawn_daemon(binary: &Path, conf: &Path, port: u16) -> Child {
+    let child = Command::new(binary)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+struct Outcome {
+    transferred: bool,
+    landed: bool,
+    log: String,
+}
+
+/// Pushes one file into a `use chroot = yes` module and reports what happened.
+///
+/// `identity` is written verbatim into the module section, so the caller
+/// chooses between the `nobody` default (empty) and explicit numeric ids.
+fn push_into_chrooted_module(identity: &str, drop_uid: &str) -> Option<Outcome> {
+    let root = tempfile::tempdir().expect("temp dir");
+    let port = free_port()?;
+
+    let module = root.path().join("mod");
+    let src = root.path().join("src");
+    fs::create_dir_all(&module).expect("module dir");
+    fs::create_dir_all(&src).expect("source dir");
+    fs::write(src.join("f.txt"), b"payload\n").expect("source file");
+
+    // The daemon drops to the unprivileged identity before it writes, so the
+    // module root must be writable by that uid. Without this the receiver
+    // fails on a plain permission error and the cell would report the same
+    // "nothing landed" as the defect while proving nothing about it.
+    let chowned = Command::new("chown")
+        .arg("-R")
+        .arg(format!("{drop_uid}:{drop_uid}"))
+        .arg(&module)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false);
+    if !chowned {
+        return None;
+    }
+
+    let log_path = root.path().join("daemon.log");
+    let conf = format!(
+        "port = {port}\n\
+         use chroot = yes\n\
+         log file = {log}\n\
+         \n\
+         [m]\n\
+         \tpath = {module}\n\
+         \tread only = no\n\
+         {identity}",
+        log = log_path.display(),
+        module = module.display(),
+    );
+    let conf_path = root.path().join("rsyncd.conf");
+    fs::write(&conf_path, conf).expect("config");
+
+    let binary = oc_binary();
+    let mut daemon = spawn_daemon(&binary, &conf_path, port);
+    let status = Command::new(&binary)
+        .args([
+            "-q",
+            "-r",
+            &format!("{}/", src.display()),
+            &format!("rsync://127.0.0.1:{port}/m/"),
+        ])
+        .status()
+        .expect("run client");
+
+    let landed = module.join("f.txt").exists();
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+
+    Some(Outcome {
+        transferred: status.success(),
+        landed,
+        log: fs::read_to_string(&log_path).unwrap_or_default(),
+    })
+}
+
+/// The module leaves `uid`/`gid` unset, so a root daemon applies the `nobody`
+/// defaults - the commonest chrooted configuration there is.
+#[test]
+fn chrooted_module_serves_under_the_nobody_default() {
+    if !running_as_root() {
+        println!("SKIP: needs root - a non-root daemon applies no nobody default");
+        return;
+    }
+    let Some(drop_uid) = nobody_uid() else {
+        println!("SKIP: host has no `nobody` account");
+        return;
+    };
+    let Some(outcome) = push_into_chrooted_module("", &drop_uid) else {
+        println!("SKIP: no loopback port, or the module could not be chowned");
+        return;
+    };
+    if outcome.log.contains("chroot") && outcome.log.contains("not permitted") {
+        println!("SKIP: chroot(2) refused by this environment");
+        return;
+    }
+
+    // Non-vacuity for the PRECONDITION: a chroot that silently did not happen
+    // would make every assertion below pass while testing nothing, because the
+    // lookup would then run in the ordinary root filesystem either way.
+    assert!(
+        outcome.log.contains("chroot applied"),
+        "the daemon must actually have chrooted, otherwise this cell is inert; log:\n{}",
+        outcome.log
+    );
+    assert!(
+        !outcome.log.contains("Invalid uid") && !outcome.log.contains("Invalid gid"),
+        "the `nobody` uid/gid must resolve before the chroot \
+         (clientserver.c:831-873 precede the chroot at :1040-1050); log:\n{}",
+        outcome.log
+    );
+    assert!(outcome.transferred, "the push must succeed");
+    assert!(
+        outcome.landed,
+        "the pushed file must reach the module - an exit code alone does not \
+         show that the module served anything"
+    );
+}
+
+/// The non-vacuity companion: fully numeric ids reach ZERO name lookups, so
+/// this cell is green whichever side of the chroot the resolution happens on.
+/// Without it, a change that broke chrooted modules outright would look like a
+/// fixture problem rather than a regression in the identity resolution.
+#[test]
+fn chrooted_module_with_numeric_ids_is_unaffected() {
+    if !running_as_root() {
+        println!("SKIP: needs root - a non-root daemon cannot set uid/gid");
+        return;
+    }
+    let Some(drop_uid) = nobody_uid() else {
+        println!("SKIP: host has no `nobody` account");
+        return;
+    };
+    let identity = format!("\tuid = {drop_uid}\n\tgid = {drop_uid}\n");
+    let Some(outcome) = push_into_chrooted_module(&identity, &drop_uid) else {
+        println!("SKIP: no loopback port, or the module could not be chowned");
+        return;
+    };
+    if outcome.log.contains("chroot") && outcome.log.contains("not permitted") {
+        println!("SKIP: chroot(2) refused by this environment");
+        return;
+    }
+
+    assert!(
+        outcome.log.contains("chroot applied"),
+        "the daemon must actually have chrooted; log:\n{}",
+        outcome.log
+    );
+    assert!(outcome.transferred, "the push must succeed");
+    assert!(outcome.landed, "the pushed file must reach the module");
+}


### PR DESCRIPTION
The error arm in `sandbox.rs` already documented upstream's ordering - it says
the uid/gid name lookup "runs before the post-xfer-exec fork point (908), so no
`post-xfer exec` hook fires here". That is a description of a **pre-chroot**
lookup. The code did it **after** the chroot. The comment was right and the code
contradicted it; this PR makes the code match.

## The defect

A root daemon defaults every module that does not set an explicit numeric `uid`
to `nobody:nobody`. oc resolved those names **after** entering the chroot, where
`/etc/passwd`, `/etc/group` and the NSS shared objects do not exist, so the
lookup could not succeed. Every chrooted module answered

```
@ERROR: invalid uid nobody
```

and served nothing. The daemon's own log shows the ordering plainly - the
chroot lands first, then the lookup fails inside it:

```
rsync allowed access on module data from localhost (127.0.0.1)
chroot applied: '/var/tmp/cells1103/C2-chroot-default/mod'
oc-rsync error: Invalid uid nobody (code 1) at sandbox.rs(127) [daemon=0.6.4]
```

**Severity is conditional**, not "the default config is broken": it needs a
**root** daemon *and* an effective `use chroot` *and* a uid or gid left to the
default. A module with numeric ids was never affected.

## Upstream

Upstream resolves the identity while still outside the jail and chroots only
much later:

| what | upstream 3.5.0 `clientserver.c` |
|---|---|
| `am_root` / uid resolution (`user_to_uid`) | :831-843 |
| `gid = *` expansion (`want_all_groups`) | :849 |
| `add_a_group` | :698-707 |
| `NOBODY_GROUP` default | :873 |
| `chroot(module_chdir)` | :1040-1050 |
| `setgid` / `setgroups` / `setuid` | :1024 / :1031 / :1053 |

Only the three privilege-drop **syscalls** need the post-chroot position - they
and the chroot both need the root privileges being dropped. This PR moves the
resolution and leaves the syscalls where they were.

## Not just the uid

All four impure arms of `resolve_drop_target` are NSS lookups:

- the `nobody` user (`lookup_user_by_name`);
- the `nobody` / `nogroup` group default (`resolve_first_existing_group`);
- the `gid = *` supplementary-group enumeration (`supplementary_gids_for_uid`).

Hoisting the uid alone would have converted the defect into a subtler one, so
the whole call moves. Cell C5 below isolates exactly that: a numeric `uid` with
the `gid` still defaulted fails on master with `@ERROR: invalid gid nobody`.

## Measured, on Linux, as root

Each cell asserts BOTH the client exit code AND that the pushed file actually
landed in the module - an exit code alone does not show the module served
anything.

| cell | `use chroot` | ids | before | after | upstream 3.5.0 |
|---|---|---|---|---|---|
| C1 | no | default | exit 0, landed | exit 0, landed | exit 0, landed |
| C2 | **yes** | **default** | **exit 5, NOT landed**, `@ERROR: invalid uid nobody` | **exit 0, landed** | exit 0, landed |
| C3 | yes | `uid`+`gid` numeric | exit 0, landed | exit 0, landed | exit 0, landed |
| C4 | no | numeric | exit 0, landed | exit 0, landed | exit 0, landed |
| C5 | **yes** | numeric `uid`, **default `gid`** | **exit 5, NOT landed**, `@ERROR: invalid gid nobody` | **exit 0, landed** | exit 0, landed |

**C5 is why this is a whole-call move and not a one-line uid hoist.** It is a
SECOND live failure, in its own right: numeric `uid`, `gid` left to the default,
and master answers `@ERROR: invalid gid nobody`. A fix that hoisted only the uid
would have flipped C2 to green and left C5 exactly as broken - one defect
converted into a subtler one. C5 also shows the `nobody`/`nogroup` two-name
group probe is reachable in an ordinary configuration, not a corner case.

The upstream column is the cross-implementation control: real rsync 3.5.0 run
against the same generated configs on the same host, 5/5 green, which is what
identifies the before column as an oc-only divergence rather than a fixture
artefact. C3 is the non-vacuity companion - fully numeric ids reach zero name
lookups, so it is green on both sides of the change and would have caught a
"fix" that simply broke chrooted modules outright.

## Regression test

`tests/daemon_chroot_identity_resolution.rs` pushes into a `use chroot = yes`
module with the identity left to the default and asserts the transfer succeeded,
the file landed, and no `Invalid uid`/`Invalid gid` appears in the daemon log.
It also asserts the log contains `chroot applied` - **non-vacuity for the
precondition**, because a chroot that silently did not happen would make every
other assertion pass while testing nothing.

RED proven by pointing the same test at a binary built from this branch with
only the hoist reverted:

```
test chrooted_module_serves_under_the_nobody_default ... FAILED
  the `nobody` uid/gid must resolve before the chroot ...; log:
  chroot applied: '/tmp/.tmpZeIkK2/mod'
  oc-rsync error: Invalid uid nobody (code 1) at sandbox.rs(127)
test chrooted_module_with_numeric_ids_is_unaffected ... ok
```

⚠ **Known coverage limit, stated rather than hidden.** The defect needs
`am_root`, so the cell can only fire when the suite runs as root. CI's `nextest`
leg runs unprivileged and will report this cell as a visible `SKIP: needs root
...`, not as a silent pass. It was verified green as root and RED-proven as root
on Linux, by hand.

**No upstream-testsuite row flips with this change, and that is the point.**
Both of its config builders - `rsyncfns.build_rsyncd_conf` (:1294-1300) and
`rsyncfns.write_daemon_conf` (:2061-2063) - emit `uid = {get_rootuid()}` /
`gid = {get_rootgid()}` on the root leg, and those functions return the literal
`0`; the nonroot leg emits no `uid` line at all. So the suite exercises
`use chroot = yes` (daemon-chroot, daemon-chroot-munge-default arms B and C,
chroot-basis-forge-inner-module) and it exercises a `uid` directive - but never
the two together with a **name**, which is exactly the default a root daemon
falls into when the module has no `uid` line.

That is a coverage gap in the suite, not a reason to doubt the defect: it is
why a live failure of the commonest chrooted configuration sat behind a green
required gate. Expect no manifest row to move; this fix stands on its own
regression test and on the measured table above.

## Verification

- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`: clean.
- `cargo nextest run -p daemon --all-features`: 1916 run, 1916 passed, 6 skipped.
- `cargo nextest run --all-features -E "binary(~daemon)"`: 79 run, 79 passed.
- New cell as root: 2 passed. As non-root: 2 passed with the skip reason printed.
