### PR TITLE
docs: pin the daemon refusal exit-code citations to 3.5.0

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -102,14 +102,18 @@ pub(crate) const FEATURE_UNAVAILABLE_EXIT_CODE: i32 = 1;
 ///
 /// upstream: errcode.h:25 - `#define RERR_SYNTAX 1`. The daemon's read-only
 /// push and write-only pull rejections call `exit_cleanup(RERR_SYNTAX)`
-/// (main.c:934, main.c:1167).
+/// (main.c:951 in `do_server_sender()`, main.c:1185 in `do_server_recv()`).
 pub(crate) const RERR_SYNTAX_EXIT_CODE: i32 = 1;
 /// Exit code for a refused option or a failed `pre-xfer exec` script,
 /// mirroring upstream `RERR_UNSUPPORTED`.
 ///
-/// upstream: errcode.h:28 - `#define RERR_UNSUPPORTED 4`. clientserver.c:1183
-/// calls `exit_cleanup(RERR_UNSUPPORTED)` when `parse_arguments()` rejects a
-/// refused option, or when the `pre-xfer exec` script exits non-zero.
+/// upstream: errcode.h:28 - `#define RERR_UNSUPPORTED 4`
+///
+/// A refused option and a failed `pre-xfer exec` script share one exit path:
+/// upstream: clientserver.c:1254 - `if (!ret || err_msg) {` opens the single
+/// post-`@RSYNCD: OK` fatal branch, and
+/// upstream: clientserver.c:1267 - `exit_cleanup(RERR_UNSUPPORTED);` ends it.
+/// That is the code the peer observes for both.
 pub(crate) const RERR_UNSUPPORTED_EXIT_CODE: i32 = 4;
 /// Exit code for a generic module-session abort (chroot/setuid/setgid syscall
 /// failure, name-converter or early-exec spawn failure, and similar setup
@@ -231,14 +235,14 @@ pub(crate) const INVALID_UID_PAYLOAD: &str = "@ERROR: invalid uid {uid}";
 pub(crate) const INVALID_GID_PAYLOAD: &str = "@ERROR: invalid gid {gid}";
 /// Error payload returned when a module is read-only and the client pushes.
 ///
-/// upstream: main.c:1167 `do_server_recv()` - `rprintf(FERROR, "ERROR:
+/// upstream: main.c:1184 `do_server_recv()` - `rprintf(FERROR, "ERROR:
 /// module is read only\n")`. This fires after `setup_protocol()` and
 /// `io_start_multiplex_out()`, so the text is a plain `FERROR` message (no
 /// `@ERROR:` greeting prefix) delivered inside a `MSG_ERROR_XFER` frame.
 pub(crate) const MODULE_READ_ONLY_PAYLOAD: &str = "ERROR: module is read only";
 /// Error payload returned when a module is write-only and the client pulls.
 ///
-/// upstream: main.c:935 `do_server_sender()` - `rprintf(FERROR, "ERROR:
+/// upstream: main.c:950 `do_server_sender()` - `rprintf(FERROR, "ERROR:
 /// module is write only\n")`, delivered post-multiplex like the read-only
 /// rejection above.
 pub(crate) const MODULE_WRITE_ONLY_PAYLOAD: &str = "ERROR: module is write only";

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -335,9 +335,9 @@ fn handle_refused_option_post_handshake(
 /// `read only` module or a pull from a `write only` module - through the
 /// multiplexed error path.
 ///
-/// upstream: main.c:1166-1169 `do_server_recv()` rejects a read-only push
+/// upstream: main.c:1183-1187 `do_server_recv()` rejects a read-only push
 /// with `rprintf(FERROR, "ERROR: module is read only\n")` then
-/// `exit_cleanup(RERR_SYNTAX)`; main.c:934-936 `do_server_sender()` rejects a
+/// `exit_cleanup(RERR_SYNTAX)`; main.c:949-952 `do_server_sender()` rejects a
 /// write-only pull the same way. Both fire after `setup_protocol()` and
 /// `io_start_multiplex_out()`, so the message travels as a `MSG_ERROR_XFER`
 /// frame followed by `MSG_ERROR_EXIT`. Emitting the raw text with

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -372,8 +372,8 @@ fn process_approved_module(
     }
 
     // Enforce read-only / write-only access restrictions.
-    // upstream: main.c:1166-1169 `do_server_recv()` rejects a read-only push
-    // and main.c:934-936 `do_server_sender()` rejects a write-only pull, both
+    // upstream: main.c:1183-1187 `do_server_recv()` rejects a read-only push
+    // and main.c:949-952 `do_server_sender()` rejects a write-only pull, both
     // via `rprintf(FERROR, "ERROR: module is ...\n")` + `exit_cleanup(
     // RERR_SYNTAX)`. When --sender is absent the client is pushing (server =
     // Receiver); a read-only module must reject pushes and a write-only module

--- a/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
+++ b/crates/daemon/src/tests/chunks/daemon_error_payloads_match_upstream_wording.rs
@@ -84,7 +84,7 @@ fn daemon_error_payloads_match_upstream_wording() {
         "@ERROR: invalid gid {gid}",
     );
 
-    // upstream: main.c:1167 / main.c:935 - the read-only push and write-only
+    // upstream: main.c:1184 / main.c:950 - the read-only push and write-only
     // pull rejections fire post-multiplex via `rprintf(FERROR, "ERROR: module
     // is ...\n")`, so the payload carries a plain `ERROR:` prefix (no
     // `@ERROR:` greeting form) and travels inside a `MSG_ERROR_XFER` frame.

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_default_read_only_module.rs
@@ -70,7 +70,7 @@ fn run_daemon_rejects_push_to_default_read_only_module() {
     // #227: the default `read only = true` push rejection is post-`@RSYNCD:
     // OK`, so it must be framed as MSG_ERROR_XFER + MSG_ERROR_EXIT rather than
     // written as a raw line. Shared decoder mirrors upstream
-    // `do_server_recv()` (main.c:1166-1169).
+    // `do_server_recv()` (main.c:1183-1187).
     assert_read_only_multiplexed_rejection(&mut reader);
 
     drop(reader);

--- a/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_rejects_push_to_read_only_module.rs
@@ -69,7 +69,7 @@ fn run_daemon_rejects_push_to_read_only_module() {
     // client has already switched to multiplexed input. The daemon must first
     // finish the post-OK protocol setup (compat-flags varint + 4-byte checksum
     // seed) and then deliver the error inside a `MSG_ERROR_XFER` frame, exactly
-    // like upstream `do_server_recv()` (main.c:1166-1169) does after
+    // like upstream `do_server_recv()` (main.c:1183-1187) does after
     // `io_start_multiplex_out()`. A raw `@ERROR: ...\n` line here would be
     // decoded as a 4-byte frame header and desync the stream (the regression
     // upstream reports as `invalid multi-message 102 (code 12)`).
@@ -84,7 +84,7 @@ fn run_daemon_rejects_push_to_read_only_module() {
 /// rejection arrives as a framed `MSG_ERROR_XFER` (text `ERROR: module is read
 /// only`) followed by `MSG_ERROR_EXIT` carrying `RERR_SYNTAX` (exit 1).
 ///
-/// upstream: main.c:1166-1169 - `rprintf(FERROR, "ERROR: module is read
+/// upstream: main.c:1183-1187 - `rprintf(FERROR, "ERROR: module is read
 /// only\n")` + `exit_cleanup(RERR_SYNTAX)`; io.c encodes the FERROR message as
 /// a `MSG_ERROR_XFER` frame and the exit as `MSG_ERROR_EXIT`.
 fn assert_read_only_multiplexed_rejection(reader: &mut BufReader<TcpStream>) {

--- a/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_runs_post_xfer_exec_on_read_only_refuse.rs
@@ -4,7 +4,7 @@
 /// (child exits `RERR_SYNTAX`) fires the hook with `RSYNC_EXIT_STATUS=1`.
 ///
 /// upstream: clientserver.c:908-933 - post-xfer exec runs after the child exits
-/// for any reason; main.c:1166-1169 - the read-only push child exits
+/// for any reason; main.c:1183-1187 - the read-only push child exits
 /// `RERR_SYNTAX` (1). Regression guard for the daemon skipping the hook on the
 /// refuse early-return path.
 #[cfg(unix)]


### PR DESCRIPTION
## What

The rustdoc for the daemon's two refusal exit codes named upstream lines that
do not hold at the 3.5.0 pin. Comments only; no behaviour change.

| construct | was | is (3.5.0) |
|---|---|---|
| `RERR_UNSUPPORTED` call | `clientserver.c:1183` | `clientserver.c:1267` (branch opens at `:1254`) |
| read-only push refusal | `main.c:1167` / `:1166-1169` | `main.c:1184` / `:1183-1187` |
| write-only pull refusal | `main.c:935` / `:934-936` | `main.c:950` / `:949-952` |

`clientserver.c:1183` is the closing brace of the `if (pre_exec_pid)` block and
calls nothing. `main.c:934` is an `exit_cleanup(RERR_PROTOCOL)` on the
NDX_DONE check - a different error entirely.

The `:1183` figure was doubly misleading: it is a real line number, but in
`main.c`, where it opens the read-only refusal - so the two citations read as
if they had been crossed.

## Why these are the right lines

Every anchor was re-read in `target/interop/upstream-src/rsync-3.5.0/`. The two
that surface in a client diagnostic were then confirmed against the real 3.5.0
binary, which names its own line:

```
rsync: The server is configured to refuse --write-devices
rsync error: requested action not supported (code 4) at clientserver.c(1267)

ERROR: module is read only
rsync error: syntax or usage error (code 1) at main.c(1185)
```

`:1267` is `exit_cleanup(RERR_UNSUPPORTED);` and `:1185` is
`exit_cleanup(RERR_SYNTAX);`. The doc now cites the `rprintf` line for the
payload constants (`:1184`, `:950`) and the `exit_cleanup` line for the exit-code
constants (`:1267`, `:1185`, `:951`), matching what each constant actually is.

## The upstream rule, unchanged and re-confirmed

A refused option and a failed `pre-xfer exec` share one exit path: the single
post-`@RSYNCD: OK` fatal branch at `clientserver.c:1254` (`if (!ret || err_msg)`),
ending at `:1267` in `RERR_UNSUPPORTED` (4). The read-only push and write-only
pull rejections are decided later, in `do_server_recv()` / `do_server_sender()`,
and keep `RERR_SYNTAX` (1). oc already implements exactly that split; this PR
does not touch it.

Measured against the pinned 3.5.0 daemon and oc at this base, same client, push
direction:

| cell | upstream 3.5.0 | oc |
|---|---|---|
| `--write-devices` (default-refused) | exit 4 | exit 4 |
| push to a `read only` module | exit 1 | exit 1 |

The second row is the non-vacuity companion: a refusal upstream genuinely exits
1 on, still exiting 1.

## Verification

- `cargo fmt --all -- --check` - exit 0
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` - exit 0
- `python3 tools/ci/citation_drift_audit.py` - exit 0
- `cargo nextest run -p daemon --all-features` - `1896 tests run: 1896 passed, 6 skipped`

Citation gate, daemon crate: string-anchored 88 -> 89, unresolved 43 -> 42,
suspected-drift unchanged at 2 (two pre-existing `use chroot` rows in
`privilege.rs` and `module_state/definition.rs`, untouched here). The
`RERR_UNSUPPORTED` block is re-laid-out so each `file:line` carries its own
quoted anchor - sharing one anchor across two citations is what made the old
line unverifiable by the gate, and is why the wrong number survived review.

The exit codes themselves are pinned by tests that already exist and stay green;
mutating `handle_refused_option_post_handshake` back to exit 1 reddens exactly
`run_daemon_post_ok_refused_option_uses_multiplexed_error` and
`run_daemon_refusal_lingers_so_the_peer_can_read_it`
(`42 tests run: 40 passed, 2 failed`), leaving the read-only/write-only cells
green - so the suite does discriminate the two families.

Measured on macOS/aarch64 against the pinned 3.5.0 binary.

## Provenance: the gate did not find these

All three retargets were found by reading `rsync-3.5.0/` directly and then
confirming against the real binary's own diagnostic - not by the citation gate.
The gate could not have found them:

- `clientserver.c:1183` had no resolvable anchor at all. It shared one backticked
  string (`#define RERR_UNSUPPORTED 4`) with the `errcode.h:28` citation on the
  same line, so the gate classified it `unresolved`, not `drift`. `unresolved`
  rows are informational and do not fail the run - the wrong line number was
  invisible to it.
- `main.c:1167` / `:935` carry no quoted snippet at all, so they are not
  extracted as anchors and are never checked.

This is the shape task 1045 records: the gate is a line-count check and cannot
detect a citation pointing at the wrong code. Task 672's `"upstream" not in ln`
filter is a separate hole. Splitting the anchors (above) converts one of these
three from invisible to gate-verified; the other two remain prose the gate does
not inspect.
