### PR TITLE
fix(daemon): exit 4 on a refused option, not 1

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -303,6 +303,14 @@ fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> i
 /// `unexpected tag 72` (65 + `MPLEX_BASE`) on the receiver. Raw
 /// `@ERROR: ...\n` text would similarly produce `unexpected tag 77` (the
 /// byte `T` from "The server ..." minus `MPLEX_BASE = 7`).
+///
+/// The `MSG_ERROR_EXIT` payload carries `RERR_UNSUPPORTED`, not
+/// `RERR_SYNTAX`. upstream: clientserver.c:1254-1268 - the single post-OK
+/// fatal branch (`if (!ret || err_msg)`) covers both a refused option and a
+/// failed `pre-xfer exec`, and it ends in `exit_cleanup(RERR_UNSUPPORTED)`
+/// at clientserver.c:1267. That is the code the peer observes; the sibling
+/// read-only/write-only rejection is a different decision made later in
+/// `do_server_recv()`/`do_server_sender()` and keeps `RERR_SYNTAX`.
 fn handle_refused_option_post_handshake(
     ctx: &mut ModuleRequestContext<'_>,
     refused: &str,
@@ -315,7 +323,7 @@ fn handle_refused_option_post_handshake(
         ctx.reader.get_mut(),
         ctx.limiter,
         &error.line(),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
+        RERR_UNSUPPORTED_EXIT_CODE,
     )?;
     if let Some(log) = ctx.log_sink {
         log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);

--- a/crates/daemon/src/daemon/sections/tests.rs
+++ b/crates/daemon/src/daemon/sections/tests.rs
@@ -1293,7 +1293,7 @@ fn refuse_emits_msg_error_xfer_post_handshake() {
         &mut stream,
         &mut limiter,
         "@ERROR: The server is configured to refuse --compress",
-        FEATURE_UNAVAILABLE_EXIT_CODE,
+        RERR_UNSUPPORTED_EXIT_CODE,
     )
     .expect("send multiplexed error");
 
@@ -1324,7 +1324,7 @@ fn refuse_emits_msg_error_xfer_post_handshake() {
     let mut expected_exit = Vec::new();
     MessageFrame::new(
         MessageCode::ErrorExit,
-        FEATURE_UNAVAILABLE_EXIT_CODE.to_le_bytes().to_vec(),
+        RERR_UNSUPPORTED_EXIT_CODE.to_le_bytes().to_vec(),
     )
     .expect("frame")
     .encode_into_writer(&mut expected_exit)

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -33,6 +33,7 @@ use crate::daemon::{
     // From sections/cli_args.rs
     ProgramName,
     RERR_SYNTAX_EXIT_CODE,
+    RERR_UNSUPPORTED_EXIT_CODE,
     // From runtime_options.rs
     RuntimeOptions,
     TestSecretsEnvOverride,

--- a/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs
@@ -181,8 +181,11 @@ fn run_daemon_post_ok_refused_option_uses_multiplexed_error() {
         .expect("read MSG_ERROR_EXIT payload");
     assert_eq!(
         i32::from_le_bytes(exit_buf),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-        "refused-options exit code must mirror upstream's unsupported-feature path",
+        RERR_UNSUPPORTED_EXIT_CODE,
+        "refused-options exit code must be RERR_UNSUPPORTED (4), not RERR_SYNTAX (1): \
+         upstream's single post-OK fatal branch ends in exit_cleanup(RERR_UNSUPPORTED) \
+         at clientserver.c:1267, and that code reaches the peer verbatim through \
+         MSG_ERROR_EXIT - a client scripting on `rsync -z` being refused sees 4",
     );
 
     drop(reader);

--- a/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_refusal_lingers_so_the_peer_can_read_it.rs
@@ -156,8 +156,9 @@ fn run_daemon_refusal_lingers_so_the_peer_can_read_it() {
         .expect("MSG_ERROR_EXIT payload must survive the daemon's close");
     assert_eq!(
         i32::from_le_bytes(exit_buf),
-        FEATURE_UNAVAILABLE_EXIT_CODE,
-        "refusal exit code",
+        RERR_UNSUPPORTED_EXIT_CODE,
+        "refusal exit code must be RERR_UNSUPPORTED (4), matching the \
+         exit_cleanup(RERR_UNSUPPORTED) this test's own header cites",
     );
 
     // Drain until the connection ends: the daemon closes only after its linger


### PR DESCRIPTION
A daemon that refuses a client option after sending `@RSYNCD: OK` exits `1`
where upstream exits `4` (`RERR_UNSUPPORTED`).

## Upstream

`clientserver.c:1254-1268` is a single post-OK fatal branch:

```c
if (!ret || err_msg) {
        if (err_msg) {
                ... rwrite(FERROR, ...) ...
        } else
                option_error();
        msleep(400);
        exit_cleanup(RERR_UNSUPPORTED);
}
```

It covers both a refused option and a failed `pre-xfer exec`, and it ends in
`exit_cleanup(RERR_UNSUPPORTED)` at `:1267`. That is the code the peer
observes in the `MSG_ERROR_EXIT` payload.

## The discriminator

Not every daemon refusal maps to `4`. The sibling read-only / write-only
rejection is a **different decision**, made later in `do_server_recv()` /
`do_server_sender()`, and it keeps `RERR_SYNTAX`. This change moves only the
post-OK option-refusal branch; the read-only rejection is deliberately
untouched.

## Scope

`FEATURE_UNAVAILABLE_EXIT_CODE` -> `RERR_UNSUPPORTED_EXIT_CODE` at the
post-OK refusal site, with the two existing daemon integration tests updated
to assert the code the peer actually receives.

## Deliberately out of scope

The `@ERROR: ` payload-prefix divergence on the same path belongs to the
IOBUF work, which also owns the missing exit linger. Fixing the prefix at
one site while the other stays divergent would create two behaviours where
there is currently one consistent bug.
