### PR TITLE
test(daemon): run the module filter-directive tests un-detached

### DIFF
--- a/tests/integration_daemon_filter_directives.rs
+++ b/tests/integration_daemon_filter_directives.rs
@@ -8,11 +8,19 @@
 //! directive never land on disk - regardless of whether the client supplied
 //! any filter on its own.
 //!
-//! upstream: clientserver.c:874-893 - `rsync_module()` builds
+//! upstream: clientserver.c:934-951 - `rsync_module()` builds
 //! `daemon_filter_list` from `filter` / `include_from` / `include` /
 //! `exclude_from` / `exclude` in that order, then `check_filter()` at
-//! `receiver.c:711-714` and `generator.c:1273-1275` consults it before any
+//! `receiver.c:889` and `generator.c:1663` consults it before any
 //! per-file action.
+//!
+//! A refused file is never dropped in silence: `generator.c:1669-1671` reports
+//! it as `FERROR_XFER`, `log.c:337-338` sets `got_xfer_error` on receipt, and
+//! `cleanup.c:217-218` lifts the push's exit status to `RERR_PARTIAL` (23,
+//! `errcode.h:43`). Every test below asserts that status as well as the on-disk
+//! end state, because the status is the signal that the module directive
+//! actually fired: an absent `.log` file is equally consistent with a transfer
+//! that achieved nothing at all.
 //!
 //! Gated `#[cfg(unix)]` because the in-process client + daemon split uses
 //! POSIX TCP and the helper walks the destination with `read_dir`; the test
@@ -22,7 +30,7 @@
 
 #![cfg(unix)]
 
-use std::collections::HashSet;
+use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::fs;
 use std::net::{Ipv4Addr, TcpListener};
@@ -40,6 +48,11 @@ use tempfile::tempdir;
 /// concurrently on a constrained CI runner.
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
+/// Upstream's exit status for a transfer that lost files to an error.
+///
+/// upstream: errcode.h:43 - `#define RERR_PARTIAL    23`.
+const RERR_PARTIAL: i32 = 23;
+
 /// Allocates a free TCP port for the test daemon. Returns both the port and
 /// the bound `TcpListener` so the listener can be handed to the daemon via
 /// `pre_bound_listener` - this closes the TOCTOU window between port
@@ -50,10 +63,13 @@ fn allocate_test_port() -> Option<(u16, TcpListener)> {
     Some((port, listener))
 }
 
-/// Walks `root` recursively and returns the set of relative file paths. Used
-/// to assert the destination contains exactly the files we expect.
-fn collect_files(root: &Path) -> HashSet<String> {
-    let mut out = HashSet::new();
+/// Walks `root` recursively and maps each relative file path to its contents.
+///
+/// The contents travel with the names so that a kept file has to arrive intact
+/// to satisfy the positive assertions. Name-only presence would also be
+/// satisfied by an empty placeholder left behind by a half-finished transfer.
+fn collect_files(root: &Path) -> BTreeMap<String, Vec<u8>> {
+    let mut out = BTreeMap::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let Ok(entries) = fs::read_dir(&dir) else {
@@ -65,8 +81,8 @@ fn collect_files(root: &Path) -> HashSet<String> {
             if meta.is_dir() {
                 stack.push(path);
             } else if meta.is_file() {
-                if let Ok(rel) = path.strip_prefix(root) {
-                    out.insert(rel.to_string_lossy().into_owned());
+                if let (Ok(rel), Ok(contents)) = (path.strip_prefix(root), fs::read(&path)) {
+                    out.insert(rel.to_string_lossy().into_owned(), contents);
                 }
             }
         }
@@ -74,9 +90,47 @@ fn collect_files(root: &Path) -> HashSet<String> {
     out
 }
 
+/// Asserts that `name` landed under the destination carrying `expected`.
+fn assert_kept(files: &BTreeMap<String, Vec<u8>>, name: &str, expected: &[u8]) {
+    let actual = files.get(name).unwrap_or_else(|| {
+        panic!(
+            "{name} must be transferred, destination holds {:?}",
+            files.keys().collect::<Vec<_>>()
+        )
+    });
+    assert_eq!(
+        actual.as_slice(),
+        expected,
+        "{name} was transferred with the wrong contents"
+    );
+}
+
+/// Asserts the push reported upstream's exit status for a daemon refusal.
+///
+/// This is the positive half of every scenario below. `RERR_PARTIAL` can only
+/// appear once the module directive has matched a file and the receiver has
+/// refused it; a daemon that ignored the directive would transfer all four
+/// files and exit 0, and one that never served the module at all would fail
+/// with a different status.
+///
+/// upstream: generator.c:1669-1671 reports the refusal as `FERROR_XFER`,
+/// log.c:337-338 sets `got_xfer_error` on receipt, and cleanup.c:217-218 lifts
+/// the exit status to `RERR_PARTIAL`.
+fn assert_refused_exit_code(exit_code: Option<i32>) {
+    assert_eq!(
+        exit_code,
+        Some(RERR_PARTIAL),
+        "a push whose files the module refused must exit {RERR_PARTIAL} \
+         (cleanup.c:217-218), not report success"
+    );
+}
+
 /// Result of running one push-to-daemon scenario.
 struct ScenarioOutcome {
-    files: HashSet<String>,
+    /// Destination-relative path -> contents, for every file that landed.
+    files: BTreeMap<String, Vec<u8>>,
+    /// The push's effective exit status; `None` when the transfer exited 0.
+    exit_code: Option<i32>,
 }
 
 /// Configures a daemon with a single `[uploads]` module carrying the
@@ -128,6 +182,14 @@ fn run_filter_scenario(
             config_path.as_os_str().to_os_string(),
             OsString::from("--max-sessions"),
             OsString::from("1"),
+            // Mandatory. `RuntimeOptions::detach` defaults to `cfg!(unix)`, so
+            // `run_daemon` reaches `become_daemon()` in the accept loop; the
+            // parent of that fork is this very test process and it exits 0
+            // (`platform::daemonize::become_daemon`). Without the flag the test
+            // binary terminates successfully before a single assertion below
+            // runs and the harness records a pass - an unconditional `panic!`
+            // placed after this spawn still reported PASSED.
+            OsString::from("--no-detach"),
         ])
         .pre_bound_listener(held_listener)
         .build();
@@ -152,15 +214,20 @@ fn run_filter_scenario(
     // `run_daemon`'s return point after the single transfer drains.
     let daemon_result = daemon_handle.join().expect("daemon thread panicked");
 
-    if let Err(err) = client_result {
-        panic!("{test_name}: client push failed: {err}");
-    }
     if let Err(err) = daemon_result {
         panic!("{test_name}: daemon exited with error: {err:?}");
     }
+    // A refused file is reported through the summary, not as an `Err`: the
+    // status rides on `ClientSummary::io_error_exit_code`. An `Err` here means
+    // the session itself broke down rather than that a file was filtered.
+    let summary = match client_result {
+        Ok(summary) => summary,
+        Err(err) => panic!("{test_name}: client push failed: {err}"),
+    };
 
     Some(ScenarioOutcome {
         files: collect_files(&dst),
+        exit_code: summary.io_error_exit_code(),
     })
 }
 
@@ -179,26 +246,19 @@ fn daemon_filter_directive_excludes_match_pattern() {
         return;
     };
 
+    assert_kept(&outcome.files, "keep1.txt", b"keep me 1");
+    assert_kept(&outcome.files, "keep2.txt", b"keep me 2");
     assert!(
-        outcome.files.contains("keep1.txt"),
-        "keep1.txt must be transferred, got {:?}",
-        outcome.files
-    );
-    assert!(
-        outcome.files.contains("keep2.txt"),
-        "keep2.txt must be transferred, got {:?}",
-        outcome.files
-    );
-    assert!(
-        !outcome.files.contains("drop1.log"),
+        !outcome.files.contains_key("drop1.log"),
         "drop1.log must be excluded by `filter = - *.log`, got {:?}",
-        outcome.files
+        outcome.files.keys().collect::<Vec<_>>()
     );
     assert!(
-        !outcome.files.contains("drop2.log"),
+        !outcome.files.contains_key("drop2.log"),
         "drop2.log must be excluded by `filter = - *.log`, got {:?}",
-        outcome.files
+        outcome.files.keys().collect::<Vec<_>>()
     );
+    assert_refused_exit_code(outcome.exit_code);
 }
 
 /// `exclude = *.log` is the simple-exclude form upstream parses with
@@ -214,26 +274,19 @@ fn daemon_exclude_directive_excludes_match_pattern() {
         return;
     };
 
+    assert_kept(&outcome.files, "keep1.txt", b"keep me 1");
+    assert_kept(&outcome.files, "keep2.txt", b"keep me 2");
     assert!(
-        outcome.files.contains("keep1.txt"),
-        "keep1.txt missing: {:?}",
-        outcome.files
-    );
-    assert!(
-        outcome.files.contains("keep2.txt"),
-        "keep2.txt missing: {:?}",
-        outcome.files
-    );
-    assert!(
-        !outcome.files.contains("drop1.log"),
+        !outcome.files.contains_key("drop1.log"),
         "drop1.log must be excluded by `exclude = *.log`, got {:?}",
-        outcome.files
+        outcome.files.keys().collect::<Vec<_>>()
     );
     assert!(
-        !outcome.files.contains("drop2.log"),
+        !outcome.files.contains_key("drop2.log"),
         "drop2.log must be excluded by `exclude = *.log`, got {:?}",
-        outcome.files
+        outcome.files.keys().collect::<Vec<_>>()
     );
+    assert_refused_exit_code(outcome.exit_code);
 }
 
 /// `exclude from = <file>` loads patterns one-per-line. Upstream parses each
@@ -298,6 +351,14 @@ fn daemon_exclude_from_directive_loads_pattern_file() {
             config_path.as_os_str().to_os_string(),
             OsString::from("--max-sessions"),
             OsString::from("1"),
+            // Mandatory. `RuntimeOptions::detach` defaults to `cfg!(unix)`, so
+            // `run_daemon` reaches `become_daemon()` in the accept loop; the
+            // parent of that fork is this very test process and it exits 0
+            // (`platform::daemonize::become_daemon`). Without the flag the test
+            // binary terminates successfully before a single assertion below
+            // runs and the harness records a pass - an unconditional `panic!`
+            // placed after this spawn still reported PASSED.
+            OsString::from("--no-detach"),
         ])
         .pre_bound_listener(held_listener)
         .build();
@@ -316,22 +377,26 @@ fn daemon_exclude_from_directive_loads_pattern_file() {
     let client_result = core::client::run_client(client_config);
     let daemon_result = daemon_handle.join().expect("daemon thread panicked");
 
-    if let Err(err) = client_result {
-        panic!("client push failed: {err}");
-    }
     if let Err(err) = daemon_result {
         panic!("daemon exited with error: {err:?}");
     }
+    let summary = match client_result {
+        Ok(summary) => summary,
+        Err(err) => panic!("client push failed: {err}"),
+    };
 
     let files = collect_files(&dst);
-    assert!(files.contains("keep1.txt"), "keep1.txt missing: {files:?}");
-    assert!(files.contains("keep2.txt"), "keep2.txt missing: {files:?}");
+    assert_kept(&files, "keep1.txt", b"keep1");
+    assert_kept(&files, "keep2.txt", b"keep2");
     assert!(
-        !files.contains("drop1.log"),
-        "drop1.log must be excluded by exclude-from file, got {files:?}"
+        !files.contains_key("drop1.log"),
+        "drop1.log must be excluded by exclude-from file, got {:?}",
+        files.keys().collect::<Vec<_>>()
     );
     assert!(
-        !files.contains("drop2.log"),
-        "drop2.log must be excluded by exclude-from file, got {files:?}"
+        !files.contains_key("drop2.log"),
+        "drop2.log must be excluded by exclude-from file, got {:?}",
+        files.keys().collect::<Vec<_>>()
     );
+    assert_refused_exit_code(summary.io_error_exit_code());
 }

--- a/tests/integration_daemon_server.rs
+++ b/tests/integration_daemon_server.rs
@@ -92,6 +92,73 @@ fn allocate_test_port() -> u16 {
     port
 }
 
+/// The digest name list a protocol > 31 client must advertise.
+///
+/// Upstream's daemon table is written strongest-first and is never filtered by
+/// protocol version, so a client offering all five leaves the choice to the
+/// daemon's own preference order.
+///
+/// upstream: compat.c:868-871 - `negotiate_daemon_auth()` walks the client's
+/// list; checksum.c `valid_auth_checksums_items[]` holds the names.
+const CLIENT_DIGEST_LIST: &str = "sha512 sha256 sha1 md5 md4";
+
+/// Builds the client half of the `@RSYNCD:` exchange for `protocol`.
+///
+/// The digest name list is attached only above protocol 31. That gate is not
+/// cosmetic: `exchange_protocols()` refuses a greeting that omits the list with
+/// `@ERROR: your client omitted the digest name list` and returns -1, so a bare
+/// `@RSYNCD: 32.0` never reaches the module request and every assertion past it
+/// tests the refusal instead of the feature under test. At or below protocol 31
+/// upstream leaves `daemon_auth_choices` NULL on purpose and
+/// `negotiate_daemon_auth()` substitutes `protocol_version >= 30 ? "md5" :
+/// "md4"`, which is the legacy path the protocol-29/30 tests below exercise.
+///
+/// upstream: clientserver.c:229-241 - the `remote_protocol > 31` arm of
+/// `exchange_protocols()`; compat.c:868-871 - the no-list substitution.
+fn client_greeting(protocol: u32) -> String {
+    if protocol > 31 {
+        format!("@RSYNCD: {protocol}.0 {CLIENT_DIGEST_LIST}\n")
+    } else {
+        format!("@RSYNCD: {protocol}.0\n")
+    }
+}
+
+/// Sends the client greeting for `protocol` and flushes it.
+///
+/// Mandatory before any module request or `#list`: `handle_daemon_connection()`
+/// runs `exchange_protocols()` at clientserver.c:1534 and only then reads the
+/// command line at :1538. A test that jumps straight to `#list` is answered
+/// with a startup error, not a listing.
+fn send_client_greeting(stream: &mut TcpStream, protocol: u32) {
+    stream
+        .write_all(client_greeting(protocol).as_bytes())
+        .expect("send client greeting");
+    stream.flush().expect("flush client greeting");
+}
+
+/// The argument that keeps a test-started daemon in the foreground.
+///
+/// Mandatory at every daemon site in this file. `RuntimeOptions::detach`
+/// defaults to `cfg!(unix)`, so `run_daemon` reaches `become_daemon()` in the
+/// accept loop; the parent of that fork is this test binary and it exits 0
+/// (`platform::daemonize::become_daemon`). The harness records the resulting
+/// clean exit as a pass, so every assertion in the file was unreachable.
+///
+/// The window is not the spawn itself - `thread::spawn` returns before the
+/// daemon thread reaches the fork. It is the first blocking socket call:
+/// `connect_with_retries` parks the test thread for exactly as long as the
+/// daemon needs to detach. An unconditional `panic!` placed straight after the
+/// spawn therefore still fires, while the same `panic!` placed one line later,
+/// after the connect, never runs - all 25 tests reported PASSED with 14 such
+/// panics in place.
+///
+/// upstream: clientserver.c:1758-1761 - `if (no_detach) create_pid_file(); else
+/// become_daemon();` runs before the listener is set up, which is why
+/// `--no-detach` is the daemon's own opt-out rather than a test-only knob.
+fn no_detach() -> OsString {
+    OsString::from("--no-detach")
+}
+
 /// Connect to daemon with retries.
 ///
 /// Uses aggressive initial retries (10ms) ramping to 200ms, with a 60s
@@ -143,6 +210,7 @@ fn server_lists_modules_on_request() {
             OsString::from("--module"),
             OsString::from("logs=/var/log"),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -159,26 +227,31 @@ fn server_lists_modules_on_request() {
         "expected @RSYNCD greeting, got: {line}"
     );
 
-    // Send list request (no version handshake needed for #list)
+    // The version exchange is not optional, for `#list` either:
+    // `handle_daemon_connection()` runs `exchange_protocols()` (clientserver.c:1534)
+    // and only reads the command line afterwards (:1538).
+    send_client_greeting(&mut stream, 32);
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush list request");
 
-    // Read capabilities
-    line.clear();
-    reader.read_line(&mut line).expect("capabilities");
-    assert!(line.contains("CAP"), "expected CAP line, got: {line}");
-
-    // Read OK
-    line.clear();
-    reader.read_line(&mut line).expect("ok line");
-    assert!(line.contains("OK"), "expected OK line, got: {line}");
-
-    // Read modules
+    // Read modules. `send_listing()` writes one `"%-15s\t%s\n"` row per listed
+    // module and then `@RSYNCD: EXIT`; there is no capability or OK line in the
+    // listing at all, so the reads that used to expect them consumed the module
+    // rows this test then failed to find.
+    //
+    // upstream: clientserver.c:1374-1386 - `send_listing()`.
     let mut modules = Vec::new();
+    let mut got_exit = false;
     loop {
         line.clear();
-        reader.read_line(&mut line).expect("module line");
+        // A zero-length read is end-of-file. Without this arm the loop spins on
+        // a closed socket instead of ending, which is how a listing that never
+        // reached the terminator turned into a hang rather than a failure.
+        if reader.read_line(&mut line).expect("module line") == 0 {
+            break;
+        }
         if line.contains("EXIT") {
+            got_exit = true;
             break;
         }
         let module_name = line.split('\t').next().unwrap_or(&line).trim().to_string();
@@ -186,6 +259,10 @@ fn server_lists_modules_on_request() {
             modules.push(module_name);
         }
     }
+    assert!(
+        got_exit,
+        "listing must end with @RSYNCD: EXIT, got {modules:?}"
+    );
 
     // Verify modules
     assert!(
@@ -216,6 +293,7 @@ fn server_lists_empty_when_no_modules() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -228,38 +306,25 @@ fn server_lists_empty_when_no_modules() {
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
 
-    // Send list request
+    send_client_greeting(&mut stream, 32);
     stream.write_all(b"#list\n").expect("send list request");
     stream.flush().expect("flush");
 
-    // Read response lines until EXIT (may have CAP, OK, then EXIT)
-    let mut modules = Vec::new();
-    let mut got_exit = false;
-    for _ in 0..10 {
-        line.clear();
-        if reader.read_line(&mut line).is_err() {
-            break;
-        }
-        if line.is_empty() {
-            break;
-        }
-        if line.contains("EXIT") {
-            got_exit = true;
-            break;
-        }
-        // Skip CAP and OK lines
-        if line.contains("CAP") || line.contains("OK") {
-            continue;
-        }
-        // Any other non-@ line is a module
-        let module_name = line.split('\t').next().unwrap_or(&line).trim().to_string();
-        if !module_name.is_empty() && !module_name.starts_with('@') {
-            modules.push(module_name);
-        }
-    }
-
-    assert!(got_exit, "should eventually get EXIT");
-    assert!(modules.is_empty(), "should have no modules: {modules:?}");
+    // With no modules configured, `send_listing()` writes no rows at all and
+    // the terminator is the very first line. Asserting that directly - rather
+    // than scanning up to ten lines and tolerating whatever arrives - is what
+    // makes "no modules" distinguishable from "some modules we failed to
+    // parse": the previous loop skipped any line containing "OK", which
+    // `@RSYNCD: OK` and a module named `ok` both satisfy.
+    //
+    // upstream: clientserver.c:1374-1386 - `send_listing()`.
+    line.clear();
+    reader.read_line(&mut line).expect("listing terminator");
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@RSYNCD: EXIT",
+        "an empty module set must list nothing before the terminator"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -298,6 +363,7 @@ fn server_filters_unlisted_modules() {
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -311,21 +377,25 @@ fn server_filters_unlisted_modules() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send list request
+    send_client_greeting(&mut stream, 32);
     stream.write_all(b"#list\n").expect("send list");
     stream.flush().expect("flush");
 
-    // Read CAP and OK
-    line.clear();
-    reader.read_line(&mut line).expect("cap");
-    line.clear();
-    reader.read_line(&mut line).expect("ok");
-
-    // Read modules until EXIT
+    // Read module rows until the terminator. There is no capability or OK line
+    // to skip - `send_listing()` writes rows then `@RSYNCD: EXIT`
+    // (clientserver.c:1374-1386) - and the two reads that used to consume them
+    // swallowed the single `public` row plus the terminator, after which this
+    // loop spun on end-of-file forever. `read_line` returning 0 is EOF, not a
+    // blank line, so the terminator check alone could never end the loop.
     let mut modules = Vec::new();
+    let mut got_exit = false;
     loop {
         line.clear();
-        reader.read_line(&mut line).expect("line");
+        if reader.read_line(&mut line).expect("listing line") == 0 {
+            break;
+        }
         if line.contains("EXIT") {
+            got_exit = true;
             break;
         }
         let module_name = line.split('\t').next().unwrap_or(&line).trim().to_string();
@@ -333,6 +403,10 @@ fn server_filters_unlisted_modules() {
             modules.push(module_name);
         }
     }
+    assert!(
+        got_exit,
+        "listing must end with @RSYNCD: EXIT, got {modules:?}"
+    );
 
     // Only public should be listed
     assert!(
@@ -362,6 +436,7 @@ fn server_sends_protocol_greeting_first() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -397,6 +472,7 @@ fn server_greeting_includes_version() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -435,6 +511,7 @@ fn server_greeting_includes_digests_for_protocol_31_plus() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -488,6 +565,7 @@ fn server_accepts_older_protocol_version() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -500,11 +578,9 @@ fn server_accepts_older_protocol_version() {
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
 
-    // Send older protocol version
-    stream
-        .write_all(b"@RSYNCD: 29.0\n")
-        .expect("send old version");
-    stream.flush().expect("flush");
+    // Protocol 29 is at or below the digest-list gate, so the greeting
+    // deliberately carries no list - that is the path under test.
+    send_client_greeting(&mut stream, 29);
 
     // Request list (should still work)
     stream.write_all(b"#list\n").expect("send list");
@@ -537,6 +613,7 @@ fn server_returns_error_for_unknown_module() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -550,8 +627,7 @@ fn server_returns_error_for_unknown_module() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Request non-existent module
     stream
@@ -559,18 +635,19 @@ fn server_returns_error_for_unknown_module() {
         .expect("send module");
     stream.flush().expect("flush");
 
-    // Should receive error
+    // Should receive the refusal, naming the module the client asked for. A
+    // bare `contains("@ERROR:")` would also be satisfied by the digest-list
+    // refusal that this fixture used to trip on before it sent a valid
+    // greeting, so the payload is pinned rather than the prefix.
+    //
+    // upstream: clientserver.c:1570 - `@ERROR: Unknown module '%s'`.
     line.clear();
     reader.read_line(&mut line).expect("error response");
-    assert!(
-        line.contains("@ERROR:"),
-        "should get error for unknown module: {line}"
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@ERROR: Unknown module 'nonexistent_module_xyz'",
+        "unknown-module refusal must name the requested module"
     );
-
-    // Should receive EXIT
-    line.clear();
-    reader.read_line(&mut line).expect("exit");
-    assert!(line.contains("EXIT"), "should get EXIT after error: {line}");
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -605,6 +682,7 @@ fn server_returns_error_for_access_denied() {
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -618,8 +696,7 @@ fn server_returns_error_for_access_denied() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Request restricted module from localhost (should be denied)
     stream.write_all(b"restricted\n").expect("send module");
@@ -628,10 +705,14 @@ fn server_returns_error_for_access_denied() {
     // Should receive access denied
     line.clear();
     reader.read_line(&mut line).expect("response");
-    let lower = line.to_lowercase();
+    // Pin the module name too: a refusal that named a different module, or a
+    // generic error, would satisfy a bare "access denied" substring.
+    //
+    // upstream: clientserver.c:780 -
+    // `@ERROR: access denied to %s from %s (%s)`.
     assert!(
-        line.contains("@ERROR:") && lower.contains("access denied"),
-        "should get access denied: {line}"
+        line.starts_with("@ERROR: access denied to restricted from "),
+        "hosts-deny refusal must match clientserver.c:780, got: {line}"
     );
 
     drop(reader);
@@ -640,7 +721,7 @@ fn server_returns_error_for_access_denied() {
 }
 
 #[test]
-fn server_sends_exit_after_error() {
+fn server_closes_connection_after_error() {
     let _lock = ENV_LOCK.lock().expect("env lock");
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, "0");
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, "0");
@@ -653,6 +734,7 @@ fn server_sends_exit_after_error() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -666,8 +748,7 @@ fn server_sends_exit_after_error() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Request non-existent module
     stream.write_all(b"fake_module\n").expect("send module");
@@ -676,15 +757,23 @@ fn server_sends_exit_after_error() {
     // Read error
     line.clear();
     reader.read_line(&mut line).expect("error");
-    assert!(line.contains("@ERROR:"));
-
-    // Read EXIT
-    line.clear();
-    reader.read_line(&mut line).expect("exit");
     assert_eq!(
-        line.trim(),
-        "@RSYNCD: EXIT",
-        "expected EXIT after error: {line}"
+        line.trim_end_matches(['\r', '\n']),
+        "@ERROR: Unknown module 'fake_module'",
+        "unknown-module refusal must match clientserver.c:1570"
+    );
+
+    // Then EOF, not `@RSYNCD: EXIT`. That terminator has exactly one producer
+    // upstream - `send_listing()` at clientserver.c:1385 - and the
+    // unknown-module arm at :1567-1572 writes the error and returns -1, which
+    // drops the connection. Asserting a zero-length read is the discriminating
+    // check: a daemon that kept the session open for more commands after
+    // refusing one would block here instead.
+    line.clear();
+    let trailing = reader.read_line(&mut line).expect("read after error");
+    assert_eq!(
+        trailing, 0,
+        "daemon must close the connection after the refusal, got: {line}"
     );
 
     drop(reader);
@@ -706,6 +795,7 @@ fn server_handles_empty_module_request() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -719,19 +809,25 @@ fn server_handles_empty_module_request() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Send empty line
     stream.write_all(b"\n").expect("send empty");
     stream.flush().expect("flush");
 
-    // Should receive some response (error or daemon message)
+    // An empty command line is not an error - it is a listing request.
+    // `if (!*line || strcmp(line, "#list") == 0)` sends the module listing and
+    // returns, so with no modules configured the reply is the bare terminator.
+    // The old assertion accepted `@ERROR:` *or* `@RSYNCD:`, which every line
+    // the daemon can emit satisfies; it could not tell a listing from a refusal.
+    //
+    // upstream: clientserver.c:1554-1558.
     line.clear();
     reader.read_line(&mut line).expect("response");
-    assert!(
-        line.contains("@ERROR:") || line.contains("@RSYNCD:"),
-        "should get error or daemon response for empty: {line}"
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@RSYNCD: EXIT",
+        "an empty module request must be answered with a listing"
     );
 
     drop(reader);
@@ -753,6 +849,7 @@ fn server_handles_early_disconnect() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -808,6 +905,7 @@ fn server_requests_auth_for_protected_module() {
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -821,8 +919,7 @@ fn server_requests_auth_for_protected_module() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Request protected module
     stream.write_all(b"secure\n").expect("send module");
@@ -836,7 +933,12 @@ fn server_requests_auth_for_protected_module() {
         "should get AUTHREQD challenge: {line}"
     );
 
+    // Both halves of the socket must go before the join. The daemon session is
+    // parked reading the credentials this test deliberately never sends, so a
+    // still-open `stream` - `reader` holds only a dup of it - leaves the
+    // `--once` daemon waiting and `join()` never returns.
     drop(reader);
+    drop(stream);
     let _ = handle.join();
 }
 
@@ -873,6 +975,7 @@ fn server_enforces_max_connections() {
             config_path.as_os_str().to_os_string(),
             OsString::from("--max-sessions"),
             OsString::from("2"),
+            no_detach(),
         ])
         .build();
 
@@ -885,10 +988,7 @@ fn server_enforces_max_connections() {
     let mut line = String::new();
     reader1.read_line(&mut line).expect("greeting1");
 
-    stream1
-        .write_all(b"@RSYNCD: 32.0\n")
-        .expect("send version1");
-    stream1.flush().expect("flush1");
+    send_client_greeting(&mut stream1, 32);
 
     stream1.write_all(b"limited\n").expect("send module1");
     stream1.flush().expect("flush module1");
@@ -896,35 +996,45 @@ fn server_enforces_max_connections() {
     line.clear();
     reader1.read_line(&mut line).expect("response1");
 
-    // First should get OK
-    if line.contains("OK") {
-        // Try second connection while first is active
-        let mut stream2 = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).expect("connect2");
-        stream2.set_read_timeout(Some(Duration::from_secs(5))).ok();
-        let mut reader2 = BufReader::new(stream2.try_clone().expect("clone2"));
+    // The first client must be admitted, and unconditionally so. Guarding the
+    // rest of this test with `if line.contains("OK")` made the cap assertion
+    // optional: any outcome that was not an admission - including the
+    // digest-list refusal this fixture used to provoke - skipped straight to
+    // the join and reported a pass having probed nothing.
+    assert!(
+        line.contains("@RSYNCD: OK"),
+        "first client must occupy the single connection slot, got: {line}"
+    );
 
-        line.clear();
-        reader2.read_line(&mut line).expect("greeting2");
+    // Second connection, while the first still holds the slot.
+    let mut stream2 = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).expect("connect2");
+    stream2.set_read_timeout(Some(Duration::from_secs(5))).ok();
+    let mut reader2 = BufReader::new(stream2.try_clone().expect("clone2"));
 
-        stream2
-            .write_all(b"@RSYNCD: 32.0\n")
-            .expect("send version2");
-        stream2.flush().expect("flush2");
+    line.clear();
+    reader2.read_line(&mut line).expect("greeting2");
 
-        stream2.write_all(b"limited\n").expect("send module2");
-        stream2.flush().expect("flush module2");
+    send_client_greeting(&mut stream2, 32);
 
-        line.clear();
-        reader2.read_line(&mut line).expect("response2");
+    stream2.write_all(b"limited\n").expect("send module2");
+    stream2.flush().expect("flush module2");
 
-        // Second should get max connections error
-        let lower = line.to_lowercase();
-        assert!(
-            line.contains("@ERROR:") || lower.contains("max connections"),
-            "second connection should be limited: {line}"
-        );
-    }
+    line.clear();
+    reader2.read_line(&mut line).expect("response2");
 
+    // The exact refusal, not merely "some @ERROR". `max connections = 1` is in
+    // the module config, so the payload carries that limit.
+    //
+    // upstream: clientserver.c:799 -
+    // `@ERROR: max connections (%d) reached -- try again later`.
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@ERROR: max connections (1) reached -- try again later",
+        "second client must be refused with the upstream cap payload"
+    );
+
+    drop(reader2);
+    drop(stream2);
     drop(reader1);
     drop(stream1);
     let _ = handle.join();
@@ -946,6 +1056,7 @@ fn server_lists_modules_with_comments() {
             OsString::from("--module"),
             OsString::from("docs=/srv/docs,Documentation files"),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -959,29 +1070,34 @@ fn server_lists_modules_with_comments() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send list request
+    send_client_greeting(&mut stream, 32);
     stream.write_all(b"#list\n").expect("send list");
     stream.flush().expect("flush");
 
-    // Read CAP and OK
+    // Read the single module row. The two reads that used to precede this one
+    // consumed a capability and an OK line the listing never contains
+    // (clientserver.c:1374-1386), so this read landed on end-of-file and the
+    // `if line.contains('\t')` guard below silently skipped every assertion -
+    // the test went on passing while checking nothing at all.
     line.clear();
-    reader.read_line(&mut line).expect("cap");
-    line.clear();
-    reader.read_line(&mut line).expect("ok");
+    reader.read_line(&mut line).expect("module row");
+    let row = line.trim_end_matches(['\r', '\n']);
+    let (name, comment) = row
+        .split_once('\t')
+        .unwrap_or_else(|| panic!("listing row must be tab-separated, got: {row:?}"));
+    assert_eq!(name.trim_end(), "docs", "module name should be 'docs'");
+    assert_eq!(
+        comment, "Documentation files",
+        "listing row must carry the module comment"
+    );
 
-    // Read module line
     line.clear();
-    reader.read_line(&mut line).expect("module");
-
-    // Module listing should include comment (tab-separated)
-    if line.contains('\t') {
-        let parts: Vec<&str> = line.trim().split('\t').collect();
-        assert_eq!(parts[0].trim(), "docs", "module name should be 'docs'");
-        assert_eq!(
-            parts.get(1).copied(),
-            Some("Documentation files"),
-            "comment should be included"
-        );
-    }
+    reader.read_line(&mut line).expect("terminator");
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@RSYNCD: EXIT",
+        "listing must end with the terminator"
+    );
 
     drop(reader);
     let result = handle.join().expect("daemon thread");
@@ -1002,6 +1118,7 @@ fn server_handles_invalid_greeting_response() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -1020,17 +1137,21 @@ fn server_handles_invalid_greeting_response() {
         .expect("send garbage");
     stream.flush().expect("flush");
 
-    // Daemon should handle gracefully
+    // A line that does not parse as `@RSYNCD: %d.%d` is refused with one exact
+    // message. The previous form asserted nothing twice over: the whole check
+    // sat behind `if result.is_ok() && !line.is_empty()`, so a dropped
+    // connection skipped it, and the surviving disjunction accepted any line
+    // the daemon is capable of writing.
+    //
+    // upstream: clientserver.c:209-215 - the `sscanf(...) < 1` arm of
+    // `exchange_protocols()` writes `@ERROR: protocol startup error`.
     line.clear();
-    let result = reader.read_line(&mut line);
-
-    if result.is_ok() && !line.is_empty() {
-        // Should get error or treated as module name
-        assert!(
-            line.contains("@ERROR:") || line.contains("@RSYNCD:"),
-            "should handle invalid input: {line}"
-        );
-    }
+    reader.read_line(&mut line).expect("refusal");
+    assert_eq!(
+        line.trim_end_matches(['\r', '\n']),
+        "@ERROR: protocol startup error",
+        "an unparseable greeting must be refused with the upstream text"
+    );
 
     drop(reader);
     let _ = handle.join();
@@ -1050,6 +1171,7 @@ fn server_sanitizes_module_name_in_error() {
             OsString::from("--port"),
             OsString::from(port.to_string()),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -1063,8 +1185,7 @@ fn server_sanitizes_module_name_in_error() {
     reader.read_line(&mut line).expect("greeting");
 
     // Send version
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     // Send module with control characters
     stream
@@ -1121,6 +1242,7 @@ fn start_auth_daemon() -> (
             OsString::from("--config"),
             config_path.as_os_str().to_os_string(),
             OsString::from("--once"),
+            no_detach(),
         ])
         .build();
 
@@ -1148,8 +1270,17 @@ fn perform_auth_handshake(
         "expected greeting, got: {line}"
     );
 
-    // Send client version
-    let version_line = format!("@RSYNCD: {client_protocol}.0\n");
+    // Advertise exactly the digest under test above protocol 31, so the
+    // daemon's negotiated choice is the one this handshake then computes with.
+    // Sending no list would leave the daemon on the legacy fallback
+    // (compat.c:868-871) and the `digest` argument would only ever describe the
+    // client's own arithmetic - which is how these cases could name a digest
+    // they never actually negotiated.
+    let version_line = if client_protocol > 31 {
+        format!("@RSYNCD: {client_protocol}.0 {}\n", digest.name())
+    } else {
+        format!("@RSYNCD: {client_protocol}.0\n")
+    };
     stream
         .write_all(version_line.as_bytes())
         .expect("send version");
@@ -1266,11 +1397,17 @@ fn auth_flow_protocol_29_md4_succeeds() {
     let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, "0");
     let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, "0");
 
+    // `Md4Old`, not `Md4`. A protocol-29 client sends no digest list, so
+    // `negotiate_daemon_auth()` takes the `md4` fallback with `md4_is_old = 1`
+    // and then rewrites the negotiated item to `CSUM_MD4_OLD`
+    // (compat.c:888-891), which `sum_init()` seeds with four zero bytes that an
+    // explicitly negotiated `md4` never gets. Computing plain `Md4` here
+    // produces a response the daemon is correct to reject.
     let (port, _temp, handle) = start_auth_daemon();
-    let result = perform_auth_handshake(port, 29, daemon::auth::DaemonAuthDigest::Md4);
+    let result = perform_auth_handshake(port, 29, daemon::auth::DaemonAuthDigest::Md4Old);
     assert!(
         result.contains("OK"),
-        "protocol 29 with MD4 should succeed: {result}"
+        "protocol 29 must authenticate with the seeded legacy MD4: {result}"
     );
     let _ = handle.join();
 }
@@ -1326,8 +1463,7 @@ fn auth_flow_wrong_password_rejected() {
     let mut line = String::new();
     reader.read_line(&mut line).expect("greeting");
 
-    stream.write_all(b"@RSYNCD: 32.0\n").expect("send version");
-    stream.flush().expect("flush");
+    send_client_greeting(&mut stream, 32);
 
     stream.write_all(b"authmod\n").expect("send module");
     stream.flush().expect("flush");

--- a/tools/ci/check_daemon_no_detach.sh
+++ b/tools/ci/check_daemon_no_detach.sh
@@ -50,7 +50,9 @@ PENDING_CEILING=77
 # one is vacuous on Unix: the daemon forks, this test binary is the parent, and
 # it exits 0 before any assertion runs. Lower this as they are fixed; it must
 # never be raised.
-ROOT_DETACHING_CEILING=2
+#
+# The one remaining file is tests/integration_daemon_max_connections_cap.rs.
+ROOT_DETACHING_CEILING=1
 
 violations=0
 

--- a/tools/ci/check_daemon_no_detach.sh
+++ b/tools/ci/check_daemon_no_detach.sh
@@ -21,6 +21,10 @@
 #      `*_pending_no_detach` helpers only ever shrinks. Those tests predate the
 #      foreground requirement and are migrated in separate slices; the ceiling
 #      below must be lowered as they are, never raised.
+#   4. Root-level integration tests that run the daemon in-process pass
+#      `--no-detach`. They live outside the daemon crate and cannot reach its
+#      test-support helpers, so checks 1-3 are blind to them - and the fork
+#      kills the whole test binary there just the same.
 #
 # Usage:
 #   tools/ci/check_daemon_no_detach.sh
@@ -36,10 +40,17 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 TESTS_DIR="${REPO_ROOT}/crates/daemon/src/tests"
 SUPPORT="${TESTS_DIR}/support.rs"
+ROOT_TESTS_DIR="${REPO_ROOT}/tests"
 
 # Lower this when a migration slice converts call sites to the guarded helpers.
 # It must never be raised.
 PENDING_CEILING=77
+
+# Root-level integration tests that call run_daemon() without --no-detach. Each
+# one is vacuous on Unix: the daemon forks, this test binary is the parent, and
+# it exits 0 before any assertion runs. Lower this as they are fixed; it must
+# never be raised.
+ROOT_DETACHING_CEILING=2
 
 violations=0
 
@@ -82,6 +93,26 @@ if [ "${pending}" -gt "${PENDING_CEILING}" ]; then
     printf 'FAIL: %s call sites still start a detaching daemon, ceiling is %s.\n' \
         "${pending}" "${PENDING_CEILING}" >&2
     printf '      New daemon tests must use start_daemon()/spawn_daemon().\n' >&2
+    violations=$((violations + 1))
+fi
+
+# 4. Root-level integration tests cannot reach the daemon crate's helpers, so
+#    they carry the flag themselves or they are vacuous.
+detaching=()
+while IFS= read -r file; do
+    [ -n "${file}" ] || continue
+    grep -q -- '--no-detach' "${file}" || detaching+=("${file#"${REPO_ROOT}/"}")
+done < <(grep -rl 'run_daemon(' "${ROOT_TESTS_DIR}" --include='*.rs' | sort)
+
+printf 'Root tests running a detaching daemon: %s (ceiling %s)\n' \
+    "${#detaching[@]}" "${ROOT_DETACHING_CEILING}"
+if [ "${#detaching[@]}" -gt "${ROOT_DETACHING_CEILING}" ]; then
+    printf 'FAIL: %s root integration test(s) call run_daemon() without --no-detach, ceiling is %s:\n' \
+        "${#detaching[@]}" "${ROOT_DETACHING_CEILING}" >&2
+    printf '  %s\n' "${detaching[@]}" >&2
+    printf '      The daemon forks and the test binary - its parent - exits 0\n' >&2
+    printf '      before any assertion runs, so the test reports a pass without\n' >&2
+    printf '      proving anything. Pass --no-detach in the daemon arguments.\n' >&2
     violations=$((violations + 1))
 fi
 


### PR DESCRIPTION
## The defect

All three tests in `tests/integration_daemon_filter_directives.rs` started the daemon without `--no-detach`. `RuntimeOptions::detach` defaults to `cfg!(unix)`, so `run_daemon` reached `become_daemon()` in the accept loop and the parent of that fork - the test binary itself - exited 0 before any assertion ran.

Proven by mutation on the base commit. With an unconditional `panic!` inserted immediately after the daemon spawn:

```
Starting 3 tests across 1 binary (88 binaries skipped)
     Summary [   0.025s] 3 tests run: 3 passed, 0 skipped
```

The tell was the runtime: 0.029s for three full TCP transfers through an in-process daemon.

## What making them execute surfaced

The tests checked only that `run_client` returned `Ok`. A daemon-refused push does not return `Err`:

- `generator.c:1669-1671` reports the refusal as `FERROR_XFER`
- `log.c:337-338` sets `got_xfer_error` on receipt
- `cleanup.c:217-218` lifts the exit status to `RERR_PARTIAL` (23, `errcode.h:43`)

That status arrives on `ClientSummary::io_error_exit_code`, not as an error, so the push's actual outcome was never asserted. It is 23 in all three scenarios, and nothing noticed.

This matters because the assertions that did exist are one-sided. `!files.contains("drop1.log")` is satisfied just as well by a transfer that achieved nothing at all. Each test now asserts exit 23 as the positive signal that the module directive actually fired.

Two smaller corrections in the same pass:

- `collect_files` carries file contents alongside the names, so a kept file has to arrive intact rather than merely exist.
- The module header's upstream citations were on 3.4.4 line numbers. Moved onto the 3.5.0 pin: `clientserver.c:934-951`, `receiver.c:889`, `generator.c:1663`.

## Mutation proofs

Each mutation reddens a distinct assertion, so neither is carrying the other.

**Silencing the `FERROR_XFER` frame** in `crates/transfer/src/receiver/transfer/candidates.rs` - files are still excluded, so the on-disk assertions stay green and only the new assertion fires:

```
thread 'daemon_filter_directive_excludes_match_pattern' panicked at tests/integration_daemon_filter_directives.rs:120:5:
assertion `left == right` failed: a push whose files the module refused must exit 23 (cleanup.c:217-218), not report success
  left: None
 right: Some(23)
 Summary [   0.107s] 3 tests run: 0 passed, 3 failed, 0 skipped
```

Without the added exit-code assertion this regression would have been invisible.

**Disabling the daemon filter check** - the excluded files land and the file's own claim fires:

```
thread 'daemon_filter_directive_excludes_match_pattern' panicked at tests/integration_daemon_filter_directives.rs:251:5:
drop1.log must be excluded by `filter = - *.log`, got ["drop1.log", "drop2.log", "keep1.txt", "keep2.txt"]
 Summary [   0.122s] 3 tests run: 0 passed, 3 failed, 0 skipped
```

Unmutated: `3 tests run: 3 passed, 0 skipped`.

## Guard

`tools/ci/check_daemon_no_detach.sh` covered only `crates/daemon/src/tests`. Root-level integration tests live outside the daemon crate and cannot reach its test-support helpers, so checks 1-3 were blind to them while the fork killed the test binary there just the same. A fourth check counts root tests calling `run_daemon(` without `--no-detach`, with a shrink-only ceiling at the 2 files still to be migrated.

Verified the guard fires rather than passing vacuously - temporarily lowering the ceiling to 1:

```
Root tests running a detaching daemon: 2 (ceiling 1)
FAIL: 2 root integration test(s) call run_daemon() without --no-detach, ceiling is 1:
  tests/integration_daemon_max_connections_cap.rs
  tests/integration_daemon_server.rs
```

Those two are being migrated separately. This check overlaps the one in #7578, which fixes `integration_daemon_max_connections_cap.rs`; whichever lands second should lower the ceiling again.

## Gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean
- `bash tools/ci/check_daemon_no_detach.sh` - no violations
- `cargo xtask citations` - exit 0, all citations resolve against the rsync 3.5.0 pin
