### PR TITLE
fix(build): make daemon-seccomp reachable from the oc-rsync binary

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -200,6 +200,20 @@ jobs:
             args: "-p fast_io --features landlock"
             apt: ""
             needs_bin: false
+          # The feature originates in `daemon` but has to be reachable from the
+          # root `bin` package that owns the `oc-rsync` binary, or no shipped
+          # build can ever carry the filter. That forwarding edge is what this
+          # row pins, hence the qualified `bin/daemon-seccomp` spec: a bare
+          # `--features daemon-seccomp` alongside `-p daemon` resolves against
+          # the daemon crate and passes even when the root package declares
+          # nothing - exactly the hole that let the edge go missing. Selecting
+          # `-p bin` builds the `[[bin]]` as part of the test build, and with
+          # the row's feature set rather than the default one, so this row is
+          # `needs_bin: false` for the same reason `default-features` is.
+          - name: daemon-seccomp
+            args: "-p bin -p daemon --features bin/daemon-seccomp"
+            apt: ""
+            needs_bin: false
           - name: openssl
             args: "-p checksums --features openssl"
             apt: "libssl-dev pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,22 @@ async = ["daemon/async", "core/async"]
 # systemd sd-notify integration for daemon
 sd-notify = ["daemon/sd-notify"]
 
+# ============================================================================
+# Security Hardening Features
+# ============================================================================
+
+# Seccomp BPF syscall allowlist for the daemon's post-fork TCP worker, layered
+# above the Landlock LSM defense that Linux builds already compile in. Linux
+# only: `daemon`'s `seccompiler` dependency is `cfg(target_os = "linux")`-gated,
+# so enabling this elsewhere is a no-op rather than an error.
+#
+# Two different defaults, do not conflate them. At BUILD time the feature is
+# opt-in and NOT in `default`, so stock `oc-rsync` binaries - including the
+# release artefacts - carry no filter. Once compiled in, the filter is ON at
+# RUNTIME by default; operators opt out with `OC_RSYNC_NO_SECCOMP=1` or
+# `OC_RSYNC_DAEMON_SECCOMP=0`. See `docs/design/lsm-seccomp-allowlist.md`.
+daemon-seccomp = ["daemon/daemon-seccomp"]
+
 [dependencies]
 cli = { path = "crates/cli", default-features = false }
 daemon = { path = "crates/daemon", default-features = false }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Separately, [Upstream Testsuite 3.5.0dev](https://github.com/oferchen/rsync/acti
 
 | Platform | Tier | Notes |
 |---|---|---|
-| Linux x86_64 / aarch64 | **Tier 1** | Full `io_uring` + `splice` + `vmsplice` + Landlock + seccomp. Every required CI cell runs the full nextest workspace. Production deployment target. |
+| Linux x86_64 / aarch64 | **Tier 1** | Full `io_uring` + `splice` + `vmsplice` + Landlock. Every required CI cell runs the full nextest workspace. Production deployment target. A seccomp BPF syscall allowlist for the daemon worker is available behind `--features daemon-seccomp`; it is off in default builds and in the released binaries. |
 | macOS x86_64 / aarch64 | **Tier 1** | `kqueue` + `sendfile` + `clonefile`. Every required CI cell runs the full nextest workspace. Full metadata, ACL, and xattr parity including AppleDouble (`._foo`) resource-fork preservation. |
 | Windows x86_64 | **Tier 2** | IOCP file I/O, `TransmitFile`, ReFS reflink, `CopyFileExW`, `FILE_FLAG_DELETE_ON_CLOSE`. `splice` / `vmsplice` / `io_uring` are Linux-only and intentionally not implemented; the receiver uses IOCP-batched `WriteFile`, which is faster than the upstream Cygwin `read`/`write` fallback. NTFS DACL preservation, xattrs via NTFS Alternate Data Streams, and IOCP socket I/O (`WSARecv` / `WSASend`) are shipped; POSIX symlinks are materialized (directory links fall back to a junction when unprivileged, unprivileged file symlinks are skipped with a warning), while POSIX device nodes / FIFOs remain stubbed in line with NTFS limits. Required CI cells test the `core`, `engine`, and `cli` crates. See [Windows support matrix](docs/user/windows-support-matrix.md) and the [Windows Tier 2 stub inventory](docs/audits/win-tier2-stub-inventory.md). |
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -36,9 +36,14 @@ acl = ["core/acl", "metadata/acl"]
 # Filename charset transcoding via the module `charset =` directive (iconv).
 iconv = ["core/iconv", "protocol/iconv"]
 # Seccomp BPF syscall allowlist applied to the post-fork worker on Linux,
-# layered above the SEC-1.p Landlock LSM defense. Opt-in until the 14-day bake
-# in `docs/design/lsm-seccomp-allowlist.md` completes. No-op on non-Linux
-# (the dependency is `cfg(target_os = "linux")`-gated).
+# layered above the SEC-1.p Landlock LSM defense. Two defaults, distinct: the
+# feature is opt-in at BUILD time (absent from every default feature set, so
+# release artefacts carry no filter), and the filter is ON at RUNTIME once the
+# feature is compiled in - `OC_RSYNC_NO_SECCOMP=1` or
+# `OC_RSYNC_DAEMON_SECCOMP=0` opts out. See
+# `docs/design/lsm-seccomp-allowlist.md`. Reach it from the `oc-rsync` binary
+# with the root package's `daemon-seccomp` forwarding feature. No-op on
+# non-Linux (the dependency is `cfg(target_os = "linux")`-gated).
 daemon-seccomp = ["dep:seccompiler"]
 # Opt-in (default-off): let the daemon-sender's socket write side dispatch
 # io_uring `IORING_OP_SEND_ZC` when the client sends `--zero-copy` and the

--- a/docs/design/lsm-seccomp-allowlist.md
+++ b/docs/design/lsm-seccomp-allowlist.md
@@ -166,13 +166,22 @@ Alternatives considered and rejected:
 
 1. Phase 5 landed the feature behind `--features daemon-seccomp`.
 2. 14-day bake completed with zero missing-syscall reports.
-3. The filter is now **default-ON** when the feature is compiled in.
-   Operators opt out with `OC_RSYNC_NO_SECCOMP=1` or
-   `OC_RSYNC_DAEMON_SECCOMP=0`.
-4. Stdio daemon sessions (remote-shell mode via `lsh.sh` / SSH) are
+3. The filter is now **default-ON at runtime** when the feature is compiled
+   in. Operators opt out with `OC_RSYNC_NO_SECCOMP=1` or
+   `OC_RSYNC_DAEMON_SECCOMP=0`. This says nothing about the build-time
+   default, which is covered next.
+4. The feature remains **off at build time**: it is not in the `default`
+   feature set of the root `bin` package that owns the `oc-rsync` binary, so
+   the release artefacts contain no filter at all. Reaching it requires an
+   explicit `--features daemon-seccomp` (the root package forwards to
+   `daemon/daemon-seccomp`). Flipping that build-time default is a separate,
+   gated decision: the allowlist is derived from a 3.5.0 syscall survey and
+   still has open gaps against parts of the tree, so a default flip would
+   `EPERM` legitimate operations.
+5. Stdio daemon sessions (remote-shell mode via `lsh.sh` / SSH) are
    excluded - the filter only applies to TCP worker threads, never to a
    whole stdio process where it would restrict post-transfer cleanup.
-5. The companion `landlock-feature-guidance.md` documents the layered
+6. The companion `landlock-feature-guidance.md` documents the layered
    defense story for distro packagers.
 
 ## Allowlist completeness criterion

--- a/docs/packaging/landlock-feature-guidance.md
+++ b/docs/packaging/landlock-feature-guidance.md
@@ -139,25 +139,20 @@ oc-rsync --daemon --no-detach --log-file=- 2>&1 | \
 
 `daemon-seccomp` adds a kernel-enforced syscall allowlist on top of Landlock. Where Landlock denies a path-based syscall with `EACCES`, seccomp denies an unlisted syscall with `SIGSYS` before the kernel ever consults the LSM stack. The two layers compose: a regression that bypasses `*at` helpers still hits Landlock; one that skips Landlock still hits seccomp.
 
-`daemon-seccomp` is a feature of the `daemon` crate. Enable it by adding it to the daemon dependency in the workspace root `Cargo.toml`, then run a plain build:
-
-```toml
-# root Cargo.toml
-daemon = { path = "crates/daemon", default-features = false, features = ["daemon-seccomp"] }
-```
+`daemon-seccomp` originates in the `daemon` crate; the root package forwards it, so packagers enable it on the command line and need no manifest edit:
 
 ```sh
-cargo build --release --bin oc-rsync --locked
+cargo build --release --bin oc-rsync --locked --features daemon-seccomp
 ```
 
-Landlock is already compiled in (no `landlock` flag), and there is no root-level `landlock` / `daemon-seccomp` feature; passing either to `--features` on the `oc-rsync` binary fails.
+Landlock is already compiled in and has no root-level `landlock` flag; passing `--features landlock` to the `oc-rsync` binary fails.
 
-- Opt-in only until the 14-day bake window in `docs/design/lsm-seccomp-allowlist.md` completes. Default builds remain seccomp-free; distros that want the extra layer enable both flags.
-- Default action is `KILL_PROCESS`: an unlisted syscall delivers `SIGSYS` synchronously and terminates the worker. The parent `accept(2)` loop survives, so the daemon keeps serving other clients.
+- Build-time opt-in, and it stays that way: `daemon-seccomp` is not in the root package's `default` list, so stock builds and the released binaries carry no filter. Once compiled in, the filter is on at runtime by default; `OC_RSYNC_NO_SECCOMP=1` or `OC_RSYNC_DAEMON_SECCOMP=0` turns it off without a rebuild.
+- Default action is `Errno(EPERM)`, not `KILL_PROCESS`: an unlisted syscall fails with `EPERM` and the worker stays alive, so a filter gap degrades a transfer rather than killing it mid-flight.
 - Per-architecture: `x86_64` and `aarch64` are supported. On other architectures the helper logs `seccomp BPF unavailable in this build` and Landlock remains the sole layer.
 - Stackable with chroot, mount namespaces, AppArmor, SELinux, and Landlock. No extra system dependencies; `seccompiler` is a pure-Rust crate that talks to `seccomp(2)` directly.
 
-The 14-day bake window starts at merge of the opt-in feature. After zero missing-syscall reports, a follow-up PR flips the feature on by default for Linux release builds; operators who need to opt out get `--no-default-features` or a build-time exclude.
+The 14-day bake window completed with zero missing-syscall reports, which is what made the filter default-on *at runtime* once compiled in. It did not make it default-on *at build time*, and no follow-up has flipped that: the allowlist still has open gaps against parts of the tree, so enabling it for every Linux release build would `EPERM` legitimate operations. Distros that want the extra layer opt in explicitly, per the build recipe above.
 
 ## Diagnostics: `--lsm-status` flag
 


### PR DESCRIPTION
## The defect

`daemon-seccomp` is declared in exactly one manifest, `crates/daemon/Cargo.toml:42`:

```toml
daemon-seccomp = ["dep:seccompiler"]
```

The root manifest is package `bin`, which owns `[[bin]] name = "oc-rsync"`. It pulls `daemon` with `default-features = false` and forwards exactly two of its features -- `daemon/async` and `daemon/sd-notify`. `crates/cli/Cargo.toml`, the only other dependent, forwards `daemon/async-daemon` and nothing else. Neither forwards `daemon-seccomp`.

```
$ grep -rn "daemon-seccomp" --include=Cargo.toml .
./crates/daemon/Cargo.toml:42:daemon-seccomp = ["dep:seccompiler"]
./crates/daemon/Cargo.toml:116:# `daemon-seccomp` feature is enabled. AWS rust-vmm maintained, safe-wrapper
```

Consequences:

1. **The feature is unreachable from the shipped binary.** `-p bin --all-features` enables only `bin`'s own declared features, and this is not one of them. The only invocation that compiles the filter in is a *workspace* `--all-features` (`ci.yml:131` clippy, `ci.yml:299` nextest). The release artefacts are built by `release-cross.yml:229` (`cargo build --locked --profile dist --target ... --features openssl`) and `:358` (`cross build ... --features openssl-vendored`) -- default features plus openssl. **No released `oc-rsync` has the worker filter compiled in.**
2. **`README.md` was false.** The Tier-1 Linux row read `Full io_uring + splice + vmsplice + Landlock + seccomp`. Landlock is real -- `crates/daemon/Cargo.toml` pins `fast_io` with `features = ["landlock"]` unconditionally on Linux. seccomp was in no shipped build.
3. **`crates/daemon/Cargo.toml` carried a stale comment** -- "Opt-in until the 14-day bake in `docs/design/lsm-seccomp-allowlist.md` completes" -- contradicted by that doc's own Bake plan, which records the bake as completed and the filter as default-ON. The two statements are about different defaults: the doc means the *runtime* default within the feature, the manifest comment reads as if the *build-time* opt-in were provisional.

Two further errors surfaced while fixing (3), both in `docs/packaging/landlock-feature-guidance.md`, the doc distro packagers are pointed at:

- It told packagers to hand-edit the root manifest's `daemon` dependency, because "there is no root-level `landlock` / `daemon-seccomp` feature; passing either to `--features` on the `oc-rsync` binary fails." True before this PR, and the reason the recipe existed.
- It stated "Default action is `KILL_PROCESS`". The code uses `SeccompAction::Errno(libc::EPERM as u32)` (`crates/daemon/src/daemon/sections/seccomp.rs:110`), and the design doc explicitly lists `KillProcess` under "alternatives considered and rejected". Corrected.

## Non-vacuity proof

New CI row in `.github/workflows/_test-features.yml`, Linux feature matrix:

```yaml
- name: daemon-seccomp
  args: "-p bin -p daemon --features bin/daemon-seccomp"
  apt: ""
  needs_bin: false
```

**RED on the pre-change manifest** (pristine `origin/master`, 69359e3):

```
$ cargo build -p bin --features daemon-seccomp
error: the package 'bin' does not contain this feature: daemon-seccomp
help: package with the missing feature: daemon
```

and the row's exact selection:

```
$ cargo tree -p bin -p daemon --features bin/daemon-seccomp -e no-normal -e no-build -e no-dev
error: none of the selected packages contains this feature: bin/daemon-seccomp
selected packages: daemon, bin
```

Negative control for consequence 1 -- even `--all-features` on `bin` leaves the crate out of the graph on a Linux target:

```
$ cargo tree -p bin --all-features --target x86_64-unknown-linux-gnu -i seccompiler
error: package ID specification `seccompiler` did not match any packages
```

**GREEN after the manifest edit:**

```
$ cargo tree -p bin -p daemon --features bin/daemon-seccomp -e no-normal -e no-build -e no-dev
bin v0.6.4 (...)

daemon v0.6.4 (.../crates/daemon)

$ cargo tree -p bin --features daemon-seccomp --target x86_64-unknown-linux-gnu -i seccompiler
seccompiler v0.5.0
└── daemon v0.6.4 (.../crates/daemon)
    ├── bin v0.6.4 (...)
    └── cli v0.6.4 (.../crates/cli)
        └── bin v0.6.4 (...)

$ cargo check --locked -p bin --features daemon-seccomp
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.91s
```

### Why the qualified `bin/daemon-seccomp` spec

A bare `--features daemon-seccomp` alongside `-p daemon` is **vacuous**. Verified on pre-change `origin/master`:

```
$ cargo tree -p bin -p daemon --features daemon-seccomp -e no-normal -e no-build -e no-dev
bin v0.6.4 (...)

daemon v0.6.4 (.../crates/daemon)
```

No error -- cargo resolves the bare name against `daemon`, which does declare it, so the row would have been green on the broken manifest and proved nothing. The qualified spec names the forwarding edge and nothing else.

### `needs_bin` and the bin-build-coverage gate

`tools/ci/check_bin_build_coverage.py` derives `bin` as both a resolver-consumer crate and the package owning the `[[bin]]`. A row selecting `-p bin` builds `oc-rsync` as part of its own test build -- and at the row's feature set rather than the default one, which the shared "Build oc-rsync" step could not do. Same reasoning as the existing `--workspace` `default-features` row, hence `needs_bin: false`. Gate run locally against the edited YAML:

```
$ python3 tools/ci/check_bin_build_coverage.py
resolver-consumer crates (derived): bin, cli, core, engine, metadata, test-support, transfer
package owning the oc-rsync [[bin]]: bin
examined 73 test cell(s) across 54 workflow file(s)
ok: every test cell that can reach the resolver builds oc-rsync first
```

`tools/ci/check_locked_flags.sh` and `tools/ci/check_pr_check_name_uniqueness.py` also pass.

Runtime risk from the new row is nil: `ci.yml:299` already runs `--workspace --all-features`, which enables `daemon-seccomp` and runs `bin`'s integration tests against a filtered daemon. The row adds manifest-edge coverage, not new runtime exposure.

## The default is deliberately unchanged

`daemon-seccomp` stays out of `default`. The allowlist is derived from a 3.5.0 syscall survey and has open gaps against parts of the tree; flipping the build-time default would `EPERM` legitimate operations. That flip is a separate, gated decision and is not proposed here. The runtime default within the feature is untouched -- still ON once compiled in, with `OC_RSYNC_NO_SECCOMP=1` / `OC_RSYNC_DAEMON_SECCOMP=0` as the opt-outs.

## Verification

- `cargo fmt --all -- --check` -- clean.
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` -- fails on a pre-existing `clippy::collapsible_if` in `crates/logging/src/tracing_bridge.rs:194` under local rustc 1.94. This PR touches no `.rs` file (diff is 4 manifests/docs + 1 workflow), so the result is identical to master.
- No `Cargo.lock` change: `seccompiler` was already locked as an optional dependency of `daemon`.
