### PR TITLE
fix(daemon): keep accepting after one client's session error

### DIFF
--- a/crates/daemon/src/daemon/sections/module_parsing/errors.rs
+++ b/crates/daemon/src/daemon/sections/module_parsing/errors.rs
@@ -170,13 +170,6 @@ fn accept_error(address: SocketAddr, error: io::Error) -> DaemonError {
     network_error("accept connection on", address, error)
 }
 
-fn stream_error(peer: Option<SocketAddr>, action: &str, error: io::Error) -> DaemonError {
-    match peer {
-        Some(addr) => network_error(action, addr, error),
-        None => network_error(action, "connection", error),
-    }
-}
-
 fn network_error<T: fmt::Display>(action: &str, target: T, error: io::Error) -> DaemonError {
     let text = format!("failed to {action} {target}: {error}");
     DaemonError::new(

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_engine.rs
@@ -641,7 +641,7 @@ fn run_accept_loop(
     state: &mut AcceptLoopState<'_>,
 ) -> Result<(), DaemonError> {
     loop {
-        if let Some(true) = check_signals_and_maintain(state)? {
+        if let Some(true) = check_signals_and_maintain(state) {
             break;
         }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -386,7 +386,7 @@ fn serve_connections(
     let mut engine = build_accept_engine(listeners, &bound_addresses, &state)?;
     run_accept_loop(engine.as_mut(), &mut state)?;
 
-    let result = drain_workers(&mut state.workers);
+    drain_workers(&mut state.workers, log_sink.as_ref());
 
     let shutdown_status = match state.served {
         0 => String::from("No connections handled; shutting down"),
@@ -408,5 +408,5 @@ fn serve_connections(
 
     drop(pid_guard);
 
-    result
+    Ok(())
 }

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -31,12 +31,13 @@ struct AcceptLoopState<'a> {
 
 /// Checks signal flags and performs maintenance tasks between accept iterations.
 ///
-/// Returns `Some(true)` to break the loop, `None` to continue. Propagates
-/// errors from worker reaping.
-fn check_signals_and_maintain(
-    state: &mut AcceptLoopState<'_>,
-) -> Result<Option<bool>, DaemonError> {
-    reap_finished_workers(&mut state.workers)?;
+/// Returns `Some(true)` to break the loop, `None` to continue. Nothing this
+/// step does can end the daemon: reaping a worker only reports one finished
+/// session, and reload/status failures are logged in place. That mirrors
+/// upstream's accept loop, whose body has no error exit at all
+/// (socket.c:724-778).
+fn check_signals_and_maintain(state: &mut AcceptLoopState<'_>) -> Option<bool> {
+    reap_finished_workers(&mut state.workers, state.log_sink.as_ref());
 
     if state.signal_flags.shutdown.load(Ordering::Relaxed) {
         if let Some(log) = state.log_sink.as_ref() {
@@ -44,7 +45,7 @@ fn check_signals_and_maintain(
                 .with_role(Role::Daemon);
             log_message(log, &message);
         }
-        return Ok(Some(true));
+        return Some(true);
     }
 
     // upstream: main.c - SIGUSR1 stops accepting new connections
@@ -64,7 +65,7 @@ fn check_signals_and_maintain(
         {
             log_sd_notify_failure(state.log_sink.as_ref(), "graceful exit status", &error);
         }
-        return Ok(Some(true));
+        return Some(true);
     }
 
     if state
@@ -105,7 +106,7 @@ fn check_signals_and_maintain(
         state.active_connections = current_active;
     }
 
-    Ok(None)
+    None
 }
 
 /// Refuses an accepted socket once the daemon hits its concurrent

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -198,8 +198,7 @@ fn describe_panic_payload_handles_non_string_payload() {
 #[test]
 fn join_worker_handles_successful_thread() {
     let handle = thread::spawn(|| Ok(()));
-    let result = join_worker(handle);
-    assert!(result.is_ok());
+    join_worker(handle, None);
 }
 
 #[test]
@@ -210,11 +209,7 @@ fn join_worker_handles_connection_closed_error() {
             io::Error::new(io::ErrorKind::BrokenPipe, "connection closed"),
         ))
     });
-    let result = join_worker(handle);
-    assert!(
-        result.is_ok(),
-        "BrokenPipe should be treated as normal close"
-    );
+    join_worker(handle, None);
 }
 
 #[test]
@@ -223,10 +218,44 @@ fn join_worker_swallows_panicking_thread() {
         panic!("simulated handler crash");
     });
     // join_worker blocks until the thread completes - no sleep needed
-    let result = join_worker(handle);
+    join_worker(handle, None);
+}
+
+/// The classification this fix rests on: a worker carries the outcome of one
+/// session, so no error it can hold is fatal to the listener. Reaping a
+/// worklist of session failures must drain it and hand nothing back the accept
+/// loop could act on.
+///
+/// upstream: socket.c:679 `waitpid(-1, NULL, WNOHANG)` - the parent reaps the
+/// per-connection child with a NULL status pointer and never inspects the
+/// session's outcome at all.
+#[test]
+fn reap_finished_workers_drains_session_failures_without_a_fatal_channel() {
+    let mut workers: Vec<thread::JoinHandle<WorkerResult>> = Vec::new();
+    for kind in [
+        io::ErrorKind::InvalidData,
+        io::ErrorKind::PermissionDenied,
+        io::ErrorKind::BrokenPipe,
+        io::ErrorKind::TimedOut,
+    ] {
+        workers.push(thread::spawn(move || {
+            Err((
+                Some("127.0.0.1:12345".parse().unwrap()),
+                io::Error::new(kind, "session failure"),
+            ))
+        }));
+    }
+    for handle in &workers {
+        while !handle.is_finished() {
+            thread::yield_now();
+        }
+    }
+
+    reap_finished_workers(&mut workers, None);
+
     assert!(
-        result.is_ok(),
-        "join_worker must swallow panics to keep the daemon alive"
+        workers.is_empty(),
+        "every finished worker must be reaped regardless of how its session ended"
     );
 }
 

--- a/crates/daemon/src/daemon/sections/server_runtime/workers.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/workers.rs
@@ -1,59 +1,91 @@
 type WorkerResult = Result<(), (Option<SocketAddr>, io::Error)>;
 
-/// Joins finished worker threads and propagates fatal errors.
+/// Joins finished worker threads.
 ///
 /// Iterates through the worker list, joining any that have completed. This
 /// prevents unbounded thread handle accumulation in long-running daemons.
 fn reap_finished_workers(
     workers: &mut Vec<thread::JoinHandle<WorkerResult>>,
-) -> Result<(), DaemonError> {
+    log_sink: Option<&SharedLogSink>,
+) {
     let mut index = 0;
     while index < workers.len() {
         if workers[index].is_finished() {
             let handle = workers.remove(index);
-            join_worker(handle)?;
+            join_worker(handle, log_sink);
         } else {
             index += 1;
         }
     }
-    Ok(())
 }
 
 /// Waits for all remaining worker threads to complete.
-fn drain_workers(workers: &mut Vec<thread::JoinHandle<WorkerResult>>) -> Result<(), DaemonError> {
+fn drain_workers(
+    workers: &mut Vec<thread::JoinHandle<WorkerResult>>,
+    log_sink: Option<&SharedLogSink>,
+) {
     while let Some(handle) = workers.pop() {
-        join_worker(handle)?;
+        join_worker(handle, log_sink);
     }
-    Ok(())
 }
 
-/// Joins a single worker thread and maps its result to a `DaemonError`.
+/// Joins a single worker thread and reports its outcome.
 ///
-/// Normal connection closures (broken pipe, reset, aborted) are treated as
-/// success. Panics that escape `catch_unwind` are logged and swallowed to
-/// keep the daemon alive.
+/// A worker runs exactly one session against one accepted socket, so every
+/// outcome it can carry - an I/O failure on that socket, a rejected protocol
+/// state transition, a panic that escaped `catch_unwind` - describes that one
+/// connection and nothing else. None of them says anything about the listening
+/// socket, whose own failures travel a different path entirely: `bind_error`
+/// when a listener cannot be bound or made non-blocking, and the accept
+/// engine's `poll` result. Those still propagate and still end the daemon.
 ///
-/// upstream: rsync forks per connection, so a crash only kills that
-/// child process.
-fn join_worker(handle: thread::JoinHandle<WorkerResult>) -> Result<(), DaemonError> {
+/// The join point therefore has no fatal class to report, which is why it
+/// returns nothing at all rather than a `Result` a caller might act on.
+///
+/// upstream: socket.c:753-765 `start_accept_loop()` runs the session in a
+/// forked child that ends at `_exit(ret)`, and socket.c:676-684
+/// `sigchld_handler()` reaps it with `waitpid(-1, NULL, WNOHANG)` - a NULL
+/// status pointer, so the parent discards the session's outcome without ever
+/// inspecting it. The `while (1)` loop at socket.c:724 has no error exit;
+/// `poll` failure (:738), `accept` failure (:748) and even `fork` failure
+/// (:766) each keep the loop running. Only listener setup is fatal, via
+/// `exit_cleanup(RERR_SOCKETIO)` at socket.c:699 and socket.c:715.
+fn join_worker(handle: thread::JoinHandle<WorkerResult>, log_sink: Option<&SharedLogSink>) {
     match handle.join() {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err((peer, error))) => {
-            let kind = error.kind();
-            if is_connection_closed_error(kind) {
-                Ok(())
-            } else {
-                Err(stream_error(peer, "serve legacy handshake", error))
-            }
-        }
+        Ok(Ok(())) => {}
+        Ok(Err((peer, error))) => report_session_failure(peer, &error, log_sink),
         Err(payload) => {
             let description = describe_panic_payload(payload);
             let error = io::Error::other(format!(
                 "worker thread panicked (unwind escaped catch_unwind): {description}"
             ));
             eprintln!("{error} [daemon={}]", env!("CARGO_PKG_VERSION"));
-            Ok(())
         }
+    }
+}
+
+/// Logs a session that ended in an error, without disturbing the accept loop.
+///
+/// Normal connection closures (broken pipe, reset, aborted) are silent: they
+/// are how a finished client leaves, not a failure. Everything else is
+/// reported at error level against the peer that caused it, mirroring the
+/// per-connection child's own diagnostic in upstream's fork model.
+fn report_session_failure(
+    peer: Option<SocketAddr>,
+    error: &io::Error,
+    log_sink: Option<&SharedLogSink>,
+) {
+    if is_connection_closed_error(error.kind()) {
+        return;
+    }
+    let target = peer.map_or_else(|| "connection".to_owned(), |addr| addr.to_string());
+    let text = format!("failed to serve legacy handshake {target}: {error}");
+    match log_sink {
+        Some(log) => {
+            let message = rsync_error!(SOCKET_IO_EXIT_CODE, text).with_role(Role::Daemon);
+            log_message(log, &message);
+        }
+        None => eprintln!("{text} [daemon={}]", env!("CARGO_PKG_VERSION")),
     }
 }
 

--- a/docs/DAEMON_PROCESS_MODEL.md
+++ b/docs/DAEMON_PROCESS_MODEL.md
@@ -91,6 +91,18 @@ The `join_worker` function provides a second defense layer: if a panic somehow
 escapes `catch_unwind`, the `JoinHandle::join()` returns `Err(payload)` which
 is logged and swallowed rather than propagated.
 
+The same holds for an ordinary session error. A worker runs exactly one session
+against one accepted socket, so every outcome it can carry - an I/O failure on
+that socket, a rejected protocol state transition, an escaped panic - describes
+that connection and nothing else. `join_worker` therefore returns nothing at
+all: there is no fatal class for it to hand back. Failures of the *listening*
+socket travel a separate path (`bind_error` when a listener cannot be bound or
+made non-blocking, and the accept engine's `poll` result) and still end the
+daemon. This mirrors upstream, where the parent reaps its per-connection child
+with `waitpid(-1, NULL, WNOHANG)` (`socket.c:679`) - a NULL status pointer, so
+the session's outcome is discarded outright - and whose `while (1)` accept loop
+(`socket.c:724-778`) has no error exit at all.
+
 **Why `AssertUnwindSafe`?**  The session closure captures `Arc`-wrapped shared
 state (module list, MOTD lines, log sink).  These types are not inherently
 `UnwindSafe`, but the closure does not observe torn state because each session

--- a/tests/daemon_session_error_keeps_listener.rs
+++ b/tests/daemon_session_error_keeps_listener.rs
@@ -1,0 +1,187 @@
+//! One malformed client must not take the daemon's accept loop down with it.
+//!
+//! oc-rsync serves each accepted connection on a thread, so a session error
+//! travels back to the accept loop through a `JoinHandle`. Upstream serves
+//! each connection in a forked child and the parent reaps it with
+//! `waitpid(-1, NULL, WNOHANG)` (socket.c:679) - a NULL status pointer, so the
+//! child's outcome is discarded outright. The parent's `while (1)` accept loop
+//! (socket.c:724-778) has no error exit at all: `poll` failure, `accept`
+//! failure and `fork` failure each `continue`. Only listener setup can end the
+//! daemon (`exit_cleanup(RERR_SOCKETIO)` at socket.c:699 and socket.c:715).
+//!
+//! This test pins that contract for the threaded model: client one drives an
+//! invalid `@RSYNCD:` state transition, and client two must still complete a
+//! real transfer against the same listener afterwards.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use core::client::ClientConfig;
+use daemon::{DaemonConfig, run_daemon};
+use tempfile::tempdir;
+
+const MODULE_NAME: &str = "uploads";
+
+/// Allocates a free TCP port and hands the bound listener to the daemon so
+/// there is no TOCTOU window between allocation and the daemon's own bind.
+fn allocate_test_port() -> Option<(u16, TcpListener)> {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0u16)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    Some((port, listener))
+}
+
+/// Connects, reads the greeting, then sends the `@RSYNCD:` version banner
+/// twice. The second banner re-drives `Greeting -> ModuleSelect` from
+/// `ModuleSelect`, which the connection FSM rejects, producing a session error
+/// that is neither a broken pipe nor a reset.
+fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
+    let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let mut stream = loop {
+        match TcpStream::connect_timeout(&target, Duration::from_millis(500)) {
+            Ok(stream) => break stream,
+            Err(_) if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+            Err(err) => return Err(format!("connect: {err}")),
+        }
+    };
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .map_err(|err| format!("set_read_timeout: {err}"))?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(10)))
+        .map_err(|err| format!("set_write_timeout: {err}"))?;
+
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .map_err(|err| format!("clone stream: {err}"))?,
+    );
+    let mut greeting = String::new();
+    reader
+        .read_line(&mut greeting)
+        .map_err(|err| format!("read greeting: {err}"))?;
+    if !greeting.starts_with("@RSYNCD:") {
+        return Err(format!("unexpected greeting: {greeting:?}"));
+    }
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 md5 md4\n@RSYNCD: 32.0 md5 md4\n")
+        .map_err(|err| format!("send repeated banner: {err}"))?;
+    stream.flush().map_err(|err| format!("flush: {err}"))?;
+
+    let mut rest = String::new();
+    let _ = reader.read_to_string(&mut rest);
+    Ok(rest.lines().map(str::to_owned).collect())
+}
+
+#[test]
+fn session_error_does_not_stop_the_accept_loop() {
+    let Some((port, held_listener)) = allocate_test_port() else {
+        eprintln!("session_error_does_not_stop_the_accept_loop: skipped, no free port");
+        return;
+    };
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    let log_path = temp.path().join("daemon.log");
+    fs::create_dir(&src).expect("create src");
+    fs::create_dir(&dst).expect("create dst");
+    fs::write(src.join("payload.txt"), b"second client payload").expect("write payload");
+
+    let config_path = temp.path().join("rsyncd.conf");
+    fs::write(
+        &config_path,
+        format!(
+            "[{name}]\npath = {dst}\nuse chroot = false\nread only = false\n",
+            name = MODULE_NAME,
+            dst = dst.display(),
+        ),
+    )
+    .expect("write rsyncd.conf");
+
+    let daemon_config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            config_path.as_os_str().to_os_string(),
+            OsString::from("--log-file"),
+            log_path.as_os_str().to_os_string(),
+            OsString::from("--max-sessions"),
+            OsString::from("2"),
+            // `RuntimeOptions::detach` defaults to true on Unix: without this
+            // the daemon forks and the parent of that fork is the test
+            // process, which exits 0 before a single assertion runs.
+            OsString::from("--no-detach"),
+        ])
+        .pre_bound_listener(held_listener)
+        .build();
+
+    let daemon_handle = thread::spawn(move || run_daemon(daemon_config));
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let provoker = run_provoker(port, deadline);
+
+    // The accept loop reaps finished workers on its next idle poll (50ms).
+    thread::sleep(Duration::from_millis(500));
+
+    let mut src_arg = src.clone().into_os_string();
+    src_arg.push("/");
+    let url = format!("rsync://127.0.0.1:{port}/{MODULE_NAME}/");
+    let client_config = ClientConfig::builder()
+        .transfer_args([src_arg, OsString::from(&url)])
+        .recursive(true)
+        .build();
+    let client_result = core::client::run_client(client_config);
+
+    let daemon_result = daemon_handle.join().expect("daemon thread panicked");
+    let log_contents = fs::read_to_string(&log_path).unwrap_or_default();
+
+    // The property: the second client's transfer completes. Asserted on the
+    // landed bytes, not merely on the absence of a crash.
+    assert!(
+        client_result.is_ok(),
+        "second client must complete after the first client's session error; \
+         got {client_result:?}, daemon={daemon_result:?}, log:\n{log_contents}"
+    );
+    let landed = fs::read(dst.join("payload.txt")).unwrap_or_default();
+    assert_eq!(
+        landed, b"second client payload",
+        "second client's file must land in the module directory"
+    );
+    assert!(
+        daemon_result.is_ok(),
+        "one client's session error must not fail the daemon: {daemon_result:?}"
+    );
+
+    // Non-vacuity: the first client has to have genuinely broken its session.
+    // If the daemon ever starts answering a repeated banner cleanly this
+    // fixture stops provoking anything, and the property above would pass
+    // while proving nothing - so fail loudly here instead.
+    let provoker_trailing = provoker.expect("provoker client failed before it could provoke");
+    assert!(
+        provoker_trailing.is_empty(),
+        "first client must be dropped mid-session, not answered; got {provoker_trailing:?}"
+    );
+    let failure_lines: Vec<&str> = log_contents
+        .lines()
+        .filter(|line| line.contains("failed to serve legacy handshake"))
+        .collect();
+    assert_eq!(
+        failure_lines.len(),
+        1,
+        "expected exactly one logged session failure for the first client; log:\n{log_contents}"
+    );
+    assert!(
+        failure_lines[0].contains("invalid daemon connection transition"),
+        "the provoked failure must be the rejected state transition: {}",
+        failure_lines[0]
+    );
+}


### PR DESCRIPTION
## The defect

`join_worker` treated any session error that was not a connection close as fatal to the accept loop. One malformed client killed the listener for everybody:

```
Err(DaemonError { exit_code: SocketIo, message: "failed to serve legacy handshake
127.0.0.1:54215: invalid daemon connection transition: ModuleSelect -> ModuleSelect" })
```

## Upstream has no mechanism to port here

Upstream serves each connection in a forked child process, so a session outcome physically cannot reach the parent's accept loop. oc-rsync uses threads, so this failure mode is ours alone and the fix has to be reasoned out rather than copied. What upstream establishes is the **contract**, at the 3.5.0 pin:

| upstream 3.5.0 | what it does |
|---|---|
| `socket.c:697-699` | `open_socket_in()` returns NULL -> `exit_cleanup(RERR_SOCKETIO)` |
| `socket.c:708-716` | `listen()` fails -> `exit_cleanup(RERR_SOCKETIO)` |
| `socket.c:724` | `while (1)` - the loop body has **no** error exit |
| `socket.c:738` | `poll(...) < 1` -> `continue` |
| `socket.c:748` | `accept()` failed (`fd < 0`) -> `continue` |
| `socket.c:753-765` | child runs `fn(fd, fd)`, ends at `_exit(ret)` |
| `socket.c:766-773` | `fork()` failed -> log, close fd, keep looping |
| `socket.c:676-684` | `sigchld_handler()` reaps with `waitpid(-1, NULL, WNOHANG)` - **NULL status pointer**, so the session's outcome is discarded outright |

The contract: **only listener setup can end the daemon. No per-connection outcome, of any kind, is even inspected.**

## Error classification

Everything `join_worker` can observe originates in `spawn_connection_worker`'s closure, which calls `ConnectionContext::serve_session` -> `handle_session` on the accepted client socket. There is no other producer of a `WorkerResult`.

| class | origin | verdict |
|---|---|---|
| `BrokenPipe` / `ConnectionReset` / `ConnectionAborted` | client left | per-connection, silent (unchanged) |
| PROXY-header read/parse failure | `handle_session` -> `parse_proxy_header` on the client socket | per-connection, logged |
| greeting / module-select / auth / transfer I/O failure | `handle_legacy_session` on the client socket | per-connection, logged |
| rejected FSM transition (`transition_error`) | `handle_legacy_session`, protocol state of that one session | per-connection, logged |
| panic escaping `catch_unwind` | one session's stack | per-connection, logged (unchanged) |
| **listener bind / `listen` / `set_nonblocking` failure** | `bind_error`, engine construction | **fatal, unchanged** |
| **accept-engine `poll` result** | `AcceptEngine::poll` | **fatal, unchanged** |

The last two rows never travel through a `JoinHandle`. So the join point observes **zero** listener-fatal classes.

## The fix

`join_worker`, `reap_finished_workers` and `drain_workers` return `()` rather than `Result`. The invariant is stated in the type: the join path has no channel through which it could end the accept loop. `check_signals_and_maintain` likewise drops its `Result` - nothing that step does can fail the daemon.

This is not "swallow everything". Listener-fatal errors are on a different path entirely and still propagate out of `serve_connections`; a daemon whose listening socket is genuinely broken still exits rather than spinning. Per-connection errors are logged at error level against the peer, keeping the operator-visible text (`failed to serve legacy handshake <peer>: <error>`) byte-identical to what previously came back as a `DaemonError`, so existing log greps keep working. `stream_error` had no other caller and is removed.

Note the async accept path already logged-and-continued (`async_listener.rs:199-205`). The sync path was the outlier.

## Verification

New `tests/daemon_session_error_keeps_listener.rs`: client one drives `ModuleSelect -> ModuleSelect` by repeating the `@RSYNCD:` banner; client two then completes a real push through `core::client::run_client` against the same listener. Asserted on the landed bytes, not on the absence of a crash.

**Non-vacuity** is asserted explicitly: the daemon must have logged exactly one `failed to serve legacy handshake ... invalid daemon connection transition` line, and the first client must have been dropped mid-session rather than answered. If the daemon ever starts handling a repeated banner cleanly, this test fails loudly rather than passing while proving nothing. (The first fixture attempt sent a bare `@RSYNCD: 32.0`, which protocol 32 refuses for the missing digest list - a clean `@ERROR`, no session error at all. That inert version is what these assertions catch.)

The test passes `--no-detach` explicitly. Without it `RuntimeOptions::detach` defaults to true on Unix, the daemon forks, and the parent of that fork is the test process, which exits 0 before any assertion runs - the test binary reported PASS in 0.013s with the body never executing.

**Mutation proof.** With the production change reverted and the test kept:

```
Summary [   0.538s] 1 test run: 0 passed, 1 failed, 548 skipped
  FAIL [   0.535s] bin::daemon_session_error_keeps_listener session_error_does_not_stop_the_accept_loop

second client must complete after the first client's session error; got
Err(ClientError { exit_code: SocketIo, ... "failed to read daemon greeting from
127.0.0.1:65389: Connection refused (61)" }), daemon=Err(DaemonError { exit_code:
SocketIo, ... "failed to serve legacy handshake 127.0.0.1:65390: invalid daemon
connection transition: ModuleSelect -> ModuleSelect" })
```

The second client gets `Connection refused`: the listener is gone. With the fix restored:

```
Summary [   0.618s] 1 test run: 1 passed, 548 skipped
```

Also added a unit test pinning the classification directly: `reap_finished_workers` drains a worklist of four differently-failed sessions and hands back nothing the accept loop could act on.

## Gates

- `cargo fmt --all -- --check` clean; `tools/ci/check_rustfmt_all.py` clean (3368 files - the changed files are `include!`d and invisible to plain `cargo fmt`).
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` clean.
- `tools/ci/citation_drift_audit.py` exit 0.
- `tools/ci/check_daemon_no_detach.sh` clean, pending ceiling unchanged at 77.
- `cargo nextest run -p daemon --all-features`: 1897 tests run: 1897 passed (1 leaky), 6 skipped.
- `cargo nextest run -p bin --all-features -E 'binary(/daemon/)'`: 78 tests run: 78 passed, 1 skipped.
