### PR TITLE
fix(fast_io): let the auto zero-copy policy reach SEND_ZC

### DIFF
--- a/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
+++ b/crates/cli/src/frontend/command_builder/sections/transfer_behavior_options.rs
@@ -285,12 +285,13 @@ pub(crate) fn add_transfer_behavior_options(command: ClapCommand) -> ClapCommand
                     .help(
                         "Allow I/O-level zero-copy syscalls (sendfile, \
                          splice, copy_file_range) when supported by the \
-                         kernel. The io_uring SEND_ZC dispatch is gated \
-                         behind the `iouring-send-zc` cargo feature, which \
-                         is not in the default feature set; default builds \
-                         downgrade to plain io_uring SEND on the socket \
-                         path. Default policy is auto/enabled. Independent \
-                         of filesystem-level reflink/CoW cloning.",
+                         kernel. Default policy is auto/enabled. Under the \
+                         auto policy the io_uring SEND_ZC socket dispatch \
+                         additionally requires the `iouring-send-zc` cargo \
+                         feature, which is not in the default feature set; \
+                         without it the socket path uses plain io_uring \
+                         SEND. Independent of filesystem-level reflink/CoW \
+                         cloning.",
                     )
                     .action(ArgAction::SetTrue)
                     .overrides_with("no-zero-copy"),

--- a/crates/cli/src/frontend/help.rs
+++ b/crates/cli/src/frontend/help.rs
@@ -229,7 +229,7 @@ pub(super) fn help_text(program_name: ProgramName) -> String {
             "      --cow        Allow copy-on-write reflinks for whole-file copies (default).\n",
             "      --no-cow     Disable copy-on-write reflinks; always use the portable std::fs::copy fallback.\n",
             "      --reflink=MODE Copy-on-write reflink policy (auto, always, never).\n",
-            "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range; io_uring SEND_ZC only when built with the iouring-send-zc cargo feature, otherwise downgrades to plain io_uring SEND) when supported by the kernel. This is the default (policy=auto/enabled).\n",
+            "      --zero-copy  Allow I/O-level zero-copy (sendfile, splice, copy_file_range) when supported by the kernel. This is the default (policy=auto/enabled). Under the default auto policy the io_uring SEND_ZC socket dispatch also needs the iouring-send-zc cargo feature; without it the socket path uses plain io_uring SEND.\n",
             "      --no-zero-copy  Disable I/O-level zero-copy; route through portable userspace read/write loops. Does not affect filesystem-level reflink/CoW cloning.\n",
             "      --parallel-delta-scan  Opt-in: scan a large file's delta across multiple cores (sender side). Only engages for large, duplicate-free basis files (duplicate-content basis files fall back to the sequential scan). Reconstruction and matched/literal stats are unaffected; the literal-token wire framing may differ by a few bytes at a range boundary. Local-only, never forwarded to a remote peer. Default off.\n",
             "      --rayon-threads=N  Cap the rayon worker pool to N threads (1-1024).\n",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -41,15 +41,15 @@ iconv = ["core/iconv", "protocol/iconv"]
 # (the dependency is `cfg(target_os = "linux")`-gated).
 daemon-seccomp = ["dep:seccompiler"]
 # Opt-in (default-off): let the daemon-sender's socket write side dispatch
-# io_uring `IORING_OP_SEND_ZC` when the client sends `--zero-copy` and the
+# io_uring `IORING_OP_SEND_ZC` under the default `ZeroCopyPolicy::Auto` when the
 # running kernel advertises the opcode. Forwards the `iouring-send-zc` group
-# (which pulls `io_uring`) into `fast_io`. Default builds keep io_uring OUT of
-# the daemon's dependency graph, so `socket_writer_from_fd_zero_copy` resolves
-# to the fallback that degrades `--zero-copy` to the plain socket write path -
-# byte- and behavior-identical to the pre-feature daemon. On non-Linux the
-# `io-uring` crate dependency is target-gated, so enabling this feature there is
-# a no-op that still degrades to the plain writer. See
-# docs/design/iouring-send-zc.md for the buffer-lifetime contract.
+# (which pulls `io_uring`) into `fast_io`. Without it, `Auto` - the policy every
+# client arrives with, since the oc-invented `--zero-copy` flag is never
+# forwarded to a peer argv - keeps the plain socket write path, byte- and
+# behavior-identical to the pre-feature daemon. On non-Linux the `io-uring`
+# crate dependency is target-gated, so enabling this feature there is a no-op
+# that still degrades to the plain writer. See docs/design/iouring-send-zc.md
+# for the buffer-lifetime contract.
 daemon-zero-copy = ["fast_io/iouring-send-zc"]
 # QUIC daemon transport (default-off, opt-in oc extension). Gates parsing and
 # storage of the `quic cert file` / `quic key file` / `quic port` global

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -623,10 +623,13 @@ fn process_approved_module(
     // `setup_transfer_streams`); arming the drain there would spawn a thread that
     // hangs on a half-closed socket clone on Windows.
     let arm_drain = should_arm_delta_drain(&client_args);
-    // The daemon-sender's socket write side opts into io_uring SEND_ZC only when
-    // the client sent `--zero-copy` (parsed into `config.write.zero_copy_policy`
-    // by `apply_long_form_args`). Auto/Disabled keep the current writer, so the
-    // default path is byte- and behavior-identical.
+    // The daemon-sender's socket write side opts into io_uring SEND_ZC when
+    // `fast_io::send_zc_policy_permits` accepts this policy (parsed into
+    // `config.write.zero_copy_policy` by `apply_long_form_args`). `Disabled`
+    // never does. `Auto` - what every client arrives with, since `--zero-copy`
+    // is a local knob no peer argv carries - does so only in builds with the
+    // `iouring-send-zc` cargo feature, so a stock build's default path is byte-
+    // and behavior-identical.
     let zero_copy_policy = config.write.zero_copy_policy;
     let mut streams = match setup_transfer_streams(ctx, arm_drain, zero_copy_policy)? {
         Some(s) => s,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -72,17 +72,21 @@ fn should_arm_delta_drain(_client_args: &[String]) -> bool {
 ///
 /// Wraps a plaintext TCP write clone into the daemon-sender's byte sink.
 ///
-/// When `zero_copy_policy` is
-/// [`ZeroCopyPolicy::Enabled`](fast_io::ZeroCopyPolicy::Enabled) on Unix, the
-/// socket fd is handed to [`fast_io::socket_writer_from_fd_zero_copy`], which
-/// returns an `IORING_OP_SEND_ZC` writer when the running kernel advertises the
-/// opcode and otherwise degrades to a plain fd writer. The `TcpStream` is kept
-/// alive alongside the returned writer (the factory borrows the fd but does not
-/// take ownership), so the fd stays valid for the transfer's lifetime.
+/// When `zero_copy_policy` permits SEND_ZC on Unix - which
+/// [`fast_io::send_zc_policy_permits`] answers - the socket fd is handed to
+/// [`fast_io::socket_writer_from_fd_zero_copy`], which returns an
+/// `IORING_OP_SEND_ZC` writer when the running kernel advertises the opcode and
+/// otherwise degrades to a plain fd writer. The `TcpStream` is kept alive
+/// alongside the returned writer (the factory borrows the fd but does not take
+/// ownership), so the fd stays valid for the transfer's lifetime.
 ///
-/// For every other case - `Auto`/`Disabled`, or non-Unix - the current
-/// `TcpStream` writer is returned unchanged, keeping the default path
-/// byte-identical.
+/// The policy gate has two arms, not one. `Disabled` (`--no-zero-copy`) never
+/// reaches the factory. `Auto` - the default every client arrives with, since
+/// the oc-invented `--zero-copy` flag is deliberately never forwarded to a peer
+/// argv - reaches it only in builds carrying the `iouring-send-zc` cargo
+/// feature; that feature is the IUS-4 release gate which raises the socket-send
+/// kernel floor from 5.6 to 6.0. A stock build therefore keeps `Auto` on the
+/// unchanged `TcpStream` writer. On non-Unix there is no raw-fd path at all.
 #[cfg(unix)]
 fn daemon_socket_writer(
     write_stream: TcpStream,
@@ -90,7 +94,7 @@ fn daemon_socket_writer(
 ) -> Box<dyn Write + Send> {
     use std::os::unix::io::AsRawFd;
 
-    if !matches!(zero_copy_policy, fast_io::ZeroCopyPolicy::Enabled) {
+    if !fast_io::send_zc_policy_permits(zero_copy_policy) {
         return Box::new(write_stream);
     }
 

--- a/crates/fast_io/Cargo.toml
+++ b/crates/fast_io/Cargo.toml
@@ -162,10 +162,13 @@ macos-gcd = ["dep:block2"]
 adaptive-basis-dispatch = []
 
 # iouring-send-zc: Linux-only opt-in dispatch for IORING_OP_SEND_ZC on the
-# socket-send path. Requires the `io_uring` feature. When enabled, the
-# transport send path routes payloads >= 4 KiB through `ZeroCopySender`,
-# which submits the zero-copy send opcode against a registered buffer pool
-# so the kernel can DMA pages directly without a userspace copy. Default
+# socket-send path. Requires the `io_uring` feature. The feature is the
+# policy gate for the DEFAULT `ZeroCopyPolicy::Auto`: with it on, `Auto`
+# permits SEND_ZC (subject to the runtime opcode probe) and the dispatch
+# threshold drops from 16 KiB to 4 KiB; with it off, `Auto` keeps the plain
+# socket write path. An explicit `--zero-copy` (`Enabled`) is honoured either
+# way. It also exposes `ZeroCopySender`, the registered-buffer-pool wrapper
+# that lets the kernel DMA pages directly without a userspace copy. Default
 # off; IUS-4 (docs/design/ius-4-decision-2026-05-22.md) kept this opt-in
 # under the data-missing branch of the framing rule because the IUS-3
 # multi-kernel bench numbers have not been captured. Promotion to the

--- a/crates/fast_io/src/io_uring/socket_factory.rs
+++ b/crates/fast_io/src/io_uring/socket_factory.rs
@@ -147,16 +147,17 @@ pub fn socket_writer_from_fd(
 }
 
 /// Creates a socket writer that dispatches `IORING_OP_SEND_ZC` when `policy`
-/// is [`ZeroCopyPolicy::Enabled`](crate::ZeroCopyPolicy::Enabled) and the
-/// running kernel advertises the opcode; otherwise returns a standard `Write`
-/// wrapper over the raw fd.
+/// permits it ([`crate::send_zc_policy_permits`]) and the running kernel
+/// advertises the opcode; otherwise returns a standard `Write` wrapper over
+/// the raw fd.
 ///
 /// This is the entry point the daemon-sender uses to opt a plaintext socket
-/// into zero-copy sends via `--zero-copy`. Unlike [`socket_writer_from_fd`],
-/// it is keyed on [`ZeroCopyPolicy`](crate::ZeroCopyPolicy) so the caller
-/// expresses SEND_ZC intent directly rather than through the orthogonal
-/// io_uring on/off axis. `Auto` and `Disabled` both yield the plain fd writer,
-/// keeping the default transfer path byte-identical.
+/// into zero-copy sends. Unlike [`socket_writer_from_fd`], it is keyed on
+/// [`ZeroCopyPolicy`](crate::ZeroCopyPolicy) so the caller expresses SEND_ZC
+/// intent directly rather than through the orthogonal io_uring on/off axis.
+/// `Disabled` always yields the plain fd writer; `Auto` does so too unless
+/// the build carries the `iouring-send-zc` cargo feature, which keeps a
+/// stock build's default transfer path byte-identical.
 ///
 /// The buffer-lifetime contract of SEND_ZC is upheld inside the returned
 /// writer: `IoUringSocketWriter::submit_send` drains both the transfer and
@@ -169,26 +170,28 @@ pub fn socket_writer_from_fd(
 ///
 /// # Errors
 ///
-/// Returns an error only when `policy` is `Enabled` and the per-thread ring
-/// cannot be constructed on the calling thread. `Auto`/`Disabled` never fail.
+/// Never returns an error: every failure to build the zero-copy writer
+/// degrades to the plain fd writer, which preserves the framing byte for
+/// byte. The `io::Result` is kept for signature parity with the non-Linux
+/// stub and the sibling factories.
 pub fn socket_writer_from_fd_zero_copy(
     fd: RawFd,
     buffer_capacity: usize,
     policy: crate::ZeroCopyPolicy,
 ) -> io::Result<IoUringOrStdSocketWriter> {
-    if !matches!(policy, crate::ZeroCopyPolicy::Enabled) {
+    if !crate::send_zc_policy_permits(policy) {
         let writer = FdWriter(fd);
         return Ok(IoUringOrStdSocketWriter::Std(Box::new(writer)));
     }
 
-    // SEND_ZC requested. Build a writer whose config sets
-    // `zero_copy_policy = Enabled` so `IoUringSocketWriter::from_raw_fd`
-    // resolves `send_zc_active` from the kernel probe. If io_uring is
+    // SEND_ZC permitted. Carry the caller's policy into the config so
+    // `IoUringSocketWriter::from_raw_fd` re-applies the same predicate before
+    // resolving `send_zc_active` from the kernel probe. If io_uring is
     // unavailable or the writer cannot be built, fall back to the plain fd
     // writer so the transfer still proceeds with byte-identical framing.
     let config = IoUringConfig {
         buffer_size: buffer_capacity,
-        zero_copy_policy: crate::ZeroCopyPolicy::Enabled,
+        zero_copy_policy: policy,
         ..IoUringConfig::default()
     };
     if is_io_uring_available() {

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1030,22 +1030,54 @@ fn zero_copy_large_payload_roundtrip() {
     );
 }
 
-// Auto/Disabled must NOT engage SEND_ZC: the factory returns the plain fd
-// `Std` writer, preserving the default socket write path. This is the
-// HARD default-path invariant at the fast_io boundary.
+// `Disabled` must NOT engage SEND_ZC on any build: the factory returns the
+// plain fd `Std` writer, preserving the default socket write path. This is the
+// HARD `--no-zero-copy` invariant at the fast_io boundary.
 #[test]
-fn zero_copy_auto_and_disabled_yield_std_writer() {
-    for policy in [crate::ZeroCopyPolicy::Auto, crate::ZeroCopyPolicy::Disabled] {
-        let (fd_a, fd_b) = make_socket_pair();
-        let writer = socket_writer_from_fd_zero_copy(fd_a, 16 * 1024, policy).unwrap();
-        assert!(
-            matches!(writer, IoUringOrStdSocketWriter::Std(_)),
-            "{policy:?} must yield the plain Std writer, not a SEND_ZC writer"
+fn zero_copy_disabled_yields_std_writer() {
+    let (fd_a, fd_b) = make_socket_pair();
+    let writer =
+        socket_writer_from_fd_zero_copy(fd_a, 16 * 1024, crate::ZeroCopyPolicy::Disabled).unwrap();
+    assert!(
+        matches!(writer, IoUringOrStdSocketWriter::Std(_)),
+        "Disabled must yield the plain Std writer, not a SEND_ZC writer"
+    );
+    drop(writer);
+    close_fd(fd_a);
+    close_fd(fd_b);
+}
+
+// `Auto` follows the `iouring-send-zc` cargo feature, which is the IUS-4
+// release gate. Without it a stock build keeps the plain `Std` writer, so the
+// default transfer path is byte-identical; with it `Auto` reaches the io_uring
+// writer, whose own kernel probe then decides whether real SEND_ZC SQEs fly.
+//
+// A socketpair is AF_UNIX, where SEND_ZC's notification path is not wired, so
+// this asserts only which writer the factory picked - `zero_copy_large_payload_
+// roundtrip` covers the loopback-TCP opcode behaviour.
+#[test]
+fn zero_copy_auto_follows_the_send_zc_feature_gate() {
+    let (fd_a, fd_b) = make_socket_pair();
+    let writer =
+        socket_writer_from_fd_zero_copy(fd_a, 16 * 1024, crate::ZeroCopyPolicy::Auto).unwrap();
+    let picked_io_uring = matches!(writer, IoUringOrStdSocketWriter::IoUring(_));
+    if cfg!(feature = "iouring-send-zc") {
+        assert_eq!(
+            picked_io_uring,
+            is_io_uring_available(),
+            "with the feature on, Auto must reach the io_uring writer whenever \
+             io_uring itself is available"
         );
-        drop(writer);
-        close_fd(fd_a);
-        close_fd(fd_b);
+    } else {
+        assert!(
+            !picked_io_uring,
+            "without the feature, Auto must keep the plain Std writer so a \
+             stock build's default path is unchanged"
+        );
     }
+    drop(writer);
+    close_fd(fd_a);
+    close_fd(fd_b);
 }
 
 /// Regression test for issue #1872: an `IORING_OP_SEND` on a back-pressured

--- a/crates/fast_io/src/io_uring_common.rs
+++ b/crates/fast_io/src/io_uring_common.rs
@@ -178,13 +178,13 @@ impl IoUringConfig {
 
     /// Returns whether socket writers may attempt `IORING_OP_SEND_ZC`.
     ///
-    /// True only when the configured policy is
-    /// [`ZeroCopyPolicy::Enabled`](crate::ZeroCopyPolicy::Enabled). `Auto`
-    /// and `Disabled` both yield false so the default path uses regular
-    /// `IORING_OP_SEND`.
+    /// Delegates to [`crate::send_zc_policy_permits`]: `Enabled` always,
+    /// `Auto` only in builds carrying the `iouring-send-zc` cargo feature,
+    /// `Disabled` never. The kernel-opcode probe is applied separately by
+    /// the writer, so a `true` here is permission, not availability.
     #[must_use]
     pub fn allow_send_zc(&self) -> bool {
-        matches!(self.zero_copy_policy, crate::ZeroCopyPolicy::Enabled)
+        crate::send_zc_policy_permits(self.zero_copy_policy)
     }
 }
 

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -610,7 +610,7 @@ pub use policy::{
     BackendPolicy, BasisReadBackend, CowPolicy, IoUringPolicy, IocpPolicy,
     MMAP_TO_SQPOLL_THRESHOLD, MMAP_TO_SQPOLL_THRESHOLD_ENV, ZeroCopyPolicy,
     choose_basis_read_backend, choose_basis_read_backend_with_threshold,
-    mmap_to_sqpoll_threshold_bytes,
+    mmap_to_sqpoll_threshold_bytes, send_zc_policy_permits,
 };
 pub use sqpoll_basis::{
     MAX_WIRED_WINDOW_BYTES, MlockError, WiredBasisWindow, mlock_attempts, mlock_downgrades,

--- a/crates/fast_io/src/policy.rs
+++ b/crates/fast_io/src/policy.rs
@@ -247,6 +247,35 @@ pub type IocpPolicy = BackendPolicy;
 /// platforms but skips `copy_file_range`/`sendfile`/`splice` direct calls).
 pub type ZeroCopyPolicy = BackendPolicy;
 
+/// Returns whether `policy` permits `IORING_OP_SEND_ZC` on the socket-send
+/// path, before the runtime kernel-opcode probe runs.
+///
+/// This is the policy half of the two-part SEND_ZC gate; the kernel half is
+/// `io_uring::send_zc_supported`, which the writer consults at
+/// construction. Splitting them lets callers that only own a policy (the
+/// daemon-sender's writer factory) skip the io_uring machinery entirely
+/// without duplicating the meaning of each variant.
+///
+/// - [`ZeroCopyPolicy::Disabled`] - never. `--no-zero-copy` is a hard off.
+/// - [`ZeroCopyPolicy::Enabled`] - always attempt; an unsupported kernel
+///   still degrades to plain `IORING_OP_SEND` inside the writer.
+/// - [`ZeroCopyPolicy::Auto`] - attempt only in builds carrying the
+///   `iouring-send-zc` cargo feature. That feature is the IUS-4 release gate
+///   (it raises the socket-send kernel floor from 5.6 to 6.0), so a stock
+///   build keeps `Auto` on the plain socket write path and is byte-identical
+///   to a build without this predicate.
+///
+/// Mirrors the shape of `is_splice_enabled`, which applies the same
+/// policy gate to `splice(2)`.
+#[must_use]
+pub const fn send_zc_policy_permits(policy: ZeroCopyPolicy) -> bool {
+    match policy {
+        ZeroCopyPolicy::Disabled => false,
+        ZeroCopyPolicy::Enabled => true,
+        ZeroCopyPolicy::Auto => cfg!(feature = "iouring-send-zc"),
+    }
+}
+
 /// Size threshold (bytes) above which basis-file reads use io_uring+SQPOLL
 /// instead of mmap.
 ///
@@ -467,6 +496,30 @@ mod tests {
         assert_ne!(ZeroCopyPolicy::Auto, ZeroCopyPolicy::Enabled);
         assert_ne!(ZeroCopyPolicy::Auto, ZeroCopyPolicy::Disabled);
         assert_ne!(ZeroCopyPolicy::Enabled, ZeroCopyPolicy::Disabled);
+    }
+
+    /// `--no-zero-copy` is a hard off for SEND_ZC on every build.
+    #[test]
+    fn send_zc_policy_permits_rejects_disabled() {
+        assert!(!send_zc_policy_permits(ZeroCopyPolicy::Disabled));
+    }
+
+    /// An explicit `--zero-copy` is honoured regardless of the cargo feature;
+    /// the kernel-opcode probe still has the final say inside the writer.
+    #[test]
+    fn send_zc_policy_permits_accepts_enabled() {
+        assert!(send_zc_policy_permits(ZeroCopyPolicy::Enabled));
+    }
+
+    /// `Auto` is the arm the IUS-4 release gate governs: it permits SEND_ZC
+    /// exactly when the build carries `iouring-send-zc`, so a stock build's
+    /// default socket-send path is unchanged.
+    #[test]
+    fn send_zc_policy_permits_auto_follows_the_feature_gate() {
+        assert_eq!(
+            send_zc_policy_permits(ZeroCopyPolicy::Auto),
+            cfg!(feature = "iouring-send-zc")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`IORING_OP_SEND_ZC` never flew on any oc-to-oc transfer, on any kernel, in any build.

Three things had to line up and one of them could not:

1. **`Auto` was a silent synonym for `Disabled`.** `IoUringConfig::allow_send_zc`, `socket_writer_from_fd_zero_copy`, and the daemon-sender's `daemon_socket_writer` each matched only on `ZeroCopyPolicy::Enabled`.
2. **`Enabled` is unreachable from an oc client.** `--zero-copy` is an oc-invented local knob, and `build_full_daemon_args` deliberately never forwards it to a peer argv (an upstream `--server` aborts on an unknown option; `oc_flag_forwarding_tests` pins this). The daemon consequently always sees `Auto`.
3. The runtime kernel-opcode probe was correct and is unchanged.

So the whole SEND_ZC transport was dead code in practice.

## Measurement

Linux 7.0.0 (advertises `IORING_OP_SEND_ZC`), 4 cores. Instrument: `tracepoint:io_uring:io_uring_submit_req`, counting by `comm` and `op_str`; a 200 MB daemon pull over loopback with the stock client (daemon log confirms the argv is `--server --sender -e.LsfxCIvu . m/big.bin`, i.e. no `--zero-copy`).

| build | io_uring rings created by the sender | SEND_ZC SQEs |
|---|---|---|
| master, default features | 0 | 0 |
| this branch, default features | 0 | 0 |
| this branch, `--features iouring-send-zc` | 3 | 6400 |

The middle row is the point: **this change is inert on a stock build.** It does not switch anything on by itself.

At the `fast_io` boundary, on a build *without* the feature, `Enabled` already produced `IoUring(send_zc_active=true)` and one real SEND_ZC SQE — so the feature was never the gate the docs claimed it was, only a threshold change (16 KiB -> 4 KiB) plus the `ZeroCopySender` wrapper (which no production call site uses).

## Fix

`Auto` now means what its name says: dispatch when the build permits it **and** the kernel advertises the opcode, else fall back. The permission half is one predicate, `fast_io::send_zc_policy_permits`, shared by the config, the factory, and the daemon writer — the same shape as the existing `is_splice_enabled`. The kernel half stays in the cached `send_zc::is_supported` probe.

`Auto` permits SEND_ZC only in builds carrying the `iouring-send-zc` cargo feature, which is the IUS-4 release gate that raises the io_uring socket-send kernel floor from 5.6 to 6.0. `Disabled` stays a hard off on every build; `Enabled` stays force-on and keeps degrading gracefully rather than erroring, which is what it has always done.

**This PR does not promote the feature to any default set.** That is a separate release-policy decision with a measurement precondition, and the numbers below argue against it.

## Doc drift corrected in the same commit

- The factory's `# Errors` claimed `Enabled` propagates a ring-construction failure; every failure path degrades to the plain writer.
- The `--zero-copy` help text (static help and clap builder) claimed the cargo feature gates SEND_ZC outright; without it an explicit `Enabled` still dispatched.
- Both `Cargo.toml` feature comments described the feature as gating the dispatch rather than the `Auto` policy arm.

## What this does not fix

The IUS-3 promotion criteria remain unmeasurable with the instruments in the tree. Both `ius_3_send_zc_vs_send` and `szcc_send_zc_100k_iops` abort in their `send_plain` baseline group with `WriteZero: "short SEND on loopback"` — a short `IORING_OP_SEND` on a full loopback buffer that the harness treats as fatal instead of looping. Reproduced on unpatched master, so it is pre-existing and independent of this change. Neither bench ever reaches its `send_zc` group.

The two criteria in the tree also disagree: `crates/fast_io/Cargo.toml` says ">= 10% throughput on >= 2 of 4 workloads, no workload regressing by > 2%", while the bench's own module doc cites ">= 1.1 ratio on 3 of 4 workloads **and** >= 10% CPU reduction on 2 of 4" — and states that the CPU half is not measured by the harness at all.

An end-to-end stand-in A/B (11 alternating reps, 200 MB daemon pull, source page-cached, destination on tmpfs, only the cargo feature differing) measured a **large regression**, not a win:

| cell | median wall time | throughput |
|---|---|---|
| plain socket writer | 0.128 s | ~1.56 GB/s |
| SEND_ZC | 0.519 s | ~385 MB/s |

Naming the population: this bounds loopback TCP on one 4-core host at 200 MB single-file, and it compares "plain `TcpStream` write" against "io_uring SEND_ZC writer" — the two variables the default flip would change together. It says nothing about a real NIC, which is where SEND_ZC's copy avoidance is supposed to pay. The likely mechanism is that `try_send_zc` blocks on both the transfer and notification CQEs per submission, serialising every send behind a page-release round trip that buys nothing on loopback.

Recommendation: keep the feature opt-in. On the evidence available, the "no workload regressing by > 2%" criterion fails badly, and the criterion that would establish a win cannot currently be run.
