### PR TITLE
fix(receiver): never block opening a non-regular destination as basis

### DIFF
--- a/crates/fast_io/src/nofollow_open.rs
+++ b/crates/fast_io/src/nofollow_open.rs
@@ -169,12 +169,33 @@ mod imp {
 mod imp {
     use super::*;
 
+    /// NTFS reparse-point resolution is governed by separate flags on
+    /// `CreateFileW` and is not part of the rsync upstream `O_NOFOLLOW`
+    /// contract, so the leaf is opened without one; receiver-side reparse
+    /// handling is audited under WPC-3/4.
+    ///
+    /// `FILE_FLAG_BACKUP_SEMANTICS` is what lets `CreateFileW` return a
+    /// *directory* handle at all. Without it the open fails with
+    /// `PermissionDenied` and the `?` in [`super::open_basis_nofollow`]
+    /// surfaces that instead of reaching [`super::require_regular_basis`] —
+    /// so the documented `InvalidInput` refusal for a non-regular basis
+    /// would hold on Unix and silently not hold here. Opening with the flag
+    /// keeps "is this a regular file" one decision on every platform.
+    #[cfg(windows)]
     pub(super) fn open_basis_nofollow(path: &Path) -> io::Result<File> {
-        // Windows / other non-Unix: NTFS reparse-point resolution is
-        // governed by separate flags on `CreateFileW` and is not part
-        // of the rsync upstream `O_NOFOLLOW` contract. Fall through to
-        // the standard open; receiver-side reparse handling is audited
-        // under WPC-3/4.
+        use std::os::windows::fs::OpenOptionsExt;
+        use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
+
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)
+    }
+
+    /// Other non-Unix platforms have no directory-open flag to set, so the
+    /// standard open already reaches [`super::require_regular_basis`].
+    #[cfg(not(windows))]
+    pub(super) fn open_basis_nofollow(path: &Path) -> io::Result<File> {
         File::open(path)
     }
 

--- a/crates/fast_io/src/nofollow_open.rs
+++ b/crates/fast_io/src/nofollow_open.rs
@@ -18,6 +18,30 @@
 //! because the receiver already resolves the destination root before
 //! reaching the basis lookup.
 //!
+//! # Regular files only
+//!
+//! Upstream never reaches its basis open (`generator.c:2313`,
+//! `do_open_checklinks(fnamecmp)`) with a non-regular `fnamecmp`.
+//! `generator.c:2148` has already removed a non-regular destination
+//! (`delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE)`, leaving
+//! `statret = -1`); `try_dests_reg()` accepts an alt-dest candidate only
+//! when `S_ISREG(sxp->st.st_mode)` (`generator.c:1084`); `find_fuzzy()`
+//! skips anything that is not `S_ISREG(fp->mode)` (`generator.c:860,888`);
+//! and the `--partial-dir` fallback is guarded by
+//! `S_ISREG(partial_st.st_mode)` (`generator.c:2175`). Every basis upstream
+//! opens is therefore a regular file, and this helper states that invariant
+//! directly.
+//!
+//! Stating it matters because opening an unchecked node blocks: a FIFO with
+//! no writer parks the opener in `fifo_open()` indefinitely, and a device
+//! can block on carrier. The check is made on the descriptor rather than
+//! with a pre-open `fstatat(2)`, so a node swapped between check and open
+//! cannot defeat it: the open carries `O_NONBLOCK` (upstream does the same
+//! for an unchecked leaf at `generator.c:1024`,
+//! `O_RDONLY | O_NOFOLLOW | O_NONBLOCK`) so it can never park, `fstat(2)`
+//! then decides, and `O_NONBLOCK` is cleared before a regular-file
+//! descriptor is handed back so the basis read behaves exactly as before.
+//!
 //! # Platform behaviour
 //!
 //! - Unix: dirname/basename split with `O_NOFOLLOW` on the basename via
@@ -47,10 +71,33 @@ use std::path::Path;
 /// - `ELOOP` (`io::ErrorKind::FilesystemLoop` on Rust 1.78+ where
 ///   available, otherwise the raw OS error) when the basename is a
 ///   symlink.
+/// - [`io::ErrorKind::InvalidInput`] when the opened node is not a regular
+///   file (FIFO, socket, device, directory). Callers treat that as "no
+///   basis", which is the outcome upstream reaches by having already
+///   removed the obstacle at `generator.c:2148`.
 /// - Any other I/O error from opening the parent directory or the
 ///   basename (forwarded verbatim from the underlying syscall).
 pub fn open_basis_nofollow(path: &Path) -> io::Result<File> {
-    imp::open_basis_nofollow(path)
+    let file = imp::open_basis_nofollow(path)?;
+    require_regular_basis(file)
+}
+
+/// Refuses a non-regular basis and hands a regular one back with
+/// `O_NONBLOCK` cleared.
+///
+/// The descriptor is already open here, so the decision is made with
+/// `fstat(2)` on the descriptor itself: a pre-open `fstatat(2)` would leave
+/// a window in which the node it checked is replaced by the FIFO the check
+/// exists to refuse.
+fn require_regular_basis(file: File) -> io::Result<File> {
+    if !file.metadata()?.file_type().is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "delta basis is not a regular file",
+        ));
+    }
+    imp::clear_nonblock(&file)?;
+    Ok(file)
 }
 
 #[cfg(unix)]
@@ -66,7 +113,7 @@ mod imp {
             // No basename (e.g. "/" or ""): defer to the plain open and
             // let the kernel report the appropriate error. Mirrors
             // upstream's pass-through for degenerate inputs.
-            return File::open(path);
+            return open_nonblock(path);
         };
 
         // Upstream `syscall.c:727`: `if (!slash) return do_open(...)`.
@@ -74,12 +121,36 @@ mod imp {
         // root component identically: there is no dirname to split.
         let dirname = match path.parent() {
             Some(p) if !p.as_os_str().is_empty() => p,
-            _ => return File::open(path),
+            _ => return open_nonblock(path),
         };
 
         let dir = open_dir_follow(dirname)?;
-        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // `O_NONBLOCK` keeps the open itself from parking on a FIFO with no
+        // writer or a device without carrier; the node type is then decided
+        // by `fstat(2)` in `require_regular_basis`. upstream does the same
+        // for an unchecked leaf at `generator.c:1024`.
+        let flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC;
         openat(dir.as_fd(), basename, flags, 0)
+    }
+
+    /// The `if (!slash)` short-circuit's open. Carries `O_NONBLOCK` for the
+    /// same reason the `openat(2)` above does: the node type is not known
+    /// until the descriptor exists.
+    fn open_nonblock(path: &Path) -> io::Result<File> {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(path)
+    }
+
+    /// Drops `O_NONBLOCK` from an already-typed regular-file descriptor so
+    /// the basis read sees the same file status flags it saw before.
+    pub(super) fn clear_nonblock(file: &File) -> io::Result<()> {
+        let flags = rustix::fs::fcntl_getfl(file)?;
+        if flags.contains(rustix::fs::OFlags::NONBLOCK) {
+            rustix::fs::fcntl_setfl(file, flags - rustix::fs::OFlags::NONBLOCK)?;
+        }
+        Ok(())
     }
 
     /// Open `dirname` as a directory file descriptor with normal symlink
@@ -105,6 +176,13 @@ mod imp {
         // the standard open; receiver-side reparse handling is audited
         // under WPC-3/4.
         File::open(path)
+    }
+
+    /// This platform's open sets no `O_NONBLOCK`, so there is nothing to
+    /// clear. The regular-file check in `require_regular_basis` still
+    /// applies.
+    pub(super) fn clear_nonblock(_file: &File) -> io::Result<()> {
+        Ok(())
     }
 }
 
@@ -202,5 +280,66 @@ mod tests {
         let missing = tmp.path().join("does-not-exist");
         let err = open_basis_nofollow(&missing).expect_err("missing path must fail");
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    /// A FIFO with no writer must be refused, and refused *promptly*: an
+    /// `open(O_RDONLY)` without `O_NONBLOCK` parks in `fifo_open()` until a
+    /// writer arrives, which never happens for a planted destination node.
+    ///
+    /// The bound is a deadline on a worker thread, not a sleep: before the
+    /// fix this test reports a timeout instead of wedging the run.
+    #[cfg(unix)]
+    #[test]
+    fn refuses_fifo_basis_without_blocking() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let fifo = tmp.path().join("fifo-basis");
+        // Same `mkfifo(1)` shell-out as tests/drop_devices.rs.
+        let status = std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo failed: {status}");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(open_basis_nofollow(&fifo).map(|_| ()));
+        });
+
+        let outcome = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("basis open on a FIFO must return, not block on a writer");
+        let err = outcome.expect_err("a FIFO must not be accepted as a delta basis");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    /// A directory opens successfully with `O_RDONLY` but can never be read
+    /// as a delta basis. Upstream removes it at `generator.c:2148`; oc
+    /// declines it here.
+    #[test]
+    fn refuses_directory_basis() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("dir-basis");
+        std::fs::create_dir(&dir).expect("mkdir");
+        let err = open_basis_nofollow(&dir).expect_err("a directory is not a delta basis");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    /// `O_NONBLOCK` exists only to keep the open from parking. A regular
+    /// basis must be handed back with the same file status flags it had
+    /// before, so the delta read is byte-for-byte the previous behaviour.
+    #[cfg(unix)]
+    #[test]
+    fn regular_basis_descriptor_has_no_nonblock() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let basis = tmp.path().join("sub").join("basis");
+        std::fs::create_dir(basis.parent().expect("parent")).expect("mkdir");
+        std::fs::write(&basis, b"payload").expect("write basis");
+
+        let file = open_basis_nofollow(&basis).expect("regular basis must open");
+        let flags = rustix::fs::fcntl_getfl(&file).expect("fcntl F_GETFL");
+        assert!(
+            !flags.contains(rustix::fs::OFlags::NONBLOCK),
+            "O_NONBLOCK must be cleared on a regular basis descriptor: {flags:?}"
+        );
     }
 }

--- a/tests/basis_nonregular_dest_no_hang.rs
+++ b/tests/basis_nonregular_dest_no_hang.rs
@@ -1,0 +1,238 @@
+//! A non-regular delta basis must never park the receiver in `open(2)`.
+//!
+//! A FIFO with no writer blocks `open(O_RDONLY)` in `fifo_open()` until a
+//! writer arrives. The receiver's basis lookup opens whatever it finds at the
+//! destination, so a FIFO planted there wedges the transfer with no timeout and
+//! no flag required - the same `oc-rsync --server` receiver a writable daemon
+//! module runs.
+//!
+//! Upstream 3.5.0 never reaches its own basis open with a non-regular
+//! `fnamecmp`. `generator.c:2148` removes the obstacle first
+//! (`if (statret == 0 && !(stype == FT_REG || (write_devices && stype ==
+//! FT_DEVICE))) { delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE);
+//! statret = -1; }`), and the alt-dest, fuzzy and `--partial-dir` candidates
+//! are each gated on `S_ISREG` (`generator.c:1084`, `generator.c:860,888`,
+//! `generator.c:2175`). By the time `do_open_checklinks(fnamecmp)` runs at
+//! `generator.c:2313` the basis is always a regular file.
+//!
+//! oc does not have that removal, so it states the invariant at the open
+//! instead: `fast_io::open_basis_nofollow` refuses a non-regular node, and the
+//! receiver falls back to a full send. The observable result matches
+//! upstream's: exit 0, and the destination replaced by a regular file holding
+//! the source bytes.
+//!
+//! # Two call sites, not one
+//!
+//! `fast_io::open_basis_nofollow` has two production callers in
+//! `crates/transfer/src/receiver/basis.rs`: `try_open_file` (the exact
+//! destination, the `--partial-dir` fallback and the `--fuzzy` candidate) and
+//! `try_reference_directories` (the `--compare-dest` / `--copy-dest` /
+//! `--link-dest` lookup, which checked `is_file()` only *after* the open, so it
+//! parked too). Both are exercised here.
+//!
+//! # Non-vacuity
+//!
+//! Each case bounds the client with a deadline and asserts the *positive*
+//! outcome: the destination ends up a regular file holding the source bytes. A
+//! test that only checked "did not hang" would pass on an outright failure. The
+//! FIFO-ness of the fixture is asserted before the run, so a `mkfifo` that
+//! silently produced a regular file cannot make the case inert. Before the fix
+//! both cases time out.
+//!
+//! # Known remaining
+//!
+//! `--inplace` and `--write-devices` still park on a FIFO destination, at a
+//! different site: `fast_io::inplace_open::InplaceResolution::open_write`
+//! (`crates/fast_io/src/inplace_open.rs`) issues `O_WRONLY|O_CREAT`, which
+//! blocks on a FIFO waiting for a *reader*. That is not a basis open, and
+//! refusing it would not reach upstream's answer either (upstream succeeds with
+//! exit 0 by having deleted the FIFO at `generator.c:2148`). It needs that
+//! removal, which is a separate change.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::{FileTypeExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+/// Generous enough for a debug-build local wire transfer of nineteen bytes,
+/// short enough that a parked `open(2)` is reported as a failure rather than
+/// wedging the run. Before the fix the receiver never returns at all, so any
+/// finite bound distinguishes the two states.
+const RUN_TIMEOUT: Duration = Duration::from_secs(60);
+
+const PAYLOAD: &[u8] = b"non-regular-basis-payload\n";
+
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so it must be read with
+/// `env!`: at run time it is unset and a lookup would fall through to whatever
+/// stale `target/debug/oc-rsync` happens to be on disk.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
+}
+
+/// A `--rsh` shim that drops the host argument and execs the rest locally, so
+/// the transfer takes the real `--server` receiver path (a plain local copy
+/// goes through the local-copy executor and never reaches the basis lookup).
+fn write_rsh_shim(root: &Path) -> PathBuf {
+    let shim = root.join("rsh.sh");
+    fs::write(&shim, "#!/bin/sh\nshift\nexec \"$@\"\n").expect("write rsh shim");
+    let mut perms = fs::metadata(&shim).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&shim, perms).expect("chmod shim");
+    shim
+}
+
+fn make_fifo(path: &Path) {
+    // `mkfifo(1)` rather than a new libc dependency, matching the convention in
+    // tests/drop_devices.rs.
+    let status = Command::new("mkfifo")
+        .arg(path)
+        .status()
+        .expect("spawn mkfifo");
+    assert!(
+        status.success(),
+        "mkfifo {} failed: {status}",
+        path.display()
+    );
+    let file_type = fs::symlink_metadata(path)
+        .expect("stat planted node")
+        .file_type();
+    assert!(
+        file_type.is_fifo(),
+        "fixture is inert: {} is not a FIFO",
+        path.display()
+    );
+}
+
+/// Runs `cmd` under a deadline. Returns `None` when the deadline expires, which
+/// is how the pre-fix park is reported instead of hanging the suite.
+fn run_with_deadline(mut cmd: Command) -> Option<Output> {
+    let mut child = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync");
+    let deadline = Instant::now() + RUN_TIMEOUT;
+    loop {
+        match child.try_wait().expect("poll child") {
+            Some(_) => return Some(child.wait_with_output().expect("collect output")),
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+            None => std::thread::sleep(Duration::from_millis(25)),
+        }
+    }
+}
+
+/// Asserts the transfer completed inside the deadline, reported success, and
+/// left the source bytes at `dest` as a regular file.
+fn assert_transfer_landed(output: Option<Output>, dest: &Path, case: &str) {
+    let Some(output) = output else {
+        panic!(
+            "{case}: oc-rsync did not exit within {RUN_TIMEOUT:?} - the receiver \
+             parked opening a non-regular destination as the delta basis"
+        );
+    };
+    assert!(
+        output.status.success(),
+        "{case}: expected exit 0 (upstream 3.5.0 exits 0 here), got {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let meta = fs::symlink_metadata(dest)
+        .unwrap_or_else(|error| panic!("{case}: destination {} missing: {error}", dest.display()));
+    assert!(
+        meta.file_type().is_file(),
+        "{case}: destination {} is {:?}, not a regular file",
+        dest.display(),
+        meta.file_type()
+    );
+    let landed = fs::read(dest).expect("read destination");
+    assert_eq!(
+        landed, PAYLOAD,
+        "{case}: destination content does not match the source"
+    );
+}
+
+/// `try_open_file(config.file_path)` - the exact destination, the default path,
+/// no flag required. Upstream deletes the FIFO at `generator.c:2148` and writes
+/// a fresh regular file; oc declines it as a basis and does the same.
+#[test]
+fn fifo_destination_does_not_park_the_receiver() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let src = root.join("src");
+    let dst = root.join("dst");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::create_dir_all(&dst).expect("mkdir dst");
+    fs::write(src.join("obj"), PAYLOAD).expect("write source");
+    make_fifo(&dst.join("obj"));
+
+    let shim = write_rsh_shim(root);
+    let binary = oc_rsync_binary();
+    let mut cmd = Command::new(&binary);
+    cmd.arg("-e")
+        .arg(&shim)
+        .arg(format!("--rsync-path={}", binary.display()))
+        .arg(src.join("obj"))
+        .arg(format!("localhost:{}/", dst.display()));
+
+    assert_transfer_landed(run_with_deadline(cmd), &dst.join("obj"), "fifo destination");
+}
+
+/// `try_reference_directories` - the second caller. Its `is_file()` check ran
+/// *after* the open, so a FIFO in a `--compare-dest` directory parked the
+/// lookup just as the destination one did. Upstream's `try_dests_reg()` never
+/// opens it: `generator.c:1084` rejects the candidate on
+/// `!S_ISREG(sxp->st.st_mode)`.
+#[test]
+fn fifo_in_compare_dest_does_not_park_the_basis_lookup() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    let src = root.join("src");
+    let dst = root.join("dst");
+    let reference = root.join("ref");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::create_dir_all(&dst).expect("mkdir dst");
+    fs::create_dir_all(&reference).expect("mkdir ref");
+    fs::write(src.join("obj"), PAYLOAD).expect("write source");
+    make_fifo(&reference.join("obj"));
+
+    let shim = write_rsh_shim(root);
+    let binary = oc_rsync_binary();
+    let mut cmd = Command::new(&binary);
+    cmd.arg(format!("--compare-dest={}", reference.display()))
+        .arg("-e")
+        .arg(&shim)
+        .arg(format!("--rsync-path={}", binary.display()))
+        .arg(src.join("obj"))
+        .arg(format!("localhost:{}/", dst.display()));
+
+    assert_transfer_landed(
+        run_with_deadline(cmd),
+        &dst.join("obj"),
+        "fifo in --compare-dest",
+    );
+
+    // The reference directory is read-only input: the run must not have
+    // replaced the node it declined.
+    assert!(
+        fs::symlink_metadata(reference.join("obj"))
+            .expect("stat reference node")
+            .file_type()
+            .is_fifo(),
+        "the --compare-dest node must be left untouched"
+    );
+}


### PR DESCRIPTION
## The defect

A FIFO at the destination hung the receiver **indefinitely, on the default path, with no flag required**. Kernel stack from the live `oc-rsync --server` child on aarch64 Linux:

```
[<0>] wait_for_partner+0xbc/0x150
[<0>] fifo_open+0x354/0x398
[<0>] do_dentry_open ... vfs_open ... do_open
syscall: 56 (openat) flags=0x88000   # O_RDONLY|O_NOFOLLOW|O_CLOEXEC, dirfd=dst/
```

Site: `crates/transfer/src/receiver/basis.rs:225`, `try_open_file` -> `fast_io::open_basis_nofollow`. It opened the destination as the delta basis with no file-type check and no `O_NONBLOCK`. A FIFO with no writer blocks in `fifo_open()` forever.

The same `--server` receiver backs a daemon module, so a writable module with a planted FIFO was an unbounded wedge, and an unbounded external operation regardless.

## Why upstream 3.5.0 does not have it

Upstream gets safety from *ordering*, not from a type check. `generator.c:2148`:

```c
if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
        if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
                goto cleanup;
        statret = -1;
        stat_errno = ENOENT;
}
```

The obstacle is already unlinked, so there is no basis to open. Every other candidate that can become `fnamecmp` is separately gated on `S_ISREG`: the alt-dest lookup (`generator.c:1084`, `basis_link_stat(cmpbuf, &sxp->st) < 0 || !S_ISREG(sxp->st.st_mode)`), `find_fuzzy()` (`generator.c:860,888`, `!S_ISREG(fp->mode)`), and the `--partial-dir` fallback (`generator.c:2175`, `S_ISREG(partial_st.st_mode)`). By the time `do_open_checklinks(fnamecmp)` runs at `generator.c:2313`, the basis is always a regular file.

## The fix

`open_basis_nofollow()` now states that invariant directly: it refuses a non-regular node, and the receiver falls through to a full send. That reaches upstream's observable result — exit 0 with the destination replaced by a regular file holding the source bytes.

**Shape chosen: the type check (option a), made race-free on the descriptor.** A pre-open `fstatat(..., AT_SYMLINK_NOFOLLOW)` would leave a window in which the node it checked is replaced by the FIFO the check exists to refuse — and this check exists precisely because an attacker can write to the destination directory. So:

1. the open carries `O_NONBLOCK`, so it can never park — this is upstream's own idiom for an unchecked leaf, `generator.c:1024`: `do_open_atfd(dfd, leaf, O_RDONLY | O_NOFOLLOW | O_NONBLOCK, 0)`;
2. `fstat(2)` on the resulting descriptor decides;
3. `O_NONBLOCK` is cleared before a regular-file descriptor is handed back, so the delta read sees exactly the file status flags it saw before.

`O_NONBLOCK` alone (option b) was rejected: it stops the park but leaves a FIFO descriptor in hand whose zero-length `metadata()` would then be signed as a basis, and it states nothing about intent.

## Two call sites, not one

`fast_io::open_basis_nofollow` has **two** production callers, both in `crates/transfer/src/receiver/basis.rs`:

| caller | reaches | pre-fix behaviour |
| --- | --- | --- |
| `try_open_file` (:222) | the exact destination (:598), the `--fuzzy` candidate (:308), the `--partial-dir` fallback (:658) | no type check at all — parked |
| `try_reference_directories` (:184) | `--compare-dest` / `--copy-dest` / `--link-dest` | `meta.is_file()` ran **after** the open — parked just the same |

The alt-dest site was a real second park, not a theoretical one: its regular-file check was on the wrong side of the open. Fixing the shared helper covers both, and the regression test exercises both.

`crates/transfer/src/pipeline/async_signature.rs:183` (`try_open_file_for_signature`) has the same unguarded shape but no production caller; left alone.

## Non-vacuity

`tests/basis_nonregular_dest_no_hang.rs` drives the real `--server` receiver over an `--rsh` shim (a plain local copy goes through the local-copy executor and never reaches the basis lookup). Each case:

- bounds the child with a deadline and reports a timeout as a failure, rather than wedging CI;
- asserts the fixture really is a FIFO before the run, so a `mkfifo` that silently produced a regular file cannot make the case inert;
- asserts the **positive** outcome — exit 0 *and* the destination is a regular file holding the source bytes — so an outright failed transfer cannot pass.

Mutation proof, production change reverted and restored around the same test binary:

```
# production change reverted
test fifo_destination_does_not_park_the_receiver ... FAILED
test fifo_in_compare_dest_does_not_park_the_basis_lookup ... FAILED
  ... oc-rsync did not exit within 60s - the receiver parked opening a
      non-regular destination as the delta basis
test result: FAILED. 0 passed; 2 failed;   (finished in 60.03s)

# production change restored
test fifo_in_compare_dest_does_not_park_the_basis_lookup ... ok
test fifo_destination_does_not_park_the_receiver ... ok
test result: ok. 2 passed; 0 failed;       (finished in 1.68s)
```

Unit cover in `crates/fast_io/src/nofollow_open.rs` adds a FIFO case (bounded by a deadline on a worker thread), a directory case, and an assertion that a regular basis descriptor comes back with `O_NONBLOCK` cleared.

## Known remaining — NOT fixed here

All of these are the same missing `generator.c:2148` removal, which is a separate change.

- **FIFO destination under `--inplace` / `--write-devices`** still parks, at a *different* site: `fast_io::inplace_open::InplaceResolution::open_write` (`crates/fast_io/src/inplace_open.rs:108`) issues `O_WRONLY|O_CREAT`, which blocks on a FIFO waiting for a *reader*. `--write-devices` reaches it because `apply_append_implies_inplace` (`crates/transfer/src/config/mod.rs:860`) promotes inplace for every file. Sampled stack of the parked `--server` child:
  `process_whole_file -> open_output_file -> fast_io::inplace_open::open_inplace_output -> InplaceResolution::open_write -> std::fs::OpenOptions::open -> open(2)`.
  That is not a basis open, and refusing it would not reach upstream's answer either: upstream **succeeds with exit 0** there, by having deleted the FIFO at `generator.c:2148`. Bolting a refusal on would replace one wrong answer with another.
- **Directory destination**: oc exits 12; upstream `rmdir`s an empty dir and succeeds (rc 0). Non-empty: both refuse but oc reports 12 vs upstream's 23, and upstream's diagnostic `could not make way for new regular file: obj` (`delete.c:283`) exists nowhere in `crates/`.
- **In-tree symlink destination under `--inplace` / `--write-devices`**: oc keeps the symlink and writes *through* it onto the target, which also picks up the source's mode (0644 -> 0777). Upstream deletes the symlink and writes a fresh regular file, target untouched. The absolute out-of-tree variant IS refused with `ELOOP` by the sandbox resolver, so containment holds at the tree boundary.
- **Socket destination under `--inplace` / `--write-devices`**: oc exits 12 (ENXIO); upstream succeeds.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps` — no diagnostic on either changed file
- `cargo nextest run --locked -p fast_io` — 835 passed
- `cargo nextest run --locked -p transfer` — 2768 passed, 3 skipped
- `cargo nextest run --locked -p bin` (the root-level `tests/integration_*.rs` and friends, which per-crate runs do not cover) — 517 passed, 33 skipped
