### PR TITLE
ci(benchmark): compare against both rsync 3.4.4 and 3.5.0

### DIFF
--- a/.github/scripts/benchmark.py
+++ b/.github/scripts/benchmark.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """Run benchmark suite comparing oc-rsync against upstream rsync.
 
-Tests local copy, SSH (push + pull), and daemon (push + pull) modes.
-Outputs JSON results to stdout.
+Tests local copy, SSH (push + pull), and daemon (push + pull) modes against
+every upstream baseline named in `UPSTREAM_RSYNC`, and outputs JSON results
+to stdout.
+
+Two upstream releases are in circulation at once -- the current one and the
+one distributions still ship -- so a single-baseline comparison answers only
+half the question a release note is asked. Every upstream cell therefore runs
+once per baseline, and the results JSON carries a per-baseline dimension.
 """
 
 import json
@@ -14,16 +20,148 @@ import subprocess
 import sys
 import tempfile
 import time
+from dataclasses import dataclass
 
-UPSTREAM = os.environ.get("UPSTREAM_RSYNC", "")
-if not UPSTREAM:
-    sys.exit(
-        "UPSTREAM_RSYNC is not set: point it at the upstream rsync binary to "
-        "compare against, e.g. target/interop/upstream-src/rsync-3.5.0/rsync. "
-        "The caller that builds that binary owns the version, so this script "
-        "does not name one."
-    )
+import benchmark_env
+
 OC_RSYNC = "target/release/oc-rsync"
+
+
+@dataclass(frozen=True)
+class Baseline:
+    """One upstream rsync build to compare against.
+
+    `label` names the release in the results JSON, the report and the chart;
+    `path` is absolute because the SSH cells pass it to the remote end via
+    `--rsync-path`, where the working directory is the login shell's, not the
+    repository's.
+    """
+
+    label: str
+    path: str
+
+    @property
+    def slug(self) -> str:
+        """Filesystem-safe form of the label, for per-baseline directories."""
+        return re.sub(r"[^A-Za-z0-9._-]", "_", self.label)
+
+
+def _version_output(binary, *args):
+    """Capture a binary's version output, or `""` if it cannot be probed."""
+    try:
+        return subprocess.run(
+            [binary, *args], capture_output=True, timeout=10, text=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def binary_version(binary):
+    """Return the `x.y.z` release number reported by an upstream rsync build.
+
+    Upstream's banner is `rsync  version 3.5.0  protocol version 32`, so the
+    first release-shaped number in it is the release. This is deliberately
+    *not* used for oc-rsync: see `oc_rsync_versions` for why that binary needs
+    its own parser.
+    """
+    out = _version_output(binary, "--version")
+    match = re.search(r"\b(\d+\.\d+\.\d+)\b", out)
+    return match.group(1) if match else ""
+
+
+def oc_rsync_versions(binary):
+    """Return `(release, wire_compat)` for an oc-rsync build.
+
+    oc-rsync's banner leads with its own release and then names the upstream
+    wire protocol it speaks:
+
+        oc-rsync v0.6.4 (revision #9d99155e1) protocol version 32
+        Compatible with rsync 3.4.4 wire protocol
+
+    `binary_version`'s "first release-shaped number" rule cannot read this.
+    `\\b` does not match between `v` and `0`, so `v0.6.4` is skipped entirely
+    and the first number the pattern accepts is the *compatibility* version --
+    which is how a published release recorded `oc_rsync_version = '3.4.4'` for
+    a 0.6.4 build. The two numbers are different facts and are read from
+    different places: the release from the machine-readable `-VV` document
+    that exists for exactly this purpose, the compatibility version from the
+    banner line that states it.
+    """
+    release = ""
+    try:
+        release = json.loads(_version_output(binary, "-VV") or "{}").get(
+            "version", ""
+        )
+    except ValueError:
+        release = ""
+    banner = _version_output(binary, "--version")
+    if not release:
+        match = re.search(r"^\S+\s+v(\d+\.\d+\.\d+)", banner, re.M)
+        release = match.group(1) if match else ""
+        if not release:
+            print(
+                f"WARNING: cannot read oc-rsync's own release from {binary}",
+                file=sys.stderr,
+            )
+    compat = re.search(
+        r"Compatible with rsync (\d+\.\d+\.\d+) wire protocol", banner
+    )
+    return release, (compat.group(1) if compat else "")
+
+
+def parse_baselines(spec):
+    """Parse `UPSTREAM_RSYNC` into an ordered list of baselines.
+
+    Accepts a comma-separated list of `label=path` entries, or bare paths
+    whose label is then taken from the binary's own `--version` output. One
+    bare path is the historical single-baseline form and still works, so a
+    local run and CI drive the same knob.
+
+    The first entry is the primary baseline: it backs the legacy `upstream`
+    and `ratio` fields in the results JSON, serves the SSH and daemon cells
+    that are not run per baseline, and is the release the headline summary is
+    stated against.
+    """
+    baselines = []
+    seen = set()
+    for item in spec.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        label, sep, path = item.partition("=")
+        if not sep:
+            path, label = label, ""
+        path = os.path.expanduser(path)
+        # A bare command name means "whatever PATH resolves", which is how
+        # some callers name the system rsync. Resolve it here rather than
+        # treating it as a relative path, because the SSH cells hand this
+        # value to a remote shell that has its own working directory.
+        if os.sep not in path:
+            path = shutil.which(path) or path
+        path = os.path.abspath(path)
+        label = label.strip() or binary_version(path) or os.path.basename(path)
+        if label in seen:
+            sys.exit(f"duplicate baseline label {label!r} in UPSTREAM_RSYNC")
+        seen.add(label)
+        baselines.append(Baseline(label, path))
+    return baselines
+
+
+BASELINES = parse_baselines(os.environ.get("UPSTREAM_RSYNC", ""))
+if not BASELINES:
+    sys.exit(
+        "UPSTREAM_RSYNC is not set: name the upstream rsync binaries to "
+        "compare against as a comma-separated list, e.g. "
+        "'3.5.0=target/interop/upstream-src/rsync-3.5.0/rsync,"
+        "3.4.4=target/interop/upstream-src/rsync-3.4.4/rsync'. "
+        "The caller that builds those binaries owns the versions, so this "
+        "script does not name one."
+    )
+for _b in BASELINES:
+    if not os.path.isfile(_b.path):
+        sys.exit(f"upstream baseline {_b.label!r} not found at {_b.path}")
+
+PRIMARY = BASELINES[0]
 OC_RSYNC_OPENSSL = os.environ.get("OC_RSYNC_OPENSSL", "")
 OC_RSYNC_RUSSH = os.environ.get("OC_RSYNC_RUSSH", "")
 IS_LINUX = sys.platform.startswith("linux")
@@ -303,6 +441,12 @@ def wait_for_port(port, timeout=10):
 
 PER_RUN_TIMEOUT = 600  # seconds per individual rsync invocation
 
+# `/usr/bin/time` is what supplies peak RSS. Probe for it once rather than
+# wrapping every command and discovering per run that the wrapper itself is
+# missing, which would turn a missing memory column into a suite of failed
+# transfers.
+HAVE_TIME_CMD = os.access("/usr/bin/time", os.X_OK)
+
 
 def parse_peak_rss_kb(stderr_text):
     """Extract peak RSS in KB from /usr/bin/time output.
@@ -319,13 +463,16 @@ def parse_peak_rss_kb(stderr_text):
     return None
 
 
-def benchmark_rss(cmd, runs=4):
+def benchmark_rss(cmd, runs=4, before_each=None):
     """Run a command with /usr/bin/time and return timing + peak RSS stats."""
     time_flag = "-v" if IS_LINUX else "-l"
     wrapped = f"/usr/bin/time {time_flag} {cmd}"
     times = []
     rss_values = []
+    failures = 0
     for i in range(runs):
+        if before_each is not None:
+            before_each()
         start = time.perf_counter()
         try:
             result = subprocess.run(
@@ -334,6 +481,7 @@ def benchmark_rss(cmd, runs=4):
             elapsed = time.perf_counter() - start
             stderr = result.stderr.decode(errors="replace")
             if result.returncode != 0:
+                failures += 1
                 print(f"WARNING: exit {result.returncode}: {cmd}", file=sys.stderr)
                 if stderr.strip():
                     print(f"  stderr: {stderr[:200]}", file=sys.stderr)
@@ -341,38 +489,18 @@ def benchmark_rss(cmd, runs=4):
             if rss is not None:
                 rss_values.append(rss)
         except subprocess.TimeoutExpired:
+            failures += 1
             elapsed = time.perf_counter() - start
             print(
                 f"ERROR: timeout after {PER_RUN_TIMEOUT}s (run {i+1}/{runs}): {cmd}",
                 file=sys.stderr,
             )
         times.append(elapsed)
-    result = {
-        "mean": representative_secs(times),
-        "min": min(times),
-        "max": max(times),
-    }
+    result = stats(times, failures)
     if rss_values:
         result["peak_rss_kb"] = max(rss_values)
         result["avg_rss_kb"] = sum(rss_values) // len(rss_values)
     return result
-
-
-def binary_version(binary):
-    """Return the `x.y.z` release number reported by an rsync-compatible binary.
-
-    Runs `<binary> --version` and extracts the leading release number so the
-    report and chart can label the comparison against the exact upstream
-    build. Returns an empty string if the binary cannot be probed.
-    """
-    try:
-        out = subprocess.run(
-            [binary, "--version"], capture_output=True, timeout=10, text=True,
-        ).stdout
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    match = re.search(r"\b(\d+\.\d+\.\d+)\b", out)
-    return match.group(1) if match else ""
 
 
 def representative_secs(times):
@@ -391,14 +519,60 @@ def representative_secs(times):
     return ordered[mid] if n % 2 else (ordered[mid - 1] + ordered[mid]) / 2
 
 
-def benchmark(cmd, runs=6):
+def stats(times, failures=0):
+    """Timing statistics for one series of runs.
+
+    `spread_pct` states how far the fastest and slowest runs are apart as a
+    fraction of the representative value. A ratio built from two medians can
+    look decisive while resting on runs that varied by half their own
+    magnitude; publishing the spread next to the median is what makes a noisy
+    cell visible instead of hidden. `runs` is recorded so a reader can tell a
+    three-run cell from a six-run one.
+
+    `failures` counts runs the binary did not complete. A command that exits
+    immediately with an error is otherwise indistinguishable from one that
+    finished the work in a millisecond -- an upstream build without zstd
+    support rejects `--compress-choice=zstd` in about a millisecond and was
+    duly recorded as oc-rsync being 581x slower. Counting the failures is what
+    lets the summary refuse to average such a cell.
+    """
+    mean = representative_secs(times)
+    lo, hi = min(times), max(times)
+    result = {
+        "mean": mean,
+        "min": lo,
+        "max": hi,
+        "runs": len(times),
+        "spread_pct": round((hi - lo) / mean * 100, 1) if mean > 0 else 0.0,
+    }
+    if failures:
+        result["failures"] = failures
+    return result
+
+
+def series_failed(series):
+    """True when any run in this series did not complete."""
+    return bool(series.get("failures"))
+
+
+def benchmark(cmd, runs=6, before_each=None):
     """Run a command multiple times and return timing statistics.
 
     Reports the warm-up-discarded median under `mean` (kept under that key so
     the report/chart consumers are unchanged); `min`/`max` span every run.
+
+    `before_each` runs before every timed invocation, not once before the
+    series. A cell that resets its destination only once measures an initial
+    transfer in run 1 and a no-change transfer in runs 2..n -- and
+    `representative_secs` discards run 1 as the warm-up, so the published
+    "Initial sync" figure was the median of the no-change runs. Resetting per
+    run is what makes an initial-transfer cell measure an initial transfer.
     """
     times = []
+    failures = 0
     for i in range(runs):
+        if before_each is not None:
+            before_each()
         start = time.perf_counter()
         try:
             result = subprocess.run(
@@ -406,6 +580,7 @@ def benchmark(cmd, runs=6):
             )
             elapsed = time.perf_counter() - start
             if result.returncode != 0:
+                failures += 1
                 print(
                     f"WARNING: exit {result.returncode}: {cmd}",
                     file=sys.stderr,
@@ -414,29 +589,166 @@ def benchmark(cmd, runs=6):
                 if stderr:
                     print(f"  stderr: {stderr[:200]}", file=sys.stderr)
         except subprocess.TimeoutExpired:
+            failures += 1
             elapsed = time.perf_counter() - start
             print(
                 f"ERROR: timeout after {PER_RUN_TIMEOUT}s (run {i+1}/{runs}): {cmd}",
                 file=sys.stderr,
             )
         times.append(elapsed)
-    return {
-        "mean": representative_secs(times),
-        "min": min(times),
-        "max": max(times),
+    return stats(times, failures)
+
+
+MIB = 1024.0 * 1024.0
+
+
+def add_throughput(result, corpus_bytes):
+    """Annotate one series with the corpus rate it sustained, in MiB/s.
+
+    Defined as *corpus size / elapsed*, not bytes-on-the-wire: a no-change
+    sync moves almost nothing yet still has to stat and compare the whole
+    tree, and the rate a user cares about there is how fast the tool gets
+    through the tree. The harness knows the corpus size exactly; it does not
+    parse rsync's own transferred-byte accounting, so no figure here claims to
+    be wire throughput.
+    """
+    if corpus_bytes and result.get("mean", 0) > 0:
+        result["corpus_mibps"] = round(corpus_bytes / result["mean"] / MIB, 1)
+    return result
+
+
+def compare(
+    results,
+    test_id,
+    name,
+    mode,
+    up_cmd,
+    oc_cmd,
+    *,
+    runs=6,
+    runner=None,
+    up_before=None,
+    oc_before=None,
+    oc_per_baseline=False,
+    corpus_bytes=None,
+):
+    """Time oc-rsync against every upstream baseline and record one row.
+
+    `up_cmd` and `oc_cmd` take a `Baseline` and return the command line to
+    time, so a cell whose peer version matters (SSH, daemon) can point both
+    sides at the same release while a purely local cell ignores the argument.
+
+    `oc_per_baseline` says whether oc-rsync has to be re-timed for each
+    baseline. It must be true wherever the baseline is the *peer* -- an SSH
+    server or an rsync daemon -- because comparing oc-against-3.5.0 with
+    upstream-3.4.4-against-3.4.4 would credit or blame the client for a
+    difference in the server. Where the baseline is only the other contestant
+    in a local copy, oc-rsync is timed once and shared.
+
+    The row keeps the single-baseline `upstream`/`ratio` fields pointing at
+    the primary baseline so every existing consumer of this JSON still reads
+    a coherent comparison, and adds `upstreams`/`ratios` keyed by label.
+    """
+    runner = runner or benchmark
+    upstreams = {}
+    oc_results = {}
+    shared_oc = None
+
+    for baseline in BASELINES:
+        print(f"  baseline {baseline.label}...", file=sys.stderr)
+        upstreams[baseline.label] = runner(
+            up_cmd(baseline),
+            runs=runs,
+            before_each=(lambda b=baseline: up_before(b)) if up_before else None,
+        )
+        if oc_per_baseline or shared_oc is None:
+            measured = runner(
+                oc_cmd(baseline),
+                runs=runs,
+                before_each=(
+                    (lambda b=baseline: oc_before(b)) if oc_before else None
+                ),
+            )
+            if not oc_per_baseline:
+                shared_oc = measured
+        else:
+            measured = shared_oc
+        oc_results[baseline.label] = measured
+
+    oc_primary = oc_results[PRIMARY.label]
+    ratios = {
+        label: (
+            oc_results[label]["mean"] / up["mean"] if up["mean"] > 0 else 0.0
+        )
+        for label, up in upstreams.items()
     }
+
+    if corpus_bytes:
+        for series in list(upstreams.values()) + list(oc_results.values()):
+            add_throughput(series, corpus_bytes)
+
+    row = {
+        "id": test_id,
+        "name": name,
+        "mode": mode,
+        "upstreams": upstreams,
+        "ratios": {label: round(r, 2) for label, r in ratios.items()},
+        # Legacy single-baseline shape, pinned to the primary baseline.
+        "upstream": upstreams[PRIMARY.label],
+        "oc_rsync": oc_primary,
+        "ratio": round(ratios[PRIMARY.label], 2),
+    }
+    # A ratio against a binary that errored out is not a comparison. Name the
+    # series that failed so the report can say which side broke, and so the
+    # summary can leave the row out of its averages instead of reporting a
+    # 581x regression that is really a missing zstd in the upstream build.
+    failed = [
+        label for label, s in upstreams.items() if series_failed(s)
+    ] + [
+        f"oc-rsync/{label}"
+        for label, s in oc_results.items()
+        if series_failed(s)
+    ]
+    if failed:
+        row["failed_series"] = sorted(set(failed))
+    if oc_per_baseline:
+        row["oc_rsync_per_baseline"] = oc_results
+    if corpus_bytes:
+        row["corpus_bytes"] = corpus_bytes
+    results["tests"].append(row)
+    return row
+
+
+def tree_size(path):
+    """Total byte size of every regular file under `path`."""
+    return sum(
+        os.path.getsize(os.path.join(dp, f))
+        for dp, _, fn in os.walk(path)
+        for f in fn
+    )
+
+
+def wipe(*paths):
+    """Recreate each path as an empty directory."""
+    for path in paths:
+        shutil.rmtree(path, ignore_errors=True)
+        os.makedirs(path, exist_ok=True)
 
 
 def main():
     tmpdir = tempfile.mkdtemp(prefix="rsync_bench_")
-    daemon_proc = None
+    daemons = []
     results = {"tests": [], "summary": {}}
 
     try:
         src = f"{tmpdir}/src"
-        dst_up = f"{tmpdir}/dst_upstream"
+        # One destination per baseline: a shared destination would leave the
+        # second baseline's "initial" transfer facing a tree the first
+        # baseline had already written.
+        dst_up = {b.label: f"{tmpdir}/dst_upstream_{b.slug}" for b in BASELINES}
         dst_oc = f"{tmpdir}/dst_oc"
-        daemon_dst = f"{tmpdir}/daemon_dest"
+        dst_oc_per = {b.label: f"{tmpdir}/dst_oc_{b.slug}" for b in BASELINES}
+        daemon_dst = {b.label: f"{tmpdir}/daemon_dest_{b.slug}" for b in BASELINES}
 
         os.makedirs(f"{src}/small", exist_ok=True)
         os.makedirs(f"{src}/medium", exist_ok=True)
@@ -463,103 +775,172 @@ def main():
             with open(f"{src}/large/file_{i}.dat", "wb") as f:
                 f.write(os.urandom(3 * 1024 * 1024))
 
-        total_size = sum(
-            os.path.getsize(os.path.join(dp, f))
-            for dp, dn, fn in os.walk(src)
-            for f in fn
-        )
+        total_size = tree_size(src)
         total_files = sum(len(fn) for _, _, fn in os.walk(src))
 
         results["test_data"] = {
             "size_mb": round(total_size / 1024 / 1024, 1),
             "files": total_files,
         }
-        results["upstream_version"] = binary_version(UPSTREAM)
-        results["oc_rsync_version"] = binary_version(OC_RSYNC)
-
-        # Start rsync daemon for daemon benchmarks
-        port = find_free_port()
-        conf_path = f"{tmpdir}/rsyncd.conf"
-        os.makedirs(daemon_dst, exist_ok=True)
-
-        with open(conf_path, "w") as f:
-            f.write(
-                f"port = {port}\n"
-                f"use chroot = false\n"
-                f"\n"
-                f"[bench]\n"
-                f"    path = {src}\n"
-                f"    read only = true\n"
-                f"\n"
-                f"[dest]\n"
-                f"    path = {daemon_dst}\n"
-                f"    read only = false\n"
-            )
-
-        print(f"Starting rsync daemon on port {port}...", file=sys.stderr)
-        daemon_proc = subprocess.Popen(
-            [UPSTREAM, "--daemon", "--config", conf_path, "--no-detach"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+        results["baselines"] = [
+            {
+                "label": b.label,
+                "version": binary_version(b.path),
+                "path": b.path,
+                "primary": b.label == PRIMARY.label,
+            }
+            for b in BASELINES
+        ]
+        # Retained for consumers that predate the per-baseline dimension:
+        # the primary baseline is the one the legacy fields describe.
+        results["upstream_version"] = binary_version(PRIMARY.path)
+        oc_release, oc_compat = oc_rsync_versions(OC_RSYNC)
+        results["oc_rsync_version"] = oc_release
+        results["oc_rsync_wire_compat_version"] = oc_compat
+        results["environment"] = benchmark_env.capture(
+            os.environ.get("OC_RSYNC_SEND_ZC_DISPATCH", "")
         )
-        if not wait_for_port(port):
-            print("ERROR: rsync daemon failed to start", file=sys.stderr)
-            sys.exit(1)
-        print("Daemon ready.", file=sys.stderr)
+        print(
+            benchmark_env.send_zc_verdict(results["environment"]),
+            file=sys.stderr,
+        )
 
-        def reset_dst():
-            shutil.rmtree(dst_up, ignore_errors=True)
-            shutil.rmtree(dst_oc, ignore_errors=True)
-            os.makedirs(dst_up, exist_ok=True)
-            os.makedirs(dst_oc, exist_ok=True)
+        # One daemon per baseline, each on its own port with its own module
+        # tree. The daemon is the *peer* for the daemon cells, so timing
+        # oc-rsync against a single daemon while comparing it to two different
+        # upstream clients would fold a server-version difference into the
+        # client ratio.
+        ports = {}
+        for baseline in BASELINES:
+            port = find_free_port()
+            ports[baseline.label] = port
+            conf_path = f"{tmpdir}/rsyncd_{baseline.slug}.conf"
+            os.makedirs(daemon_dst[baseline.label], exist_ok=True)
+            with open(conf_path, "w") as f:
+                f.write(
+                    f"port = {port}\n"
+                    f"use chroot = false\n"
+                    f"\n"
+                    f"[bench]\n"
+                    f"    path = {src}\n"
+                    f"    read only = true\n"
+                    f"\n"
+                    f"[dest]\n"
+                    f"    path = {daemon_dst[baseline.label]}\n"
+                    f"    read only = false\n"
+                )
+            print(
+                f"Starting rsync {baseline.label} daemon on port {port}...",
+                file=sys.stderr,
+            )
+            daemons.append(
+                subprocess.Popen(
+                    [
+                        baseline.path,
+                        "--daemon",
+                        "--config",
+                        conf_path,
+                        "--no-detach",
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            )
+            if not wait_for_port(port):
+                print(
+                    f"ERROR: rsync {baseline.label} daemon failed to start",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+        print("Daemons ready.", file=sys.stderr)
 
-        def reset_daemon_dst():
-            shutil.rmtree(daemon_dst, ignore_errors=True)
-            os.makedirs(daemon_dst, exist_ok=True)
+        # The oc-vs-oc cells below (OpenSSL, io_uring, SSH transport) compare
+        # build variants of oc-rsync rather than releases of upstream, so they
+        # have no baseline dimension and speak to the primary baseline's
+        # daemon only.
+        port = ports[PRIMARY.label]
+
+        # `--rsync-path` pins the remote end of an SSH cell to the same
+        # release as the local end. Without it the remote server is whatever
+        # `rsync` the login PATH resolves, so a 3.4.4 client would be timed
+        # against a 3.5.0 server and the row would name a version it did not
+        # measure. oc-rsync takes the same option, so its SSH cells are timed
+        # against each baseline's server too and the comparison isolates the
+        # client.
+        def ssh_pin(baseline):
+            return f"--rsync-path={baseline.path}"
 
         for test in TESTS:
-            test_id = test["id"]
-            name = test["name"]
             mode = test["mode"]
             args_tpl = test["args"]
             do_reset = test["reset"]
+            is_daemon = mode.startswith("daemon_")
+            is_ssh = mode.startswith("ssh_")
+            per_baseline = is_daemon or is_ssh
 
-            print(f"Running: [{mode}] {name}...", file=sys.stderr)
+            print(f"Running: [{mode}] {test['name']}...", file=sys.stderr)
+
+            def oc_dst_for(baseline, per_baseline=per_baseline):
+                return dst_oc_per[baseline.label] if per_baseline else dst_oc
+
+            def up_args(baseline, args_tpl=args_tpl):
+                return args_tpl.format(
+                    src=src,
+                    dst=dst_up[baseline.label],
+                    port=ports[baseline.label],
+                )
+
+            def oc_args(baseline, args_tpl=args_tpl):
+                return args_tpl.format(
+                    src=src,
+                    dst=oc_dst_for(baseline),
+                    port=ports[baseline.label],
+                )
+
+            pin = ssh_pin if is_ssh else (lambda b: "")
+
+            def up_cmd(baseline):
+                return f"{baseline.path} {pin(baseline)} {up_args(baseline)}"
+
+            def oc_cmd(baseline):
+                return f"{OC_RSYNC} {pin(baseline)} {oc_args(baseline)}"
+
+            def up_before(baseline):
+                wipe(dst_up[baseline.label])
+                if is_daemon:
+                    wipe(daemon_dst[baseline.label])
+
+            def oc_before(baseline):
+                wipe(oc_dst_for(baseline))
+                if is_daemon:
+                    wipe(daemon_dst[baseline.label])
 
             if do_reset:
-                reset_dst()
-                if mode == "daemon_push":
-                    reset_daemon_dst()
-
-            up_args = args_tpl.format(src=src, dst=dst_up, port=port)
-            oc_args = args_tpl.format(src=src, dst=dst_oc, port=port)
-
-            # For daemon push, both tools push to the same daemon dest,
-            # so reset between them to get fair initial-transfer timing.
-            if mode == "daemon_push" and do_reset:
-                reset_daemon_dst()
-                up_result = benchmark(f"{UPSTREAM} {up_args}")
-                reset_daemon_dst()
-                oc_result = benchmark(f"{OC_RSYNC} {oc_args}")
+                # An initial-transfer cell has to start from an empty
+                # destination on every run, not only the first.
+                before_up, before_oc, runs = up_before, oc_before, 3
             else:
-                up_result = benchmark(f"{UPSTREAM} {up_args}")
-                oc_result = benchmark(f"{OC_RSYNC} {oc_args}")
+                before_up = before_oc = None
+                runs = 6
 
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
-            )
-
-            results["tests"].append(
-                {
-                    "id": test_id,
-                    "name": name,
-                    "mode": mode,
-                    "upstream": up_result,
-                    "oc_rsync": oc_result,
-                    "ratio": round(ratio, 2),
-                }
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                mode,
+                up_cmd,
+                oc_cmd,
+                runs=runs,
+                # Peak RSS is collected alongside the timing here, not only in
+                # the dedicated memory mode. The report has always had columns
+                # for it on these rows; without the /usr/bin/time wrapper they
+                # were dashes, so a throughput win bought with memory was
+                # invisible on the very table that claimed to show it.
+                runner=benchmark_rss if HAVE_TIME_CMD else benchmark,
+                up_before=before_up,
+                oc_before=before_oc,
+                oc_per_baseline=per_baseline,
+                corpus_bytes=total_size,
             )
 
         # OpenSSL vs pure-Rust comparison
@@ -567,12 +948,7 @@ def main():
             print("Running OpenSSL vs pure-Rust comparison...", file=sys.stderr)
             dst_pure = f"{tmpdir}/dst_pure"
             dst_ssl = f"{tmpdir}/dst_ssl"
-
-            def reset_openssl_dst():
-                shutil.rmtree(dst_pure, ignore_errors=True)
-                shutil.rmtree(dst_ssl, ignore_errors=True)
-                os.makedirs(dst_pure, exist_ok=True)
-                os.makedirs(dst_ssl, exist_ok=True)
+            wipe(dst_pure, dst_ssl)
 
             for test in OPENSSL_TESTS:
                 test_id = test["id"]
@@ -582,14 +958,26 @@ def main():
 
                 print(f"Running: [{mode}] {name}...", file=sys.stderr)
 
-                if test["reset"]:
-                    reset_openssl_dst()
-
+                runs = 3 if test["reset"] else 6
                 pure_args = args_tpl.format(src=src, dst=dst_pure, port=port)
                 ssl_args = args_tpl.format(src=src, dst=dst_ssl, port=port)
 
-                pure_result = benchmark(f"{OC_RSYNC} {pure_args}")
-                ssl_result = benchmark(f"{OC_RSYNC_OPENSSL} {ssl_args}")
+                pure_result = benchmark(
+                    f"{OC_RSYNC} {pure_args}",
+                    runs=runs,
+                    before_each=(
+                        (lambda: wipe(dst_pure)) if test["reset"] else None
+                    ),
+                )
+                ssl_result = benchmark(
+                    f"{OC_RSYNC_OPENSSL} {ssl_args}",
+                    runs=runs,
+                    before_each=(
+                        (lambda: wipe(dst_ssl)) if test["reset"] else None
+                    ),
+                )
+                add_throughput(pure_result, total_size)
+                add_throughput(ssl_result, total_size)
 
                 ratio = (
                     ssl_result["mean"] / pure_result["mean"]
@@ -629,15 +1017,10 @@ def main():
             dst_sub_push = f"{tmpdir}/dst_sub_push"
             dst_russh_push = f"{tmpdir}/dst_russh_push"
 
-            def reset_transport_pull():
-                for d in (dst_upstream_pull, dst_sub_pull, dst_russh_pull):
-                    shutil.rmtree(d, ignore_errors=True)
-                    os.makedirs(d, exist_ok=True)
-
-            def reset_transport_push():
-                for d in (dst_upstream_push, dst_sub_push, dst_russh_push):
-                    shutil.rmtree(d, ignore_errors=True)
-                    os.makedirs(d, exist_ok=True)
+            wipe(
+                dst_upstream_pull, dst_sub_pull, dst_russh_pull,
+                dst_upstream_push, dst_sub_push, dst_russh_push,
+            )
 
             for test in RUSSH_TESTS:
                 test_id = test["id"]
@@ -646,12 +1029,6 @@ def main():
                 is_push = "push" in test_id
 
                 print(f"Running: [{mode}] {name}...", file=sys.stderr)
-
-                if test["reset"]:
-                    if is_push:
-                        reset_transport_push()
-                    else:
-                        reset_transport_pull()
 
                 if is_push:
                     upstream_dst = dst_upstream_push
@@ -664,9 +1041,30 @@ def main():
                 sub_args = test["subprocess_args"].format(src=src, dst=sub_dst)
                 russh_args = test["russh_args"].format(src=src, dst=russh_dst)
 
-                upstream_result = benchmark(f"{UPSTREAM} {upstream_args}")
-                sub_result = benchmark(f"{OC_RSYNC} {sub_args}")
-                russh_result = benchmark(f"{OC_RSYNC_RUSSH} {russh_args}")
+                runs = 3 if test["reset"] else 6
+                reset = test["reset"]
+                pin = f"--rsync-path={PRIMARY.path}"
+                upstream_result = benchmark(
+                    f"{PRIMARY.path} {pin} {upstream_args}",
+                    runs=runs,
+                    before_each=(
+                        (lambda d=upstream_dst: wipe(d)) if reset else None
+                    ),
+                )
+                sub_result = benchmark(
+                    f"{OC_RSYNC} {pin} {sub_args}",
+                    runs=runs,
+                    before_each=(lambda d=sub_dst: wipe(d)) if reset else None,
+                )
+                russh_result = benchmark(
+                    f"{OC_RSYNC_RUSSH} {pin} {russh_args}",
+                    runs=runs,
+                    before_each=(
+                        (lambda d=russh_dst: wipe(d)) if reset else None
+                    ),
+                )
+                for series in (upstream_result, sub_result, russh_result):
+                    add_throughput(series, total_size)
 
                 ratio_russh_vs_sub = (
                     russh_result["mean"] / sub_result["mean"]
@@ -736,17 +1134,23 @@ def main():
                 print(f"Running: [io_uring] {test['name']}...", file=sys.stderr)
                 args_tpl = test["args"]
 
-                # Run with --io-uring (enabled)
-                shutil.rmtree(dst_uring, ignore_errors=True)
-                os.makedirs(dst_uring, exist_ok=True)
+                # Every io_uring cell is an initial transfer, so both arms
+                # reset before each run.
                 uring_args = args_tpl.format(src=src, dst=dst_uring, port=port)
-                uring_result = benchmark(f"{OC_RSYNC} --io-uring {uring_args}")
+                uring_result = benchmark(
+                    f"{OC_RSYNC} --io-uring {uring_args}",
+                    runs=3,
+                    before_each=lambda: wipe(dst_uring),
+                )
 
-                # Run with --no-io-uring (disabled)
-                shutil.rmtree(dst_no_uring, ignore_errors=True)
-                os.makedirs(dst_no_uring, exist_ok=True)
                 no_uring_args = args_tpl.format(src=src, dst=dst_no_uring, port=port)
-                no_uring_result = benchmark(f"{OC_RSYNC} --no-io-uring {no_uring_args}")
+                no_uring_result = benchmark(
+                    f"{OC_RSYNC} --no-io-uring {no_uring_args}",
+                    runs=3,
+                    before_each=lambda: wipe(dst_no_uring),
+                )
+                add_throughput(uring_result, total_size)
+                add_throughput(no_uring_result, total_size)
 
                 ratio = (
                     uring_result["mean"] / no_uring_result["mean"]
@@ -769,142 +1173,168 @@ def main():
 
         # Compression benchmarks (zlib and zstd)
         print("Running compression benchmarks...", file=sys.stderr)
-        dst_comp_up = f"{tmpdir}/dst_comp_up"
+        dst_comp_up = {b.label: f"{tmpdir}/dst_comp_up_{b.slug}" for b in BASELINES}
         dst_comp_oc = f"{tmpdir}/dst_comp_oc"
-
-        def reset_comp_dst():
-            shutil.rmtree(dst_comp_up, ignore_errors=True)
-            shutil.rmtree(dst_comp_oc, ignore_errors=True)
-            os.makedirs(dst_comp_up, exist_ok=True)
-            os.makedirs(dst_comp_oc, exist_ok=True)
+        wipe(dst_comp_oc, *dst_comp_up.values())
 
         for test in COMPRESSION_TESTS:
             print(f"Running: [compression] {test['name']}...", file=sys.stderr)
-            if test["reset"]:
-                reset_comp_dst()
-            up_args = test["args"].format(src=src, dst=dst_comp_up, port=port)
-            oc_args = test["args"].format(src=src, dst=dst_comp_oc, port=port)
-            up_result = benchmark(f"{UPSTREAM} {up_args}")
-            oc_result = benchmark(f"{OC_RSYNC} {oc_args}")
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
+            reset = test["reset"]
+            args_tpl = test["args"]
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "compression",
+                lambda b, a=args_tpl: (
+                    f"{b.path} "
+                    + a.format(src=src, dst=dst_comp_up[b.label], port=port)
+                ),
+                lambda b, a=args_tpl: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=src, dst=dst_comp_oc, port=port)
+                ),
+                runs=3 if reset else 6,
+                up_before=(lambda b: wipe(dst_comp_up[b.label])) if reset else None,
+                oc_before=(lambda b: wipe(dst_comp_oc)) if reset else None,
+                corpus_bytes=total_size,
             )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "compression",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
         # Delta transfer benchmarks (modify files then re-sync)
         print("Running delta transfer benchmarks...", file=sys.stderr)
-        dst_delta_up = f"{tmpdir}/dst_delta_up"
+        dst_delta_up = {
+            b.label: f"{tmpdir}/dst_delta_up_{b.slug}" for b in BASELINES
+        }
         dst_delta_oc = f"{tmpdir}/dst_delta_oc"
+        wipe(dst_delta_oc, *dst_delta_up.values())
 
         # Initial sync to populate destinations
-        shutil.rmtree(dst_delta_up, ignore_errors=True)
-        shutil.rmtree(dst_delta_oc, ignore_errors=True)
-        os.makedirs(dst_delta_up, exist_ok=True)
-        os.makedirs(dst_delta_oc, exist_ok=True)
-        subprocess.run(
-            f"{UPSTREAM} -av {src}/ {dst_delta_up}/",
-            shell=True, capture_output=True, timeout=PER_RUN_TIMEOUT,
-        )
-        subprocess.run(
-            f"{OC_RSYNC} -av {src}/ {dst_delta_oc}/",
-            shell=True, capture_output=True, timeout=PER_RUN_TIMEOUT,
-        )
+        for path in [dst_delta_oc, *dst_delta_up.values()]:
+            subprocess.run(
+                f"{PRIMARY.path} -av {src}/ {path}/",
+                shell=True, capture_output=True, timeout=PER_RUN_TIMEOUT,
+            )
 
         # Modify ~10% of medium files (append 4KB to trigger delta)
-        for i in range(0, 400, 10):
-            path = f"{src}/medium/file_{i}.bin"
-            with open(path, "ab") as f:
+        MODIFIED_MEDIUM = range(0, 400, 10)
+        for i in MODIFIED_MEDIUM:
+            with open(f"{src}/medium/file_{i}.bin", "ab") as f:
                 f.write(os.urandom(4096))
+
+        def stale_delta_dest(path):
+            """Roll the destination back to its pre-modification content.
+
+            Without this the first run performs the delta and every later run
+            has nothing left to send, so a delta cell would report the cost of
+            a no-change scan. Truncating to the original length restores the
+            size mismatch that makes the next run a real delta transfer.
+            """
+            for i in MODIFIED_MEDIUM:
+                with open(f"{path}/medium/file_{i}.bin", "r+b") as f:
+                    f.truncate(100 * 1024)
 
         for test in DELTA_TESTS:
             print(f"Running: [delta] {test['name']}...", file=sys.stderr)
-            up_args = test["args"].format(src=src, dst=dst_delta_up, port=port)
-            oc_args = test["args"].format(src=src, dst=dst_delta_oc, port=port)
-            up_result = benchmark(f"{UPSTREAM} {up_args}")
-            oc_result = benchmark(f"{OC_RSYNC} {oc_args}")
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
+            args_tpl = test["args"]
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "delta",
+                lambda b, a=args_tpl: (
+                    f"{b.path} "
+                    + a.format(src=src, dst=dst_delta_up[b.label], port=port)
+                ),
+                lambda b, a=args_tpl: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=src, dst=dst_delta_oc, port=port)
+                ),
+                runs=4,
+                up_before=lambda b: stale_delta_dest(dst_delta_up[b.label]),
+                oc_before=lambda b: stale_delta_dest(dst_delta_oc),
+                corpus_bytes=total_size,
             )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "delta",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
         # Restore modified files to original size for subsequent benchmarks
-        for i in range(0, 400, 10):
-            path = f"{src}/medium/file_{i}.bin"
-            with open(path, "r+b") as f:
+        for i in MODIFIED_MEDIUM:
+            with open(f"{src}/medium/file_{i}.bin", "r+b") as f:
                 f.truncate(100 * 1024)
 
         # Large single file benchmark (1GB)
         print("Running large file benchmarks...", file=sys.stderr)
         large_src = f"{tmpdir}/large_src"
-        dst_large_up = f"{tmpdir}/dst_large_up"
+        dst_large_up = {
+            b.label: f"{tmpdir}/dst_large_up_{b.slug}" for b in BASELINES
+        }
         dst_large_oc = f"{tmpdir}/dst_large_oc"
         os.makedirs(large_src, exist_ok=True)
+        wipe(dst_large_oc, *dst_large_up.values())
 
         large_file_path = f"{large_src}/bigfile.dat"
         with open(large_file_path, "wb") as f:
             # Write 1GB in 1MB chunks
             for _ in range(1024):
                 f.write(os.urandom(1024 * 1024))
+        large_size = os.path.getsize(large_file_path)
+
+        DELTA_OFFSET = 512 * 1024 * 1024
+        DELTA_SPAN = 64 * 1024
+
+        def stale_large_dest(path):
+            """Overwrite the destination's middle 64KB so the next run deltas.
+
+            Writing on the destination side also moves its mtime, so rsync's
+            quick check sees a difference and re-runs the block search instead
+            of skipping a file whose size never changed.
+            """
+            target = f"{path}/bigfile.dat"
+            if not os.path.isfile(target):
+                return
+            with open(target, "r+b") as f:
+                f.seek(DELTA_OFFSET)
+                f.write(os.urandom(DELTA_SPAN))
 
         for test in LARGE_FILE_TESTS:
             print(f"Running: [large_file] {test['name']}...", file=sys.stderr)
+            args_tpl = test["args"]
             if test["reset"]:
-                shutil.rmtree(dst_large_up, ignore_errors=True)
-                shutil.rmtree(dst_large_oc, ignore_errors=True)
-                os.makedirs(dst_large_up, exist_ok=True)
-                os.makedirs(dst_large_oc, exist_ok=True)
+                up_before = lambda b: wipe(dst_large_up[b.label])
+                oc_before = lambda b: wipe(dst_large_oc)
+            elif test["id"] == "large_file_delta":
+                up_before = lambda b: stale_large_dest(dst_large_up[b.label])
+                oc_before = lambda b: stale_large_dest(dst_large_oc)
+            else:
+                up_before = oc_before = None
 
-            # For delta test, modify a 64KB region in the middle of the file
-            if test["id"] == "large_file_delta":
-                with open(large_file_path, "r+b") as f:
-                    f.seek(512 * 1024 * 1024)
-                    f.write(os.urandom(64 * 1024))
-
-            up_args = test["args"].format(
-                src=large_src, dst=dst_large_up, port=port,
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "large_file",
+                lambda b, a=args_tpl: (
+                    f"{b.path} "
+                    + a.format(
+                        src=large_src, dst=dst_large_up[b.label], port=port,
+                    )
+                ),
+                lambda b, a=args_tpl: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=large_src, dst=dst_large_oc, port=port)
+                ),
+                runs=3,
+                up_before=up_before,
+                oc_before=oc_before,
+                corpus_bytes=large_size,
             )
-            oc_args = test["args"].format(
-                src=large_src, dst=dst_large_oc, port=port,
-            )
-            up_result = benchmark(f"{UPSTREAM} {up_args}", runs=3)
-            oc_result = benchmark(f"{OC_RSYNC} {oc_args}", runs=3)
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
-            )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "large_file",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
         # Many small files benchmark (100K files)
         print("Running many small files benchmarks...", file=sys.stderr)
         many_src = f"{tmpdir}/many_src"
-        dst_many_up = f"{tmpdir}/dst_many_up"
+        dst_many_up = {
+            b.label: f"{tmpdir}/dst_many_up_{b.slug}" for b in BASELINES
+        }
         dst_many_oc = f"{tmpdir}/dst_many_oc"
+        wipe(dst_many_oc, *dst_many_up.values())
 
         # Create 100K files x 100B across 100 directories
         for d in range(100):
@@ -913,100 +1343,98 @@ def main():
             for i in range(1000):
                 with open(f"{dir_path}/f{i:04d}.txt", "wb") as f:
                     f.write(os.urandom(100))
+        many_size = tree_size(many_src)
 
         for test in MANY_SMALL_FILES_TESTS:
             print(f"Running: [many_small] {test['name']}...", file=sys.stderr)
-            if test["reset"]:
-                shutil.rmtree(dst_many_up, ignore_errors=True)
-                shutil.rmtree(dst_many_oc, ignore_errors=True)
-                os.makedirs(dst_many_up, exist_ok=True)
-                os.makedirs(dst_many_oc, exist_ok=True)
-            up_args = test["args"].format(
-                src=many_src, dst=dst_many_up, port=port,
+            args_tpl = test["args"]
+            reset = test["reset"]
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "many_small",
+                lambda b, a=args_tpl: (
+                    f"{b.path} "
+                    + a.format(
+                        src=many_src, dst=dst_many_up[b.label], port=port,
+                    )
+                ),
+                lambda b, a=args_tpl: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=many_src, dst=dst_many_oc, port=port)
+                ),
+                runs=3,
+                up_before=(lambda b: wipe(dst_many_up[b.label])) if reset else None,
+                oc_before=(lambda b: wipe(dst_many_oc)) if reset else None,
+                corpus_bytes=many_size,
             )
-            oc_args = test["args"].format(
-                src=many_src, dst=dst_many_oc, port=port,
-            )
-            up_result = benchmark(f"{UPSTREAM} {up_args}", runs=3)
-            oc_result = benchmark(f"{OC_RSYNC} {oc_args}", runs=3)
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
-            )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "many_small",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
         # Memory usage (peak RSS) benchmark
         print("Running memory usage benchmarks...", file=sys.stderr)
-        dst_mem_up = f"{tmpdir}/dst_mem_up"
+        dst_mem_up = {
+            b.label: f"{tmpdir}/dst_mem_up_{b.slug}" for b in BASELINES
+        }
         dst_mem_oc = f"{tmpdir}/dst_mem_oc"
+        wipe(dst_mem_oc, *dst_mem_up.values())
 
         memory_tests = [
             {
                 "id": "memory_initial",
                 "name": "Initial sync (10K files)",
                 "src": src,
+                "bytes": total_size,
                 "args": "-av {src}/ {dst}/",
-                "reset": True,
             },
             {
                 "id": "memory_large_file",
                 "name": "1GB file sync",
                 "src": large_src,
+                "bytes": large_size,
                 "args": "-av {src}/ {dst}/",
-                "reset": True,
             },
             {
                 "id": "memory_many_files",
                 "name": "100K files sync",
                 "src": many_src,
+                "bytes": many_size,
                 "args": "-av {src}/ {dst}/",
-                "reset": True,
             },
         ]
 
         for test in memory_tests:
             print(f"Running: [memory] {test['name']}...", file=sys.stderr)
-            if test["reset"]:
-                shutil.rmtree(dst_mem_up, ignore_errors=True)
-                shutil.rmtree(dst_mem_oc, ignore_errors=True)
-                os.makedirs(dst_mem_up, exist_ok=True)
-                os.makedirs(dst_mem_oc, exist_ok=True)
-            up_args = test["args"].format(
-                src=test["src"], dst=dst_mem_up, port=port,
+            args_tpl = test["args"]
+            test_src = test["src"]
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "memory",
+                lambda b, a=args_tpl, s=test_src: (
+                    f"{b.path} "
+                    + a.format(src=s, dst=dst_mem_up[b.label], port=port)
+                ),
+                lambda b, a=args_tpl, s=test_src: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=s, dst=dst_mem_oc, port=port)
+                ),
+                runs=3,
+                runner=benchmark_rss if HAVE_TIME_CMD else benchmark,
+                up_before=lambda b: wipe(dst_mem_up[b.label]),
+                oc_before=lambda b: wipe(dst_mem_oc),
+                corpus_bytes=test["bytes"],
             )
-            oc_args = test["args"].format(
-                src=test["src"], dst=dst_mem_oc, port=port,
-            )
-            up_result = benchmark_rss(f"{UPSTREAM} {up_args}")
-            oc_result = benchmark_rss(f"{OC_RSYNC} {oc_args}")
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
-            )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "memory",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
         # Sparse file benchmark
         print("Running sparse file benchmarks...", file=sys.stderr)
         sparse_src = f"{tmpdir}/sparse_src"
-        dst_sparse_up = f"{tmpdir}/dst_sparse_up"
+        dst_sparse_up = {
+            b.label: f"{tmpdir}/dst_sparse_up_{b.slug}" for b in BASELINES
+        }
         dst_sparse_oc = f"{tmpdir}/dst_sparse_oc"
         os.makedirs(sparse_src, exist_ok=True)
+        wipe(dst_sparse_oc, *dst_sparse_up.values())
 
         # Create files with large zero runs (simulating sparse data)
         for i in range(50):
@@ -1016,57 +1444,104 @@ def main():
                 f.write(os.urandom(1024 * 1024))
                 f.write(b"\0" * (8 * 1024 * 1024))
                 f.write(os.urandom(1024 * 1024))
+        sparse_size = tree_size(sparse_src)
 
         for test in SPARSE_TESTS:
             print(f"Running: [sparse] {test['name']}...", file=sys.stderr)
-            if test["reset"]:
-                shutil.rmtree(dst_sparse_up, ignore_errors=True)
-                shutil.rmtree(dst_sparse_oc, ignore_errors=True)
-                os.makedirs(dst_sparse_up, exist_ok=True)
-                os.makedirs(dst_sparse_oc, exist_ok=True)
-            up_args = test["args"].format(
-                src=sparse_src, dst=dst_sparse_up, port=port,
+            args_tpl = test["args"]
+            reset = test["reset"]
+            compare(
+                results,
+                test["id"],
+                test["name"],
+                "sparse",
+                lambda b, a=args_tpl: (
+                    f"{b.path} "
+                    + a.format(
+                        src=sparse_src, dst=dst_sparse_up[b.label], port=port,
+                    )
+                ),
+                lambda b, a=args_tpl: (
+                    f"{OC_RSYNC} "
+                    + a.format(src=sparse_src, dst=dst_sparse_oc, port=port)
+                ),
+                runs=3,
+                up_before=(
+                    (lambda b: wipe(dst_sparse_up[b.label])) if reset else None
+                ),
+                oc_before=(lambda b: wipe(dst_sparse_oc)) if reset else None,
+                corpus_bytes=sparse_size,
             )
-            oc_args = test["args"].format(
-                src=sparse_src, dst=dst_sparse_oc, port=port,
-            )
-            up_result = benchmark(f"{UPSTREAM} {up_args}", runs=3)
-            oc_result = benchmark(f"{OC_RSYNC} {oc_args}", runs=3)
-            ratio = (
-                oc_result["mean"] / up_result["mean"]
-                if up_result["mean"] > 0
-                else 0
-            )
-            results["tests"].append({
-                "id": test["id"],
-                "name": test["name"],
-                "mode": "sparse",
-                "upstream": up_result,
-                "oc_rsync": oc_result,
-                "ratio": round(ratio, 2),
-            })
 
-        # Calculate summary
-        ratios = [t["ratio"] for t in results["tests"]]
+        # Calculate summary. `ratios` per row is keyed by baseline label, so
+        # the headline numbers are stated once per baseline as well; the
+        # unsuffixed fields keep describing the primary baseline for consumers
+        # that predate the dimension.
+        # Rows where a binary failed are excluded: averaging a ratio against a
+        # command that errored out in a millisecond states a performance
+        # verdict the run never measured.
+        sound = [
+            t for t in results["tests"]
+            if "ratios" in t and not t.get("failed_series")
+        ]
+        excluded = [
+            t["id"] for t in results["tests"] if t.get("failed_series")
+        ]
+
+        by_baseline = {}
+        for baseline in BASELINES:
+            label = baseline.label
+            values = [t["ratios"][label] for t in sound]
+            if not values:
+                continue
+            modes = {}
+            for t in sound:
+                modes.setdefault(t["mode"], []).append(t["ratios"][label])
+            by_baseline[label] = {
+                "avg_ratio": round(sum(values) / len(values), 2),
+                "best_ratio": round(min(values), 2),
+                "worst_ratio": round(max(values), 2),
+                "by_mode": {
+                    m: round(sum(r) / len(r), 2) for m, r in modes.items()
+                },
+            }
+
+        ratios = [
+            t["ratio"] for t in results["tests"] if not t.get("failed_series")
+        ]
         by_mode = {}
         for t in results["tests"]:
+            if t.get("failed_series"):
+                continue
             by_mode.setdefault(t["mode"], []).append(t["ratio"])
 
         results["summary"] = {
-            "avg_ratio": round(sum(ratios) / len(ratios), 2),
-            "best_ratio": round(min(ratios), 2),
-            "worst_ratio": round(max(ratios), 2),
+            "avg_ratio": round(sum(ratios) / len(ratios), 2) if ratios else 0.0,
+            "best_ratio": round(min(ratios), 2) if ratios else 0.0,
+            "worst_ratio": round(max(ratios), 2) if ratios else 0.0,
             "by_mode": {
                 m: round(sum(r) / len(r), 2) for m, r in by_mode.items()
             },
+            "by_baseline": by_baseline,
+            "excluded_tests": excluded,
         }
+        if excluded:
+            print(
+                "WARNING: excluded from the summary because a binary failed: "
+                + ", ".join(excluded),
+                file=sys.stderr,
+            )
 
         print(json.dumps(results, indent=2))
 
     finally:
-        if daemon_proc is not None:
-            daemon_proc.terminate()
-            daemon_proc.wait(timeout=5)
+        for proc in daemons:
+            proc.terminate()
+        for proc in daemons:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 

--- a/.github/scripts/benchmark_chart.py
+++ b/.github/scripts/benchmark_chart.py
@@ -35,7 +35,10 @@ from html import escape
 
 CHART_WIDTH = 800
 LEFT_MARGIN = 180
-RIGHT_MARGIN = 120
+# Wide enough for the longest ratio annotation a multi-baseline row can
+# produce ("vs 3.4.4 12.5x faster"), which would otherwise run off the
+# right edge of the SVG.
+RIGHT_MARGIN = 140
 BAR_AREA_WIDTH = CHART_WIDTH - LEFT_MARGIN - RIGHT_MARGIN
 
 TOP_MARGIN = 60
@@ -62,6 +65,13 @@ RATIO_SAME_UPPER = 1.05
 
 COLOR_UPSTREAM = "#6e7681"
 COLOR_OC_RSYNC = "#58a6ff"
+# One shade per upstream baseline, in the order the run measured them. Greys
+# and browns stay visually subordinate to oc-rsync's blue, so a reader still
+# sees which bar is the subject of the comparison when there are several
+# baselines rather than one.
+COLOR_BASELINES = (COLOR_UPSTREAM, "#a1887f", "#8d6e63", "#546e7a")
+# Matching shades for oc-rsync when it had to be re-timed per baseline.
+COLOR_OC_VARIANTS = ("#58a6ff", "#79c0ff", "#a5d6ff", "#cae8ff")
 COLOR_PURE_RUST = "#58a6ff"
 COLOR_OPENSSL = "#d2a8ff"
 COLOR_STD_IO = "#da8b45"
@@ -190,24 +200,23 @@ class BarSpec:
 
 @dataclass(frozen=True)
 class TestPair:
-    """A pair of bars (upstream + oc-rsync) for one test scenario.
+    """One test scenario: its bars, left to right, and its ratio annotations.
 
-    Some modes (e.g. the 3-way SSH transport comparison) include an optional
-    third bar and a second ratio annotation. When `third` is set:
-      - `upstream` carries the first leg (e.g. upstream rsync over ssh)
-      - `oc_rsync` carries the second leg (e.g. oc-rsync subprocess ssh)
-      - `third` carries the third leg (e.g. oc-rsync embedded russh)
-      - `ratio` annotates third vs oc_rsync (russh / subprocess)
-      - `ratio_secondary` annotates oc_rsync vs upstream (oc-sub / upstream)
+    The bar count is not fixed. An upstream-comparison row carries one bar per
+    baseline plus oc-rsync (and one oc-rsync bar per baseline when oc-rsync had
+    to be re-timed against each peer); the 3-way SSH transport row carries its
+    three transports. Modelling the row as a list rather than a fixed
+    upstream/oc-rsync pair is what lets a second baseline be added without a
+    third field, a fourth, and a rule about which ratio each one means.
+
+    `annotations` are `(prefix, ratio)` pairs rendered right of the bars. A
+    single unprefixed annotation is the one-baseline case.
     """
 
     name: str
-    upstream: BarSpec
-    oc_rsync: BarSpec
-    ratio: float
+    bars: tuple[BarSpec, ...]
+    annotations: tuple[tuple[str, float], ...]
     center_y: float
-    third: BarSpec | None = None
-    ratio_secondary: float | None = None
 
 
 @dataclass(frozen=True)
@@ -252,11 +261,20 @@ def _is_three_way_ssh(mode: str, t: dict) -> bool:
     return mode in SSH_TRANSPORT_MODES and "upstream_ssh" in t
 
 
-def _series_keys(mode: str, t: dict) -> tuple[str, ...]:
-    """Result-JSON keys holding this row's series, left to right."""
-    if _is_three_way_ssh(mode, t):
-        return ("upstream_ssh", "oc_subprocess", "oc_russh")
-    return ("upstream", "oc_rsync")
+def baseline_labels(data: dict) -> list[str]:
+    """Upstream releases this run measured, in the order it measured them."""
+    declared = data.get("baselines")
+    if declared:
+        return [b["label"] for b in declared]
+    return [data.get("upstream_version") or "3.4.4"]
+
+
+def upstream_series(t: dict, label: str) -> dict:
+    return (t.get("upstreams") or {}).get(label) or t["upstream"]
+
+
+def oc_series(t: dict, label: str) -> dict:
+    return (t.get("oc_rsync_per_baseline") or {}).get(label) or t["oc_rsync"]
 
 
 def metric_value(series: dict, unit: MetricUnit) -> float:
@@ -275,10 +293,97 @@ def metric_value(series: dict, unit: MetricUnit) -> float:
     return float(series["mean"])
 
 
-def metric_values(mode: str, t: dict) -> list[float]:
+def row_series(mode: str, t: dict, labels: list[str]) -> list[tuple]:
+    """`(series, color, legend_label)` for every bar of one row, left to right.
+
+    Modes that compare oc-rsync build variants against each other (OpenSSL,
+    io_uring, SSH transport) have no baseline dimension: their bars are the
+    variants. Only the upstream-comparison modes fan out over baselines.
+    """
+    if _is_three_way_ssh(mode, t):
+        return [
+            (t["upstream_ssh"], COLOR_SSH_UPSTREAM, "upstream (ssh subprocess)"),
+            (
+                t["oc_subprocess"],
+                COLOR_SSH_SUBPROCESS,
+                "oc-rsync (ssh subprocess)",
+            ),
+            (t["oc_russh"], COLOR_SSH_RUSSH, "oc-rsync (russh embedded)"),
+        ]
+    if mode in OPENSSL_MODES:
+        return [
+            (t["upstream"], COLOR_PURE_RUST, "pure Rust"),
+            (t["oc_rsync"], COLOR_OPENSSL, "OpenSSL"),
+        ]
+    if mode in IO_URING_MODES:
+        return [
+            (t["upstream"], COLOR_STD_IO, "standard I/O"),
+            (t["oc_rsync"], COLOR_IO_URING, "io_uring"),
+        ]
+    if mode in SSH_TRANSPORT_MODES:
+        return [
+            (t["upstream"], COLOR_SSH_SUBPROCESS, "subprocess"),
+            (t["oc_rsync"], COLOR_SSH_RUSSH, "russh"),
+        ]
+
+    series = [
+        (
+            upstream_series(t, label),
+            COLOR_BASELINES[i % len(COLOR_BASELINES)],
+            f"upstream rsync {label}",
+        )
+        for i, label in enumerate(labels)
+    ]
+    if t.get("oc_rsync_per_baseline"):
+        series += [
+            (
+                oc_series(t, label),
+                COLOR_OC_VARIANTS[i % len(COLOR_OC_VARIANTS)],
+                f"oc-rsync vs {label}",
+            )
+            for i, label in enumerate(labels)
+        ]
+    else:
+        series.append((t["oc_rsync"], COLOR_OC_RSYNC, "oc-rsync"))
+    return series
+
+
+def metric_values(mode: str, t: dict, labels: list[str]) -> list[float]:
     """Measured magnitudes for every bar of one test row, in the mode's unit."""
     unit = MODE_UNITS[mode]
-    return [metric_value(t[key], unit) for key in _series_keys(mode, t)]
+    return [metric_value(s, unit) for s, _, _ in row_series(mode, t, labels)]
+
+
+def baseline_ratio(t: dict, label: str, unit: MetricUnit) -> float:
+    """oc-rsync vs one named baseline, in the row's own unit.
+
+    Same rule as `pair_ratio`: a byte-unit row derives its ratio from the
+    magnitudes it plots, because the stored `ratio`/`ratios` fields are always
+    elapsed-time ratios.
+    """
+    if unit is MetricUnit.BYTES:
+        up = metric_value(upstream_series(t, label), unit)
+        oc = metric_value(oc_series(t, label), unit)
+        return oc / up if up > 0 else 0.0
+    return (t.get("ratios") or {}).get(label, t.get("ratio", 0.0))
+
+
+def row_annotations(
+    mode: str, t: dict, labels: list[str], unit: MetricUnit, values: list[float]
+) -> tuple[tuple[str, float], ...]:
+    """`(prefix, ratio)` annotations rendered to the right of one row."""
+    if _is_three_way_ssh(mode, t):
+        return (
+            ("oc/up", t.get("ratio_sub_vs_upstream", 0.0)),
+            ("ru/oc", t.get("ratio_russh_vs_sub", t.get("ratio", 0.0))),
+        )
+    if mode in OPENSSL_MODES or mode in IO_URING_MODES or mode in SSH_TRANSPORT_MODES:
+        return (("", t.get("ratio", 0.0)),)
+    if len(labels) == 1:
+        return (("", pair_ratio(t, unit, values[0], values[-1])),)
+    return tuple(
+        (f"vs {label}", baseline_ratio(t, label, unit)) for label in labels
+    )
 
 
 def pair_ratio(t: dict, unit: MetricUnit, up_v: float, oc_v: float) -> float:
@@ -296,14 +401,16 @@ def pair_ratio(t: dict, unit: MetricUnit, up_v: float, oc_v: float) -> float:
     return t.get("ratio", 0.0)
 
 
-def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
+def compute_layout(
+    tests_by_mode: dict[str, list[dict]], labels: list[str]
+) -> ChartLayout:
     """Compute y-positions for every element and overall chart dimensions."""
     all_times = []
     for mode, mode_tests in tests_by_mode.items():
         if MODE_UNITS.get(mode) is not MetricUnit.DURATION:
             continue
         for t in mode_tests:
-            all_times.extend(metric_values(mode, t))
+            all_times.extend(metric_values(mode, t, labels))
 
     max_time = max(all_times, default=0.0) or 1.0
     scale = BAR_AREA_WIDTH / (max_time * 1.1)
@@ -330,7 +437,7 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
         # in different units from sharing an axis.
         group_values: list[float] = []
         for t in mode_tests:
-            group_values.extend(metric_values(mode, t))
+            group_values.extend(metric_values(mode, t, labels))
         # `or 1.0` also covers an all-zero group (every measurement missing),
         # which would otherwise divide by zero.
         group_max = max(group_values, default=0.0) or 1.0
@@ -349,89 +456,35 @@ def compute_layout(tests_by_mode: dict[str, list[dict]]) -> ChartLayout:
             if j > 0:
                 y += GROUP_GAP
 
-            three_way = _is_three_way_ssh(mode, t)
+            series = row_series(mode, t, labels)
+            values = [metric_value(s, unit) for s, _, _ in series]
+            n = len(series)
+            row_height = n * BAR_HEIGHT + (n - 1) * BAR_GAP
+            center_y = y + row_height / 2
 
-            up_y = y
-            oc_y = y + BAR_HEIGHT + BAR_GAP
-            third_y = y + 2 * (BAR_HEIGHT + BAR_GAP)
-
-            if three_way:
-                # Center vertically between bar 1 and bar 3.
-                center_y = y + (3 * BAR_HEIGHT + 2 * BAR_GAP) / 2
-            else:
-                center_y = y + BAR_HEIGHT + BAR_GAP / 2
-
-            values = metric_values(mode, t)
-            if three_way:
-                up_v, oc_v, third_v = values
-            else:
-                (up_v, oc_v), third_v = values, None
-
-            up_w = max(up_v * group_scale, MIN_BAR_WIDTH)
-            oc_w = max(oc_v * group_scale, MIN_BAR_WIDTH)
-            third_w = (
-                max(third_v * group_scale, MIN_BAR_WIDTH)
-                if third_v is not None
-                else None
-            )
-
-            if mode in OPENSSL_MODES:
-                bar1_color, bar1_label = COLOR_PURE_RUST, "pure Rust"
-                bar2_color, bar2_label = COLOR_OPENSSL, "OpenSSL"
-                bar3_color, bar3_label = None, None
-            elif mode in IO_URING_MODES:
-                bar1_color, bar1_label = COLOR_STD_IO, "standard I/O"
-                bar2_color, bar2_label = COLOR_IO_URING, "io_uring"
-                bar3_color, bar3_label = None, None
-            elif mode in SSH_TRANSPORT_MODES:
-                if three_way:
-                    bar1_color, bar1_label = (
-                        COLOR_SSH_UPSTREAM, "upstream (ssh subprocess)"
-                    )
-                    bar2_color, bar2_label = (
-                        COLOR_SSH_SUBPROCESS, "oc-rsync (ssh subprocess)"
-                    )
-                    bar3_color, bar3_label = (
-                        COLOR_SSH_RUSSH, "oc-rsync (russh embedded)"
-                    )
-                else:
-                    bar1_color, bar1_label = COLOR_SSH_SUBPROCESS, "subprocess"
-                    bar2_color, bar2_label = COLOR_SSH_RUSSH, "russh"
-                    bar3_color, bar3_label = None, None
-            else:
-                bar1_color, bar1_label = COLOR_UPSTREAM, "upstream"
-                bar2_color, bar2_label = COLOR_OC_RSYNC, "oc-rsync"
-                bar3_color, bar3_label = None, None
-
-            third_bar = None
-            ratio_secondary = None
-            if three_way and third_w is not None and bar3_color is not None:
-                third_bar = BarSpec(
-                    third_y, third_w, third_v, bar3_color, bar3_label
+            bars = tuple(
+                BarSpec(
+                    y + k * (BAR_HEIGHT + BAR_GAP),
+                    max(value * group_scale, MIN_BAR_WIDTH),
+                    value,
+                    color,
+                    legend_label,
                 )
-                # Primary ratio = russh / oc subprocess.
-                # Secondary ratio = oc subprocess / upstream.
-                ratio_primary = t.get("ratio_russh_vs_sub", t.get("ratio", 0.0))
-                ratio_secondary = t.get("ratio_sub_vs_upstream", 0.0)
-            else:
-                ratio_primary = pair_ratio(t, unit, up_v, oc_v)
+                for k, ((_, color, legend_label), value) in enumerate(
+                    zip(series, values)
+                )
+            )
 
             pairs.append(
                 TestPair(
                     name=t["name"],
-                    upstream=BarSpec(up_y, up_w, up_v, bar1_color, bar1_label),
-                    oc_rsync=BarSpec(oc_y, oc_w, oc_v, bar2_color, bar2_label),
-                    ratio=ratio_primary,
+                    bars=bars,
+                    annotations=row_annotations(mode, t, labels, unit, values),
                     center_y=center_y,
-                    third=third_bar,
-                    ratio_secondary=ratio_secondary,
                 )
             )
 
-            if three_way:
-                y += 3 * BAR_HEIGHT + 2 * BAR_GAP
-            else:
-                y += 2 * BAR_HEIGHT + BAR_GAP
+            y += row_height
 
         groups.append(ModeGroup(
             label=MODE_LABELS[mode],
@@ -658,10 +711,8 @@ class ChartBuilder:
                 f'text-anchor="end" font-size="11" fill="{COLOR_LABEL}">'
                 f"{escape(pair.name)}</text>"
             )
-            self._add_bar(pair.upstream, group.unit)
-            self._add_bar(pair.oc_rsync, group.unit)
-            if pair.third is not None:
-                self._add_bar(pair.third, group.unit)
+            for bar in pair.bars:
+                self._add_bar(bar, group.unit)
             self._add_speedup(pair, group.unit)
 
     def add_legend(
@@ -671,24 +722,35 @@ class ChartBuilder:
         has_io_uring: bool = False,
         has_ssh_transport: bool = False,
         has_ssh_3way: bool = False,
-        upstream_version: str = "3.4.4",
+        baselines: tuple[str, ...] = ("3.4.4",),
     ) -> None:
         cx = CHART_WIDTH / 2
         self._parts.append(f'<g transform="translate({cx - 160}, {y:.0f})">')
-        self._parts.append(
-            f'<rect x="0" y="0" width="12" height="12" rx="2" fill="{COLOR_UPSTREAM}"/>'
-        )
-        self._parts.append(
-            f'<text x="16" y="10" font-size="11" fill="{COLOR_LABEL}">'
-            f'upstream rsync {escape(upstream_version)}</text>'
-        )
-        self._parts.append(
-            f'<rect x="170" y="0" width="12" height="12" rx="2" fill="{COLOR_OC_RSYNC}"/>'
-        )
-        self._parts.append(
-            f'<text x="186" y="10" font-size="11" fill="{COLOR_LABEL}">oc-rsync</text>'
-        )
+        # One swatch per baseline, in measurement order, then oc-rsync. A
+        # legend naming a single upstream release would leave the reader
+        # guessing which grey bar is which release.
         row = 0
+        for i, label in enumerate(baselines):
+            ry = row * 18
+            self._parts.append(
+                f'<rect x="0" y="{ry}" width="12" height="12" rx="2" '
+                f'fill="{COLOR_BASELINES[i % len(COLOR_BASELINES)]}"/>'
+            )
+            self._parts.append(
+                f'<text x="16" y="{ry + 10}" font-size="11" fill="{COLOR_LABEL}">'
+                f'upstream rsync {escape(label)}</text>'
+            )
+            if i == 0:
+                self._parts.append(
+                    f'<rect x="170" y="{ry}" width="12" height="12" rx="2" '
+                    f'fill="{COLOR_OC_RSYNC}"/>'
+                )
+                self._parts.append(
+                    f'<text x="186" y="{ry + 10}" font-size="11" '
+                    f'fill="{COLOR_LABEL}">oc-rsync</text>'
+                )
+            row += 1
+        row -= 1
         if has_openssl:
             row += 1
             ry = row * 18
@@ -799,30 +861,29 @@ class ChartBuilder:
             )
 
     def _add_speedup(self, pair: TestPair, unit: MetricUnit) -> None:
-        text, color = ratio_text(pair.ratio, unit)
+        """Stack this row's ratio annotations, centred on the bar group."""
         x = CHART_WIDTH - RIGHT_MARGIN + 10
-        if pair.ratio_secondary is not None:
-            # Stack two ratios for the 3-way comparison: oc-sub vs upstream
-            # above, russh vs oc-sub below.
-            sec_text, sec_color = ratio_text(pair.ratio_secondary, unit)
-            y_top = pair.center_y - 4
-            y_bot = pair.center_y + 12
+        count = len(pair.annotations)
+        if count == 1:
+            prefix, ratio = pair.annotations[0]
+            text, color = ratio_text(ratio, unit)
+            label = f"{prefix} {text}".strip()
             self._parts.append(
-                f'<text x="{x}" y="{y_top:.1f}" '
-                f'font-size="10" font-weight="600" fill="{sec_color}">'
-                f"oc/up {escape(sec_text)}</text>"
-            )
-            self._parts.append(
-                f'<text x="{x}" y="{y_bot:.1f}" '
-                f'font-size="10" font-weight="600" fill="{color}">'
-                f"ru/oc {escape(text)}</text>"
-            )
-        else:
-            y = pair.center_y + 4
-            self._parts.append(
-                f'<text x="{x}" y="{y:.1f}" '
+                f'<text x="{x}" y="{pair.center_y + 4:.1f}" '
                 f'font-size="11" font-weight="600" fill="{color}">'
-                f"{escape(text)}</text>"
+                f"{escape(label)}</text>"
+            )
+            return
+
+        line_height = 16
+        top = pair.center_y - (count - 1) * line_height / 2 + 4
+        for i, (prefix, ratio) in enumerate(pair.annotations):
+            text, color = ratio_text(ratio, unit)
+            label = f"{prefix} {text}".strip()
+            self._parts.append(
+                f'<text x="{x}" y="{top + i * line_height:.1f}" '
+                f'font-size="10" font-weight="600" fill="{color}">'
+                f"{escape(label)}</text>"
             )
 
 
@@ -844,11 +905,12 @@ def generate_chart(data: dict) -> str:
         m in SSH_TRANSPORT_MODES and any("upstream_ssh" in t for t in ts)
         for m, ts in tests_by_mode.items()
     )
-    layout = compute_layout(tests_by_mode)
+    labels = baseline_labels(data)
+    layout = compute_layout(tests_by_mode, labels)
 
     extra_legend_rows = (
         int(has_openssl) + int(has_io_uring) + int(has_ssh_transport)
-        + int(has_ssh_3way)
+        + int(has_ssh_3way) + max(len(labels) - 1, 0)
     )
     extra_legend = extra_legend_rows * 18
     chart_height = layout.chart_height + extra_legend
@@ -858,10 +920,16 @@ def generate_chart(data: dict) -> str:
     test_data = data.get("test_data", {})
     size_mb = test_data.get("size_mb", "?")
     files = test_data.get("files", "?")
-    upstream_version = data.get("upstream_version") or "3.4.4"
+    oc_version = data.get("oc_rsync_version") or ""
+    env = data.get("environment") or {}
+    kernel = env.get("kernel_release")
+    machine = env.get("machine", "x86_64")
+    subject = f"oc-rsync {oc_version}".strip()
     builder.add_title(
-        f"oc-rsync vs upstream rsync {upstream_version}",
-        f"{size_mb} MB, {files} files \u2014 Linux x86_64 CI",
+        f"{subject} vs upstream rsync "
+        + " and ".join(labels),
+        f"{size_mb} MB, {files} files \u2014 Linux {machine}"
+        + (f", kernel {kernel}" if kernel else " CI"),
     )
 
     # No global x-axis grid: with per-group scaling -- and with modes that do
@@ -876,7 +944,7 @@ def generate_chart(data: dict) -> str:
         has_io_uring,
         has_ssh_transport,
         has_ssh_3way,
-        upstream_version,
+        tuple(labels),
     )
 
     return builder.render()

--- a/.github/scripts/benchmark_env.py
+++ b/.github/scripts/benchmark_env.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Capture the machine a benchmark ran on, and probe io_uring SEND_ZC.
+
+A benchmark whose environment is unstated cannot be compared across runs: a
+number from a 2-vCPU cloud runner and a number from a bare-metal host are not
+the same measurement, and neither is a number from a kernel that cannot run
+the zero-copy send path.
+
+`IORING_OP_SEND_ZC` (Linux 6.0+) is the specific capability the release
+benchmark has to state, because oc-rsync's io_uring send path can only be
+exercised on a kernel that advertises it. Support is *probed*, not inferred:
+distros backport features and container runtimes misreport kernel versions,
+so a `uname -r` comparison alone would be a claim rather than a measurement.
+The probe mirrors `fast_io::io_uring::send_zc::probe_send_zc` -- the mainline
+version floor AND the `IORING_REGISTER_PROBE` opcode bit, both required --
+so this module and the Rust dispatch cannot disagree about the same kernel.
+
+Pure stdlib (ctypes), so it runs wherever benchmark.py runs.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import platform
+import sys
+
+# include/uapi/linux/io_uring.h. Cross-checked against the io-uring crate's
+# generated sys bindings, which is what fast_io's probe resolves
+# `opcode::SendZc::CODE` to.
+IORING_OP_SEND_ZC = 47
+IORING_REGISTER_PROBE = 8
+IO_URING_OP_SUPPORTED = 1 << 0
+
+# io_uring_setup(2) / io_uring_register(2). These landed after the kernel
+# unified syscall numbering, so the numbers are the same on every Linux
+# architecture that has io_uring at all.
+SYS_IO_URING_SETUP = 425
+SYS_IO_URING_REGISTER = 427
+
+# sizeof(struct io_uring_params): 7 x __u32 + __u32 resv[3] + two 40-byte
+# offset structs. Only its size matters here -- it is passed zeroed.
+IO_URING_PARAMS_SIZE = 120
+
+# struct io_uring_probe: 16-byte header (last_op, ops_len, resv, resv2[3])
+# followed by a flexible array of 8-byte struct io_uring_probe_op.
+PROBE_HEADER_SIZE = 16
+PROBE_OP_SIZE = 8
+PROBE_NR_OPS = 256
+
+# Mainline release that shipped IORING_OP_SEND_ZC. Some 5.x vendor kernels
+# advertise the opcode bit but ship incomplete zero-copy semantics, so the
+# floor is required in addition to the opcode bit -- the same pairing
+# fast_io applies before it will ever submit a SEND_ZC SQE.
+SEND_ZC_KERNEL_MIN = (6, 0)
+
+
+def parse_kernel_version(release: str) -> tuple[int, int] | None:
+    """Extract `(major, minor)` from a `uname -r` release string."""
+    parts = release.split("-", 1)[0].split(".")
+    try:
+        return int(parts[0]), int(parts[1])
+    except (IndexError, ValueError):
+        return None
+
+
+def _probe_send_zc_opcode() -> tuple[bool | None, str]:
+    """Ask the running kernel whether it advertises `IORING_OP_SEND_ZC`.
+
+    Returns `(advertised, detail)`. `advertised` is None when the question
+    could not be asked at all -- no io_uring, or the ring was refused -- which
+    is a different answer from "asked, and the kernel said no".
+    """
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+    except OSError as exc:  # pragma: no cover - no libc is not a real host
+        return None, f"libc unavailable: {exc}"
+
+    libc.syscall.restype = ctypes.c_long
+
+    params = (ctypes.c_ubyte * IO_URING_PARAMS_SIZE)()
+    libc.syscall.argtypes = [ctypes.c_long, ctypes.c_uint, ctypes.c_void_p]
+    ctypes.set_errno(0)
+    fd = libc.syscall(SYS_IO_URING_SETUP, 4, ctypes.byref(params))
+    if fd < 0:
+        err = ctypes.get_errno()
+        return None, f"io_uring_setup failed: {os.strerror(err)} (errno {err})"
+
+    try:
+        size = PROBE_HEADER_SIZE + PROBE_OP_SIZE * PROBE_NR_OPS
+        buf = (ctypes.c_ubyte * size)()
+        libc.syscall.argtypes = [
+            ctypes.c_long,
+            ctypes.c_int,
+            ctypes.c_uint,
+            ctypes.c_void_p,
+            ctypes.c_uint,
+        ]
+        ctypes.set_errno(0)
+        rc = libc.syscall(
+            SYS_IO_URING_REGISTER,
+            fd,
+            IORING_REGISTER_PROBE,
+            ctypes.byref(buf),
+            PROBE_NR_OPS,
+        )
+        if rc < 0:
+            err = ctypes.get_errno()
+            return None, (
+                f"IORING_REGISTER_PROBE failed: {os.strerror(err)} (errno {err})"
+            )
+
+        last_op = buf[0]
+        ops_len = buf[1]
+        for i in range(min(ops_len, PROBE_NR_OPS)):
+            base = PROBE_HEADER_SIZE + i * PROBE_OP_SIZE
+            if buf[base] != IORING_OP_SEND_ZC:
+                continue
+            flags = buf[base + 2] | (buf[base + 3] << 8)
+            supported = bool(flags & IO_URING_OP_SUPPORTED)
+            return supported, (
+                f"IORING_REGISTER_PROBE: op {IORING_OP_SEND_ZC} "
+                f"{'advertised' if supported else 'not advertised'} "
+                f"(last_op={last_op}, ops_len={ops_len})"
+            )
+        return False, (
+            f"IORING_REGISTER_PROBE: op {IORING_OP_SEND_ZC} absent from the "
+            f"probe table (last_op={last_op}, ops_len={ops_len})"
+        )
+    finally:
+        os.close(fd)
+
+
+def probe_send_zc() -> dict:
+    """Full SEND_ZC availability answer for the running kernel.
+
+    Reports the version floor and the opcode bit as separate facts, then the
+    conjunction, so a report can distinguish "kernel too old" from "io_uring
+    is blocked here" from "the opcode is simply not offered".
+    """
+    release = platform.release()
+    if not sys.platform.startswith("linux"):
+        return {
+            "supported": False,
+            "opcode": IORING_OP_SEND_ZC,
+            "kernel_release": release,
+            "kernel_floor": "%d.%d" % SEND_ZC_KERNEL_MIN,
+            "meets_kernel_floor": False,
+            "opcode_advertised": None,
+            "detail": f"not Linux (sys.platform={sys.platform})",
+        }
+
+    parsed = parse_kernel_version(release)
+    meets_floor = parsed is not None and parsed >= SEND_ZC_KERNEL_MIN
+    advertised, detail = _probe_send_zc_opcode()
+    return {
+        "supported": bool(meets_floor and advertised),
+        "opcode": IORING_OP_SEND_ZC,
+        "kernel_release": release,
+        "kernel_floor": "%d.%d" % SEND_ZC_KERNEL_MIN,
+        "meets_kernel_floor": meets_floor,
+        "opcode_advertised": advertised,
+        "detail": detail,
+    }
+
+
+def send_zc_verdict(env: dict) -> str:
+    """One sentence stating whether these numbers can show SEND_ZC at all.
+
+    Deliberately blunt in the negative case: a benchmark published from a
+    kernel that cannot run the zero-copy send path must not be read as
+    evidence about that path.
+    """
+    zc = env.get("io_uring_send_zc", {})
+    dispatch = env.get("oc_rsync_send_zc_dispatch", "")
+    if not zc.get("supported"):
+        return (
+            "**SEND_ZC UNAVAILABLE** - the kernel these numbers were measured "
+            f"on ({zc.get('kernel_release', 'unknown')}) does not offer "
+            f"IORING_OP_SEND_ZC ({zc.get('detail', 'no probe detail')}). "
+            "No figure below is evidence about the io_uring zero-copy send "
+            "path."
+        )
+    line = (
+        f"Kernel {zc.get('kernel_release')} advertises IORING_OP_SEND_ZC "
+        f"({zc.get('detail')})."
+    )
+    if dispatch and dispatch != "enabled":
+        line += (
+            f" The measured oc-rsync binary does not dispatch it: {dispatch}."
+        )
+    return line
+
+
+def capture(oc_rsync_send_zc_dispatch: str = "") -> dict:
+    """Environment block published alongside the measurements."""
+    return {
+        "platform": sys.platform,
+        "kernel_release": platform.release(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+        "io_uring_send_zc": probe_send_zc(),
+        # Declared by the build step that produced the benchmarked binary:
+        # `iouring-send-zc` is not in any default feature set, and the
+        # binary's --version output does not enumerate fast_io features, so
+        # the workflow that ran cargo is the only place this is knowable.
+        "oc_rsync_send_zc_dispatch": oc_rsync_send_zc_dispatch
+        or "not declared by the build",
+    }
+
+
+if __name__ == "__main__":
+    import json
+
+    env = capture(os.environ.get("OC_RSYNC_SEND_ZC_DISPATCH", ""))
+    print(json.dumps(env, indent=2))
+    print(send_zc_verdict(env), file=sys.stderr)

--- a/.github/scripts/benchmark_report.py
+++ b/.github/scripts/benchmark_report.py
@@ -3,6 +3,10 @@
 
 Reads benchmark_results.json from the current directory and writes
 a markdown table grouped by transfer mode to stdout.
+
+Every upstream-comparison table carries one column per baseline the run
+measured, because the two upstream releases in circulation are two different
+answers and publishing only one of them hides the other.
 """
 
 import json
@@ -13,6 +17,7 @@ import sys
 # benchmark_chart is pure stdlib, so importing its size formatter here keeps one
 # definition of the IEC convention rather than a second copy that can drift.
 from benchmark_chart import fmt_bytes
+from benchmark_env import send_zc_verdict
 
 MODE_LABELS = {
     "local": "Local Copy",
@@ -61,6 +66,41 @@ ALL_LABELS = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Per-baseline accessors
+#
+# A results file written before the baseline dimension existed has a single
+# `upstream` series and a single `ratio`. Each accessor falls back to that
+# shape so an archived run still renders, and so the renderer self-tests can
+# state one fact at a time without restating the whole schema.
+# ---------------------------------------------------------------------------
+
+
+def baseline_labels(data):
+    """Upstream releases this run measured, in the order it measured them."""
+    declared = data.get("baselines")
+    if declared:
+        return [b["label"] for b in declared]
+    return [data.get("upstream_version") or "3.5.0"]
+
+
+def upstream_series(test, label):
+    return (test.get("upstreams") or {}).get(label) or test["upstream"]
+
+
+def oc_series(test, label):
+    return (test.get("oc_rsync_per_baseline") or {}).get(label) or test["oc_rsync"]
+
+
+def per_baseline_oc(test):
+    """True when oc-rsync was re-timed against each baseline as a peer."""
+    return bool(test.get("oc_rsync_per_baseline"))
+
+
+def test_ratio(test, label):
+    return (test.get("ratios") or {}).get(label, test.get("ratio", 0.0))
+
+
 def ratio_indicator(ratio):
     if ratio < 0.95:
         return "faster"
@@ -84,35 +124,96 @@ def speedup_phrase(ratio):
         return f"{ratio:.2f}x slower"
 
 
-def highlight_lines(summary):
-    """Lead with oc-rsync's widest wins over upstream across transfer modes."""
-    by_mode = summary.get("by_mode", {})
-    ranked = sorted(
-        (
-            (mode, ratio)
-            for mode, ratio in by_mode.items()
-            if mode in UPSTREAM_COMPARISON_MODES
-        ),
-        key=lambda kv: kv[1],
-    )
+def failed_series(test):
+    """Series in this row whose binary did not complete, if any."""
+    return test.get("failed_series") or []
+
+
+def fmt_secs(series):
+    """Elapsed time with the run-to-run spread that produced it.
+
+    The published figure is a median. Printing it alone lets a cell whose
+    fastest and slowest runs differed by half their own magnitude read exactly
+    like a cell that repeated to within a percent, so the spread travels with
+    the number rather than sitting unread in the JSON.
+    """
+    mean = series.get("mean", 0.0)
+    spread = series.get("spread_pct")
+    if spread is None:
+        return f"{mean:.3f}s"
+    return f"{mean:.3f}s ±{spread:.0f}%"
+
+
+def fmt_rate(series):
+    """Corpus rate in MiB/s, or a dash when the corpus size was not recorded.
+
+    This is corpus bytes over elapsed seconds, not bytes on the wire: it is
+    the rate at which the tool got through the tree, which is comparable
+    across an initial transfer and a no-change scan of the same corpus.
+    """
+    rate = series.get("corpus_mibps")
+    return f"{rate:.0f}" if rate else "-"
+
+
+def highlight_lines(data, labels):
+    """Lead with oc-rsync's widest wins over upstream, stated per baseline."""
+    summary = data.get("summary", {})
+    per_baseline = summary.get("by_baseline") or {}
     lines = ["### Highlights\n"]
-    avg = summary.get("avg_ratio")
-    if avg is not None:
-        phrase = speedup_phrase(avg)
-        # "at parity" reads "at parity with upstream"; a speedup reads
-        # "Nx faster/slower than upstream".
-        connector = "with" if phrase == "at parity" else "than"
-        lines.append(
-            f"- **Overall:** oc-rsync is {phrase} {connector} upstream "
-            f"on average across transfer modes."
+
+    for label in labels:
+        stats = per_baseline.get(label) or summary
+        by_mode = stats.get("by_mode", {})
+        avg = stats.get("avg_ratio")
+        if avg is not None:
+            phrase = speedup_phrase(avg)
+            # "at parity" reads "at parity with upstream"; a speedup reads
+            # "Nx faster/slower than upstream".
+            connector = "with" if phrase == "at parity" else "than"
+            lines.append(
+                f"- **vs rsync {label}:** oc-rsync is {phrase} {connector} "
+                f"upstream on average across transfer modes."
+            )
+        ranked = sorted(
+            (
+                (mode, ratio)
+                for mode, ratio in by_mode.items()
+                if mode in UPSTREAM_COMPARISON_MODES
+            ),
+            key=lambda kv: kv[1],
         )
-    wins = [(m, r) for m, r in ranked if r < 0.95][:3]
-    for mode, ratio in wins:
-        lines.append(
-            f"- **{UPSTREAM_COMPARISON_MODES[mode]}:** {speedup_phrase(ratio)}."
-        )
-    if not wins:
-        lines.append("- oc-rsync holds parity with upstream across measured modes.")
+        wins = [(m, r) for m, r in ranked if r < 0.95][:3]
+        for mode, ratio in wins:
+            lines.append(
+                f"  - {UPSTREAM_COMPARISON_MODES[mode]}: {speedup_phrase(ratio)}."
+            )
+        if not wins:
+            lines.append(
+                f"  - oc-rsync holds parity with rsync {label} across measured "
+                f"modes."
+            )
+    lines.append("")
+    return lines
+
+
+def environment_lines(data):
+    """State the machine and the io_uring capability the numbers rest on.
+
+    A benchmark whose environment is unstated cannot be compared across runs,
+    and the SEND_ZC line is deliberately loud in the negative: numbers taken
+    on a kernel without the opcode are not evidence about the zero-copy send
+    path, whatever else they show.
+    """
+    env = data.get("environment")
+    if not env:
+        return []
+    lines = ["### Environment\n"]
+    lines.append(
+        f"- Kernel `{env.get('kernel_release', 'unknown')}` on "
+        f"`{env.get('machine', 'unknown')}`, "
+        f"{env.get('cpu_count', '?')} CPUs."
+    )
+    lines.append(f"- {send_zc_verdict(env)}")
     lines.append("")
     return lines
 
@@ -133,7 +234,7 @@ def memory_indicator(ratio):
     return "higher"
 
 
-def rss_cells(t):
+def rss_cells(t, primary):
     """Return the three peak-RSS cells for a comparison row.
 
     benchmark_rss() records `peak_rss_kb` for every mode, not just the memory
@@ -142,9 +243,13 @@ def rss_cells(t):
     run that timed out, or a platform whose /usr/bin/time output this parser
     does not recognise -- so a missing value degrades to a dash rather than
     inventing a number or dropping the row.
+
+    Peak RSS is shown against the primary baseline only. Memory use is a
+    property of the binary and its workload, not of the peer it talked to, so
+    a column per baseline would repeat one measurement rather than add one.
     """
-    up_kb = t["upstream"].get("peak_rss_kb")
-    oc_kb = t["oc_rsync"].get("peak_rss_kb")
+    up_kb = upstream_series(t, primary).get("peak_rss_kb")
+    oc_kb = oc_series(t, primary).get("peak_rss_kb")
     if not up_kb or not oc_kb:
         return "-", "-", "-"
     ratio = oc_kb / up_kb
@@ -155,20 +260,72 @@ def rss_cells(t):
     )
 
 
+def comparison_table(tests, labels, *, with_rss):
+    """Render one upstream-comparison table across every baseline."""
+    primary = labels[0]
+    split_oc = any(per_baseline_oc(t) for t in tests)
+
+    headers = ["Test"] + [f"rsync {label}" for label in labels]
+    if split_oc:
+        headers += [f"oc-rsync vs {label}" for label in labels]
+    else:
+        headers.append("oc-rsync")
+    headers += [f"oc / {label}" for label in labels]
+    headers.append("oc-rsync MiB/s")
+    if with_rss:
+        headers += [f"rsync {primary} RSS", "oc-rsync RSS", "Peak RSS"]
+
+    print("| " + " | ".join(headers) + " |")
+    print("|" + "|".join("------" for _ in headers) + "|")
+
+    for t in tests:
+        broken = failed_series(t)
+        name = t["name"]
+        if broken:
+            # A ratio against a binary that errored out is not a comparison.
+            # Say so on the row rather than letting the number stand.
+            name = f"{name} **(failed: {', '.join(broken)})**"
+        cells = [name]
+        cells += [fmt_secs(upstream_series(t, label)) for label in labels]
+        if split_oc:
+            cells += [fmt_secs(oc_series(t, label)) for label in labels]
+        else:
+            cells.append(fmt_secs(t["oc_rsync"]))
+        for label in labels:
+            ratio = test_ratio(t, label)
+            cells.append(f"{ratio_indicator(ratio)} {ratio:.2f}x")
+        cells.append(fmt_rate(oc_series(t, primary)))
+        if with_rss:
+            cells += list(rss_cells(t, primary))
+        print("| " + " | ".join(cells) + " |")
+
+    print()
+
+
 def main():
     with open("benchmark_results.json") as f:
         data = json.load(f)
 
-    upstream_version = data.get("upstream_version") or "3.5.0"
+    labels = baseline_labels(data)
+    primary = labels[0]
+    oc_version = data.get("oc_rsync_version") or "unknown"
+    wire_compat = data.get("oc_rsync_wire_compat_version")
 
     print("## Benchmark Results\n")
+    baseline_phrase = " and ".join(f"rsync {label}" for label in labels)
+    compat_note = (
+        f" (wire-compatible with rsync {wire_compat})" if wire_compat else ""
+    )
     print(
-        f"oc-rsync vs upstream rsync {upstream_version} on "
+        f"oc-rsync {oc_version}{compat_note} vs upstream {baseline_phrase} on "
         f"{data['test_data']['size_mb']}MB "
         f"({data['test_data']['files']} files).\n"
     )
 
-    for line in highlight_lines(data["summary"]):
+    for line in environment_lines(data):
+        print(line)
+
+    for line in highlight_lines(data, labels):
         print(line)
 
     # Group tests by mode
@@ -180,26 +337,8 @@ def main():
         tests = by_mode.get(mode, [])
         if not tests:
             continue
-
         print(f"### {label}\n")
-        print(
-            f"| Test | rsync {upstream_version} | oc-rsync | Time | "
-            f"rsync {upstream_version} RSS | oc-rsync RSS | Peak RSS |"
-        )
-        print("|------|----------|----------|------|----------|----------|----------|")
-
-        for t in tests:
-            up = t["upstream"]["mean"]
-            oc = t["oc_rsync"]["mean"]
-            ratio = t["ratio"]
-            ind = ratio_indicator(ratio)
-            up_rss, oc_rss, rss_ratio = rss_cells(t)
-            print(
-                f"| {t['name']} | {up:.3f}s | {oc:.3f}s | {ind} {ratio:.2f}x "
-                f"| {up_rss} | {oc_rss} | {rss_ratio} |"
-            )
-
-        print()
+        comparison_table(tests, labels, with_rss=True)
 
     # OpenSSL vs Pure Rust comparison
     for mode, label in OPENSSL_MODES.items():
@@ -241,7 +380,8 @@ def main():
 
     # SSH transport: 3-way (upstream vs oc-rsync subprocess vs oc-rsync russh)
     # when the new fields are present; otherwise fall back to the legacy
-    # subprocess-vs-russh 2-bar render.
+    # subprocess-vs-russh 2-bar render. This mode compares oc-rsync transports
+    # against one another, so it is measured against the primary baseline only.
     for mode, label in SSH_TRANSPORT_MODES.items():
         tests = by_mode.get(mode, [])
         if not tests:
@@ -253,7 +393,7 @@ def main():
         if three_way:
             print(
                 "| Test "
-                "| Upstream (ssh) "
+                f"| Upstream {primary} (ssh) "
                 "| oc-rsync (ssh) "
                 "| oc-rsync (russh) "
                 "| oc-sub / upstream "
@@ -303,60 +443,93 @@ def main():
         tests = by_mode.get(mode, [])
         if not tests:
             continue
-
         print(f"### {label}\n")
-        print(f"| Test | rsync {upstream_version} | oc-rsync | Ratio |")
-        print("|------|----------|----------|-------|")
-
-        for t in tests:
-            up = t["upstream"]["mean"]
-            oc = t["oc_rsync"]["mean"]
-            ratio = t["ratio"]
-            ind = ratio_indicator(ratio)
-            print(f"| {t['name']} | {up:.3f}s | {oc:.3f}s | {ind} {ratio:.2f}x |")
-
-        print()
+        comparison_table(tests, labels, with_rss=False)
 
     # Memory usage (peak RSS)
     mem_tests = by_mode.get(MEMORY_MODE, [])
     if mem_tests:
         print("### Memory Usage (Peak RSS)\n")
-        print(
-            f"| Test | rsync {upstream_version} | oc-rsync | Time Ratio "
-            f"| RSS rsync {upstream_version} | RSS oc-rsync |"
-        )
-        print("|------|----------|----------|------------|-------------|-------------|")
+        headers = ["Test"]
+        headers += [f"rsync {label}" for label in labels]
+        headers += ["oc-rsync", "Time Ratio"]
+        headers += [f"RSS rsync {label}" for label in labels]
+        headers.append("RSS oc-rsync")
+        print("| " + " | ".join(headers) + " |")
+        print("|" + "|".join("------" for _ in headers) + "|")
 
         for t in mem_tests:
-            up = t["upstream"]["mean"]
-            oc = t["oc_rsync"]["mean"]
-            ratio = t["ratio"]
-            ind = ratio_indicator(ratio)
-            up_rss = t["upstream"].get("peak_rss_kb")
-            oc_rss = t["oc_rsync"].get("peak_rss_kb")
-            up_rss_str = f"{up_rss / 1024:.1f}MB" if up_rss else "N/A"
-            oc_rss_str = f"{oc_rss / 1024:.1f}MB" if oc_rss else "N/A"
-            print(
-                f"| {t['name']} | {up:.3f}s | {oc:.3f}s "
-                f"| {ind} {ratio:.2f}x | {up_rss_str} | {oc_rss_str} |"
-            )
+            ratio = test_ratio(t, primary)
+            cells = [t["name"]]
+            cells += [fmt_secs(upstream_series(t, label)) for label in labels]
+            cells.append(fmt_secs(t["oc_rsync"]))
+            cells.append(f"{ratio_indicator(ratio)} {ratio:.2f}x")
+            for label in labels:
+                kb = upstream_series(t, label).get("peak_rss_kb")
+                cells.append(f"{kb / 1024:.1f}MB" if kb else "N/A")
+            oc_kb = t["oc_rsync"].get("peak_rss_kb")
+            cells.append(f"{oc_kb / 1024:.1f}MB" if oc_kb else "N/A")
+            print("| " + " | ".join(cells) + " |")
 
         print()
 
     # Summary
     summary = data["summary"]
-    print(f"### Summary\n")
-    print(f"**Overall:** {summary['avg_ratio']}x average ratio")
-    print(f"(best {summary['best_ratio']}x, worst {summary['worst_ratio']}x)\n")
+    per_baseline = summary.get("by_baseline") or {}
+    print("### Summary\n")
+    for label in labels:
+        stats = per_baseline.get(label) or summary
+        print(
+            f"**vs rsync {label}:** {stats['avg_ratio']}x average ratio "
+            f"(best {stats['best_ratio']}x, worst {stats['worst_ratio']}x)\n"
+        )
 
-    print("| Mode | Avg Ratio |")
-    print("|------|-----------|")
+    header = ["Mode"] + [f"Avg ratio vs {label}" for label in labels]
+    print("| " + " | ".join(header) + " |")
+    print("|" + "|".join("------" for _ in header) + "|")
+    variant_modes = []
     for mode, label in ALL_LABELS.items():
-        if mode in summary.get("by_mode", {}):
-            r = summary["by_mode"][mode]
-            print(f"| {label} | {r:.2f}x |")
+        row_values = []
+        for baseline in labels:
+            stats = per_baseline.get(baseline) or summary
+            row_values.append(stats.get("by_mode", {}).get(mode))
+        if all(v is None for v in row_values):
+            # A mode with no baseline dimension: it compares oc-rsync build
+            # variants against each other. Repeating one number under two
+            # baseline headings would claim a comparison that was not made,
+            # so those modes get their own table below.
+            fallback = summary.get("by_mode", {}).get(mode)
+            if fallback is not None:
+                variant_modes.append((label, fallback))
+            continue
+        cells = [label] + [
+            f"{v:.2f}x" if v is not None else "-" for v in row_values
+        ]
+        print("| " + " | ".join(cells) + " |")
 
-    print(f"\n_Ratio < 1.0 = oc-rsync faster, > 1.0 = upstream faster_")
+    if variant_modes:
+        print("\n**oc-rsync build variants** (no upstream baseline):\n")
+        print("| Mode | Avg Ratio |")
+        print("|------|-----------|")
+        for label, value in variant_modes:
+            print(f"| {label} | {value:.2f}x |")
+
+    excluded = summary.get("excluded_tests") or []
+    if excluded:
+        print(
+            f"\n> **{len(excluded)} test(s) excluded from these averages** "
+            f"because a binary did not complete: "
+            f"{', '.join(f'`{e}`' for e in excluded)}. Their rows above are "
+            f"marked; a ratio against a command that errored out states a "
+            f"verdict the run never measured."
+        )
+
+    print("\n_Ratio < 1.0 = oc-rsync faster, > 1.0 = upstream faster._")
+    print(
+        "_Elapsed figures are the warm-up-discarded median of the timed runs; "
+        "`±N%` is the min-to-max spread of that cell. `oc-rsync MiB/s` is "
+        "corpus bytes over elapsed seconds, not bytes on the wire._"
+    )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/benchmark-tooling.yml
+++ b/.github/workflows/benchmark-tooling.yml
@@ -16,18 +16,24 @@ name: Benchmark tooling
 on:
   pull_request:
     paths:
+      - '.github/scripts/benchmark.py'
       - '.github/scripts/benchmark_chart.py'
+      - '.github/scripts/benchmark_env.py'
       - '.github/scripts/benchmark_report.py'
       - 'tools/ci/tests/test_benchmark_chart.py'
+      - 'tools/ci/tests/test_benchmark_harness.py'
       - 'tools/ci/tests/test_benchmark_report.py'
       - '.github/workflows/benchmark-tooling.yml'
   push:
     branches:
       - master
     paths:
+      - '.github/scripts/benchmark.py'
       - '.github/scripts/benchmark_chart.py'
+      - '.github/scripts/benchmark_env.py'
       - '.github/scripts/benchmark_report.py'
       - 'tools/ci/tests/test_benchmark_chart.py'
+      - 'tools/ci/tests/test_benchmark_harness.py'
       - 'tools/ci/tests/test_benchmark_report.py'
       - '.github/workflows/benchmark-tooling.yml'
 
@@ -49,7 +55,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Self-test benchmark_chart.py and benchmark_report.py
+      - name: Self-test the benchmark harness and renderers
         run: |
+          python3 tools/ci/tests/test_benchmark_harness.py
           python3 tools/ci/tests/test_benchmark_chart.py
           python3 tools/ci/tests/test_benchmark_report.py
+
+      # The self-test above exercises the SEND_ZC probe but asserts it "either
+      # way", so it is silent about what this runner actually offers. Record
+      # the verdict here: it is the environment every benchmark number
+      # published from a GitHub runner rests on, it costs a second, and
+      # benchmark.yml only answers it on a tag build. A runner that cannot
+      # offer the opcode cannot produce numbers about the zero-copy send path,
+      # and that is worth knowing on every pull request rather than once a
+      # release.
+      - name: Record the runner's io_uring SEND_ZC capability
+        run: |
+          set -euo pipefail
+          echo "Runner kernel: $(uname -r) ($(uname -m))"
+          python3 .github/scripts/benchmark_env.py > runner_env.json
+          cat runner_env.json
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          env = json.loads(Path("runner_env.json").read_text())
+          zc = env["io_uring_send_zc"]
+          print("## GitHub runner io_uring capability\n")
+          print(f"- Kernel `{env['kernel_release']}` on `{env['machine']}`, "
+                f"{env['cpu_count']} CPUs")
+          print(f"- Meets the {zc['kernel_floor']} floor: "
+                f"**{zc['meets_kernel_floor']}**")
+          print(f"- Opcode {zc['opcode']} advertised: "
+                f"**{zc['opcode_advertised']}**")
+          print(f"- IORING_OP_SEND_ZC usable: **{zc['supported']}** "
+                f"({zc['detail']})")
+          PY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,11 +35,50 @@ jobs:
   benchmark:
     name: Performance Benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Raised from 90 because every upstream cell now runs once per baseline,
+    # the SSH and daemon cells re-time oc-rsync against each peer, and the
+    # initial-transfer cells reset between runs instead of measuring a
+    # no-change sync from run 2 onwards.
+    #
+    # Measured on this runner, not guessed: the dual-baseline suite itself
+    # takes 12m47s and the whole job 19m51s with warm caches. The three
+    # release builds are the variable part -- 5m32s warm, so allow roughly
+    # 40m cold -- which puts the cold-cache worst case near 55m. 120 is a bit
+    # over 2x that. An hours-long budget was tempting after a loaded 4-core
+    # aarch64 host took 3.5h, but that host is not this runner, and an
+    # over-long timeout means a hung run holds a scarce runner for hours
+    # before failing.
+    timeout-minutes: 120
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # First, before any build: the probe needs only the checkout and
+      # python3, and a runner that cannot offer the opcode is a fact worth
+      # having in the first minute rather than after a twenty-five-minute
+      # build. A benchmark whose environment is unstated cannot be compared
+      # across runs, so the answer is published even when it is "yes".
+      - name: Probe io_uring SEND_ZC on the runner kernel
+        id: send_zc
+        run: |
+          set -euo pipefail
+          echo "Runner kernel: $(uname -r) ($(uname -m))"
+          python3 .github/scripts/benchmark_env.py > send_zc_probe.json
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+          env = json.loads(Path("send_zc_probe.json").read_text())
+          zc = env["io_uring_send_zc"]
+          print("## Benchmark environment\n")
+          print(f"- Kernel `{env['kernel_release']}` on `{env['machine']}`, "
+                f"{env['cpu_count']} CPUs")
+          print(f"- IORING_OP_SEND_ZC supported: **{zc['supported']}** "
+                f"({zc['detail']})")
+          PY
+          if [ "$(python3 -c "import json;print(json.load(open('send_zc_probe.json'))['io_uring_send_zc']['supported'])")" != "True" ]; then
+            echo "::warning title=SEND_ZC unavailable::This runner's kernel does not advertise IORING_OP_SEND_ZC. The published benchmark numbers cannot show the io_uring zero-copy send path; the report says so explicitly."
+          fi
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
@@ -69,15 +108,20 @@ jobs:
           cargo build --locked --release --features embedded-ssh
           cp target/release/oc-rsync target/release/oc-rsync-russh
 
-      - name: Cache upstream rsync
-        id: cache-rsync
+      # Two upstream releases are in circulation at once: 3.5.0 is current,
+      # 3.4.4 is what most distributions still ship. Comparing against only
+      # one of them answers half the question a release note is asked, so
+      # both are built and both are handed to the benchmark. Separate cache
+      # keys so a change to one version cannot invalidate the other.
+      - name: Cache upstream rsync 3.5.0
+        id: cache-rsync-350
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: target/interop/upstream-src/rsync-3.5.0
           key: upstream-rsync-3.5.0-${{ runner.os }}-full
 
       - name: Build upstream rsync 3.5.0
-        if: steps.cache-rsync.outputs.cache-hit != 'true'
+        if: steps.cache-rsync-350.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           mkdir -p target/interop/upstream-src
@@ -93,6 +137,40 @@ jobs:
             make -j$(nproc)
           fi
 
+      - name: Cache upstream rsync 3.4.4
+        id: cache-rsync-344
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: target/interop/upstream-src/rsync-3.4.4
+          key: upstream-rsync-3.4.4-${{ runner.os }}-full
+
+      - name: Build upstream rsync 3.4.4
+        if: steps.cache-rsync-344.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p target/interop/upstream-src
+          cd target/interop/upstream-src
+
+          if [ ! -d rsync-3.4.4 ]; then
+            curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
+          fi
+
+          cd rsync-3.4.4
+          if [ ! -f rsync ]; then
+            ./configure
+            make -j$(nproc)
+          fi
+
+      - name: Self-test benchmark harness and renderers
+        # Run before the benchmark, not after: the suite takes hours, and a
+        # harness or renderer defect discovered afterwards has already cost
+        # the whole tag build. A metric regression here fails fast instead of
+        # shipping a misleading chart to the release page.
+        run: |
+          python3 tools/ci/tests/test_benchmark_harness.py
+          python3 tools/ci/tests/test_benchmark_chart.py
+          python3 tools/ci/tests/test_benchmark_report.py
+
       - name: Set up SSH loopback
         run: |
           sudo systemctl start ssh
@@ -102,31 +180,36 @@ jobs:
           chmod 600 ~/.ssh/authorized_keys
           ssh -o StrictHostKeyChecking=no localhost true
 
+      # Only one binary can own `rsync` on PATH, and it is 3.5.0: it is the
+      # primary baseline, so a cell that reaches PATH rather than an explicit
+      # path lands on the release the headline numbers are stated against.
+      # The benchmark's own SSH cells do not rely on this -- they pass
+      # `--rsync-path` so each cell's remote end matches its own baseline --
+      # but anything else on the runner that shells out to `rsync` gets 3.5.0.
       - name: Install upstream rsync to PATH
         run: sudo cp target/interop/upstream-src/rsync-3.5.0/rsync /usr/local/bin/rsync
 
       - name: Run benchmark
         id: benchmark
         env:
-          # The build step above owns the upstream version; naming it again
-          # inside benchmark.py is what let the two drift apart.
-          UPSTREAM_RSYNC: target/interop/upstream-src/rsync-3.5.0/rsync
+          # The build steps above own the upstream versions; naming them again
+          # inside benchmark.py is what let the two drift apart. The first
+          # entry is the primary baseline.
+          UPSTREAM_RSYNC: >-
+            3.5.0=target/interop/upstream-src/rsync-3.5.0/rsync,3.4.4=target/interop/upstream-src/rsync-3.4.4/rsync
           OC_RSYNC_OPENSSL: target/release/oc-rsync-openssl
           OC_RSYNC_RUSSH: target/release/oc-rsync-russh
+          # `iouring-send-zc` is not in any default feature set and the
+          # binary's --version does not enumerate fast_io features, so the
+          # cargo invocation above is the only place this is knowable. Change
+          # it in step with the build, not independently.
+          OC_RSYNC_SEND_ZC_DISPATCH: >-
+            compiled out (iouring-send-zc cargo feature not enabled in the release build)
         run: |
           set -euo pipefail
           python3 .github/scripts/benchmark.py > benchmark_results.json
           python3 .github/scripts/benchmark_report.py > benchmark_report.md
           cat benchmark_report.md
-
-      - name: Self-test benchmark renderers
-        # The chart and report are published as release assets, so the
-        # renderers are exercised against synthetic results before the real
-        # ones are drawn. A metric regression here fails the tag build
-        # instead of shipping a misleading chart to the release page.
-        run: |
-          python3 tools/ci/tests/test_benchmark_chart.py
-          python3 tools/ci/tests/test_benchmark_report.py
 
       - name: Generate benchmark chart
         run: |
@@ -144,6 +227,7 @@ jobs:
             benchmark_report.md
             benchmark.svg
             benchmark.png
+            send_zc_probe.json
 
       - name: Generate step summary
         run: |

--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ See also the `SSH TRANSPORT` section of `oc-rsync(1)` for the man-page summary.
 
 ### Performance
 
-![Benchmark: oc-rsync vs upstream rsync 3.5.0](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)
+![Benchmark: oc-rsync vs upstream rsync 3.5.0 and 3.4.4](https://github.com/oferchen/rsync/releases/latest/download/benchmark.png)
 
-Benchmarked against upstream rsync 3.5.0 on each tagged release across local, SSH, and daemon transfer modes. Every mode reports both **elapsed time** and **peak RSS**, so a throughput win bought with memory is visible rather than hidden; the chart, a per-mode breakdown and the exact upstream build string are attached to every [GitHub release](https://github.com/oferchen/rsync/releases/latest).
+Benchmarked on each tagged release against **both** upstream rsync 3.5.0 (current) and 3.4.4 (what most distributions ship), across local, SSH, and daemon transfer modes. Every mode reports **elapsed time**, **peak RSS** and a **corpus rate** in MiB/s, each median figure carrying the run-to-run spread that produced it, so a throughput win bought with memory -- or resting on one lucky run -- is visible rather than hidden. The chart, a per-mode breakdown per baseline, the kernel the numbers were taken on and whether it advertises io_uring `IORING_OP_SEND_ZC` are attached to every [GitHub release](https://github.com/oferchen/rsync/releases/latest).
 
 Threaded architecture replaces upstream's fork-based pipeline while keeping full protocol compatibility, reducing syscall overhead and context switches. Adaptive I/O buffers scale from 8KB to 1MB based on file size. Optional io_uring on Linux 5.6+ with three policies: *auto* (default; probe kernel and fall back to standard I/O), `--io-uring` (require io_uring; error if unavailable), `--no-io-uring` (always use standard buffered I/O). The active backend is reported in `--version` output. See `oc-rsync(1)` for details.
 

--- a/tools/ci/tests/test_benchmark_chart.py
+++ b/tools/ci/tests/test_benchmark_chart.py
@@ -299,6 +299,96 @@ class RenderedChart(unittest.TestCase):
         self.assertIn("no data", section)
 
 
+DUAL_BASELINE = {
+    "upstream_version": "3.5.0",
+    "oc_rsync_version": "0.6.4",
+    "baselines": [
+        {"label": "3.5.0", "version": "3.5.0", "path": "/a", "primary": True},
+        {"label": "3.4.4", "version": "3.4.4", "path": "/b", "primary": False},
+    ],
+    "test_data": {"size_mb": 100, "files": 1000},
+    "summary": {"avg_ratio": 0.5, "best_ratio": 0.25, "worst_ratio": 1.0,
+                "by_mode": {}},
+    "tests": [
+        {
+            "id": "local_initial",
+            "name": "Initial sync",
+            "mode": "local",
+            # 4.00s / 2.00s / 1.00s: three magnitudes no two of which can be
+            # confused, so a chart that plotted the legacy `upstream` twice
+            # would lose "2.00s" entirely.
+            "upstreams": {
+                "3.5.0": {"mean": 4.0, "min": 4.0, "max": 4.0},
+                "3.4.4": {"mean": 2.0, "min": 2.0, "max": 2.0},
+            },
+            "ratios": {"3.5.0": 0.25, "3.4.4": 0.5},
+            "upstream": {"mean": 4.0, "min": 4.0, "max": 4.0},
+            "oc_rsync": {"mean": 1.0, "min": 1.0, "max": 1.0},
+            "ratio": 0.25,
+        },
+        {
+            "id": "memory_initial",
+            "name": "Initial sync",
+            "mode": "memory",
+            "upstreams": {
+                "3.5.0": {"mean": 0.5, "peak_rss_kb": 8192},
+                "3.4.4": {"mean": 0.5, "peak_rss_kb": 16384},
+            },
+            "ratios": {"3.5.0": 0.5, "3.4.4": 0.5},
+            "upstream": {"mean": 0.5, "peak_rss_kb": 8192},
+            "oc_rsync": {"mean": 0.25, "peak_rss_kb": 65536},
+            "ratio": 0.5,
+        },
+    ],
+}
+
+
+class DualBaselineChart(unittest.TestCase):
+    """Every baseline the run measured must reach the published chart."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.svg = bc.generate_chart(DUAL_BASELINE)
+        cls.local = mode_section(cls.svg, "Local Copy", "Memory Usage")
+        cls.memory = mode_section(cls.svg, "Memory Usage", None)
+
+    def test_a_row_carries_one_bar_per_baseline_plus_oc_rsync(self):
+        labels = texts(self.local)
+        for magnitude in ("4.00s", "2.00s", "1.00s"):
+            self.assertIn(
+                magnitude, labels,
+                f"{magnitude} is missing: a baseline was dropped or plotted "
+                f"from the legacy single-upstream field",
+            )
+
+    def test_each_baseline_gets_its_own_ratio_annotation(self):
+        self.assertIn("vs 3.5.0 4.0x faster", self.local)
+        self.assertIn("vs 3.4.4 2.0x faster", self.local)
+
+    def test_the_legend_names_every_baseline(self):
+        self.assertIn("upstream rsync 3.5.0", self.svg)
+        self.assertIn("upstream rsync 3.4.4", self.svg)
+
+    def test_the_title_names_the_subject_and_both_baselines(self):
+        self.assertIn("oc-rsync 0.6.4 vs upstream rsync 3.5.0 and 3.4.4", self.svg)
+
+    def test_a_byte_row_derives_each_baselines_ratio_from_plotted_bytes(self):
+        """64 MiB against 8 MiB and 16 MiB: 8.0x and 4.0x, not the time ratio."""
+        self.assertIn("8.00 MiB", self.memory)
+        self.assertIn("16.00 MiB", self.memory)
+        self.assertIn("64.00 MiB", self.memory)
+        self.assertIn("vs 3.5.0 8.0x more memory", self.memory)
+        self.assertIn("vs 3.4.4 4.0x more memory", self.memory)
+        self.assertNotIn("faster", self.memory)
+
+    def test_a_single_baseline_run_keeps_its_unprefixed_annotation(self):
+        """The one-baseline shape must not grow a redundant `vs X` prefix."""
+        section = mode_section(
+            bc.generate_chart(SYNTHETIC), "Local Copy", "Memory Usage"
+        )
+        self.assertIn(">5.0x faster<", section)
+
+
 class RenderedReport(unittest.TestCase):
     """The markdown report already handled RSS correctly; pin that."""
 

--- a/tools/ci/tests/test_benchmark_harness.py
+++ b/tools/ci/tests/test_benchmark_harness.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Regression tests for the release benchmark harness itself.
+
+Three defects motivated these, and each is guarded by asserting the value a
+correct implementation produces *and* a value only the broken one could:
+
+1. The published `benchmark_results.json` for v0.6.4 recorded
+   `oc_rsync_version = '3.4.4'` for a 0.6.4 build. `\\b(\\d+\\.\\d+\\.\\d+)\\b`
+   cannot match inside `v0.6.4` -- there is no word boundary between `v` and
+   `0` -- so the first number the pattern accepted was the *wire
+   compatibility* version from the next banner line. Asserting only "the
+   release is 0.6.4" would pass on a parser that read the right line by luck,
+   so these tests also assert the compatibility version is reported, and
+   separately.
+
+2. An initial-transfer cell reset its destination once and then timed six
+   runs, and `representative_secs` discards the first as the warm-up. The
+   published "Initial sync" figure was therefore the median of five no-change
+   runs. The guard is on *how many times* the reset hook fires.
+
+3. Only the primary baseline existed. The guard is that a second baseline is
+   parsed, ordered, and kept distinct from the first.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS = REPO_ROOT / ".github" / "scripts"
+
+# benchmark.py resolves its baselines at import time and exits when none are
+# named, which is the behaviour CI depends on. Point it at a binary that
+# certainly exists so the module can be imported and its helpers exercised.
+os.environ.setdefault("UPSTREAM_RSYNC", "probe=/bin/echo")
+sys.path.insert(0, str(SCRIPTS))
+
+
+def load_script(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bench = load_script("benchmark")
+env = load_script("benchmark_env")
+
+
+OC_BANNER = """\
+oc-rsync v0.6.4 (revision #9d99155e1) protocol version 32
+Compatible with rsync 3.4.4 wire protocol
+Built in Rust 2024 for aarch64-linux
+"""
+
+OC_VV = '{"program": "oc-rsync", "version": "0.6.4", "protocol": "32.0"}'
+
+UPSTREAM_BANNER = "rsync  version 3.5.0  protocol version 32\n"
+
+
+def fake_binary(tmp: Path, name: str, banner: str, vv: str | None) -> str:
+    """A stand-in binary that prints a fixed --version / -VV document."""
+    path = tmp / name
+    vv_body = f'cat <<"EOF"\n{vv}\nEOF' if vv else "exit 1"
+    path.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "-VV" ]; then\n'
+        f"{vv_body}\n"
+        "else\n"
+        f'cat <<"EOF"\n{banner}EOF\n'
+        "fi\n"
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return str(path)
+
+
+class OcRsyncVersionLabel(unittest.TestCase):
+    """oc-rsync's release and its wire compatibility are two different facts."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.oc = fake_binary(
+            Path(self.tmp.name), "oc-rsync", OC_BANNER, OC_VV
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_release_is_oc_rsyncs_own_version(self):
+        release, _ = bench.oc_rsync_versions(self.oc)
+        self.assertEqual(release, "0.6.4")
+        self.assertNotEqual(
+            release, "3.4.4", "the wire compatibility version was published "
+            "as oc-rsync's release"
+        )
+
+    def test_wire_compatibility_is_reported_separately(self):
+        _, compat = bench.oc_rsync_versions(self.oc)
+        self.assertEqual(compat, "3.4.4")
+
+    def test_banner_is_the_fallback_when_the_json_document_is_absent(self):
+        """A build whose -VV cannot be parsed must still name its release."""
+        oc = fake_binary(
+            Path(self.tmp.name), "oc-rsync-nojson", OC_BANNER, None
+        )
+        release, compat = bench.oc_rsync_versions(oc)
+        self.assertEqual(release, "0.6.4")
+        self.assertEqual(compat, "3.4.4")
+
+    def test_the_old_greedy_parser_would_have_failed_this_fixture(self):
+        """Pin the mechanism, so the fixture cannot silently stop reproducing.
+
+        If this ever returns 0.6.4, the banner no longer has the shape the
+        bug needed and the tests above stop being regression tests.
+        """
+        self.assertEqual(bench.binary_version(self.oc), "3.4.4")
+
+    def test_upstream_binaries_still_use_the_leading_number_rule(self):
+        up = fake_binary(
+            Path(self.tmp.name), "rsync", UPSTREAM_BANNER, None
+        )
+        self.assertEqual(bench.binary_version(up), "3.5.0")
+
+
+class BaselineParsing(unittest.TestCase):
+    def test_labelled_entries_keep_their_order(self):
+        baselines = bench.parse_baselines(
+            "3.5.0=/bin/echo,3.4.4=/bin/echo"
+        )
+        self.assertEqual([b.label for b in baselines], ["3.5.0", "3.4.4"])
+
+    def test_paths_are_absolute_for_the_remote_end(self):
+        """SSH cells pass the path to the remote shell, whose cwd is not ours."""
+        baselines = bench.parse_baselines("x=./some/rsync")
+        self.assertTrue(baselines[0].path.startswith("/"))
+
+    def test_a_bare_path_takes_its_label_from_the_binary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            up = fake_binary(Path(tmp), "rsync", UPSTREAM_BANNER, None)
+            baselines = bench.parse_baselines(up)
+        self.assertEqual([b.label for b in baselines], ["3.5.0"])
+
+    def test_a_bare_command_name_resolves_through_path(self):
+        """`UPSTREAM_RSYNC=rsync` means the system rsync, not ./rsync."""
+        baselines = bench.parse_baselines("echo")
+        self.assertEqual(baselines[0].path, shutil.which("echo"))
+
+    def test_duplicate_labels_are_refused(self):
+        with self.assertRaises(SystemExit):
+            bench.parse_baselines("3.5.0=/bin/echo,3.5.0=/bin/true")
+
+    def test_an_empty_spec_yields_no_baselines(self):
+        self.assertEqual(bench.parse_baselines("  "), [])
+
+    def test_labels_become_filesystem_safe_directory_slugs(self):
+        baseline = bench.parse_baselines("3.5.0-rc/1=/bin/echo")[0]
+        self.assertEqual(baseline.slug, "3.5.0-rc_1")
+
+
+class PerRunReset(unittest.TestCase):
+    """An initial-transfer cell must start empty on every run, not just run 1."""
+
+    def test_before_each_fires_once_per_run(self):
+        calls = []
+        bench.benchmark("true", runs=4, before_each=lambda: calls.append(1))
+        self.assertEqual(
+            len(calls), 4,
+            "resetting once per cell leaves runs 2..n measuring a no-change "
+            "sync, and the warm-up run that did the real work is discarded",
+        )
+
+    def test_no_hook_means_no_reset(self):
+        result = bench.benchmark("true", runs=2)
+        self.assertEqual(result["runs"], 2)
+
+    def test_rss_runner_also_resets_per_run(self):
+        if not os.access("/usr/bin/time", os.X_OK):
+            self.skipTest("/usr/bin/time is not available")
+        calls = []
+        bench.benchmark_rss("true", runs=3, before_each=lambda: calls.append(1))
+        self.assertEqual(len(calls), 3)
+
+
+class Statistics(unittest.TestCase):
+    def test_spread_is_the_min_to_max_range_over_the_median(self):
+        # The warm-up run (1.0) is dropped, so the median is that of
+        # [2.0, 3.0, 4.0] = 3.0; min/max still span every run, so the spread
+        # is (4.0 - 1.0) / 3.0 = 100%.
+        s = bench.stats([1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(s["mean"], 3.0)
+        self.assertEqual(s["min"], 1.0)
+        self.assertEqual(s["max"], 4.0)
+        self.assertEqual(s["runs"], 4)
+        self.assertAlmostEqual(s["spread_pct"], 100.0)
+
+    def test_a_repeatable_cell_reports_no_spread(self):
+        self.assertEqual(bench.stats([1.0, 1.0, 1.0])["spread_pct"], 0.0)
+
+    def test_throughput_is_corpus_bytes_over_elapsed(self):
+        series = {"mean": 2.0}
+        bench.add_throughput(series, 1024 * 1024 * 100)
+        self.assertEqual(series["corpus_mibps"], 50.0)
+
+    def test_throughput_is_omitted_when_the_corpus_size_is_unknown(self):
+        series = {"mean": 2.0}
+        bench.add_throughput(series, None)
+        self.assertNotIn("corpus_mibps", series)
+
+
+class ComparisonRows(unittest.TestCase):
+    def setUp(self):
+        self.saved = bench.BASELINES, bench.PRIMARY
+        bench.BASELINES = [
+            bench.Baseline("3.5.0", "/bin/echo"),
+            bench.Baseline("3.4.4", "/bin/true"),
+        ]
+        bench.PRIMARY = bench.BASELINES[0]
+
+    def tearDown(self):
+        bench.BASELINES, bench.PRIMARY = self.saved
+
+    def _row(self, **kwargs):
+        results = {"tests": []}
+        seen = []
+
+        def runner(cmd, runs=1, before_each=None):
+            seen.append(cmd)
+            if before_each is not None:
+                before_each()
+            return {"mean": float(len(seen)), "min": 1.0, "max": 1.0}
+
+        row = bench.compare(
+            results,
+            "id",
+            "name",
+            "local",
+            lambda b: f"up:{b.label}",
+            lambda b: f"oc:{b.label}",
+            runner=runner,
+            **kwargs,
+        )
+        return row, seen
+
+    def test_every_baseline_gets_its_own_upstream_series(self):
+        row, seen = self._row()
+        self.assertEqual(sorted(row["upstreams"]), ["3.4.4", "3.5.0"])
+        self.assertIn("up:3.5.0", seen)
+        self.assertIn("up:3.4.4", seen)
+
+    def test_the_legacy_fields_describe_the_primary_baseline(self):
+        row, _ = self._row()
+        self.assertEqual(row["upstream"], row["upstreams"]["3.5.0"])
+        self.assertEqual(row["ratio"], row["ratios"]["3.5.0"])
+
+    def test_a_local_cell_times_oc_rsync_once(self):
+        """The baseline is the other contestant, not the peer."""
+        _, seen = self._row()
+        self.assertEqual([c for c in seen if c.startswith("oc:")], ["oc:3.5.0"])
+
+    def test_a_peer_cell_times_oc_rsync_against_each_baseline(self):
+        row, seen = self._row(oc_per_baseline=True)
+        self.assertEqual(
+            [c for c in seen if c.startswith("oc:")], ["oc:3.5.0", "oc:3.4.4"]
+        )
+        self.assertEqual(sorted(row["oc_rsync_per_baseline"]), ["3.4.4", "3.5.0"])
+
+    def test_ratios_differ_when_the_baselines_differ(self):
+        row, _ = self._row()
+        self.assertNotEqual(
+            row["ratios"]["3.5.0"], row["ratios"]["3.4.4"],
+            "both baselines were divided into the same upstream time",
+        )
+
+
+class FailedRuns(unittest.TestCase):
+    """A command that errors out in a millisecond is not a fast command."""
+
+    def test_a_nonzero_exit_is_counted(self):
+        result = bench.benchmark("exit 4", runs=3)
+        self.assertEqual(result["failures"], 3)
+        self.assertTrue(bench.series_failed(result))
+
+    def test_a_clean_run_records_no_failure_key(self):
+        result = bench.benchmark("true", runs=2)
+        self.assertNotIn("failures", result)
+        self.assertFalse(bench.series_failed(result))
+
+    def test_a_failing_baseline_marks_the_row(self):
+        saved = bench.BASELINES, bench.PRIMARY
+        bench.BASELINES = [bench.Baseline("3.5.0", "/bin/echo")]
+        bench.PRIMARY = bench.BASELINES[0]
+        try:
+            results = {"tests": []}
+            row = bench.compare(
+                results, "compress_zstd", "zstd", "compression",
+                lambda b: "exit 4",
+                lambda b: "true",
+                runs=2,
+            )
+        finally:
+            bench.BASELINES, bench.PRIMARY = saved
+        self.assertEqual(row["failed_series"], ["3.5.0"])
+
+    def test_a_sound_row_carries_no_failure_marker(self):
+        saved = bench.BASELINES, bench.PRIMARY
+        bench.BASELINES = [bench.Baseline("3.5.0", "/bin/echo")]
+        bench.PRIMARY = bench.BASELINES[0]
+        try:
+            row = bench.compare(
+                {"tests": []}, "local", "local", "local",
+                lambda b: "true",
+                lambda b: "true",
+                runs=2,
+            )
+        finally:
+            bench.BASELINES, bench.PRIMARY = saved
+        self.assertNotIn("failed_series", row)
+
+
+class SendZcProbe(unittest.TestCase):
+    def test_kernel_version_parsing(self):
+        self.assertEqual(env.parse_kernel_version("7.0.0-29-generic"), (7, 0))
+        self.assertEqual(env.parse_kernel_version("6.8.0-45-azure"), (6, 8))
+        self.assertIsNone(env.parse_kernel_version("weird"))
+
+    def test_probe_reports_the_opcode_it_asked_about(self):
+        probe = env.probe_send_zc()
+        self.assertEqual(probe["opcode"], 47)
+        self.assertEqual(probe["kernel_floor"], "6.0")
+        self.assertIsInstance(probe["supported"], bool)
+
+    def test_support_requires_both_the_floor_and_the_opcode(self):
+        """Neither half alone is enough; state both, and conjoin them."""
+        probe = dict(env.probe_send_zc())
+        if probe["supported"]:
+            self.assertTrue(probe["meets_kernel_floor"])
+            self.assertTrue(probe["opcode_advertised"])
+        else:
+            self.assertFalse(
+                probe["meets_kernel_floor"] and probe["opcode_advertised"]
+            )
+
+    def test_an_unsupported_kernel_is_stated_loudly(self):
+        verdict = env.send_zc_verdict(
+            {
+                "io_uring_send_zc": {
+                    "supported": False,
+                    "kernel_release": "5.4.0",
+                    "detail": "below the 6.0 floor",
+                }
+            }
+        )
+        self.assertIn("SEND_ZC UNAVAILABLE", verdict)
+        self.assertIn("No figure below is evidence", verdict)
+
+    def test_a_supported_kernel_still_names_a_binary_that_cannot_use_it(self):
+        verdict = env.send_zc_verdict(
+            {
+                "io_uring_send_zc": {
+                    "supported": True,
+                    "kernel_release": "7.0.0",
+                    "detail": "op 47 advertised",
+                },
+                "oc_rsync_send_zc_dispatch": "compiled out",
+            }
+        )
+        self.assertIn("advertises IORING_OP_SEND_ZC", verdict)
+        self.assertIn("does not dispatch it", verdict)
+
+
+class ModuleEntryPoint(unittest.TestCase):
+    def test_benchmark_py_refuses_to_run_without_a_baseline(self):
+        """Naming the version in two places is what let them drift apart."""
+        environ = dict(os.environ, UPSTREAM_RSYNC="")
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS / "benchmark.py")],
+            capture_output=True, text=True, env=environ,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("UPSTREAM_RSYNC is not set", proc.stderr)
+
+    def test_a_missing_baseline_binary_is_refused(self):
+        environ = dict(os.environ, UPSTREAM_RSYNC="9.9.9=/nonexistent/rsync")
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPTS / "benchmark.py")],
+            capture_output=True, text=True, env=environ,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not found", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/ci/tests/test_benchmark_report.py
+++ b/tools/ci/tests/test_benchmark_report.py
@@ -135,6 +135,147 @@ class PeakRssColumns(unittest.TestCase):
         self.assertIn("| - | - | - |", out)
 
 
+def dual_baseline_results() -> dict:
+    """A two-baseline result set whose numbers cannot be confused.
+
+    Every magnitude is distinct and the legacy single-baseline `upstream` /
+    `ratio` fields deliberately carry the *primary* baseline's values, so a
+    renderer that ignored the new `upstreams` / `ratios` keys and fell back to
+    the legacy pair would render the 3.5.0 figures twice -- visible as the
+    3.4.4 numbers going missing rather than as a crash.
+    """
+    up_350 = {"mean": 4.000, "min": 3.9, "max": 4.1, "spread_pct": 5.0,
+              "peak_rss_kb": 8192, "corpus_mibps": 25.0}
+    up_344 = {"mean": 2.000, "min": 1.9, "max": 2.1, "spread_pct": 10.0,
+              "peak_rss_kb": 4096, "corpus_mibps": 50.0}
+    oc = {"mean": 1.000, "min": 0.9, "max": 1.1, "spread_pct": 20.0,
+          "peak_rss_kb": 16384, "corpus_mibps": 100.0}
+    return {
+        "upstream_version": "3.5.0",
+        "oc_rsync_version": "0.6.4",
+        "oc_rsync_wire_compat_version": "3.4.4",
+        "baselines": [
+            {"label": "3.5.0", "version": "3.5.0", "path": "/a", "primary": True},
+            {"label": "3.4.4", "version": "3.4.4", "path": "/b", "primary": False},
+        ],
+        "environment": {
+            "platform": "linux",
+            "kernel_release": "5.4.0-generic",
+            "machine": "x86_64",
+            "cpu_count": 4,
+            "io_uring_send_zc": {
+                "supported": False,
+                "kernel_release": "5.4.0-generic",
+                "detail": "below the 6.0 floor",
+            },
+            "oc_rsync_send_zc_dispatch": "compiled out",
+        },
+        "test_data": {"size_mb": 100, "files": 1000},
+        "summary": {
+            "by_mode": {"local": 0.25},
+            "avg_ratio": 0.25,
+            "best_ratio": 0.25,
+            "worst_ratio": 0.25,
+            "by_baseline": {
+                "3.5.0": {"avg_ratio": 0.25, "best_ratio": 0.25,
+                          "worst_ratio": 0.25, "by_mode": {"local": 0.25}},
+                "3.4.4": {"avg_ratio": 0.50, "best_ratio": 0.50,
+                          "worst_ratio": 0.50, "by_mode": {"local": 0.50}},
+            },
+        },
+        "tests": [
+            {
+                "id": "local_initial",
+                "name": "Initial sync",
+                "mode": "local",
+                "upstreams": {"3.5.0": up_350, "3.4.4": up_344},
+                "ratios": {"3.5.0": 0.25, "3.4.4": 0.50},
+                "upstream": up_350,
+                "oc_rsync": oc,
+                "ratio": 0.25,
+                "corpus_bytes": 100 * 1024 * 1024,
+            }
+        ],
+    }
+
+
+class DualBaselineColumns(unittest.TestCase):
+    """Both upstream releases must reach the published table."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.out = render(dual_baseline_results())
+
+    def test_both_baselines_are_named_in_the_header(self):
+        self.assertIn("rsync 3.5.0", self.out)
+        self.assertIn("rsync 3.4.4", self.out)
+
+    def test_each_baselines_own_timing_is_rendered(self):
+        self.assertIn("4.000s", self.out)
+        self.assertIn("2.000s", self.out)
+
+    def test_the_secondary_ratio_comes_from_ratios_not_the_legacy_field(self):
+        """0.50 exists only under `ratios`; 0.25 is the legacy `ratio`."""
+        self.assertIn("faster 0.50x", self.out)
+        self.assertIn("faster 0.25x", self.out)
+
+    def test_the_summary_states_a_verdict_per_baseline(self):
+        self.assertIn("vs rsync 3.5.0", self.out)
+        self.assertIn("vs rsync 3.4.4", self.out)
+
+    def test_spread_travels_with_the_median(self):
+        self.assertIn("4.000s ±5%", self.out)
+        self.assertIn("1.000s ±20%", self.out)
+
+    def test_corpus_rate_is_published(self):
+        self.assertIn("MiB/s", self.out)
+        self.assertIn("100", self.out)
+
+    def test_oc_rsync_is_labelled_with_its_own_release(self):
+        """The published v0.6.4 results said `oc_rsync_version = '3.4.4'`."""
+        self.assertIn("oc-rsync 0.6.4", self.out)
+        self.assertNotIn("oc-rsync 3.4.4", self.out)
+
+    def test_wire_compatibility_is_stated_as_a_separate_fact(self):
+        self.assertIn("wire-compatible with rsync 3.4.4", self.out)
+
+    def test_the_environment_the_numbers_came_from_is_stated(self):
+        self.assertIn("5.4.0-generic", self.out)
+        self.assertIn("x86_64", self.out)
+
+    def test_a_kernel_without_send_zc_is_called_out(self):
+        """Numbers from such a kernel say nothing about the zero-copy path."""
+        self.assertIn("SEND_ZC UNAVAILABLE", self.out)
+
+
+class FailedCells(unittest.TestCase):
+    """A cell whose binary errored out must not read as a performance result."""
+
+    def _results(self):
+        data = dual_baseline_results()
+        t = data["tests"][0]
+        t["id"] = "compress_zstd_initial"
+        t["failed_series"] = ["3.5.0"]
+        # The harness leaves such a row out of the averages, so the summary
+        # names it rather than silently dropping it.
+        data["summary"]["excluded_tests"] = ["compress_zstd_initial"]
+        return data
+
+    def test_the_row_says_which_side_failed(self):
+        out = render(self._results())
+        self.assertIn("failed: 3.5.0", out)
+
+    def test_the_summary_names_what_it_excluded(self):
+        out = render(self._results())
+        self.assertIn("compress_zstd_initial", out)
+        self.assertIn("excluded from these averages", out)
+
+    def test_a_sound_run_carries_no_exclusion_notice(self):
+        out = render(dual_baseline_results())
+        self.assertNotIn("excluded from these averages", out)
+        self.assertNotIn("failed:", out)
+
+
 class UpstreamVersionLabel(unittest.TestCase):
     def test_version_label_comes_from_the_measured_binary(self):
         """The column header must name the build actually benchmarked.


### PR DESCRIPTION
## What changed

The release benchmark measured oc-rsync against **one** upstream release. Two are in circulation at once — 3.5.0 is current, 3.4.4 is what most distributions still ship — so a single-baseline table answered half the question a release note is asked. It now runs every upstream cell against both.

`UPSTREAM_RSYNC` takes an ordered `label=path` list (a bare path or command name still works, so `_benchmark-macos.yml` and local runs are unchanged). The first entry is the **primary** baseline: it backs the legacy `upstream`/`ratio` fields, so an archived results file still renders.

Where the baseline is the **peer** rather than the other contestant — the SSH server, the rsync daemon — oc-rsync is re-timed against each one. The SSH cells pass `--rsync-path` so both ends of a cell speak the same release; previously the remote end was whatever `rsync` the login PATH resolved, which would have made a 3.4.4 client / 3.5.0 server pair and labelled it "3.4.4". One daemon is started per baseline on its own port. `/usr/local/bin/rsync` can only hold one binary and keeps **3.5.0**, the primary baseline — the benchmark's own SSH cells no longer depend on it, so it now governs only whatever else on the runner shells out to `rsync`.

`_benchmark-windows.yml` and `_benchmark-macos.yml` stay single-baseline; they are best-effort platform sniffs, not the release comparison, and doubling their cost buys nothing.

## Defects found and fixed

**1. `oc_rsync_version` was not oc-rsync's version.** The published v0.6.4 `benchmark_results.json` recorded `oc_rsync_version = '3.4.4'`. `binary_version()` takes the first `\b(\d+\.\d+\.\d+)\b` out of `--version`, and `\b` does not match between `v` and `0`, so `v0.6.4` was skipped entirely and the first number the pattern accepted was the *wire compatibility* version on the next banner line. Confirmed against a real binary:

```
$ oc-rsync --version | head -2
oc-rsync v0.6.4 (revision #9d99155e1) protocol version 32
Compatible with rsync 3.4.4 wire protocol

$ python3 -c "re.search(r'\b(\d+\.\d+\.\d+)\b', out).group(1)"   ->  3.4.4
```

The release now comes from the machine-readable `-VV` document (`{"version": "0.6.4"}`), which exists for exactly this purpose; the compatibility version is published separately as `oc_rsync_wire_compat_version`. The regression test asserts *both* the corrected value and that the old parser still mis-reads the fixture, so the fixture cannot quietly stop reproducing the bug.

**2. Every "Initial sync" cell measured a no-change sync.** The destination was reset once, then timed six times, and `representative_secs` discards the first run as the warm-up — so the published initial-transfer figure was the median of five *no-change* runs. Measured on a 300 MB corpus:

```
reset once, then 6 runs:   run1 1.73s | 0.03  0.04  0.04  0.04  0.02   -> published 0.04s
reset before every run:    1.27s  1.31s  1.22s                         -> published 1.27s
```

43x off. Resets now run before every timed invocation, and the delta cells roll their destination back each run so a delta cell measures a delta. Reset cells drop 6 → 3 runs to bound the added time.

**3. The peak-RSS columns on the transfer tables were always dashes.** Only the `memory` mode wrapped its runs in `/usr/bin/time`, while the report has carried RSS columns on every transfer row. Those cells now collect RSS, guarded by a one-time probe for `/usr/bin/time` so a host without it degrades to plain timing instead of failing every transfer.

**4. A failed run was recorded as a very fast run.** An upstream build without zstd rejects `--compress-choice=zstd` in about a millisecond. The harness recorded that as a legitimate 0.001 s measurement and published *"oc-rsync 581x slower"*, dragging the headline average from 0.59x to 23.61x. Non-zero exits and timeouts are now counted per series; a row with any failure is named on the table and left out of the averages.

## Metrics — what was added and why each discriminates

| Metric | Why it discriminates |
|---|---|
| Elapsed median (kept) | The comparison itself. |
| **Peak RSS** (kept; now actually populated on every transfer row) | Separates "faster" from "faster by buying memory". The Linux run shows oc-rsync 2.9x faster on local copy while holding 3.61x the RSS — invisible before. |
| **`corpus_mibps`** (new) | Corpus bytes / elapsed. Puts cells of different corpus sizes on one scale and stays comparable between an initial transfer and a no-change scan of the same tree. Explicitly *not* wire throughput: the harness knows the corpus size exactly and does not parse rsync's transferred-byte accounting, and the report says so. |
| **`spread_pct`** (new) | `(max − min) / median`, printed as `±N%` beside every figure. A median alone lets a cell whose runs varied 15x read exactly like one that repeated to within 1%. In the Linux run the checksum cell came out `±221%` and the delta-checksum cell `±1523%` — those ratios are noise, and now they say so on the page instead of in JSON nobody opens. |
| `runs` (new) | Distinguishes a 3-run cell from a 6-run one. |

No metric was invented that the harness cannot compute from what it already collects.

## SEND_ZC kernel requirement

`benchmark_env.py` probes `IORING_OP_SEND_ZC` (opcode 47) directly via `io_uring_setup(2)` + `IORING_REGISTER_PROBE`, requiring **both** the mainline 6.0 floor **and** the advertised opcode bit — the same conjunction `fast_io::io_uring::send_zc::probe_send_zc` applies before it will ever submit a SEND_ZC SQE, so the two cannot disagree about the same kernel. Pure stdlib ctypes; no build dependency.

The probe runs as its own workflow step *before* the long benchmark, writes the verdict to the step summary, uploads `send_zc_probe.json`, and emits a `::warning::` annotation when the runner cannot offer the opcode. The report repeats it and, in the negative case, says plainly that **no figure below is evidence about the zero-copy send path**.

The benchmarked binary has the dispatch **compiled out** — `iouring-send-zc` is in no default feature set and `--version` does not enumerate `fast_io` features, so the only place that fact is knowable is the cargo invocation. The workflow declares it in `OC_RSYNC_SEND_ZC_DISPATCH` next to that invocation, and the report states it alongside the kernel verdict. Kernel capability and binary capability are two facts and are reported as two facts.

## Validation on Linux

Full suite, end to end, both baselines:

```
$ uname -r ; uname -m
7.0.0-29-generic
aarch64

$ python3 .github/scripts/benchmark_env.py
"io_uring_send_zc": {
  "supported": true, "opcode": 47, "kernel_floor": "6.0",
  "meets_kernel_floor": true, "opcode_advertised": true,
  "detail": "IORING_REGISTER_PROBE: op 47 advertised (last_op=64, ops_len=65)"
}
```

Cross-checked against the binary's own reporter (`io_uring: compiled in, available (kernel 7.0, 65 ops)` — the same 65). Negative controls run: probing an absent opcode (250) returns `False` with "absent from the probe table", and forcing the floor to 99.0 returns `supported=false, opcode_advertised=true`. The probe discriminates; it does not just say yes.

Real comparison table (648.3 MB, 10 100 files; oc-rsync 0.6.4; 4-core aarch64):

| Cell | rsync 3.5.0 | rsync 3.4.4 | oc-rsync | oc / 3.5.0 | oc / 3.4.4 | Peak RSS |
|---|---|---|---|---|---|---|
| Local initial | 1.883s ±7% | 0.836s ±28% | 0.657s ±35% | faster 0.35x | faster 0.79x | higher 3.61x |
| Local no-change | 0.076s ±8% | 0.074s ±5% | 0.045s ±16% | faster 0.59x | faster 0.61x | higher 3.15x |
| SSH pull initial | 2.796s ±5% | 1.679s ±4% | 3.100s / 2.008s | slower 1.11x | slower 1.20x | higher 2.13x |
| SSH push initial | 2.871s ±34% | 2.203s ±22% | 2.424s / 1.276s | faster 0.84x | faster 0.58x | higher 3.19x |
| Daemon pull initial | 1.901s ±16% | 0.695s ±14% | 8.498s / 6.674s | **slower 4.47x** | **slower 9.60x** | higher 3.69x |
| Daemon push initial | 1.608s ±4% | 0.595s ±6% | 4.003s / 3.332s | slower 2.49x | slower 5.60x | higher 3.34x |
| zlib initial | 16.965s ±16% | 15.269s ±21% | 0.684s ±2% | faster 0.04x | faster 0.04x | — |
| Sparse initial | 2.005s ±76% | 0.915s ±173% | 0.123s ±18% | faster 0.06x | faster 0.13x | — |
| 100K files initial | 3.941s ±56% | 2.239s ±97% | 3.938s ±22% | ~same 1.00x | slower 1.76x | — |

(The SSH and daemon rows show two oc-rsync figures because oc-rsync is re-timed against each baseline's server.)

Two things this table shows that a single-baseline one could not:

- **The two baselines disagree, materially.** Daemon pull is 4.5x slower against 3.5.0 and 9.6x slower against 3.4.4; local initial is 0.35x against 3.5.0 and 0.79x against 3.4.4. Upstream 3.5.0 is itself markedly slower than 3.4.4 on several cells, which a comparison against 3.5.0 alone reads as an oc-rsync win.
- **The daemon-pull regression is real and tight** (±6% and ±1% spread), not a noisy cell. That is a finding for a separate issue, not for this PR.

Caveats, stated so the numbers are not over-read: the host's upstream builds lack zstd, so the two zstd cells failed and are marked and excluded (which is how defect 4 surfaced); the oc-rsync binary is a pre-built 0.6.4 at `9d99155e1`; and another job was running io_uring probes on the same host, visible in the wide spreads on several cells. The run validates the harness, not the release.

## Tests

`tools/ci/tests/test_benchmark_harness.py` is new (35 tests): baseline parsing, ordering and PATH resolution; the version parsers, including one asserting the *old* parser still mis-reads the fixture; per-run reset counting; spread and throughput arithmetic; per-baseline vs shared oc-rsync timing; failure counting and exclusion; and the SEND_ZC probe with both negative arms.

The chart and report suites gain dual-baseline cases with magnitudes chosen so a renderer that fell back to the legacy single-upstream field loses a number rather than crashing — verified by mutating `upstream_series` to ignore `upstreams`, which fails 2 tests.

All three suites are wired into **both** `benchmark-tooling.yml` (the PR gate, with `benchmark.py` and `benchmark_env.py` added to its path filters) and `benchmark.yml`, so the new file is not inert. The workflow edits were validated by re-extracting the step from the committed YAML with `yaml.safe_load` and executing it: on macOS it correctly reports SEND_ZC unavailable and emits the warning; on Linux it correctly reports the opcode advertised and emits none.

## Cost

Job timeout 90 → 300 minutes, set from a measurement (the same suite took ~3.5 h on a 4-core host) rather than from the old value plus a guess. The self-test moves ahead of the benchmark so a harness or renderer defect fails in seconds instead of after the run.
