### PR TITLE
fix(batch): carry hardlinks through --write-batch and --read-batch

### DIFF
--- a/crates/batch/src/replay/delta_phase.rs
+++ b/crates/batch/src/replay/delta_phase.rs
@@ -31,6 +31,7 @@ use super::dispatch::{
 ///
 /// upstream: receiver.c:recv_files() reads NDX + iflags + sum_head per file,
 /// then delta tokens, then file checksum. NDX_DONE signals phase transitions.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn apply_delta_phase(
     reader: &mut BatchReader,
     entries: &mut Vec<protocol::flist::FileEntry>,
@@ -38,6 +39,7 @@ pub(super) fn apply_delta_phase(
     flags: &BatchFlags,
     result: &mut ReplayResult,
     verbosity: i32,
+    transferred: &mut Vec<usize>,
 ) -> BatchResult<()> {
     let proto = reader.config().protocol_version;
     let mut codec_state = CodecState::new(flags, proto as u32);
@@ -81,7 +83,7 @@ pub(super) fn apply_delta_phase(
         }
 
         if ndx <= NDX_FLIST_OFFSET {
-            handle_inc_recurse_segment(reader, entries, dest_root, &mut flist_segments)?;
+            handle_inc_recurse_segment(reader, entries, dest_root, &mut flist_segments, proto)?;
             result.file_count = entries.len() as u64;
             continue;
         }
@@ -95,6 +97,7 @@ pub(super) fn apply_delta_phase(
             ndx,
             proto,
             verbosity,
+            transferred,
         )?;
     }
 
@@ -184,6 +187,7 @@ fn process_file_ndx(
     ndx: i32,
     proto: i32,
     verbosity: i32,
+    transferred: &mut Vec<usize>,
 ) -> BatchResult<()> {
     let stream = reader
         .inner_reader()
@@ -252,10 +256,15 @@ fn process_file_ndx(
     // files; directories and symlinks were created in the flist phase and must
     // not be overwritten with a delta-reconstructed file.
     if is_regular {
-        apply_file_delta(&dest_path, basis_exists, delta_ops, sum_head)
-    } else {
-        Ok(())
+        apply_file_delta(&dest_path, basis_exists, delta_ops, sum_head)?;
+        // Records which cluster member the batch actually fed, so the hardlink
+        // pass links the rest of its cluster to this file rather than to a
+        // destination the batch never wrote.
+        // upstream: hlink.c:516 finish_hard_link() - "FIRST combined with DONE
+        // means we were the first to get done".
+        transferred.push(flat_index);
     }
+    Ok(())
 }
 
 /// Reads delta tokens for one file, dispatching by compression codec.
@@ -319,6 +328,7 @@ fn handle_inc_recurse_segment(
     entries: &mut Vec<protocol::flist::FileEntry>,
     dest_root: &Path,
     flist_segments: &mut Vec<(i32, usize, usize)>,
+    proto: i32,
 ) -> BatchResult<()> {
     let prev_len = entries.len();
 
@@ -327,6 +337,10 @@ fn handle_inc_recurse_segment(
     let seg_ndx_start = prev_seg.0 + prev_seg.2 as i32 + 1;
 
     reader.read_incremental_flist_segment(entries)?;
+
+    // upstream: flist.c:1335-1341 - the group tag names a wire index, so it has
+    // to be stamped before the segment is sorted out of wire order.
+    super::assign_hardlink_gnums(&mut entries[prev_len..], seg_ndx_start, proto);
 
     // upstream: flist.c:2771 - sort each sub-list segment after receiving.
     // INC_RECURSE batches require protocol >= 30, so pre29 is always false.

--- a/crates/batch/src/replay/mod.rs
+++ b/crates/batch/src/replay/mod.rs
@@ -46,8 +46,9 @@ mod fs_ops;
 #[cfg(test)]
 mod tests;
 
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use protocol::flist::sort_file_list;
 
@@ -131,6 +132,26 @@ pub fn replay(
 
     let mut entries = reader.read_protocol_flist()?;
 
+    // upstream: flist.c:1335-1341 - recv_file_entry() stamps F_HL_GNUM while
+    // the entry is still in wire order, because the tag a follower carries is
+    // the leader's *unsorted* index. Doing it after the sort below would name
+    // a different entry.
+    let proto = reader.config().protocol_version;
+    let initial_ndx_start = if reader
+        .header()
+        .and_then(|h| h.compat_flags)
+        .map(|cf| {
+            protocol::CompatibilityFlags::from_bits(cf as u32)
+                .contains(protocol::CompatibilityFlags::INC_RECURSE)
+        })
+        .unwrap_or(false)
+    {
+        1
+    } else {
+        0
+    };
+    assign_hardlink_gnums(&mut entries, initial_ndx_start, proto);
+
     // upstream: flist.c:2771 - flist_sort_and_clean() after recv_file_list().
     // NDX values from the generator reference sorted positions, not wire order.
     let pre29 = reader.config().protocol_version < 29;
@@ -156,6 +177,7 @@ pub fn replay(
     prepare_directories_and_symlinks(&entries, dest_root, verbosity, &mut result)?;
 
     // Phase 2: Apply delta operations for regular files.
+    let mut transferred = Vec::new();
     apply_delta_phase(
         &mut reader,
         &mut entries,
@@ -163,7 +185,12 @@ pub fn replay(
         &flags,
         &mut result,
         verbosity,
+        &mut transferred,
     )?;
+
+    // Phase 2.5: rebuild the hardlink clusters. The batch carries the payload
+    // for one member per cluster, exactly as upstream's generator requested it.
+    link_hardlink_clusters(&entries, &transferred, dest_root, &flags)?;
 
     // Phase 3: Apply metadata. Directories are done last because setting
     // timestamps on a directory before writing its contents would cause the
@@ -172,6 +199,159 @@ pub fn replay(
     apply_all_metadata(&entries, dest_root, &flags, verbosity);
 
     Ok(result)
+}
+
+/// Stamps each hardlink cluster member with its group tag, mirroring the
+/// `F_HL_GNUM` bookkeeping upstream does as it reads the file list.
+///
+/// A follower already arrives carrying the tag - the leader's file-list index -
+/// so only the leader needs one, and it uses its own index. Below protocol 30
+/// there is no index on the wire at all and the cluster is named by the
+/// trailing `(dev, ino)` pair, which is folded onto the same index space here.
+///
+/// `ndx_start` is the wire index of the segment's first entry, so the tags this
+/// assigns live in the same space as the ones followers carry.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1335-1341`: `F_HL_GNUM(file) = flist->ndx_start + flist->used`
+///   for an `XMIT_HLINK_FIRST` entry, `= first_hlink_ndx` otherwise.
+/// - `flist.c:1343-1362`: the protocol 28-29 arm groups by `(dev, ino)`.
+pub(super) fn assign_hardlink_gnums(
+    entries: &mut [protocol::flist::FileEntry],
+    ndx_start: i32,
+    protocol_version: i32,
+) {
+    if protocol_version >= 30 {
+        for (offset, entry) in entries.iter_mut().enumerate() {
+            if entry.hlinked() && entry.hlink_first() {
+                let ndx = ndx_start.saturating_add(offset as i32).max(0);
+                entry.set_hardlink_idx(ndx as u32);
+            }
+        }
+        return;
+    }
+
+    let mut groups: HashMap<(i64, i64), u32> = HashMap::new();
+    for (offset, entry) in entries.iter_mut().enumerate() {
+        if !entry.hlinked() {
+            continue;
+        }
+        let (Some(dev), Some(ino)) = (entry.hardlink_dev(), entry.hardlink_ino()) else {
+            continue;
+        };
+        let ndx = ndx_start.saturating_add(offset as i32).max(0) as u32;
+        let gnum = *groups.entry((dev, ino)).or_insert(ndx);
+        entry.set_hardlink_idx(gnum);
+    }
+}
+
+/// Recreates the hardlink clusters described by the file list.
+///
+/// The batch holds the payload for a single member of each cluster, so every
+/// other member is materialised as a link to it rather than from delta data.
+/// `transferred` names the flat entry indices that phase 2 actually wrote,
+/// which is what makes the link source the member the batch fed - upstream
+/// picks the same file for the same reason ("FIRST combined with DONE means we
+/// were the first to get done"). A cluster whose members were all already
+/// up to date has no transferred member; the first one in file-list order then
+/// becomes the source, matching upstream's `virtual first`.
+///
+/// # Upstream Reference
+///
+/// - `hlink.c:113-194`: `match_gnums()` clusters by `F_HL_GNUM`.
+/// - `hlink.c:496-565`: `finish_hard_link()` links the rest of the cluster to
+///   the member that completed.
+/// - `hlink.c:224-256`: `maybe_hard_link()` leaves a member alone when it
+///   already shares the source's `(st_dev, st_ino)`.
+fn link_hardlink_clusters(
+    entries: &[protocol::flist::FileEntry],
+    transferred: &[usize],
+    dest_root: &Path,
+    flags: &BatchFlags,
+) -> BatchResult<()> {
+    if !flags.preserve_hard_links {
+        return Ok(());
+    }
+
+    let mut sources: HashMap<u32, PathBuf> = HashMap::new();
+    for &index in transferred {
+        let Some(entry) = entries.get(index) else {
+            continue;
+        };
+        if !entry.hlinked() {
+            continue;
+        }
+        if let Some(gnum) = entry.hardlink_idx() {
+            sources
+                .entry(gnum)
+                .or_insert_with(|| dest_root.join(entry.name()));
+        }
+    }
+
+    for entry in entries {
+        if !entry.hlinked() || entry.file_type() != protocol::flist::FileType::Regular {
+            continue;
+        }
+        let Some(gnum) = entry.hardlink_idx() else {
+            continue;
+        };
+        let dest_path = dest_root.join(entry.name());
+        let source_path = match sources.get(&gnum) {
+            Some(path) => path.clone(),
+            None => {
+                sources.insert(gnum, dest_path);
+                continue;
+            }
+        };
+        if source_path == dest_path || already_hard_linked(&source_path, &dest_path) {
+            continue;
+        }
+        if dest_path.symlink_metadata().is_ok() {
+            fs::remove_file(&dest_path).map_err(|e| {
+                BatchError::Io(std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to replace '{}' with a hard link: {e}",
+                        dest_path.display()
+                    ),
+                ))
+            })?;
+        }
+        fast_io::hard_link(&source_path, &dest_path).map_err(|e| {
+            BatchError::Io(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "link {} => {} failed: {e}",
+                    dest_path.display(),
+                    source_path.display()
+                ),
+            ))
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Whether the two paths already name the same inode.
+///
+/// upstream: `hlink.c:230-231 maybe_hard_link()` compares `st_dev`/`st_ino`
+/// and leaves the destination untouched when they match.
+#[cfg(unix)]
+fn already_hard_linked(source: &Path, dest: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    match (fs::symlink_metadata(source), fs::symlink_metadata(dest)) {
+        (Ok(a), Ok(b)) => a.dev() == b.dev() && a.ino() == b.ino(),
+        _ => false,
+    }
+}
+
+/// Non-Unix platforms expose no inode identity, so the link is always redone.
+#[cfg(not(unix))]
+fn already_hard_linked(source: &Path, dest: &Path) -> bool {
+    let _ = (source, dest);
+    false
 }
 
 /// Phase 1: Create directories and symlinks, ensure parent dirs for regular files.

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -301,6 +301,22 @@ pub(crate) struct CopyContext<'a> {
     /// Used to compute the traversal→sorted index mapping that upstream's
     /// `flist_sort_and_clean()` produces after reading the batch flist.
     batch_entry_sort_data: Vec<(Vec<u8>, bool)>,
+    /// `(st_dev, st_ino)` to the traversal index of the entry that first
+    /// carried that inode, for `--write-batch -H`.
+    ///
+    /// upstream: `flist.c:599-625 send_file_entry()` consults `idev_find()`
+    /// for every non-directory with `st_nlink > 1`; a miss makes the entry the
+    /// group leader (`XMIT_HLINK_FIRST`) and records its index, a hit makes it
+    /// a follower carrying the leader's index.
+    batch_hlink_first_ndx: HashMap<(u64, u64), i32>,
+    /// Hardlink group number per flist entry in traversal order, `None` for
+    /// entries outside any cluster.
+    ///
+    /// upstream: `flist.c:1335-1341 recv_file_entry()` stores the same value in
+    /// `F_HL_GNUM`; `hlink.c:match_gnums()` then transfers only the
+    /// sorted-first member of each group, so the batch must carry delta data
+    /// for that member alone.
+    batch_entry_hlink_gnum: Vec<Option<i32>>,
     /// Traversal index of the current file being delta-captured.
     batch_current_delta_idx: i32,
     /// Zero-based file-list index counter for batch NDX framing.

--- a/crates/engine/src/local_copy/context_impl/options/batch.rs
+++ b/crates/engine/src/local_copy/context_impl/options/batch.rs
@@ -568,13 +568,19 @@ impl<'a> CopyContext<'a> {
         // traversal-order entry ends up in the sorted flist.
         let traversal_to_sorted = self.build_batch_sort_mapping();
 
+        // upstream: hlink.c:113-194 match_gnums() - one member per hardlink
+        // cluster is transferred and the rest are linked to it, so the batch
+        // must carry the payload exactly once per cluster.
+        let suppressed = self.batch_hlink_suppressed_indices(&traversal_to_sorted);
+
+        let mut entries = std::mem::take(&mut self.batch_delta_entries);
+        entries.retain(|(traversal_idx, _)| !suppressed.contains(traversal_idx));
+
         // Write each file's delta data with the correct sorted NDX.
         let codec = self
             .batch_ndx_codec
             .as_mut()
             .expect("batch_ndx_codec must exist when batch_delta_buf is set");
-
-        let mut entries = std::mem::take(&mut self.batch_delta_entries);
         // Sort entries by their post-sort NDX so the delta stream is in
         // ascending NDX order, matching what upstream's recv_files() expects.
         entries.sort_by_key(|(traversal_idx, _)| {
@@ -685,6 +691,99 @@ impl<'a> CopyContext<'a> {
         traversal_to_sorted
     }
 
+    /// Returns the batch protocol version and whether the recorded stream
+    /// flags carry `--hard-links`.
+    ///
+    /// The flag is taken from the header this same writer already wrote, for
+    /// the reason spelled out on `build_batch_flist_writer`: the reader
+    /// configures itself from the header, so deriving it from the live options
+    /// here would let the two sides disagree.
+    pub(super) fn batch_hard_link_context(&self) -> Option<(i32, bool)> {
+        let guard = self.options.get_batch_writer()?.lock().ok()?;
+        Some((
+            guard.config().protocol_version,
+            guard.stream_flags().preserve_hard_links,
+        ))
+    }
+
+    /// Assigns the hardlink cluster of the flist entry about to be captured
+    /// and records its group number in traversal order.
+    ///
+    /// Returns `None` for an entry outside any cluster. Otherwise returns the
+    /// traversal index of the cluster leader together with whether this entry
+    /// *is* that leader - the first sighting of the inode.
+    ///
+    /// upstream: `flist.c:1628-1635 make_file()` remembers `(st_dev, st_ino)`
+    /// for every non-directory with `st_nlink > 1`, and
+    /// `flist.c:599-625 send_file_entry()` turns a first sighting into
+    /// `XMIT_HLINK_FIRST` (recording `first_ndx + ndx`) and every repeat into a
+    /// follower carrying the leader's index.
+    pub(super) fn assign_batch_hlink_group(
+        &mut self,
+        metadata: &fs::Metadata,
+        preserve_hard_links: bool,
+    ) -> Option<(i32, bool)> {
+        let ndx = self.batch_flist_index;
+        let assigned = batch_hlink_key(metadata, preserve_hard_links).map(|key| {
+            let leader = *self.batch_hlink_first_ndx.entry(key).or_insert(ndx);
+            (leader, leader == ndx)
+        });
+        self.batch_entry_hlink_gnum
+            .push(assigned.map(|(leader, _)| leader));
+        assigned
+    }
+
+    /// Traversal indices whose recorded delta data must not reach the batch
+    /// because a hardlink cluster mate carries it instead.
+    ///
+    /// upstream: `hlink.c:113-194 match_gnums()` marks the *sorted-first*
+    /// member of each group `FLAG_HLINK_FIRST`; `generator.c` then routes every
+    /// other member through `hlink.c:300 hard_link_check()`, which returns 1
+    /// (skip) so no data is ever requested for it. A batch that repeated the
+    /// payload for each mate would therefore not be one upstream could have
+    /// produced.
+    ///
+    /// Only members that actually recorded delta data are eligible to keep it:
+    /// under plain `--write-batch` the live copy hardlinks the mates instead of
+    /// reading them, so the payload sits on whichever member the walk reached
+    /// first and dropping it would leave the cluster with no content at all.
+    fn batch_hlink_suppressed_indices(&self, traversal_to_sorted: &[i32]) -> HashSet<i32> {
+        let mut leaders: HashMap<i32, (i32, i32)> = HashMap::new();
+        for (traversal_idx, _) in &self.batch_delta_entries {
+            let Some(Some(gnum)) = self
+                .batch_entry_hlink_gnum
+                .get(*traversal_idx as usize)
+                .copied()
+            else {
+                continue;
+            };
+            let sorted = traversal_to_sorted
+                .get(*traversal_idx as usize)
+                .copied()
+                .unwrap_or(*traversal_idx);
+            leaders
+                .entry(gnum)
+                .and_modify(|best| {
+                    if sorted < best.0 {
+                        *best = (sorted, *traversal_idx);
+                    }
+                })
+                .or_insert((sorted, *traversal_idx));
+        }
+
+        let keep: HashSet<i32> = leaders.values().map(|&(_, idx)| idx).collect();
+        self.batch_delta_entries
+            .iter()
+            .map(|(traversal_idx, _)| *traversal_idx)
+            .filter(|traversal_idx| {
+                matches!(
+                    self.batch_entry_hlink_gnum.get(*traversal_idx as usize),
+                    Some(Some(_))
+                ) && !keep.contains(traversal_idx)
+            })
+            .collect()
+    }
+
     /// Increments the batch flist index counter.
     ///
     /// Called after each flist entry is captured to the batch file.
@@ -784,4 +883,27 @@ fn batch_entry_compare(
 
         i += 1;
     }
+}
+
+/// The `(st_dev, st_ino)` key a batch flist entry contributes to hardlink
+/// grouping, or `None` when the entry cannot belong to a cluster.
+///
+/// upstream: `flist.c:1628-1635 make_file()` - under protocol 28 and above the
+/// candidate test is `!S_ISDIR(st.st_mode) && st.st_nlink > 1`.
+#[cfg(unix)]
+fn batch_hlink_key(metadata: &fs::Metadata, preserve_hard_links: bool) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+
+    if !preserve_hard_links || metadata.is_dir() || metadata.nlink() <= 1 {
+        return None;
+    }
+    Some((metadata.dev(), metadata.ino()))
+}
+
+/// Non-Unix platforms expose no inode identity through `fs::Metadata`, so no
+/// entry can be recognised as a cluster member.
+#[cfg(not(unix))]
+fn batch_hlink_key(metadata: &fs::Metadata, preserve_hard_links: bool) -> Option<(u64, u64)> {
+    let _ = (metadata, preserve_hard_links);
+    None
 }

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -81,6 +81,8 @@ impl<'a> CopyContext<'a> {
             batch_delta_sum_head: protocol::wire::SumHead::WHOLE_FILE,
             batch_delta_sum_head_offset: 0,
             batch_entry_sort_data: Vec::new(),
+            batch_hlink_first_ndx: HashMap::new(),
+            batch_entry_hlink_gnum: Vec::new(),
             batch_current_delta_idx: 0,
             batch_flist_index: 0,
             batch_ndx_codec,

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -117,6 +117,50 @@ fn build_protocol_file_entry(
     entry
 }
 
+/// Stamps the hardlink identity of a cluster member onto its flist entry.
+///
+/// Protocol 30 and above name the cluster by the leader's file-list index:
+/// `FileListWriter` reads `u32::MAX` as "this entry is the leader" and emits
+/// `XMIT_HLINKED | XMIT_HLINK_FIRST`, and any other value as a follower whose
+/// abbreviated entry is just flags, name and `write_varint(first_hlink_ndx)`.
+/// Protocols 28 and 29 have no index; the cluster is named by the trailing
+/// `(dev, ino)` pair instead.
+///
+/// upstream: `flist.c:599-625` computes `first_hlink_ndx` and the two xflags,
+/// `flist.c:668-672` writes the follower's index and abbreviates the entry, and
+/// `flist.c:741-753` writes the pre-30 `(dev, ino)` pair.
+fn apply_hardlink_fields(
+    entry: &mut protocol::flist::FileEntry,
+    metadata: &fs::Metadata,
+    hlink_group: Option<(i32, bool)>,
+    protocol_version: i32,
+) {
+    let Some((leader_ndx, is_leader)) = hlink_group else {
+        return;
+    };
+
+    if protocol_version >= 30 {
+        // upstream: flist.c:602-605 - a new group records its own index and is
+        // flagged XMIT_HLINK_FIRST; the sentinel is how the writer spells that.
+        entry.set_hardlink_idx(if is_leader {
+            u32::MAX
+        } else {
+            leader_ndx.max(0) as u32
+        });
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        entry.set_hardlink_dev(metadata.dev() as i64);
+        entry.set_hardlink_ino(metadata.ino() as i64);
+    }
+    #[cfg(not(unix))]
+    let _ = metadata;
+}
+
 /// Captures a file entry to the batch file using the protocol wire format.
 ///
 /// When batch mode is active, encodes the file entry using the protocol
@@ -143,13 +187,22 @@ pub(crate) fn capture_batch_file_entry(
     #[cfg(not(unix))]
     let numeric_ids = true;
 
-    let entry = build_protocol_file_entry(
+    // The stream flags recorded in the header are what the reader configures
+    // itself from, so the hardlink decision has to come from the same place.
+    let (protocol_version, preserve_hard_links) =
+        context.batch_hard_link_context().unwrap_or((0, false));
+    // Must run for every captured entry, cluster member or not: the group
+    // numbers it records are indexed by traversal position.
+    let hlink_group = context.assign_batch_hlink_group(metadata, preserve_hard_links);
+
+    let mut entry = build_protocol_file_entry(
         source_path,
         relative_path,
         metadata,
         is_top_dir,
         numeric_ids,
     );
+    apply_hardlink_fields(&mut entry, metadata, hlink_group, protocol_version);
 
     let mut buf = Vec::with_capacity(128);
     let flist_writer = context

--- a/crates/engine/tests/only_write_batch_hard_links.rs
+++ b/crates/engine/tests/only_write_batch_hard_links.rs
@@ -1,0 +1,195 @@
+//! Regression test for UTS `batch-only-remove-source-regression`: a batch
+//! written with `-H` must carry the hardlink clusters, and replaying it must
+//! rebuild them.
+//!
+//! Before the fix the two ends failed independently. The writer's
+//! `build_protocol_file_entry()` never set any hardlink identity, so the
+//! encoded flist carried neither `XMIT_HLINKED` nor a group index and the
+//! payload was repeated once per cluster member; replay decoded the hardlink
+//! fields an upstream-written batch does carry but never acted on them. A
+//! cluster therefore came back as unrelated copies whichever side produced the
+//! batch.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:599-625` - `send_file_entry()` flags the first sighting of an
+//!   inode `XMIT_HLINK_FIRST` and every repeat a follower.
+//! - `flist.c:668-672` - the follower entry is just flags, name and
+//!   `write_varint(first_hlink_ndx)`.
+//! - `flist.c:1335-1341` - `recv_file_entry()` stamps `F_HL_GNUM` in wire
+//!   order.
+//! - `hlink.c:113-194` - `match_gnums()` clusters by that tag so one member is
+//!   transferred and the rest are linked to it.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::sync::{Arc, Mutex};
+
+use batch::{BatchConfig, BatchFlags, BatchMode, BatchReader, BatchWriter};
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use protocol::CompatibilityFlags;
+use tempfile::tempdir;
+
+/// Builds an `--only-write-batch` writer whose recorded stream flags say
+/// `-rH`, since the reader and the flist encoder both configure themselves
+/// from the header rather than from the live options.
+///
+/// The compat flags mirror the production set assembled by
+/// `cli::frontend::execution::drive::workflow::run`, `INC_RECURSE` deliberately
+/// omitted so the flist encodes flat.
+fn make_writer(path: &std::path::Path) -> Arc<Mutex<BatchWriter>> {
+    let compat_flags = CompatibilityFlags::SAFE_FILE_LIST
+        | CompatibilityFlags::AVOID_XATTR_OPTIMIZATION
+        | CompatibilityFlags::CHECKSUM_SEED_FIX
+        | CompatibilityFlags::INPLACE_PARTIAL_DIR
+        | CompatibilityFlags::VARINT_FLIST_FLAGS;
+    let config = BatchConfig::new(
+        BatchMode::OnlyWrite,
+        path.to_string_lossy().into_owned(),
+        32,
+    )
+    .with_compat_flags(compat_flags.bits() as i32)
+    .with_checksum_seed(1);
+    let mut writer = BatchWriter::new(config).expect("create batch writer");
+    let flags = BatchFlags {
+        recurse: true,
+        preserve_hard_links: true,
+        ..Default::default()
+    };
+    writer.write_header(flags).expect("write batch header");
+    Arc::new(Mutex::new(writer))
+}
+
+/// A three-member hardlink cluster plus an unrelated file of identical content
+/// must survive `--only-write-batch` followed by `--read-batch`: every member
+/// materialises with the source payload, the three share one inode, and the
+/// look-alike that was never hard-linked keeps an inode of its own.
+#[test]
+fn only_write_batch_replay_rebuilds_hard_link_clusters() {
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let dest_write = temp.path().join("dst_write");
+    let dest_replay = temp.path().join("dst_replay");
+    let batch_path = temp.path().join("batch.bin");
+
+    fs::create_dir_all(&source).expect("create source dir");
+    fs::create_dir_all(&dest_write).expect("create write-side dest");
+    fs::create_dir_all(&dest_replay).expect("create replay-side dest");
+
+    let payload: Vec<u8> = (0..40 * 1024).map(|i| (i % 251) as u8).collect();
+    // "b-leader" sorts before "m-middle" and "z-trailer", so the cluster
+    // leader is not the last member the walk reaches; the sort mapping has to
+    // be what picks which member carries the payload.
+    fs::write(source.join("b-leader"), &payload).expect("write cluster leader");
+    fs::hard_link(source.join("b-leader"), source.join("m-middle")).expect("link second member");
+    fs::hard_link(source.join("b-leader"), source.join("z-trailer")).expect("link third member");
+    // Same bytes, separate inode: proves the grouping keys on (dev, ino) and
+    // not on content.
+    fs::write(source.join("a-twin"), &payload).expect("write unlinked twin");
+
+    // A pre-existing destination whose content differs, so a member that is
+    // neither transferred nor linked keeps visibly stale bytes.
+    for name in ["a-twin", "b-leader", "m-middle", "z-trailer"] {
+        fs::write(dest_replay.join(name), b"stale destination bytes").expect("seed destination");
+    }
+
+    let writer = make_writer(&batch_path);
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .hard_links(true)
+        .batch_writer(Some(Arc::clone(&writer)));
+
+    let mut src_os = source.clone().into_os_string();
+    src_os.push("/");
+    let operands = vec![src_os, dest_write.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(LocalCopyExecution::DryRun, options)
+        .expect("only-write-batch dry-run succeeds");
+
+    Arc::try_unwrap(writer)
+        .expect("writer uniquely owned")
+        .into_inner()
+        .expect("writer mutex not poisoned")
+        .finalize()
+        .expect("finalize batch writer");
+
+    let read_cfg = BatchConfig::new(
+        BatchMode::Read,
+        batch_path.to_string_lossy().into_owned(),
+        32,
+    )
+    .with_active_flags(BatchFlags {
+        recurse: true,
+        preserve_hard_links: true,
+        ..Default::default()
+    });
+
+    // The flist itself must name the cluster: one member flagged first and the
+    // other two carrying its index.
+    let mut reader = BatchReader::new(read_cfg.clone()).expect("open batch reader");
+    reader.read_header().expect("read batch header");
+    let entries = reader.read_protocol_flist().expect("decode flist");
+    let cluster: Vec<&protocol::flist::FileEntry> = entries
+        .iter()
+        .filter(|entry| {
+            matches!(entry.name(), "b-leader" | "m-middle" | "z-trailer") && entry.hlinked()
+        })
+        .collect();
+    assert_eq!(
+        cluster.len(),
+        3,
+        "all three cluster members must be flagged XMIT_HLINKED; got {:?}",
+        entries
+            .iter()
+            .map(|e| (e.name().to_owned(), e.hlinked()))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        cluster.iter().filter(|entry| entry.hlink_first()).count(),
+        1,
+        "exactly one member carries XMIT_HLINK_FIRST"
+    );
+    let twin = entries
+        .iter()
+        .find(|entry| entry.name() == "a-twin")
+        .expect("unlinked twin present in flist");
+    assert!(
+        !twin.hlinked(),
+        "a file with st_nlink == 1 must not be flagged as hard-linked"
+    );
+    drop(reader);
+
+    batch::replay::replay(&read_cfg, &dest_replay, 0).expect("replay succeeds");
+
+    for name in ["a-twin", "b-leader", "m-middle", "z-trailer"] {
+        assert_eq!(
+            fs::read(dest_replay.join(name)).expect("read replayed file"),
+            payload,
+            "{name} must carry the source payload after replay"
+        );
+    }
+
+    let ino = |name: &str| {
+        fs::symlink_metadata(dest_replay.join(name))
+            .expect("stat replayed file")
+            .ino()
+    };
+    assert_eq!(
+        ino("b-leader"),
+        ino("m-middle"),
+        "cluster members must share one inode after replay"
+    );
+    assert_eq!(
+        ino("b-leader"),
+        ino("z-trailer"),
+        "cluster members must share one inode after replay"
+    );
+    assert_ne!(
+        ino("b-leader"),
+        ino("a-twin"),
+        "a same-content file that was never hard-linked must keep its own inode"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -27,7 +27,7 @@ bare-do-open-symlink-race pass
 basis-xname-traversal fail
 batch-file-symlink skip
 batch-mode pass
-batch-only-remove-source-regression fail
+batch-only-remove-source-regression pass
 change-shrink pass
 change-vanish pass
 chdir-symlink-race pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -27,7 +27,7 @@ bare-do-open-symlink-race pass
 basis-xname-traversal fail
 batch-file-symlink pass
 batch-mode pass
-batch-only-remove-source-regression fail
+batch-only-remove-source-regression pass
 change-shrink pass
 change-vanish pass
 chdir-symlink-race pass


### PR DESCRIPTION
Upstream testsuite cell `batch-only-remove-source-regression` fails on both
pipe legs (nonroot and root) with `the retained batch did not reproduce the
source hard link`. Upstream rsync 3.5.0 passes it. Content was already
byte-correct; only the `-H` hardlink data was lost, and only on the batch path
(a plain `-aH` local transfer links correctly).

## Two coupled defects

A cross matrix of writer x replayer, `-aH --only-write-batch` then
`-aH --read-batch`, on a source directory holding two names for one inode
(aarch64 Linux, upstream 3.5.0 built from the pinned tarball):

| write | replay | before | after |
|---|---|---|---|
| upstream | upstream | LINKED | LINKED |
| upstream | oc-rsync | NOTLINKED, follower content stale | LINKED |
| oc-rsync | upstream | NOTLINKED | LINKED |
| oc-rsync | oc-rsync | NOTLINKED | LINKED |

Both directions failed, so both ends were wrong and fixing one would have left
the cell red.

**Writer.** `build_protocol_file_entry()` never set any hardlink identity on
the flist entry it built, so the encoded batch flist carried neither
`XMIT_HLINKED` nor a group index, and the payload was written once per cluster
member (the batch was 1878 bytes where upstream's was 1005 for the same tree).

**Replay.** `batch::replay` decoded the hardlink fields an upstream-written
batch does carry - `FileListReader` already resolves the abbreviated follower
entry - but nothing ever acted on them, so a cluster came back as unrelated
copies and the follower kept its pre-replay bytes.

## The format, from upstream

Mirrored rather than invented; the citations are to the pinned 3.5.0 tree.

- `flist.c:1628-1635` `make_file()`: an entry is a cluster candidate when
  `!S_ISDIR(st.st_mode) && st.st_nlink > 1` (protocol >= 28).
- `flist.c:599-625` `send_file_entry()`: `idev_find(dev, ino)` returns -1 for a
  first sighting, which records `first_ndx + ndx` and sets `XMIT_HLINK_FIRST`;
  every repeat becomes a follower. `XMIT_HLINKED` is set either way.
- `flist.c:668-672`: a follower writes `write_varint(first_hlink_ndx)` right
  after the name and then `goto the_end` - no length, mtime, mode or ownership
  follows.
- `flist.c:741-753`: below protocol 30 there is no index; the cluster is named
  by a trailing `(dev, ino)` pair instead.
- `flist.c:1335-1341` `recv_file_entry()`: `F_HL_GNUM` is stamped while the
  entry is still in wire order - the leader records its own index, a follower
  the one it was sent.
- `hlink.c:113-194` `match_gnums()`: clusters by that tag over the *sorted*
  list and marks the sorted-first member `FLAG_HLINK_FIRST`; `generator.c`
  routes every other member through `hlink.c:300 hard_link_check()`, which
  returns 1 (skip), so the payload is requested exactly once per cluster.
- `hlink.c:496-565` `finish_hard_link()`: the member that completes becomes the
  link source - "FIRST combined with DONE means we were the first to get done".

No divergence from that format. The one place this implementation has a choice
upstream does not is which member the replay treats as the link source: the
replay uses the member the batch actually fed rather than assuming the
sorted-first, which is the same rule `finish_hard_link()` applies and keeps a
batch written by either implementation replayable.

## The fix

Writer (`crates/engine`): `capture_batch_file_entry()` groups candidates by
`(st_dev, st_ino)` in traversal order, stamping the first sighting with the
`u32::MAX` sentinel `FileListWriter` reads as `XMIT_HLINK_FIRST` and every
repeat with the leader's index (or the `(dev, ino)` pair below protocol 30).
`flush_batch_delta_to_batch()` then drops the duplicated payloads through the
traversal-to-sorted mapping it already builds, leaving one per cluster - the
sorted-first, as `match_gnums()` makes upstream do.

Replay (`crates/batch`): group tags are stamped in wire order before the sort
(and per segment under INC_RECURSE, where the tags live in that segment's NDX
space), the delta phase records which entries it wrote, and a pass after it
links each cluster to the member the batch fed. A member that already shares
the source's inode is left alone, matching `hlink.c:224-256 maybe_hard_link()`.

## Evidence

- The cell passes on both legs with the fixed binary: nonroot `PASS`, and under
  `sudo` `PASS`.
- Full 3.5.0 pipe suite, non-root: 254 passed, 5 failed, 86 skipped. All five
  failures (`basis-xname-traversal`, `filter-merge-content-echo`,
  `partial-protected-regular-retry-linux`, `rrsync-backup-dir-inband-pivot`,
  `rrsync-merge-file-confine`) are already recorded `fail` in the manifest, so
  nothing regressed.
- Six sibling batch cells still pass (`batch-mode`, `write-batch-quoting`,
  `write-batch-filter-injection`, `operator-path-write-batch`,
  `scanner-batch-flag-mismatch`, `hardlinks`); `batch-file-symlink` still skips
  as non-root.
- Mutation proof, writer half reverted (`assign_batch_hlink_group` forced to
  find no cluster): the two writer rows redden and only those -
  `oc->upstream` and `oc->oc` NOTLINKED, `upstream->oc` still LINKED - and the
  cell fails at `the retained batch did not reproduce the source hard link`,
  the original message.
- Mutation proof, replay half reverted (`link_hardlink_clusters` disabled): the
  two replay rows redden and only those - `upstream->oc` and `oc->oc`
  NOTLINKED with stale follower content, `oc->upstream` still LINKED - and the
  cell fails at `the retained batch did not install hard-linked payloads`.
- New regression test
  `crates/engine/tests/only_write_batch_hard_links.rs` covers a three-member
  cluster whose sorted-first member is not the one the walk reaches first, plus
  a same-content file that was never linked. Both mutations above kill it.

## Manifests

`batch-only-remove-source-regression` flipped `fail` -> `pass` in
`tools/ci/upstream-3.5.0-expect.nonroot.txt` and `.root.txt`, in the same
commit as the fix.
