### PR TITLE
fix(receiver): rmdir a directory obstacle instead of backing it up

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
@@ -43,6 +43,20 @@ impl LstatOutcome {
         }
     }
 
+    /// Reports whether the entry is a directory.
+    ///
+    /// The receiver's obstacle decision splits on exactly this test, so it has
+    /// to read the type from the same sandbox-anchored `fstatat` that observed
+    /// the entry rather than re-resolving the path: a swap in between would let
+    /// the removal act on a different inode from the one it classified.
+    #[must_use]
+    pub fn is_dir(&self) -> bool {
+        match self {
+            Self::At(meta) => meta.is_dir(),
+            Self::Std(meta) => meta.is_dir(),
+        }
+    }
+
     /// Inode number of the entry.
     #[must_use]
     pub fn ino(&self) -> u64 {

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -726,7 +726,7 @@ fn is_permission_error(err: &io::Error) -> bool {
 /// verbatim, with no parenthesised number to invent.
 ///
 /// upstream: `rsync-3.5.0/log.c` `rsyserr()` - `"%s: %s (%d)"`.
-fn upstream_errno_text(error: &io::Error) -> String {
+pub(crate) fn upstream_errno_text(error: &io::Error) -> String {
     let display = error.to_string();
     // A tagged failure is an `io::Error::new(kind, payload)`, i.e. the `Custom`
     // variant, whose `raw_os_error()` is `None` even though the payload wraps a

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -493,9 +493,16 @@ impl ReceiverContext {
     /// backup mechanism failed; the caller skips creating the replacement,
     /// mirroring upstream `atomic_create` returning 0 when `make_backup` fails.
     ///
+    /// This is the backup ARM of the obstacle decision, not the decision
+    /// itself: it is reached only from
+    /// [`ReceiverContext::make_way_for_replacement`], which has already ruled
+    /// out a directory. Upstream's `dir_in_the_way` (`generator.c:2469`) makes
+    /// `make_backup` unreachable for a directory in both modes, so calling this
+    /// with one would back up something upstream removes.
+    ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2018-2020` - `if (make_backups > 0 ...) if (!make_backup(fname, ...)) return 0;`
+    /// - `generator.c:2476-2478` - `if (make_backups > 0 && !dir_in_the_way) { if (!make_backup(fname, skip_atomic)) return 0; }`
     #[cfg(unix)]
     pub(in crate::receiver) fn backup_existing_before_replace(
         &self,

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -15,6 +15,8 @@ use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_f
 
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
+#[cfg(any(unix, windows))]
+use crate::receiver::directory::obstacle::MakeWayFor;
 
 impl ReceiverContext {
     /// Reports whether a received symlink's mtime should be preserved.
@@ -190,41 +192,21 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // symlink up before it is removed when --backup is set; on
-                // backup-mechanism failure upstream skips the entry.
-                match self.backup_existing_before_replace(
-                    &link_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: route the obstacle unlink through the sandbox
-                        // dirfd when the destination parent is the sandbox root,
-                        // so a TOCTOU swap on `link_path` between the readlink
-                        // above and this unlink cannot redirect the syscall to
-                        // an attacker-chosen parent. Falls back to path-based
-                        // `remove_file` otherwise.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &link_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing symlink {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // - one decision for the obstacle: rmdir a directory, back up
+                // or unlink anything else. The refusal is reported inside.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if fast_io::lstat_via_sandbox_or_fallback(
                 sandbox,
@@ -234,43 +216,22 @@ impl ReceiverContext {
             )
             .is_ok()
             {
-                // SEC-1.f: when the sandbox is plumbed and the destination
-                // parent is the sandbox root, the obstacle stat goes through
-                // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
-                // `link_path` cannot redirect the probe to a different
-                // inode. Falls back to `symlink_metadata` otherwise.
-                //
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // obstacle up before removal when --backup is set.
-                match self.backup_existing_before_replace(
-                    &link_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: matching unlink also goes through the sandbox
-                        // dirfd via `unlinkat` so the obstacle-remove syscall is
-                        // anchored on the same parent the stat just observed.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &link_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing obstacle {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // for a non-symlink obstacle. The stat above only selects this
+                // arm; `make_way_for_replacement` re-reads the type through the
+                // same sandbox dirfd to decide between rmdir and backup/unlink.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if !self.config.reference_directories.is_empty() {
                 // upstream: generator.c:1978 - `else if (basis_dir[0] != NULL)`
@@ -507,42 +468,33 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // symlink up before removal when --backup is set.
-                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        let _ = fs::remove_file(&link_path);
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing symlink {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK).
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if fs::symlink_metadata(&link_path).is_ok() {
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // obstacle up before removal when --backup is set.
-                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        let _ = fs::remove_file(&link_path);
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing obstacle {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // for a non-symlink obstacle.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             }
 

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -13,6 +13,7 @@ mod creation;
 pub(in crate::receiver) mod deletion;
 mod links;
 mod missing_args;
+mod obstacle;
 mod special;
 
 /// Normalizes a filename for cross-platform comparison.

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -66,8 +66,16 @@ pub(in crate::receiver) enum MakeWayFor {
     /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
     Symlink,
     /// upstream `DEL_FOR_DEVICE` - `"device file"`.
+    ///
+    /// Unix only: `create_specials` is the sole constructor and Windows has
+    /// no `mknod` path, so on Windows this variant is unconstructible and
+    /// `-D warnings` rejects it as dead code.
+    #[cfg(unix)]
     Device,
     /// upstream `DEL_FOR_SPECIAL` - `"special file"`.
+    ///
+    /// Unix only, for the same reason as [`Self::Device`].
+    #[cfg(unix)]
     Special,
 }
 
@@ -77,7 +85,9 @@ impl MakeWayFor {
     const fn description(self) -> &'static str {
         match self {
             Self::Symlink => "symlink",
+            #[cfg(unix)]
             Self::Device => "device file",
+            #[cfg(unix)]
             Self::Special => "special file",
         }
     }

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -1,0 +1,425 @@
+//! The receiver's single decision site for an existing destination entry that
+//! stands where a symlink, FIFO, socket, or device node has to be created.
+//!
+//! Upstream makes this decision in exactly one place. `atomic_create()` sets
+//! `dir_in_the_way` when the obstacle is a directory, which also forces
+//! `skip_atomic`, so a directory obstacle reaches `delete_item()` whether or
+//! not `--backup` is set - the `make_backup` arm is unreachable for it in
+//! either mode. `delete_item()` then splits on the same test one level down:
+//! the `rmdir` arm for a directory, the `make_backup`/`unlink` arm in the
+//! `else`. Keeping both arms in one function here is what makes oc's structure
+//! answer upstream's; deciding the directory case inside the backup path would
+//! leave every `--backup`-off shape decided somewhere else.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:2469` - `int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);`
+//! - `generator.c:2471-2472` - `dir_in_the_way` forces `skip_atomic = 1`
+//! - `generator.c:2477-2483` - `if (make_backups > 0 && !dir_in_the_way) make_backup(...)`
+//!   `else if (skip_atomic) delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag)`
+//! - `delete.c:222-226` - the `rmdir` arm for `S_ISDIR(mode)`
+//! - `delete.c:227-238` - the `make_backup`/`unlink` arm in the `else`
+//! - `delete.c:178-181` - `cannot delete non-empty directory: %s` at `FINFO`
+//! - `delete.c:273-286` - `could not make way for %s %s: %s` at `FERROR_XFER`
+//!
+//! # Known residual: `DEL_RECURSE`
+//!
+//! `generator.c:2481` computes `int del_opts = delete_mode || force_delete ?
+//! DEL_RECURSE : 0`, so under `--delete` or `--force` upstream removes a
+//! POPULATED directory obstacle recursively and completes at exit 0. Measured
+//! against 3.5.0 over a real `--server` child: `--force`, `--delete`, and both
+//! together each give `rc=0` with the symlink in place, where this arm refuses
+//! at 23.
+//!
+//! Neither flag is reachable from here. `--force` is parsed and discarded by
+//! the server arg parser (`cli/src/frontend/server/flags.rs:615`, `"--force"
+//! => {}`) and has no field in `ParsedServerFlags`, so the receiver cannot
+//! know it was asked for. Wiring it is a server-arg and config change, not an
+//! obstacle-removal one, and is deliberately out of scope here: before this
+//! module existed the same shape aborted the whole transfer at 12 with the
+//! sibling files unsent, so the refusal below is strictly closer to upstream,
+//! not a new divergence.
+
+#[cfg(any(unix, windows))]
+use std::io;
+#[cfg(any(unix, windows))]
+use std::path::Path;
+
+#[cfg(any(unix, windows))]
+use crate::pipeline::receiver::upstream_errno_text;
+#[cfg(any(unix, windows))]
+use crate::receiver::ReceiverContext;
+
+/// The kind of item the receiver is clearing the way for.
+///
+/// Names the `DEL_FOR_*` flag upstream ORs into `delete_item`'s flags, which
+/// selects the noun in the `could not make way for new %s: %s` diagnostic.
+/// Upstream picks it from the *new* entry's type, not the obstacle's
+/// (`generator.c:2041-2047`).
+///
+/// # Upstream Reference
+///
+/// - `delete.c:275-282` - the `DEL_MAKE_ROOM` switch that picks the noun
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy)]
+pub(in crate::receiver) enum MakeWayFor {
+    /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
+    Symlink,
+    /// upstream `DEL_FOR_DEVICE` - `"device file"`.
+    Device,
+    /// upstream `DEL_FOR_SPECIAL` - `"special file"`.
+    Special,
+}
+
+#[cfg(any(unix, windows))]
+impl MakeWayFor {
+    /// upstream: `delete.c:275-279` - the `desc` assigned per `DEL_FOR_*`.
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Symlink => "symlink",
+            Self::Device => "device file",
+            Self::Special => "special file",
+        }
+    }
+}
+
+/// Reports whether `error` is the kernel's "directory is not empty" refusal.
+///
+/// Linux and the BSDs disagree on the errno `rmdir(2)` raises for a populated
+/// directory, and upstream tests only `ENOTEMPTY` because its own `rmdir` path
+/// never sees the BSD spelling. Accepting both keeps the diagnostic identical
+/// across the platforms oc builds for.
+///
+/// upstream: `delete.c:260-263` - `if (S_ISDIR(mode) && errno == ENOTEMPTY)`
+#[cfg(unix)]
+fn is_not_empty(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::ENOTEMPTY) | Some(libc::EEXIST)
+    )
+}
+
+/// Windows reports a populated directory as `ERROR_DIR_NOT_EMPTY`, which `std`
+/// surfaces as a raw OS error rather than a named `io::ErrorKind`.
+#[cfg(windows)]
+fn is_not_empty(error: &io::Error) -> bool {
+    const ERROR_DIR_NOT_EMPTY: i32 = 145;
+    error.raw_os_error() == Some(ERROR_DIR_NOT_EMPTY)
+}
+
+#[cfg(any(unix, windows))]
+impl ReceiverContext {
+    /// Clears whatever stands at `existing` so a fresh non-regular entry can be
+    /// created there, reporting any refusal the way upstream reports it.
+    ///
+    /// `Ok(())` means the path is free: it was already absent, it was removed,
+    /// or it was moved into the backup area. `Err` means the entry must be
+    /// skipped; the diagnostic has already been emitted, so the caller only has
+    /// to `continue`.
+    ///
+    /// The directory arm never consults `--backup`: upstream's `dir_in_the_way`
+    /// excludes a directory obstacle from `make_backup` in both modes and sends
+    /// it to `delete_item`'s `rmdir`, which clears an empty directory and
+    /// refuses a populated one.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2469-2485` - `atomic_create()`'s `dir_in_the_way` split
+    /// - `delete.c:205-239` - `delete_item()`'s `rmdir` and `make_backup` arms
+    #[cfg(unix)]
+    pub(in crate::receiver) fn make_way_for_replacement<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        // SEC-1.f: when the sandbox is plumbed and the destination parent is
+        // the sandbox root the obstacle stat goes through
+        // `fstatat(AT_SYMLINK_NOFOLLOW)`, so a TOCTOU symlink swap on
+        // `existing` cannot redirect the probe to a different inode.
+        let Ok(metadata) =
+            fast_io::lstat_via_sandbox_or_fallback(sandbox, dest_dir, relative_path, existing)
+        else {
+            // upstream: delete.c:268-269 maps ENOENT to DR_SUCCESS and
+            // backup.c:236 returns "nothing to keep" - either way there is
+            // nothing in the way to make way for.
+            return Ok(());
+        };
+
+        if metadata.is_dir() {
+            // upstream: generator.c:2469 - dir_in_the_way, so neither the
+            // backup arm nor the atomic temp-and-rename applies.
+            return self.rmdir_obstacle(
+                writer,
+                existing,
+                relative_path,
+                dest_dir,
+                sandbox,
+                make_way_for,
+            );
+        }
+
+        // upstream: generator.c:2477 / delete.c:228-230 - the backup arm, which
+        // the `is_dir` test above has already excluded a directory from.
+        match self.backup_existing_before_replace(existing, relative_path, dest_dir, sandbox) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => return self.report_backup_failure(writer, relative_path, error),
+        }
+
+        // SEC-1.g: the obstacle unlink is anchored on the same sandbox dirfd
+        // the stat above used, so a swap between the two cannot redirect the
+        // syscall to an attacker-chosen parent.
+        //
+        // upstream: delete.c:236-237 - `what = "unlink"; ok = del_unlink(fbuf) == 0;`
+        match fast_io::unlink_via_sandbox_or_fallback(
+            sandbox,
+            dest_dir,
+            relative_path,
+            existing,
+            fast_io::UnlinkFlags::File,
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_unlink_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Windows variant: no dirfd sandbox, so the probe and the removal are
+    /// path-based, matching the Windows symlink-create path.
+    #[cfg(windows)]
+    pub(in crate::receiver) fn make_way_for_replacement<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let Ok(metadata) = std::fs::symlink_metadata(existing) else {
+            return Ok(());
+        };
+
+        if metadata.is_dir() {
+            return self.rmdir_obstacle(writer, existing, relative_path, make_way_for);
+        }
+
+        match self.backup_existing_before_replace(existing, relative_path, dest_dir) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => return self.report_backup_failure(writer, relative_path, error),
+        }
+
+        match std::fs::remove_file(existing) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_unlink_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// The directory arm: `rmdir`, plus upstream's two-line refusal when the
+    /// directory is not empty.
+    ///
+    /// Upstream reaches `rmdir` for this shape because `atomic_create` passes
+    /// `del_opts` without `DEL_RECURSE` unless `--delete`/`--force` is in play,
+    /// so `delete_dir_contents` only probes emptiness and reports it; the
+    /// contents are never removed to make room.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:222-226` - `what = "rmdir"; ok = do_rmdir_at(fbuf) == 0;`
+    #[cfg(unix)]
+    fn rmdir_obstacle<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        match fast_io::unlink_via_sandbox_or_fallback(
+            sandbox,
+            dest_dir,
+            relative_path,
+            existing,
+            fast_io::UnlinkFlags::Dir,
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_rmdir_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Windows variant of [`Self::rmdir_obstacle`].
+    #[cfg(windows)]
+    fn rmdir_obstacle<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        match std::fs::remove_dir(existing) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_rmdir_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Renders a failed `rmdir` the way `delete_item` does.
+    ///
+    /// A vanished directory is not a failure - upstream maps `ENOENT` to
+    /// `DR_SUCCESS` and creates the replacement. A populated one gets the
+    /// `FINFO` emptiness notice before the `FERROR_XFER` refusal; any other
+    /// errno gets `delete_file: rmdir(...) failed` in its place.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:259-268` - the `ENOTEMPTY` / `rsyserr` / `ENOENT` split
+    fn report_rmdir_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        if error.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        if is_not_empty(&error) {
+            // upstream: delete.c:178-181 - delete_dir_contents() reports the
+            // emptiness probe at FINFO before delete_item() names the item it
+            // blocked. FINFO leaves the exit code alone; the FERROR_XFER line
+            // that follows is what lifts it to RERR_PARTIAL.
+            let _ = self.emit_info_line(
+                writer,
+                &format!(
+                    "cannot delete non-empty directory: {}\n",
+                    relative_path.display()
+                ),
+            );
+        } else {
+            // upstream: delete.c:264-266 - rsyserr(FERROR_XFER, errno,
+            // "delete_file: %s(%s) failed", what, fbuf).
+            let _ = self.emit_error_xfer_line(
+                writer,
+                &format!(
+                    "rsync: [receiver] delete_file: rmdir({}) failed: {}\n",
+                    relative_path.display(),
+                    upstream_errno_text(&error)
+                ),
+            );
+        }
+        self.report_make_way_failure(writer, relative_path, make_way_for, error)
+    }
+
+    /// Renders a failed obstacle `unlink` the way `delete_item` does.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:264-266` - `rsyserr(FERROR_XFER, errno, "delete_file: %s(%s) failed", ...)`
+    fn report_unlink_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        if error.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        let _ = self.emit_error_xfer_line(
+            writer,
+            &format!(
+                "rsync: [receiver] delete_file: unlink({}) failed: {}\n",
+                relative_path.display(),
+                upstream_errno_text(&error)
+            ),
+        );
+        self.report_make_way_failure(writer, relative_path, make_way_for, error)
+    }
+
+    /// Emits `could not make way for new %s: %s` and returns the error so the
+    /// caller skips the entry.
+    ///
+    /// The line is `FERROR_XFER`, which sets the peer's `got_xfer_error` and so
+    /// lifts a zero exit to `RERR_PARTIAL` (23). Reporting the same event at a
+    /// verbosity-gated `debug_log!` instead - which is what these call sites
+    /// used to do - leaves the run exiting 0 with the obstacle still standing.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:272-286` - the `DEL_MAKE_ROOM` block reached via `check_ret`
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+    /// - `cleanup.c:217-218` - `got_xfer_error` lifts a zero exit to `RERR_PARTIAL`
+    fn report_make_way_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _ = self.emit_error_xfer_line(
+            writer,
+            &format!(
+                "could not make way for new {}: {}\n",
+                make_way_for.description(),
+                relative_path.display()
+            ),
+        );
+        Err(error)
+    }
+
+    /// Reports a backup mechanism that could not preserve the obstacle.
+    ///
+    /// Upstream is loud here and skips the entry: every `return 0` path in
+    /// `make_backup_inner()` has already called `rsyserr` (or `copy_valid_path`
+    /// has), and `atomic_create` then returns 0 without creating the
+    /// replacement. `FERROR` rather than `FERROR_XFER` matches upstream, which
+    /// leaves `got_xfer_error` clear on this arm.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `backup.c:400-401` - `rsyserr(FERROR, errno, "keep_backup failed: %s -> \"%s\"", ...)`
+    /// - `generator.c:2478-2479` - `if (!make_backup(fname, skip_atomic)) return 0;`
+    fn report_backup_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _ = self.emit_error_line(
+            writer,
+            &format!(
+                "rsync: [receiver] keep_backup failed: {}: {}\n",
+                relative_path.display(),
+                upstream_errno_text(&error)
+            ),
+        );
+        Err(error)
+    }
+}

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -37,6 +37,8 @@ use protocol::flist::{FileEntry, FileType};
 #[cfg(unix)]
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
+#[cfg(unix)]
+use crate::receiver::directory::obstacle::MakeWayFor;
 
 impl ReceiverContext {
     /// Creates FIFO, socket, and device nodes from the file list entries.
@@ -181,44 +183,31 @@ impl ReceiverContext {
                     }
                 }
 
-                // upstream: generator.c:2018-2020 atomic_create - when --backup
-                // is set and an existing item is being replaced, preserve it to
-                // the backup location before it is removed. On backup-mechanism
-                // failure upstream returns 0 from atomic_create (skips the
-                // entry); mirror that by logging and continuing.
-                match self.backup_existing_before_replace(
-                    &node_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: route the obstacle unlink through the sandbox
-                        // dirfd when the destination parent is the sandbox root
-                        // so a TOCTOU swap between the stat above and this
-                        // unlink cannot redirect the syscall. Falls back to
-                        // path-based removal otherwise. The result is
-                        // intentionally ignored: a dangling obstacle simply
-                        // surfaces as a create failure below.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &node_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing special file {}: {}",
-                            node_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2091 atomic_create(..., del_for_flag) -
+                // one decision for the obstacle: rmdir a directory, back up or
+                // unlink anything else. The refusal is reported inside, so a
+                // blocked entry no longer exits 0 in silence.
+                //
+                // upstream: generator.c:2041-2047 - the noun in the refusal
+                // comes from the NEW entry's type, DEL_FOR_DEVICE for a device
+                // and DEL_FOR_SPECIAL for a FIFO or socket.
+                let make_way_for = if is_device {
+                    MakeWayFor::Device
+                } else {
+                    MakeWayFor::Special
+                };
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &node_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        make_way_for,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
 
                 // upstream: generator.c:1675 atomic_create -> do_mknod_at

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -119,10 +119,10 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 /// This test plants a regular file where the symlink's PARENT
 /// component has to be, so the underlying `symlink` syscall returns
 /// `ENOTDIR` - a non-EACCES class. The fix must surface it as `Err`.
-/// EACCES is covered by the discrimination test in the deletion module
-/// - one fail-loud regression per site is sufficient because both
-/// sites share the same upstream-parity rule (`PermissionDenied` is
-/// the only non-fatal class).
+/// EACCES is covered by the discrimination test in the deletion
+/// module: one fail-loud regression per site is sufficient because
+/// both sites share the same upstream-parity rule (`PermissionDenied`
+/// is the only non-fatal class).
 ///
 /// ⚠ The fixture used to plant an empty DIRECTORY at the leaf and rely
 /// on `symlinkat` returning EEXIST over it. That only worked because

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -116,13 +116,23 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 /// planted non-symlink leaf were all silently skipped while the
 /// receiver exited `rc=0` with the symlink missing.
 ///
-/// This test plants a regular file at the destination leaf so the
-/// underlying `symlink` syscall returns `AlreadyExists` (EEXIST), a
-/// non-EACCES class. The fix must surface it as `Err`. EACCES is
-/// covered by the discrimination test in the deletion module - one
-/// fail-loud regression per site is sufficient because both sites
-/// share the same upstream-parity rule (`PermissionDenied` is the
-/// only non-fatal class).
+/// This test plants a regular file where the symlink's PARENT
+/// component has to be, so the underlying `symlink` syscall returns
+/// `ENOTDIR` - a non-EACCES class. The fix must surface it as `Err`.
+/// EACCES is covered by the discrimination test in the deletion module
+/// - one fail-loud regression per site is sufficient because both
+/// sites share the same upstream-parity rule (`PermissionDenied` is
+/// the only non-fatal class).
+///
+/// ⚠ The fixture used to plant an empty DIRECTORY at the leaf and rely
+/// on `symlinkat` returning EEXIST over it. That only worked because
+/// oc had no directory arm in its obstacle removal: upstream's
+/// `atomic_create` sets `dir_in_the_way` and `delete_item` `rmdir`s an
+/// empty directory (`generator.c:2469`, `delete.c:222-226`), so the
+/// symlink lands and there is no error to surface. The old fixture's
+/// closing assertion - "the planted directory must persist" - asserted
+/// the defect. A path COMPONENT is the right vehicle: `delete_item`
+/// only ever clears the leaf, so no removal can make way for this one.
 ///
 /// upstream: generator.c:1603 atomic_create -> do_symlink - EACCES is
 /// non-fatal (increment io_error and continue); every other class is
@@ -133,20 +143,17 @@ fn create_symlinks_surfaces_non_eacces_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let dest = tmp.path();
 
-    // Plant a directory at the leaf path. `read_link` returns Err
-    // (not a symlink), `lstat` sees the directory, and the obstacle
-    // `unlink_via_sandbox_or_fallback(UnlinkFlags::File)` fails with
-    // EISDIR which is swallowed by the pre-existing `let _ = ...`
-    // obstacle-removal contract (the receiver is allowed to attempt
-    // the obstacle removal but is not required to succeed). The flow
-    // then reaches `symlinkat`, which returns AlreadyExists/EEXIST -
-    // a non-EACCES class the fix must surface.
-    std::fs::create_dir(dest.join("blocked")).expect("plant directory obstacle");
+    // A regular file standing in for the `blocked` directory component.
+    // `read_link` and `lstat` on `blocked/link` both return ENOTDIR, so
+    // the obstacle path is not entered at all; the `create_dir_all` of
+    // the parent cannot succeed either, and `symlinkat` then returns
+    // ENOTDIR - a non-EACCES class the fix must surface.
+    std::fs::write(dest.join("blocked"), b"not a directory\n").expect("plant file component");
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
     ctx.file_list = vec![FileEntry::new_symlink(
-        "blocked".into(),
+        "blocked/link".into(),
         "/etc/passwd".into(),
     )];
 
@@ -159,15 +166,15 @@ fn create_symlinks_surfaces_non_eacces_error() {
         err.kind(),
         std::io::ErrorKind::PermissionDenied,
         "EACCES is the upstream-parity non-fatal branch; this scenario \
-         plants a directory at the leaf to exercise the fail-loud branch \
-         via AlreadyExists/EEXIST",
+         plants a file where a path component belongs to exercise the \
+         fail-loud branch via ENOTDIR",
     );
-    // The on-disk obstacle must persist - the receiver did not silently
-    // delete the directory in lieu of the symlink.
+    // The on-disk obstruction must persist - the receiver did not
+    // silently consume it while reporting the symlink failure as `()`.
     assert!(
-        dest.join("blocked").is_dir(),
-        "the planted directory must persist - the receiver must not silently \
-         consume it while reporting the symlink failure as `()`",
+        dest.join("blocked").is_file(),
+        "the planted file must persist - the obstacle removal clears the \
+         leaf, never a path component",
     );
 }
 

--- a/tests/directory_obstacle_removal.rs
+++ b/tests/directory_obstacle_removal.rs
@@ -1,0 +1,347 @@
+//! A directory standing where a symlink or special file has to be created is
+//! removed, never backed up - and a populated one is refused out loud.
+//!
+//! upstream `generator.c:2464-2485` `atomic_create()`:
+//!
+//! ```text
+//! int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);
+//! if (!del_for_flag || dir_in_the_way || tmpdir || !get_tmpname(tmpname, fname, True))
+//!         skip_atomic = 1;
+//! ...
+//! if (make_backups > 0 && !dir_in_the_way) {
+//!         if (!make_backup(fname, skip_atomic))
+//!                 return 0;
+//! } else if (skip_atomic) {
+//!         int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
+//!         if (delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag) != 0)
+//!                 return 0;
+//! }
+//! ```
+//!
+//! `dir_in_the_way` forces `skip_atomic`, so a directory obstacle reaches
+//! `delete_item()` in BOTH modes: the `make_backup` arm is unreachable for it
+//! whether or not `--backup` is set. `delete_item()` then splits the same way
+//! one level down - the `rmdir` arm at `delete.c:222-226`, the
+//! `make_backup`/`unlink` arm in the `else` at `delete.c:227-238`.
+//!
+//! That is why the removal and the reporting are one change and not two. oc
+//! had no directory arm at all, so:
+//!
+//! | src kind | obstacle | rsync 3.5.0 | oc before |
+//! |---|---|---|---|
+//! | symlink | empty dir     | 0, symlink placed | 12, dir kept, sibling not transferred |
+//! | symlink | non-empty dir | 23 + two diagnostics | 12, dir kept, sibling not transferred |
+//! | fifo    | empty dir     | 0, fifo placed | **0 in silence**, dir kept |
+//! | fifo    | non-empty dir | 23 + two diagnostics | **0 in silence**, dir kept |
+//!
+//! and under `--backup` with a sibling backup dir, oc RENAMED the directory
+//! into the backup area - a wrong-data outcome at exit 0, where upstream
+//! removes it.
+//!
+//! Measured against rsync 3.5.0 (protocol 32) over a real `--server` child on
+//! both ends. Every cell below was run against that binary first; the
+//! expectations are its output, not a reading of the source.
+//!
+//! ⚠ These must run over a REAL `--server` process. A local transfer takes the
+//! engine's local-copy executor, which refuses a directory obstacle in its own
+//! error type (`local_copy/error.rs:427`, "cannot replace existing directory
+//! with symbolic link") and exercises none of the receiver path under test.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// `rsync` invokes `$RSYNC_RSH <host> <command...>`; drop the host and exec the
+/// command locally, so the receiver really is a separate `--server` process.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+const SIBLING: &str = "sibling payload\n";
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+/// What the source names `obstacle`.
+#[derive(Clone, Copy)]
+enum Source {
+    Symlink,
+    Fifo,
+}
+
+/// Builds `src/{obstacle,sibling}` and `dst/{obstacle/,sibling}`, where
+/// `dst/obstacle` is a directory and `src/obstacle` is the non-regular entry
+/// that has to replace it.
+///
+/// `sibling` is load-bearing: upstream keeps transferring it when the obstacle
+/// is refused, so it separates "the obstacle entry was skipped" from "the whole
+/// transfer stopped". oc did the latter.
+fn fixture(source: Source, populate_obstacle: bool) -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::create_dir_all(root.join("dst/obstacle")).expect("create dst obstacle");
+    fs::create_dir_all(root.join("outside")).expect("create outside");
+
+    match source {
+        Source::Symlink => {
+            std::os::unix::fs::symlink("../outside", root.join("src/obstacle"))
+                .expect("plant source symlink");
+        }
+        Source::Fifo => {
+            // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than
+            // a new unsafe libc call in the test tree.
+            let status = std::process::Command::new("mkfifo")
+                .arg(root.join("src/obstacle"))
+                .status()
+                .expect("spawn mkfifo");
+            assert!(status.success(), "mkfifo failed: {status}");
+        }
+    }
+    fs::write(root.join("src/sibling"), SIBLING).expect("write src sibling");
+    if populate_obstacle {
+        fs::write(root.join("dst/obstacle/occupant"), "occupant\n").expect("populate obstacle");
+    }
+
+    let shim = write_rsh_shim(&root);
+    Fixture {
+        _temp: temp,
+        root,
+        shim,
+    }
+}
+
+/// Pushes `src/` to `dst/` through the shim against an external `--server`
+/// receiver. `extra` carries the `--backup` flags where a cell needs them.
+fn push(fx: &Fixture, extra: &[&str]) -> (Option<i32>, String, String) {
+    let binary = oc_rsync_binary();
+    let out = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        // -l keeps symlinks as symlinks, -D materialises the fifo, -I defeats
+        // the quick check so the obstacle entry is always reconsidered.
+        .args(["-rlDI"])
+        .args(extra)
+        .arg("--rsh")
+        .arg(&fx.shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("{}/src/", fx.root.display()))
+        .arg(format!("obshost:{}/dst/", fx.root.display()))
+        .run()
+        .expect("push did not finish");
+    (
+        out.status,
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn obstacle(fx: &Fixture) -> PathBuf {
+    fx.root.join("dst/obstacle")
+}
+
+/// The headline for `--backup` off: an EMPTY directory is `rmdir`'d and the
+/// symlink takes its place, at exit 0.
+///
+/// upstream: `delete.c:222-226` - the `rmdir` arm of `delete_item()`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_symlink() {
+    let fx = fixture(Source::Symlink, false);
+
+    let (status, _stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "rsync 3.5.0 rmdir's the empty directory and creates the symlink at \
+         exit 0; oc reported `server error: File exists` and stopped. \
+         stderr was: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside"),
+        "the symlink has to actually replace the directory - a still-standing \
+         directory means the removal never ran"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "the rest of the transfer must still land"
+    );
+}
+
+/// Same for a FIFO, which is the shape oc failed SILENTLY on: it reported exit
+/// 0 while leaving the directory in place and never creating the node.
+///
+/// This cell is the one that distinguishes "the removal works" from "the
+/// removal now fails loudly instead of silently" - every other cell here would
+/// pass under a change that only added diagnostics.
+///
+/// upstream: `generator.c:2091` `atomic_create(file, fname, NULL, NULL, rdev,
+/// &sx, dest_existed ? del_for_flag : 0)`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_fifo() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let fx = fixture(Source::Fifo, false);
+
+    let (status, _stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    let meta = fs::symlink_metadata(obstacle(&fx)).expect("obstacle must still exist");
+    assert!(
+        meta.file_type().is_fifo(),
+        "oc reported exit 0 here while leaving the directory standing and \
+         never creating the fifo - silent data loss, not a loud failure. \
+         The obstacle is now: {meta:?}"
+    );
+}
+
+/// A POPULATED directory is refused, and the refusal is audible: upstream's
+/// two lines plus `RERR_PARTIAL`.
+///
+/// This is the reporting half. Before the change the same shape exited 0 (fifo)
+/// or 12 (symlink) and printed nothing an operator could act on, because the
+/// failure went to a verbosity-gated `debug_log!`.
+///
+/// upstream: `delete.c:178-181` `cannot delete non-empty directory: %s` at
+/// `FINFO`, then `delete.c:283-285` `could not make way for %s %s: %s` at
+/// `FERROR_XFER`, whose `got_xfer_error` lifts the exit to 23
+/// (`log.c:310-311`, `cleanup.c:217-218`).
+#[test]
+fn a_populated_directory_obstacle_is_refused_at_23() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(23),
+        "rsync 3.5.0 exits 23 for this shape. stdout: {stdout} stderr: {stderr}"
+    );
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("cannot delete non-empty directory: obstacle"),
+        "upstream reports the emptiness probe at FINFO before naming the item \
+         it blocked. output was: {output}"
+    );
+    assert!(
+        output.contains("could not make way for new symlink: obstacle"),
+        "upstream's FERROR_XFER line is what makes the run exit non-zero; \
+         without it the obstacle is skipped in silence. output was: {output}"
+    );
+    assert!(
+        obstacle(&fx).is_dir(),
+        "the contents are never removed to make room - `del_opts` carries no \
+         DEL_RECURSE here"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "a refused obstacle skips its own entry only; upstream keeps going, \
+         and oc used to abandon the rest of the batch"
+    );
+}
+
+/// The noun in the refusal comes from the NEW entry's type, not the obstacle's.
+///
+/// upstream: `generator.c:2041-2047` picks `DEL_FOR_DEVICE` or
+/// `DEL_FOR_SPECIAL`; `delete.c:275-282` turns it into the printed noun.
+#[test]
+fn the_refusal_names_the_new_entrys_kind() {
+    let fx = fixture(Source::Fifo, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("could not make way for new special file: obstacle"),
+        "a FIFO is DEL_FOR_SPECIAL, so upstream says `special file` here and \
+         `symlink` in the cell above. output was: {output}"
+    );
+}
+
+/// The non-vacuity companion, and the reason the two halves ship together.
+///
+/// `dir_in_the_way` excludes a directory from `make_backup` in BOTH modes, so
+/// under `--backup` the empty directory is still `rmdir`'d and the symlink
+/// still lands at exit 0. oc instead RENAMED the directory into the backup
+/// area - a wrong-data outcome that exited 0, so no exit-code assertion could
+/// have caught it.
+///
+/// Reporting the obstacle failure loudly WITHOUT this removal would turn this
+/// cell from a wrong-data pass into a hard failure on a shape upstream
+/// completes at 0. That is what makes the halves inseparable.
+///
+/// upstream: `generator.c:2476` - `if (make_backups > 0 && !dir_in_the_way)`.
+#[test]
+fn a_directory_obstacle_is_removed_not_backed_up_under_backup() {
+    let fx = fixture(Source::Symlink, false);
+    fs::create_dir_all(fx.root.join("dst/bak")).expect("create backup dir");
+
+    let (status, _stdout, stderr) = push(&fx, &["-b", "--backup-dir=bak"]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "upstream completes this shape at exit 0. stderr was: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside"),
+        "the symlink must land under --backup exactly as it does without it"
+    );
+    assert!(
+        !fx.root.join("dst/bak/obstacle").exists(),
+        "upstream never backs a directory obstacle up - dir_in_the_way keeps \
+         it out of make_backup in both modes. oc renamed it into the backup \
+         area, which is a data outcome no exit code reports"
+    );
+}
+
+/// The same `--backup` run, with the obstacle populated: still refused, still
+/// audible, and still not copied into the backup area.
+#[test]
+fn a_populated_directory_obstacle_under_backup_is_refused_not_backed_up() {
+    let fx = fixture(Source::Symlink, true);
+    fs::create_dir_all(fx.root.join("dst/bak")).expect("create backup dir");
+
+    let (status, stdout, stderr) = push(&fx, &["-b", "--backup-dir=bak"]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    assert!(
+        obstacle(&fx).join("occupant").exists(),
+        "the populated directory and its contents stay put"
+    );
+    assert!(
+        !fx.root.join("dst/bak/obstacle").exists(),
+        "and no part of it is moved into the backup area"
+    );
+}


### PR DESCRIPTION
## What

A directory standing where the receiver has to create a symlink, FIFO, socket, or device node was neither removed nor reported. The five `backup_existing_before_replace` call sites in `links.rs` / `special.rs` each did:

```rust
Ok(false) => { let _ = fast_io::unlink_via_sandbox_or_fallback(.., UnlinkFlags::File); }
Err(e)    => { debug_log!(Recv, 1, "failed to back up existing obstacle …"); continue; }
```

`File`-only, so it structurally cannot `rmdir` a directory by any route; the result discarded; the failure on a verbosity gate with no `MessageCode` and no effect on the exit code.

## Why the removal and the reporting are ONE change

Upstream decides this in one place, and the decision is ordered:

```c
/* generator.c:2469 */
int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);
if (!del_for_flag || dir_in_the_way || tmpdir || !get_tmpname(tmpname, fname, True))
        skip_atomic = 1;
...
if (make_backups > 0 && !dir_in_the_way) {          /* :2477 */
        if (!make_backup(fname, skip_atomic)) return 0;
} else if (skip_atomic) {                           /* :2480 */
        int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
        if (delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag) != 0) return 0;
}
```

`dir_in_the_way` forces `skip_atomic`, so **a directory obstacle reaches `delete_item` whether or not `--backup` is set** — the `make_backup` arm is unreachable for it in either mode. `delete_item` then splits on the same test one level down: the `rmdir` arm at `delete.c:222-226`, the `make_backup`/`unlink` arm in the `else` at `delete.c:227-238`.

Two consequences, and they are what make this a single commit:

1. **A guard on the backup path cannot work.** It could only cover the `--backup`-on half; the four `--backup`-off shapes in the table below would still be decided in `links.rs`/`special.rs`. That is a divergence from upstream's structure by construction, not by taste.
2. **The reporting alone is a regression.** Measured by mutation, with the removal disabled and the diagnostics in place, a symlink over an **empty** directory gives:

   ```
   rsync: [receiver] delete_file: unlink(obstacle) failed: Operation not permitted (1)
   could not make way for new symlink: obstacle
   left: Some(23)   right: Some(0)
   ```

   — exit 23 on a shape 3.5.0 completes at exit 0.

So the five call sites now share one `make_way_for_replacement`, which owns both arms and emits upstream's diagnostics itself. `backup_existing_before_replace` is now called from exactly one place.

## Measured

rsync 3.5.0 (protocol 32) vs oc, over a real `--server` child on both ends (`-e` wrapper, `--rsync-path` pinning both sides). Not the local-copy executor: that path refuses a directory obstacle in its own error type (`local_copy/error.rs:427`) and exercises none of this.

`--backup` off, `-rlDI`, source `obstacle` replacing `dst/obstacle/`:

| src kind | obstacle | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|---|
| symlink | empty dir | **0**, symlink placed | **12** `server error: File exists (17)`, dir kept | **0**, symlink placed |
| symlink | non-empty dir | **23** + two diagnostics | **12**, dir kept | **23** + same two diagnostics |
| fifo | empty dir | **0**, fifo placed | **0 SILENT**, dir kept | **0**, fifo placed |
| fifo | non-empty dir | **23** + two diagnostics | **0 SILENT**, dir kept | **23** + same two diagnostics |

Three things in that table are worse than the exit codes suggest:

- **Both FIFO rows reported success while losing the node.** Silent data loss, not a loud failure.
- **The failing rows abandoned the rest of the batch.** The sibling file upstream transfers at exit 23 was never written.
- **Under `--backup`, oc RENAMED the directory into the backup area** (`--backup-dir=bak` → `bak/obstacle`), which upstream never does. A wrong-data outcome at exit 0, which no exit-code assertion could have caught. Now removed.

The two `regular file` rows of the same matrix (12 vs 0/23) are the `DEL_FOR_FILE` site at `generator.c:2148` and are deliberately untouched here — see "Relationship to the wider obstacle-removal work" below.

Also verified by strace of the server child, on the exact shape the failing testsuite cell hits (`--backup-dir` equal to the obstacle):

```
linkat(AT_FDCWD, ".../dst/a", AT_FDCWD, ".../dst/a/a", 0) = -1 EPERM
renameat(AT_FDCWD, ".../dst/a", AT_FDCWD, ".../dst/a/a")  = -1 EINVAL
```

…and then nothing. No `rmdir`, no `symlinkat`, no output at `-vvv --debug=RECV5,BACKUP5`.

## Diagnostics

Upstream's text and routing, per arm:

- populated directory → `cannot delete non-empty directory: %s` at `FINFO` (`delete.c:178-181`), then `could not make way for new %s: %s` at `FERROR_XFER` (`delete.c:283-285`). The `FERROR_XFER` sets the peer's `got_xfer_error` (`log.c:310-311`), which lifts a zero exit to `RERR_PARTIAL` (`cleanup.c:217-218`).
- other `rmdir`/`unlink` errno → `delete_file: rmdir(...) failed` / `unlink(...) failed` at `FERROR_XFER` (`delete.c:264-266`), then the same refusal line.
- `ENOENT` → not a failure; upstream maps it to `DR_SUCCESS` (`delete.c:268-269`) and creates the replacement.
- backup-arm failure → `keep_backup failed: <path>` at **`FERROR`**, not `FERROR_XFER`. Upstream leaves `got_xfer_error` clear on that arm (`backup.c:400-401`), so the exit code is unchanged there.

The noun comes from the **new** entry's type, not the obstacle's (`generator.c:2041-2047` picks `DEL_FOR_DEVICE`/`DEL_FOR_SPECIAL`; `delete.c:275-282` turns it into the word), so a FIFO says `special file` where a symlink says `symlink`.

The obstacle type is read from the same sandbox-anchored `fstatat` the removal is anchored on (new `LstatOutcome::is_dir`), so a TOCTOU swap between classifying and removing cannot make the two disagree.

## Test

`tests/directory_obstacle_removal.rs`, six cells, all through a real `--server` child.

**Mutation-proven, each half reverted in turn:**

| mutation | red | green |
|---|---|---|
| reporting restored to the swallow (removal intact) | the 3 refusal cells (23 → 0, no diagnostics) | the 3 removal cells |
| removal arm deleted (reporting intact) | 5 of 6, incl. `an_empty_directory_obstacle_is_removed_for_a_symlink` at **23 where upstream is 0** | 1 |

The FIFO-over-empty-directory cell is the one that separates the halves: it is **green** under the first mutation and **red** under the second, so it distinguishes "the removal works" from "the removal now fails loudly instead of silently". Nothing else in the set does.

The non-vacuity companion is `a_directory_obstacle_is_removed_not_backed_up_under_backup`: a shape upstream completes at exit 0 must still exit 0 after the change, and must not leave the directory in the backup area.

**Regression surface.** One existing unit test had to move: `receiver::tests::munge_symlinks::create_symlinks_surfaces_non_eacces_error` planted an **empty directory** at the leaf to make `symlinkat` return `EEXIST`, and closed with `assert!(dest.join("blocked").is_dir(), "the planted directory must persist")` — an assertion on the defect. Its invariant (non-EACCES → `Err`) is real and kept; the fixture now plants a regular file where a path **component** belongs, giving `ENOTDIR`. `delete_item` only ever clears the leaf, so no obstacle removal can make way for that one.

## Verification

- Full 3.5.0 python suite, 345 cells, nonroot, aarch64 Linux: 253 pass / 6 fail / 86 skip. The six failures are **exactly** the six the expect manifest already names (`basis-xname-traversal`, `batch-only-remove-source-regression`, `filter-merge-content-echo`, `partial-protected-regular-retry-linux`, `rrsync-backup-dir-inband-pivot`, `rrsync-merge-file-confine`). No row moves in either direction, so `tools/ci/upstream-3.5.0-expect.{nonroot,root}.txt` are unchanged.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — no finding in any changed file.
- `cargo nextest run --workspace --all-features` — 32881 tests, 32880 passed. The one failure is `xtask … backdated_tree_populates_and_backdates_the_root`, a pre-existing macOS-host failure (`touch -d @1614830767`: BSD `touch` rejects the `@epoch` form), unrelated to this change.
- `tools/ci/citation_drift_audit.py` — exit 0.

## `rrsync-backup-dir-inband-pivot`: 2 of 3 assertions flipped, and the third is named

This is the cell that motivated the change. It has three assertions past the escape check. Before: all three failed at the first one. After:

| assertion | before | after |
|---|---|---|
| `got.returncode != 0` | rc=0 ❌ | **rc=12 ✅** |
| `pivot == '../outside'` | `None` ❌ | **`'../outside'` ✅** |
| `'/proc/self/fd/' in got.stderr` | ❌ | ❌ still |

The mechanism now works end to end: the `rmdir` frees the name (so the transfer's own symlink is planted, `pivot='../outside'`) **and** destroys the inode `rrsync` holds on fd 5, so the later `authorized_keys` backup opens a deleted directory and fails. 3.5.0 does exactly this and exits 11 at `rsync.c:894-896`.

The remaining assertion is **not** obstacle-removal territory, and there are two independent reasons for it:

1. The failure is `ENOENT`, and `pipeline/receiver.rs:445/508` reaches `commit_failure` only on the `is_permission_error` branch; `ENOENT` takes the fatal `return Err(e)` instead, so the upstream-shaped line is never rendered.
2. Even on that branch the operand would be wrong: `disk_commit/process/commit.rs:110-116` passes `attach_commit_op(CommitOp::Backup, &begin.file_path, e)` — the **pre-image**, not the backup destination. The comment at `pipeline/receiver.rs:316-320` already documents this ("oc names the pre-image only; the backup destination is chosen inside make_backup and is not carried back on the error"), so `/proc/self/fd/5/authorized_keys` would still not appear.

Both belong to #7582 ("abort with 11 when a commit-path backup fails"), which routes the fatal backup failure through `commit_failure` and flushes the queued line. The manifest row is left at `fail` rather than re-baselined.

## Relationship to the wider obstacle-removal work

The general missing removal is upstream's `delete_item(… DEL_FOR_FILE)` at `generator.c:2148`, which covers a **regular file** landing on an obstacle. That is a different call site and is not touched here — the two `regular file` rows of the matrix above are unchanged (12 where upstream is 0 or 23). This change builds the shared decision function with both of `delete_item`'s arms, so routing that site onto it later is a call-site change rather than a reconciliation of two overlapping mechanisms. #7583's `write_devices && stype == FT_DEVICE` carve-out is the other half of that line and is orthogonal to both.

## Known residual, measured and deliberately out of scope

`generator.c:2481` computes `int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0`, so under `--delete` or `--force` upstream removes a **populated** directory obstacle recursively and completes at exit 0. Measured against 3.5.0: `--force`, `--delete`, and both together each give `rc=0` with the symlink in place, where this arm refuses at 23.

Neither flag is reachable from the receiver. `--force` is parsed and **discarded** by the server arg parser (`cli/src/frontend/server/flags.rs:615`, `"--force" => {}`) and has no field in `ParsedServerFlags`. Wiring it is a server-arg and config change, not an obstacle-removal one. Before this change the same shape aborted the whole transfer at 12 with the sibling files unsent, so the refusal is strictly closer to upstream, not a new divergence. Recorded in the module doc so it is not rediscovered as a surprise.
