### PR TITLE
fix(server): bound a peer-named merge file by --confine-root

### DIFF
--- a/crates/cli/src/frontend/execution/drive/workflow/run.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/run.rs
@@ -290,10 +290,13 @@ where
     // flag past the parser is what makes those two states distinguishable.
     logging::set_quiet(quiet);
 
-    // Publish `--insecure-links` for the operator-path ownership walk. Upstream
-    // reads its `insecure_links` global from inside `ona_open()`
-    // (syscall.c:301), so the answer reaches every operator-path open without
-    // any of them naming the flag; this is where oc gives that global a value.
+    // Publish `--insecure-links` and `--confine-root` for the operator-path
+    // ownership walk. Upstream reads its `insecure_links` and `confine_root`
+    // globals from inside `ona_open()` (syscall.c:300, :316-328), so the answer
+    // reaches every operator-path open without any of them naming the flags;
+    // this is where oc gives those globals a value. Without the root, a
+    // `--confine-root` transfer walks ownership but measures against nothing,
+    // so a peer-named merge file resolving outside the root is read.
     //
     // Client side only. The daemon arm of `optout_allowed` reads the served
     // module's `insecure links` directive, which is not known until a module is
@@ -302,6 +305,7 @@ where
     // daemon on the default keeps the confinement fully engaged there.
     fast_io::confinement::install_local_session(
         fast_io::confinement::LocalInsecureLinks::from_local_flag(insecure_links),
+        confine_root.clone(),
     );
 
     let rayon_thread_count = rayon_threads.and_then(|n| NonZeroUsize::new(n as usize));

--- a/crates/cli/src/frontend/server/parse.rs
+++ b/crates/cli/src/frontend/server/parse.rs
@@ -14,6 +14,17 @@ use super::flags::{
 /// paths, and `main.c` `do_server_sender()` / `do_server_recv()` take `argv[0]`
 /// as the directory to change into, so it is consumed there and never appears
 /// as a transferred operand.
+///
+/// ⚠ Exactly ONE slot is the placeholder, and it is the FIRST one. Upstream
+/// consumes `argv[0]` positionally - `dir = argv[0]; argc--; argv++;` - without
+/// looking at what it holds, so every later operand is a real path even when it
+/// is spelled `.`. `rsync -r host:. dest/` sends `. .`, where the second `.` is
+/// the transfer SOURCE; a push to `host:.` sends the same pair with the second
+/// `.` as the DESTINATION. Dropping every `.` leaves the server with no
+/// operand: MEASURED as an empty file list and a silent rc=0 no-op.
+///
+/// upstream: `main.c:966-975` `do_server_sender()` - `dir = argv[0];` then
+/// `argc--; argv++;`; `main.c:1192-1194` `do_server_recv()` - the same pair.
 const CWD_PLACEHOLDER: &str = ".";
 
 /// Parses the flag string and positional arguments from server-mode argument list.
@@ -46,6 +57,10 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
     let mut flag_string = String::new();
     let mut positional_args = Vec::new();
     let mut found_flags = false;
+    // The chdir slot is a single argv position, not a value to filter for. Once
+    // it has been spent, a later `.` is an ordinary operand. See
+    // [`CWD_PLACEHOLDER`].
+    let mut cwd_placeholder_spent = false;
 
     let mut idx = 0;
     while idx < args.len() {
@@ -96,7 +111,8 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
         }
 
         // upstream uses "." as a placeholder separator between flags and paths
-        if found_flags && arg_str == CWD_PLACEHOLDER {
+        if found_flags && !cwd_placeholder_spent && arg_str == CWD_PLACEHOLDER {
+            cwd_placeholder_spent = true;
             idx += 1;
             continue;
         }
@@ -109,15 +125,17 @@ pub(super) fn parse_server_flag_string_and_args(args: &[OsString]) -> (String, V
 
     // Everything after the marker is a path, whatever it looks like - that is
     // the property `support/rrsync:558` relies on. The `.` placeholder is
-    // filtered by the same rule the loop above applies, because rrsync emits it
+    // consumed by the same rule the loop above applies, because rrsync emits it
     // AFTER the marker (`support/rrsync:655`) where upstream's own
-    // `server_options()` emits it before.
-    positional_args.extend(
-        operands
-            .iter()
-            .filter(|operand| operand.as_os_str() != OsStr::new(CWD_PLACEHOLDER))
-            .cloned(),
-    );
+    // `server_options()` emits it before - and by the same ONE-slot rule, so
+    // rrsync's `-- . .` keeps its second `.` as the transfer operand.
+    for operand in operands {
+        if !cwd_placeholder_spent && operand.as_os_str() == OsStr::new(CWD_PLACEHOLDER) {
+            cwd_placeholder_spent = true;
+            continue;
+        }
+        positional_args.push(operand.clone());
+    }
 
     (flag_string, positional_args)
 }

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -249,6 +249,26 @@ where
     // a peer-supplied value cannot widen a module even if one arrives here.
     config.connection.confine_root = long_flags.confine_root.map(std::path::PathBuf::from);
     config.connection.io_timeout = forwarded_io_timeout(long_flags.timeout.as_deref());
+    // Publish the same root for the operator-path ownership walk. Upstream has
+    // one `confine_root` global that both `confinement_root()` (for the walk)
+    // and the sender's own opens read; oc keeps the transfer-config copy above
+    // and the walk's session copy, so the value has to reach both or the walk
+    // measures against nothing. A dir-merge rule arrives over the protocol
+    // rather than in the argv the wrapper validated, so this is the path that
+    // bounds `:-s ../outside-secret`.
+    //
+    // `--server --daemon` is dispatched before this function (`frontend::mod`),
+    // so this arm is never a daemon - which is why it may honour a root that
+    // came in on a peer-supplied argv. A daemon publishes its module root
+    // instead (`install_daemon_session`), matching upstream's
+    // `am_daemon ? module_dir : confine_root`.
+    //
+    // The server has no `--insecure-links`: leaving the opt-out off is
+    // upstream's default (`options.c:134`) and keeps the confinement engaged.
+    fast_io::confinement::install_local_session(
+        fast_io::confinement::LocalInsecureLinks::from_local_flag(false),
+        config.connection.confine_root.clone(),
+    );
     config.file_selection.from0 = long_flags.from0;
     config.write.inplace = long_flags.inplace;
     // upstream: options.c:2400-2411 - append mode implies inplace. The promotion

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -458,9 +458,12 @@ fn parse_server_args_skips_split_partial_dir_flag() {
     ];
     let (flags, pos_args) = parse_server_flag_string_and_args(&args);
     assert_eq!(flags, "-vlKtpR");
-    assert!(
-        pos_args.is_empty(),
-        "split --partial-dir and value must not leak into positional args: {pos_args:?}",
+    assert_eq!(
+        pos_args,
+        vec![OsString::from(".")],
+        "split --partial-dir and value must not leak into positional args; the \
+         only operand is the second `.`, the destination (the first is the \
+         cwd placeholder): {pos_args:?}",
     );
 }
 
@@ -2886,6 +2889,40 @@ mod end_of_options {
         ])));
     }
 
+    /// A `.` in a LATER slot is a real transfer operand, not a second
+    /// placeholder. rrsync emits `-- . .` for `rsync host:. dest/`: the first
+    /// `.` is the chdir slot upstream consumes as `argv[0]`, the second is the
+    /// source the sender must enumerate.
+    ///
+    /// MEASURED before this: the sender sent an empty file list and the pull
+    /// completed rc=0 having delivered nothing - silent, so only an operand
+    /// assertion catches it.
+    ///
+    /// upstream: `main.c:966-975` `do_server_sender()` consumes ONE slot -
+    /// `dir = argv[0];` then `argc--; argv++;` - whatever it holds.
+    #[test]
+    fn only_the_first_dot_is_the_cwd_placeholder() {
+        let (_, after) = parse_server_flag_string_and_args(&argv(&["--", ".", "."]));
+        let (_, before) = parse_server_flag_string_and_args(&argv(&[".", "."]));
+
+        assert_eq!(
+            after,
+            vec![OsString::from(".")],
+            "the second `.` is the transfer operand"
+        );
+        assert_eq!(after, before, "the marker must not change the rule");
+    }
+
+    /// Non-vacuity companion: one lone `.` really is the placeholder and
+    /// really is dropped, so the cell above pins a one-slot rule rather than
+    /// "stop filtering `.`".
+    #[test]
+    fn a_lone_dot_is_still_the_placeholder() {
+        let (_, paths) = parse_server_flag_string_and_args(&argv(&["--", "."]));
+
+        assert!(paths.is_empty(), "the lone `.` is the chdir slot");
+    }
+
     /// Regression guard: an argv with no marker must parse exactly as before,
     /// so a peer that never sends one is unaffected.
     #[test]
@@ -2936,9 +2973,11 @@ fn parse_server_args_does_not_mistake_fake_super_for_the_flag_string() {
         flag_string.contains('r'),
         "the compact flag string must still carry recursion"
     );
-    assert!(
-        pos_args.is_empty(),
-        "both `.` operands are the cwd placeholder"
+    assert_eq!(
+        pos_args,
+        vec![OsString::from(".")],
+        "only the FIRST `.` is the cwd placeholder; the second is the transfer \
+         operand, which for a push to `host:.` is the destination"
     );
 }
 
@@ -2962,7 +3001,7 @@ fn parse_server_args_flag_string_is_unchanged_without_fake_super() {
     ];
     let (flag_string, pos_args) = parse_server_flag_string_and_args(&args);
     assert_eq!(flag_string, "-rlptgoDe.iLsfxC");
-    assert!(pos_args.is_empty());
+    assert_eq!(pos_args, vec![OsString::from(".")]);
 }
 
 /// Recognising the flag is only half of it: it must also reach the config the

--- a/crates/fast_io/src/confined_fallback.rs
+++ b/crates/fast_io/src/confined_fallback.rs
@@ -911,10 +911,10 @@ mod tests {
     /// ⚠ This is the LOCAL path only, and the distinction is the whole point.
     /// Production installs one of two sessions, and they differ exactly here:
     ///
-    /// - `install_local_session` sets `confine_root: None` + `NotDaemon`, so
-    ///   `root()` is `None`, the root half never fires, and only the ownership
-    ///   half runs - which follows a euid-owned symlink by design. That is the
-    ///   state this cell pins, and task 1009 is what flips it.
+    /// - `install_local_session` with no `--confine-root` sets `confine_root:
+    ///   None` + `NotDaemon`, so `root()` is `None`, the root half never
+    ///   fires, and only the ownership half runs - which follows a euid-owned
+    ///   symlink by design. That is the state this cell pins.
     /// - `install_daemon_session` sets `Daemon(module)` with
     ///   `module.root = Some(..)`, so `root()` is `Some` and the root half
     ///   FIRES. Routing is fully live on that path today, with no dependency

--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -161,17 +161,28 @@ fn path_outside_root(root: &Path, abspath: &Path, kind: PathKind) -> bool {
     kind == PathKind::Confined
 }
 
-/// Publish the opt-out for a non-daemon session: the local `--insecure-links`.
+/// Publish a non-daemon session: the local `--insecure-links` opt-out and the
+/// `--confine-root` boundary.
 ///
-/// upstream: `syscall.c:126` - the `am_daemon`-false arm of
-/// `symlink_optout_allowed()` is `return insecure_links;`, reading nothing
-/// else. So this takes nothing else.
-pub fn install_local_session(insecure_links: LocalInsecureLinks) {
+/// The two arrive together because upstream's non-daemon arms read exactly
+/// these two globals - `symlink_optout_allowed()` reads `insecure_links`,
+/// `confinement_root()` reads `confine_root` - and a session that published one
+/// without the other would answer half the question. Passing `None` for the
+/// root is the ordinary case: without `--confine-root` a non-daemon transfer
+/// confines nothing, exactly as upstream's NULL `confine_root` does.
+///
+/// # Upstream Reference
+///
+/// - `syscall.c:128-132` - the `am_daemon`-false arm of
+///   `symlink_optout_allowed()` is `return insecure_links;`.
+/// - `syscall.c:142-143` - the `am_daemon`-false arm of `confinement_root()`
+///   returns `confine_root`.
+pub fn install_local_session(insecure_links: LocalInsecureLinks, confine_root: Option<PathBuf>) {
     install_session(&Activation {
-        // Neither field is read by `optout_allowed`; they are the arm's
-        // don't-cares, spelled out here once rather than at every call site.
+        // `daemon` is this arm's don't-care, spelled out here once rather than
+        // at every call site.
         role: Role::Receiver,
-        confine_root: None,
+        confine_root,
         daemon: DaemonState::NotDaemon,
         insecure_links,
     });

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/tests.rs
@@ -2028,11 +2028,12 @@ mod no_sandbox_tail {
 
     /// The DAEMON session, which is where this routing is live today.
     ///
-    /// `install_daemon_session` supplies `module.root`, so `root()` is `Some`
-    /// and the root half of the predicate fires - unlike
-    /// `install_local_session`, which leaves it `None`. Without this cell the
-    /// suite would pin only the shape that a test fixture arranges, never the
-    /// one production actually reaches first.
+    /// `install_daemon_session` always supplies `module.root`, so `root()` is
+    /// `Some` and the root half of the predicate fires - unlike
+    /// `install_local_session`, whose root is `None` unless the operator named
+    /// `--confine-root`. Without this cell the suite would pin only the shape
+    /// that a test fixture arranges, never the one production actually
+    /// reaches first.
     /// The open tail dropped `O_NOFOLLOW` silently, so a caller asking not to
     /// follow the leaf got a FOLLOWING open and no error.
     ///

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -421,8 +421,9 @@ pub use owner_walk::{
     operator_open_append, operator_open_create_new, operator_open_read,
     operator_open_read_confined, operator_open_recv, operator_open_rw_create,
     operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
-    operator_rename, operator_rename_confined, operator_symlink_metadata, owner_trusted_parent,
-    owner_trusted_parent_kind, symlink_owner_is_trusted,
+    operator_read_to_string_confined, operator_rename, operator_rename_confined,
+    operator_symlink_metadata, owner_trusted_parent, owner_trusted_parent_kind,
+    symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -1110,6 +1110,37 @@ pub fn operator_read_to_string(path: &Path) -> io::Result<String> {
     Ok(contents)
 }
 
+/// Read a filter/merge file through the ownership walk, additionally bound to
+/// the session's confinement root.
+///
+/// The confined counterpart of [`operator_read_to_string`], standing to it as
+/// [`operator_open_read_confined`] stands to [`operator_open_read`]. A merge
+/// file is named by the PEER - a dir-merge rule travels over the protocol, not
+/// in the argv an `rrsync` wrapper validates - and its bytes become filter
+/// rules, so reading one from outside the root both reshapes the transfer and
+/// discloses the file's contents back to the peer.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/exclude.c:1680-1684` - `parse_filter_file()` sets
+///   `operator_path_resolve = 1` around `open_no_attacker_symlinks()`,
+///   exempting only the daemon's own config-supplied filter parameters.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved path lands outside the confinement root.
+/// - Otherwise as [`operator_read_to_string`], including `InvalidData` when the
+///   file is not valid UTF-8.
+pub fn operator_read_to_string_confined(path: &Path) -> io::Result<String> {
+    use std::io::Read as _;
+
+    let mut file = operator_open_read_confined(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}
+
 /// `lstat`s an operator-supplied path with its parent resolved by the ownership
 /// walk, so a foreign-owned symlink among the parent components cannot redirect
 /// the stat.

--- a/crates/fast_io/tests/confine_root_merge_alias.rs
+++ b/crates/fast_io/tests/confine_root_merge_alias.rs
@@ -1,0 +1,244 @@
+//! `--confine-root` bounds a merge-file open KERNEL-ANCHORED, not lexically.
+//!
+//! # The shape
+//!
+//! A dir-merge rule travels over the protocol as a filter rule, not in the argv
+//! an `rrsync` wrapper validated, so the peer names the merge file. Bounding
+//! that open is the job of the confinement root - and the interesting case is
+//! the one where a STRING comparison gets the wrong answer.
+//!
+//! Reach the tree through a symlink that points at its own directory
+//! (`root/self-alias -> .`) and rsync's tracked path sits one component deeper
+//! than the kernel's. A merge file's own relative `..` then pops a component
+//! that the kernel never descended:
+//!
+//! ```text
+//!   named:    <root>/self-alias/outside-link
+//!   link:     outside-link -> ../secret
+//!   LEXICAL:  <root>/self-alias/../secret  ==  <root>/secret     -> inside  ✗
+//!   KERNEL:   self-alias resolves to <root>, then ../secret      -> outside ✓
+//! ```
+//!
+//! So a resolver that normalises the string lands INSIDE the root and admits
+//! the read; only one that advances its tracked path by RESOLVED components
+//! sees the escape. [`lexical_normalisation_lands_inside_the_root`] pins that
+//! the fixture really does have this property, so the refusal below is
+//! evidence about the mechanism and not about an easier path.
+//!
+//! # Why the root and not ownership
+//!
+//! Every link here is owned by the euid running the test, which the walk
+//! FOLLOWS by design (`syscall.c:406`) - refusing an operator's own layout
+//! would break the ordinary case. The refusal therefore has to come from the
+//! confinement root, after the follow.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/syscall.c:316-328` - the `confine_root` arm seeds `abspath`
+//!   from `getcwd()` (`:327`), "It must be the PHYSICAL cwd: `curr_dir` is the lexical
+//!   name `change_dir()` was given, so after descending a trusted symlink the
+//!   tracker sits at a different depth than the kernel, and a `..` that really
+//!   escapes looks like it landed inside."
+//! - `rsync-3.5.0/syscall.c:245` `abspath_step()` - advances one RESOLVED
+//!   component at a time.
+//! - `rsync-3.5.0/syscall.c:186-240` `abspath_outside_confinement()`.
+//! - `rsync-3.5.0/exclude.c:1680-1684` `parse_filter_file()` - the merge-file
+//!   open this bounds.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Component, Path, PathBuf};
+
+use tempfile::TempDir;
+
+/// The session's confinement root is process-global, mirroring upstream's
+/// `confine_root`. Each cell installs the session it needs, so they must not
+/// interleave when the harness runs them as threads.
+static SESSION: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// A confine root reached through a self-alias, a secret beside it, and both an
+/// escaping and an in-tree merge file inside.
+struct Aliased {
+    _base: TempDir,
+    root: PathBuf,
+    secret: PathBuf,
+}
+
+fn aliased() -> Aliased {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("aliased");
+    fs::create_dir(&root).expect("mkdir root");
+
+    let secret = base.path().join("aliased-secret");
+    fs::write(&secret, "ALIASED-SECRET").expect("write the outside secret");
+
+    // The alias that makes the tracked path deeper than the kernel's.
+    symlink(".", root.join("self-alias")).expect("plant the self alias");
+    // The escape: a relative link whose `..` is spent against the REAL parent.
+    symlink("../aliased-secret", root.join("outside-link")).expect("plant the escape");
+    // The control: an ordinary merge file inside the root.
+    fs::write(root.join("intree-list"), "IN-TREE-RULES").expect("write the in-tree merge file");
+
+    Aliased {
+        _base: base,
+        root,
+        secret,
+    }
+}
+
+/// Confine to `root` the way a `--confine-root` server does.
+fn confine_to(root: &Path) -> std::sync::MutexGuard<'static, ()> {
+    let guard = SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    fast_io::confinement::install_local_session(
+        fast_io::confinement::LocalInsecureLinks::from_local_flag(false),
+        Some(root.to_path_buf()),
+    );
+    guard
+}
+
+/// Collapse `.` and `..` textually - what a resolver that never touches the
+/// filesystem would compute.
+fn lexically_normalised(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// THE INSTRUMENT CHECK, and it is what makes the pin below mean anything: the
+/// escaping path normalises to a location INSIDE the root, so a lexical
+/// resolver would admit the read. Without this cell the refusal could just as
+/// well be a string comparison getting an easy case right.
+#[test]
+fn lexical_normalisation_lands_inside_the_root() {
+    let fixture = aliased();
+    let named = fixture.root.join("self-alias").join("outside-link");
+
+    // The named path itself, before the leaf link is expanded.
+    assert!(
+        lexically_normalised(&named).starts_with(&fixture.root),
+        "the fixture must name a path that looks in-tree textually"
+    );
+    // And with the leaf link's own target spliced in the way a string-based
+    // resolver would splice it: `<root>/self-alias/../aliased-secret`.
+    let spliced = named.parent().expect("parent").join("../aliased-secret");
+    assert!(
+        lexically_normalised(&spliced).starts_with(&fixture.root),
+        "the fixture's escape must be invisible to a lexical check, or the \
+         refusal below proves nothing about kernel anchoring"
+    );
+
+    // ...while the kernel really does land outside.
+    assert_eq!(
+        fs::canonicalize(&named).expect("the escape resolves"),
+        fs::canonicalize(&fixture.secret).expect("the secret resolves"),
+        "the named path must really reach the outside secret"
+    );
+}
+
+/// THE PIN. The merge-file read is refused because the walk tracks where the
+/// open would REALLY land, having followed `self-alias` to the root itself.
+#[test]
+fn a_merge_file_escaping_through_a_self_alias_is_refused() {
+    let fixture = aliased();
+    let named = fixture.root.join("self-alias").join("outside-link");
+
+    let _session = confine_to(&fixture.root);
+    let error = fast_io::operator_read_to_string_confined(&named)
+        .expect_err("a merge file resolving outside --confine-root must be refused");
+
+    assert_eq!(
+        error.raw_os_error(),
+        Some(libc::ELOOP),
+        "the refusal must be ELOOP so callers tell it from an ordinary \
+         open failure; got {error:?}"
+    );
+}
+
+/// NON-VACUITY companion, and the one that matters: reaching the SAME
+/// directory through the SAME alias, an in-tree merge file must still be read.
+/// An over-refusing resolver would satisfy the pin above while breaking every
+/// ordinary transfer whose source argument goes through a symlink.
+#[test]
+fn an_in_tree_merge_file_through_the_same_alias_is_still_read() {
+    let fixture = aliased();
+    let named = fixture.root.join("self-alias").join("intree-list");
+
+    let _session = confine_to(&fixture.root);
+    let contents = fast_io::operator_read_to_string_confined(&named)
+        .expect("an in-tree merge file must still be read through the alias");
+
+    assert_eq!(contents, "IN-TREE-RULES");
+}
+
+/// The plants are real and TRUSTED-owned, so the refusal above is the
+/// confinement arm and not the ownership arm firing.
+#[test]
+fn the_alias_and_the_escape_are_trusted_owned_symlinks() {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let fixture = aliased();
+    for name in ["self-alias", "outside-link"] {
+        let meta = fs::symlink_metadata(fixture.root.join(name)).expect("the plant must exist");
+        assert!(
+            meta.file_type().is_symlink(),
+            "{name} must be a symlink, or the fixture does not have the shape \
+             the pin describes"
+        );
+        assert!(
+            fast_io::symlink_owner_is_trusted(meta.uid()),
+            "{name} must be TRUSTED-owned: an untrusted link would be refused \
+             on ownership and the confinement arm would never run"
+        );
+    }
+}
+
+/// The escape is refused only while a root is installed. With none - the plain
+/// local client, upstream's NULL `confine_root` - the same read succeeds, which
+/// is what shows the refusal comes from the root and not from the alias.
+#[test]
+fn without_a_root_the_same_read_succeeds() {
+    let fixture = aliased();
+    let named = fixture.root.join("self-alias").join("outside-link");
+
+    let _guard = SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    fast_io::confinement::install_local_session(
+        fast_io::confinement::LocalInsecureLinks::from_local_flag(false),
+        None,
+    );
+    let contents = fast_io::operator_read_to_string_confined(&named)
+        .expect("no root means nothing is outside it");
+
+    assert_eq!(contents, "ALIASED-SECRET");
+}
+
+/// The ANCILLARY entry point keeps its own policy: `--log-file`, the
+/// `--*-from` family and the daemon's lock/motd files may legitimately live
+/// outside the tree, so widening the merge-file rule to every operator open
+/// would be a divergence in the opposite direction.
+///
+/// upstream: `rsync-3.5.0/syscall.c:232-239`.
+#[test]
+fn an_ancillary_read_is_not_bound_by_the_root() {
+    let fixture = aliased();
+    let named = fixture.root.join("self-alias").join("outside-link");
+
+    let _session = confine_to(&fixture.root);
+    let contents = fast_io::operator_read_to_string(&named)
+        .expect("an ancillary path is not bound to the confinement root");
+
+    assert_eq!(contents, "ALIASED-SECRET");
+}

--- a/crates/fast_io/tests/operator_open_module_confinement.rs
+++ b/crates/fast_io/tests/operator_open_module_confinement.rs
@@ -276,6 +276,7 @@ fn without_a_confinement_root_a_confined_open_still_follows() {
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     fast_io::confinement::install_local_session(
         fast_io::confinement::LocalInsecureLinks::from_local_flag(false),
+        None,
     );
     let file = fast_io::operator_open_read_confined(&planted)
         .expect("no root means nothing is outside it");

--- a/crates/filters/src/merge_open.rs
+++ b/crates/filters/src/merge_open.rs
@@ -9,29 +9,58 @@
 //!
 //! Upstream opens these through the same component walk it uses for every other
 //! operator-named auxiliary file: follow a symlink only when it is owned by
-//! uid 0 or our effective uid, refuse any other-uid one.
+//! uid 0 or our effective uid, refuse any other-uid one. For a merge file it
+//! additionally arms the confinement-root refusal, because the merge pattern is
+//! peer-supplied and ownership cannot bound where it points.
 //!
 //! # Upstream Reference
 //!
 //! - `rsync-3.5.0/exclude.c:1464` - `parse_filter_file()` opens the merge file.
 //! - `rsync-3.5.0/exclude.c:811-814` - `push_local_filters()` calls it per
 //!   scanned directory.
+//! - `rsync-3.5.0/exclude.c:1680-1684` - the `operator_path_resolve = 1` that
+//!   wraps that open.
 //! - `rsync-3.5.0/syscall.c:538` - `open_no_attacker_symlinks()`; the trust
 //!   rule is at `syscall.c:406`.
 
 use std::io;
 use std::path::Path;
 
-/// Read a per-directory merge file, refusing an attacker-owned symlink.
+/// Read a per-directory merge file, refusing an attacker-owned symlink and any
+/// path that resolves outside the session's confinement root.
 ///
 /// The platform seam lives here rather than at each call site. On non-Unix
 /// targets the ownership walk has no meaning - there is no `st_uid` to trust -
 /// and this degrades to a plain read, matching how the rest of the tree gates
 /// `fast_io`'s operator-path helpers.
+///
+/// # Why the confinement and not the ownership walk alone
+///
+/// The merge PATTERN travels over the protocol as a filter rule, not in the
+/// argv an `rrsync` wrapper validates, so the peer chooses it: `:-s
+/// ../outside-secret` names a file beside the restricted directory. Ownership
+/// cannot judge that - the escape needs no symlink at all, and where one is
+/// used a non-chrooted daemon writes `--backup-dir` entries as root, so a raced
+/// link is root-owned and the walk trusts it by design. An exclude-only merge
+/// then turns every line of the file into a pattern, so nothing fails to parse
+/// and the file's contents come back to the peer as absences from the file
+/// list. Judging where the open LANDS is what closes that.
+///
+/// The daemon's own `filter` / `include from` / `exclude from` parameters are
+/// deliberately not read through here: they are operator-configured and
+/// legitimately live outside the module.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/exclude.c:1668-1684` - `parse_filter_file()` wraps its
+///   `open_no_attacker_symlinks()` in `operator_path_resolve = 1`, scoped by
+///   `if (!daemon_config_filter_file)`.
+/// - `rsync-3.5.0/syscall.c:186-240` - `abspath_outside_confinement()`, the
+///   refusal that flag arms.
 pub(crate) fn read_to_string(path: &Path) -> io::Result<String> {
     #[cfg(unix)]
     {
-        fast_io::operator_read_to_string(path)
+        fast_io::operator_read_to_string_confined(path)
     }
     #[cfg(not(unix))]
     {

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -1672,7 +1672,7 @@ mod confinement_root_tests {
     /// `--insecure-links` instead of a module directive.
     #[test]
     fn local_optout_releases_the_confine_root() {
-        install_local_session(LocalInsecureLinks::from_local_flag(true));
+        install_local_session(LocalInsecureLinks::from_local_flag(true), None);
         let connection = ConnectionConfig {
             confine_root: Some(PathBuf::from("/restricted")),
             ..Default::default()
@@ -1683,7 +1683,7 @@ mod confinement_root_tests {
     /// Non-vacuity companion for the non-daemon arm.
     #[test]
     fn a_local_session_without_the_optout_keeps_its_confine_root() {
-        install_local_session(LocalInsecureLinks::from_local_flag(false));
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
         let connection = ConnectionConfig {
             confine_root: Some(PathBuf::from("/restricted")),
             ..Default::default()

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -278,7 +278,7 @@ rrsync-copy-unsafe-links-denied pass
 rrsync-debug-denied pass
 rrsync-files-from-stdin pass
 rrsync-logfile-symlink pass
-rrsync-merge-file-confine fail
+rrsync-merge-file-confine pass
 rrsync-no-overwrite-backup-collision pass
 rrsync-no-overwrite-delay-updates pass
 rrsync-no-overwrite-logfile pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -278,7 +278,7 @@ rrsync-copy-unsafe-links-denied pass
 rrsync-debug-denied pass
 rrsync-files-from-stdin pass
 rrsync-logfile-symlink pass
-rrsync-merge-file-confine fail
+rrsync-merge-file-confine pass
 rrsync-no-overwrite-backup-collision pass
 rrsync-no-overwrite-delay-updates pass
 rrsync-no-overwrite-logfile pass


### PR DESCRIPTION
## The gap

Testsuite cell `rrsync-merge-file-confine` (3.5.0) passes on upstream and failed
on oc.

A dir-merge rule travels over the protocol as a filter rule, not in the argv an
`rrsync` wrapper validates, so the **peer** names the merge file.
`--filter=':-s ../outside-secret'` reads a file beside the restricted directory,
and because an exclude-only merge turns every line into a pattern, nothing fails
to parse: the file's contents come back as absences from the file list. No
error, no verbosity, and on a pull no `--delete` either.

oc walked the *ownership* of that open but never bounded it. Two halves were
missing, and each is independently load-bearing:

1. `filters::merge_open::read_to_string` - the per-directory merge open the
   generator scan and the receiver delete pass both use - took the **ancillary**
   entry point (`operator_read_to_string`), so the walk followed a trusted
   symlink and judged nothing about where it landed. Its sibling in the
   local-copy engine (`engine::local_copy::dir_merge::load::open_merge_file`)
   was already confined.
2. Nothing published `--confine-root` into the walk's session. Both
   `install_local_session` call sites passed `confine_root: None`, and
   `--server` mode installed no session at all, so even the already-confined
   opens measured against an empty root.

## The fix

- New `fast_io::operator_read_to_string_confined`, the confined counterpart of
  `operator_read_to_string` (as `operator_open_read_confined` is to
  `operator_open_read`). The filters seam routes onto it - one seam, three call
  sites (`enter_directory`, `load_inline_dir_merge`, `merge::read::read_rules`).
- `install_local_session` now carries the `--confine-root` root, and both the
  client (`workflow::run::execute`) and the non-daemon server
  (`run_server_mode`) publish it. A daemon still publishes its module root
  (`install_daemon_session`), matching upstream's
  `am_daemon ? module_dir : confine_root`; `--server --daemon` is dispatched
  before `run_server_mode`, so the arm that honours a peer-supplied argv value
  is never a daemon.

Without `--confine-root` the session is `(optout=false, root=None)` on both
paths - byte-identical to today - so nothing changes for an ordinary transfer.

### Kernel-anchored, not lexical

The cell's second leg reaches the tree through `root/self-alias -> .`, so
rsync's tracked path sits one component deeper than the kernel's. The merge
file's own `../secret` then normalises to `root/secret` **textually** - inside
the root - while the kernel lands outside:

```
named:    <root>/self-alias/outside-link
link:     outside-link -> ../secret
LEXICAL:  <root>/self-alias/../secret == <root>/secret   -> inside   (wrong)
KERNEL:   self-alias resolves to <root>, then ../secret  -> outside  (right)
```

`AbsPathTracker` already advanced by RESOLVED components, seeded from
`std::env::current_dir()` (the physical cwd), which is upstream's own
requirement at `syscall.c:311-322`. `crates/fast_io/tests/confine_root_merge_alias.rs`
pins it, with `lexical_normalisation_lands_inside_the_root` as the instrument
check: the fixture is provably invisible to a string comparison.

## Second defect, found while measuring

The server argv parser filtered **every** `.` operand as the cwd placeholder.
Upstream consumes one slot - `dir = argv[0]; argc--; argv++;` - whatever it
holds, so `rsync host:. dest/` (which rrsync emits as `-- . .`) left oc's server
with no operand at all. Measured: an empty file list and a silent `rc=0` no-op,
in both directions. The placeholder is now spent once.

Two existing cells asserted `pos_args.is_empty()` for `-- . .`; they encoded
this behaviour and are corrected to `["."]`.

## Sites deliberately left alone

- `daemon::sections::module_access::helpers::read_patterns_from_file` - the
  daemon's own `include from` / `exclude from`. Upstream exempts exactly these
  (`if (!daemon_config_filter_file)`); they legitimately live outside the
  module.
- `daemon::operator_file` (config, motd, secrets) - operator-configured, and
  upstream opens them with `operator_path_resolve = 0`.
- The `--files-from` opens - a different option family, and one upstream names
  among the opens that "may legitimately live elsewhere" (`syscall.c:232-239`).
- `$HOME/.cvsignore` - named by `--cvs-exclude`, not by the peer.
- `cli::frontend::filter_rules::sources` (`--*clude-from`, CLI `merge`) and the
  local-copy engine loader - both already confined.

## Upstream

- `exclude.c:1668-1684` `parse_filter_file()` - the
  `if (!daemon_config_filter_file) operator_path_resolve = 1;` around
  `open_no_attacker_symlinks()`
- `syscall.c:186-240` `abspath_outside_confinement()`
- `syscall.c:311-322` - the `confine_root` arm seeds `abspath` from `getcwd()`
  because "`curr_dir` is the lexical name `change_dir()` was given"
- `syscall.c:136-144` `confinement_root()`
- `main.c:966-975` `do_server_sender()`, `main.c:1192-1194` `do_server_recv()`

## Evidence

**Upstream control** - 3.5.0 built from the pinned tree: `PASS`.
**oc before**: `FAIL` - "the server read a merge file outside the restricted dir".

**Mutation A** - revert `merge_open` to the ancillary open, rebuild, rerun:
`FAIL`, and `strace` shows the escape as syscalls:

```
openat(AT_FDCWD, ".", O_PATH|O_DIRECTORY) = 3
newfstatat(3, "..", ...)                  = 0
openat(3, "..", O_NOFOLLOW|O_PATH|O_DIRECTORY) = 4
newfstatat(4, "outside-secret", {S_IFREG|0644, st_size=11}) = 0
openat(4, "outside-secret", O_RDONLY|O_NOFOLLOW) = 3   <- the read
```

with `secretword` missing from the delivered file list. With the fix the walk
stops at the confinement check and `secretword` arrives.

**Mutation B** - keep the confined open but drop the server's
`install_local_session(.., confine_root)`, rebuild, rerun: `FAIL`, same
assertion. Each half is independently load-bearing: the routing without the
published root confines nothing, and the published root without the routing is
never consulted at that open.

**Non-vacuity** - the cell carries its own controls, and both hold: an in-tree
`.rsync-filter` is still read and obeyed (`intree-dropped` excluded,
`intree-kept` delivered), and the in-tree merge reached through the SAME
symlinked source arg still works. `confine_root_merge_alias.rs` repeats both at
the resolver level, plus an ancillary-open control showing `--log-file` and the
`--*-from` family are still not bound by the root.

**Both testsuite legs, Linux (aarch64), 3.5.0, pipe transport:**

- nonroot: 253 passed / 6 failed / 86 skipped; mismatches vs the manifest:
  `daemon-scan-cwd-desync` (EAGAIN under a loaded VM - passes 3/3 re-run in
  isolation) and `simd-checksum` (skipped, `simdtest` not built on this host).
  `rrsync-merge-file-confine` PASS.
- root (sudo): 281 passed / 7 failed / 57 skipped; mismatches: `batch-file-symlink`
  (passes in isolation on a re-run - the char-device fixture flaked under load)
  and `simd-checksum` again. `rrsync-merge-file-confine` PASS.

`--expect-result` fails on an unexpected PASS too, so the manifest flip is
confirmed by the run rather than asserted.

`cargo nextest run -p fast_io -p filters`: 2349 passed, 0 failed.
Clippy `-D warnings` clean on the pinned 1.88.0 toolchain;
`tools/ci/check_rustfmt_all.py` clean.
