### PR TITLE
feat(receiver): stage a --partial-dir resume in place

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -480,6 +480,12 @@ pub(in crate::local_copy) fn execute_transfer_once(
     let mut guard = None;
     let mut staging_path: Option<PathBuf> = None;
 
+    // upstream: generator.c:2173-2179 + receiver.c:1137 - a `--partial-dir`
+    // entry that already exists as a regular file is both the basis name and,
+    // under `one_inplace`, the file the reconstruction is written into.
+    let one_inplace_partial_file =
+        super::write_strategy::one_inplace_partial_file(context, destination);
+
     let strategy = select_write_strategy(
         append_offset,
         inplace_enabled,
@@ -487,6 +493,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
         delay_updates_enabled,
         existing_metadata.is_some(),
         context.temp_directory_path().is_some(),
+        one_inplace_partial_file.is_some(),
         destination,
     );
 
@@ -528,6 +535,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
         append_offset,
         partial_enabled,
         strategy,
+        one_inplace_partial_file.as_deref(),
         &mut guard,
         &mut staging_path,
     )?;

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -6,6 +6,7 @@
 //! file with atomic rename.
 
 use std::fs;
+use std::io;
 use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
@@ -14,6 +15,38 @@ use logging::debug_log;
 use crate::local_copy::{CopyContext, LocalCopyError};
 
 use super::super::super::guard::DestinationWriteGuard;
+use super::super::super::paths::partial_dir_fname;
+
+/// upstream's `partialptr` when it names an existing regular file, i.e. the
+/// staging target of a `one_inplace` update.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:2173-2179` - `partial_dir && (partialptr =
+///   partial_dir_fname(fname)) != NULL && link_stat(partialptr, &partial_st, 0)
+///   == 0 && S_ISREG(partial_st.st_mode)`, otherwise `partialptr = NULL`.
+///   `link_stat(..., 0)` is an `lstat`, so a symlink planted at the partial leaf
+///   is not a regular file and is refused here exactly as it is there.
+/// - `rsync-3.5.0/receiver.c:1137-1138` - `one_inplace = inplace_partial &&
+///   fnamecmp_type == FNAMECMP_PARTIAL_DIR && fd1 != -1`.
+///
+/// The `inplace_partial` half of that conjunction is the protocol-30
+/// `CF_INPLACE_PARTIAL_DIR` capability (`compat.c:738`, `options.c:3221`), which
+/// upstream negotiates with itself on a local transfer too - and this executor
+/// IS both ends, so it is unconditionally true here. The `fd1 != -1` half guards
+/// against a *peer* claiming a partial basis the receiver's confined open then
+/// rejects (`receiver.c:1093-1105`); nothing here is peer-supplied, the path is
+/// derived locally from the operator's own `--partial-dir`, so the remaining
+/// condition is upstream's `partialptr != NULL` alone.
+pub(in crate::local_copy) fn one_inplace_partial_file(
+    context: &CopyContext,
+    destination: &Path,
+) -> Option<PathBuf> {
+    let dir = context.partial_directory_path()?;
+    let candidate = partial_dir_fname(destination, dir);
+    let metadata = fs::symlink_metadata(&candidate).ok()?;
+    metadata.is_file().then_some(candidate)
+}
 
 /// The write strategy for transferring a file to disk.
 ///
@@ -27,6 +60,13 @@ pub(in crate::local_copy) enum WriteStrategy {
     /// Write directly to destination without temp file.
     /// Truncates when no delta signature exists.
     Inplace,
+    /// upstream's `one_inplace`: write straight into the `--partial-dir` entry
+    /// and rename that entry onto the destination on commit.
+    ///
+    /// upstream: `receiver.c:1195-1196` - `fnametmp = one_inplace ? partialptr
+    /// : fname`. The in-place target is the file inside the partial dir, never
+    /// the live destination.
+    InplacePartialDir,
     /// Create new file directly - no existing destination to protect.
     /// Uses `create_new(true)` to prevent races with concurrent writers.
     Direct,
@@ -48,15 +88,38 @@ pub(in crate::local_copy) enum WriteStrategy {
 /// # Strategy selection (upstream: receiver.c)
 ///
 /// 1. **Append** - `append_offset > 0`: resume writing at end of existing file.
-/// 2. **Inplace** - `--inplace`: write directly, truncating only when no delta.
-/// 3. **AnonymousTempFile** - Linux with `O_TMPFILE` support, no `--partial`
+/// 2. **InplacePartialDir** - upstream's `one_inplace`: a `--partial-dir` entry
+///    for this file already exists as a regular file, so the reconstruction is
+///    written into it and that entry is renamed onto the destination.
+/// 3. **Inplace** - `--inplace`: write directly, truncating only when no delta.
+/// 4. **AnonymousTempFile** - Linux with `O_TMPFILE` support, no `--partial`
 ///    (partial files need a visible staging path for resume), no `--temp-dir`
 ///    (cross-device linkat would fail): anonymous inode + `linkat(2)`. Preferred
 ///    over both Direct and TempFileRename because the kernel auto-cleans the
 ///    anonymous inode on crash - no orphaned temp files or partial writes.
-/// 4. **Direct** - no existing destination AND none of `--partial`,
+/// 5. **Direct** - no existing destination AND none of `--partial`,
 ///    `--delay-updates`, `--temp-dir`: create file directly.
-/// 5. **TempFileRename** - all other cases: temp file + atomic rename.
+/// 6. **TempFileRename** - all other cases: temp file + atomic rename.
+///
+/// `one_inplace_partial_dir` outranks plain `--inplace` for the same reason
+/// upstream's `fnametmp = one_inplace ? partialptr : fname`
+/// (`receiver.c:1196`) resolves the ternary before consulting `inplace`: when a
+/// partial-dir entry is the update target it IS the target, whichever other
+/// in-place mode is also on. `--inplace`/`--append` and `--partial-dir` are in
+/// fact rejected together during config validation
+/// (`core/src/client/config/builder`, upstream `options.c:2424-2432`), so the
+/// precedence is not observable through the CLI; it is written this way so it
+/// stays upstream's if the two are ever wired together.
+///
+/// ⚠ **Append is the one exception, and it is deliberate.** Upstream's ternary
+/// picks the *target*; the append seek (`receiver.c:372-373`) is a separate
+/// decision that upstream applies to whichever fd it opened, and its offset
+/// comes from `sx.st`, which the generator has already replaced with
+/// `partial_st` (`generator.c:2271`) - i.e. from the PARTIAL file's length. This
+/// executor derives `append_offset` from the destination's length instead, which
+/// is not the file `one_inplace` writes into, so honouring it here would seek to
+/// the wrong offset in the wrong file. Append keeps its own strategy until that
+/// offset is derived from the staging target.
 pub(in crate::local_copy) fn select_write_strategy(
     append_offset: u64,
     inplace_enabled: bool,
@@ -64,10 +127,13 @@ pub(in crate::local_copy) fn select_write_strategy(
     delay_updates_enabled: bool,
     has_existing_destination: bool,
     has_temp_directory: bool,
+    one_inplace_partial_dir: bool,
     destination: &Path,
 ) -> WriteStrategy {
     if append_offset > 0 {
         WriteStrategy::Append
+    } else if one_inplace_partial_dir {
+        WriteStrategy::InplacePartialDir
     } else if inplace_enabled {
         WriteStrategy::Inplace
     } else if !partial_enabled && !has_temp_directory && can_use_anonymous_tmpfile(destination) {
@@ -108,6 +174,9 @@ pub(in crate::local_copy) fn can_use_anonymous_tmpfile(destination: &Path) -> bo
 /// Each strategy maps to a distinct I/O path:
 /// - **Append**: opens existing file and seeks to append offset
 /// - **Inplace**: opens for writing without temp file (truncates only when no delta)
+/// - **InplacePartialDir**: opens the `--partial-dir` entry through the
+///   ownership walk (upstream's `one_inplace`); the commit renames it onto the
+///   destination
 /// - **Direct**: creates new file directly when no existing destination
 /// - **TempFileRename**: creates a staging file via `DestinationWriteGuard`
 #[allow(clippy::too_many_arguments)]
@@ -119,6 +188,7 @@ pub(in crate::local_copy) fn open_destination_writer(
     append_offset: u64,
     partial_enabled: bool,
     strategy: WriteStrategy,
+    one_inplace_partial_file: Option<&Path>,
     guard: &mut Option<DestinationWriteGuard>,
     staging_path: &mut Option<PathBuf>,
 ) -> Result<fs::File, LocalCopyError> {
@@ -147,6 +217,62 @@ pub(in crate::local_copy) fn open_destination_writer(
                 fast_io::InplaceResolution::Direct,
             )
             .map_err(|error| LocalCopyError::io("copy file", destination, error))
+        }
+        WriteStrategy::InplacePartialDir => {
+            // upstream: receiver.c:1196 - `fnametmp = one_inplace ? partialptr
+            // : fname`. The reconstruction goes into the partial-dir entry; the
+            // guard's commit rename is upstream's
+            // `finish_transfer(fname, fnametmp, ...)` (receiver.c:1288).
+            let Some(partial_file) = one_inplace_partial_file else {
+                return Err(LocalCopyError::io(
+                    "copy file",
+                    destination,
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "one_inplace staging selected without a --partial-dir entry",
+                    ),
+                ));
+            };
+            let Some(partial_dir) = context.partial_directory_path() else {
+                return Err(LocalCopyError::io(
+                    "copy file",
+                    destination,
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "one_inplace staging selected without --partial-dir",
+                    ),
+                ));
+            };
+            // ⚠ Upstream never passes `O_TRUNC` here, and this does. The
+            // difference is one unported half, not a policy choice: upstream's
+            // generator makes `partialptr` the delta basis as well as the
+            // in-place target (`generator.c:2270-2273` - `fnamecmp = partialptr;
+            // fnamecmp_type = FNAMECMP_PARTIAL_DIR`), so its reconstruction
+            // reads the entry it is writing and a final `ftruncate` sizes the
+            // result. This executor still picks its basis from the destination
+            // or a `--fuzzy` candidate only, so the partial entry is pure
+            // output: nothing reads it back, and its old tail has to go on open
+            // or it would survive past a shorter result. When the basis half is
+            // ported this becomes `delta_signature.is_none()`, exactly as
+            // `WriteStrategy::Inplace` above.
+            let should_truncate = true;
+            debug_log!(
+                Io,
+                3,
+                "one_inplace staging for {} into {}",
+                record_path.display(),
+                partial_file.display()
+            );
+            let (new_guard, file) = DestinationWriteGuard::new_one_inplace(
+                destination,
+                partial_file,
+                partial_dir,
+                should_truncate,
+                Some(context.destination_root()),
+            )?;
+            *staging_path = Some(new_guard.staging_path().to_path_buf());
+            *guard = Some(new_guard);
+            Ok(file)
         }
         WriteStrategy::Direct => {
             // Direct write when there is no existing file to protect.
@@ -280,8 +406,62 @@ mod tests {
             delay,
             existing,
             temp_dir,
+            false,
             Path::new(NO_TMPFILE),
         )
+    }
+
+    /// `strategy()` with upstream's `one_inplace` gate turned on.
+    fn strategy_one_inplace(partial: bool, existing: bool) -> WriteStrategy {
+        select_write_strategy(
+            0,
+            false,
+            partial,
+            false,
+            existing,
+            false,
+            true,
+            Path::new(NO_TMPFILE),
+        )
+    }
+
+    #[test]
+    fn append_outranks_one_inplace_staging() {
+        // The append offset is measured against the destination, not against
+        // the partial-dir entry one_inplace would write into, so the append
+        // strategy keeps precedence. See the note on `select_write_strategy`.
+        assert_eq!(
+            select_write_strategy(
+                1024,
+                false,
+                true,
+                false,
+                true,
+                false,
+                true,
+                Path::new(NO_TMPFILE),
+            ),
+            WriteStrategy::Append
+        );
+    }
+
+    #[test]
+    fn existing_partial_dir_entry_selects_one_inplace_staging() {
+        // upstream: receiver.c:1195-1196 - `fnametmp = one_inplace ? partialptr
+        // : fname`. Without this the same inputs pick TempFileRename and the
+        // partial-dir entry is never opened at all.
+        assert_eq!(
+            strategy_one_inplace(true, false),
+            WriteStrategy::InplacePartialDir
+        );
+        assert_eq!(
+            strategy_one_inplace(true, true),
+            WriteStrategy::InplacePartialDir
+        );
+        assert_eq!(
+            strategy(0, false, true, false, false, false),
+            WriteStrategy::TempFileRename
+        );
     }
 
     #[test]
@@ -434,7 +614,7 @@ mod tests {
         // files need a visible staging path.
         let dir = tempfile::tempdir().expect("tempdir");
         let dest = dir.path().join("file.txt");
-        let result = select_write_strategy(0, false, true, false, true, false, &dest);
+        let result = select_write_strategy(0, false, true, false, true, false, false, &dest);
         assert_eq!(result, WriteStrategy::TempFileRename);
     }
 
@@ -443,7 +623,7 @@ mod tests {
         // --temp-dir prevents anonymous because linkat cannot cross devices.
         let dir = tempfile::tempdir().expect("tempdir");
         let dest = dir.path().join("file.txt");
-        let result = select_write_strategy(0, false, false, false, true, true, &dest);
+        let result = select_write_strategy(0, false, false, false, true, true, false, &dest);
         assert_eq!(result, WriteStrategy::TempFileRename);
     }
 

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/write_strategy.rs
@@ -637,7 +637,7 @@ mod tests {
             return;
         }
         // With existing dest, no partial, no temp-dir -> should pick anonymous.
-        let result = select_write_strategy(0, false, false, false, true, false, &dest);
+        let result = select_write_strategy(0, false, false, false, true, false, false, &dest);
         assert_eq!(result, WriteStrategy::AnonymousTempFile);
     }
 
@@ -654,7 +654,7 @@ mod tests {
         }
         // No existing dest, no partial, no delay, no temp-dir - would be Direct
         // without O_TMPFILE, but AnonymousTempFile is preferred when available.
-        let result = select_write_strategy(0, false, false, false, false, false, &dest);
+        let result = select_write_strategy(0, false, false, false, false, false, false, &dest);
         assert_eq!(result, WriteStrategy::AnonymousTempFile);
     }
 
@@ -667,7 +667,7 @@ mod tests {
             return;
         }
         // delay_updates alone should still allow anonymous.
-        let result = select_write_strategy(0, false, false, true, true, false, &dest);
+        let result = select_write_strategy(0, false, false, true, true, false, false, &dest);
         assert_eq!(result, WriteStrategy::AnonymousTempFile);
     }
 
@@ -681,7 +681,7 @@ mod tests {
         if !can_use_anonymous_tmpfile(&dest) {
             return;
         }
-        let result = select_write_strategy(0, false, false, false, true, false, &dest);
+        let result = select_write_strategy(0, false, false, false, true, false, false, &dest);
         assert_eq!(result, WriteStrategy::AnonymousTempFile);
     }
 

--- a/crates/engine/src/local_copy/executor/file/guard.rs
+++ b/crates/engine/src/local_copy/executor/file/guard.rs
@@ -35,6 +35,23 @@ enum PartialKind {
         file: PathBuf,
         remove_dir: Option<PathBuf>,
     },
+    /// upstream's `one_inplace`: the reconstruction was written straight into
+    /// the `--partial-dir` entry, so that entry IS the staging file and there is
+    /// no separate temp to move anywhere.
+    ///
+    /// On failure the file simply stays where it is - `partial_dest` names the
+    /// staging path itself, so the shared failure finaliser performs a
+    /// self-rename and leaves it untouched. On success the commit rename moves
+    /// it onto the destination and only the now-empty relative dir is removed:
+    /// upstream skips its `do_unlink_at(partialptr)` under `!one_inplace`
+    /// (`receiver.c:1291`) precisely because `finish_transfer()` has already
+    /// renamed that entry away, and then still calls
+    /// `handle_partial_dir(partialptr, PDIR_DELETE)` (`receiver.c:1299`) to
+    /// remove the directory.
+    OneInplace {
+        file: PathBuf,
+        remove_dir: Option<PathBuf>,
+    },
 }
 
 impl PartialKind {
@@ -43,7 +60,7 @@ impl PartialKind {
         match self {
             Self::Discard => None,
             Self::Keep => Some(final_path),
-            Self::Dir { file, .. } => Some(file),
+            Self::Dir { file, .. } | Self::OneInplace { file, .. } => Some(file),
         }
     }
 
@@ -502,6 +519,78 @@ impl DestinationWriteGuard {
         }
     }
 
+    /// Creates a write guard for upstream's `one_inplace` staging: the
+    /// reconstruction is written straight into the `--partial-dir` entry and
+    /// that entry is renamed onto the destination on commit.
+    ///
+    /// `partial_file` is upstream's `partialptr` - `partial_dir_fname(fname)`,
+    /// the operator-named `--partial-dir` path. It is opened through
+    /// `fast_io`'s three-arm in-place chain with
+    /// [`InplaceResolution::OperatorWalk`](fast_io::InplaceResolution::OperatorWalk),
+    /// which is upstream's `one_inplace` argument to `secure_recv_open()`: the
+    /// target is an operator-supplied path that may legitimately point outside
+    /// the transfer tree, so every component is walked and a foreign-owned
+    /// symlink is refused. Threading the walk through *every* arm is the point -
+    /// a `protected_regular` retry that dropped to the plain resolver would
+    /// follow a parent flipped to a symlink inside the `EACCES` window.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/receiver.c:1195-1196` - `if (inplace || one_inplace) {
+    ///   fnametmp = one_inplace ? partialptr : fname; }`. The in-place target of
+    ///   a `one_inplace` update is the file in the partial dir, **not** the live
+    ///   destination.
+    /// - `rsync-3.5.0/receiver.c:1204-1224` - the three-arm open chain, each arm
+    ///   handed `one_inplace`.
+    /// - `rsync-3.5.0/receiver.c:1288` - `finish_transfer(fname, fnametmp, ...)`
+    ///   with `fnametmp == partialptr` renames the grown partial onto the
+    ///   destination.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the partial-dir entry cannot be opened for writing,
+    /// including the ownership walk's refusal of a foreign-owned component.
+    pub fn new_one_inplace(
+        destination: &Path,
+        partial_file: &Path,
+        partial_dir: &Path,
+        truncate: bool,
+        dest_root: Option<&Path>,
+    ) -> Result<(Self, fs::File), LocalCopyError> {
+        let file = fast_io::open_inplace_output(
+            partial_file,
+            truncate,
+            fast_io::InplaceResolution::OperatorWalk,
+        )
+        .map_err(|error| LocalCopyError::io("copy file", partial_file, error))?;
+
+        // upstream: `handle_partial_dir()` only removes a *relative* partial
+        // dir; an absolute one is a reserved location.
+        let remove_dir = if partial_dir.is_relative() {
+            partial_file.parent().map(Path::to_path_buf)
+        } else {
+            None
+        };
+        let staging = partial_file.to_path_buf();
+        CleanupManager::global().register_partial(staging.clone(), Some(staging.clone()), false);
+
+        Ok((
+            Self {
+                final_path: destination.to_path_buf(),
+                strategy: GuardStrategy::NamedTempFile {
+                    temp_path: staging.clone(),
+                    partial: PartialKind::OneInplace {
+                        file: staging,
+                        remove_dir,
+                    },
+                },
+                committed: false,
+                dest_root: dest_root.map(Path::to_path_buf),
+            },
+            file,
+        ))
+    }
+
     /// Creates a write guard backed by an anonymous `O_TMPFILE` file descriptor.
     ///
     /// On Linux 3.11+ with a supporting filesystem, this opens an anonymous inode
@@ -582,6 +671,14 @@ impl DestinationWriteGuard {
         let GuardStrategy::NamedTempFile { temp_path, partial } = &mut self.strategy else {
             return Ok(None);
         };
+        // upstream: receiver.c:1301 - `keep_partial && partialptr && (!one_inplace
+        // || delay_updates)`. A `one_inplace` update wrote INTO the partial-dir
+        // entry, so under `--delay-updates` it is already staged there and
+        // upstream's `finish_transfer(partialptr, fnametmp, ...)` is a
+        // self-rename; only the deferred commit remains.
+        if let PartialKind::OneInplace { file, .. } = partial {
+            return Ok(Some(file.clone()));
+        }
         let PartialKind::Dir { file, .. } = partial else {
             return Ok(None);
         };
@@ -611,7 +708,8 @@ impl DestinationWriteGuard {
     pub fn partial_dir_to_remove(&self) -> Option<&Path> {
         match &self.strategy {
             GuardStrategy::NamedTempFile {
-                partial: PartialKind::Dir { remove_dir, .. },
+                partial:
+                    PartialKind::Dir { remove_dir, .. } | PartialKind::OneInplace { remove_dir, .. },
                 ..
             } => remove_dir.as_deref(),
             _ => None,
@@ -674,6 +772,17 @@ impl DestinationWriteGuard {
                             if let Some(dir) = remove_dir {
                                 let _ = fs::remove_dir(dir);
                             }
+                        }
+                    }
+                    // upstream: receiver.c:1291-1299 - under `one_inplace`
+                    // the `do_unlink_at(partialptr)` is skipped (the commit
+                    // rename already moved that entry onto the destination) but
+                    // `handle_partial_dir(partialptr, PDIR_DELETE)` still runs,
+                    // so the emptied relative partial dir is removed.
+                    Some(PartialKind::OneInplace { remove_dir, .. }) => {
+                        CleanupManager::global().unregister_partial(&temp_path);
+                        if let Some(dir) = remove_dir {
+                            let _ = fs::remove_dir(dir);
                         }
                     }
                     _ => {}
@@ -903,7 +1012,9 @@ impl DestinationWriteGuard {
         match &self.strategy {
             GuardStrategy::NamedTempFile { partial, .. } => match partial {
                 PartialKind::Discard => "finalise temporary file",
-                PartialKind::Keep | PartialKind::Dir { .. } => "finalise partial file",
+                PartialKind::Keep | PartialKind::Dir { .. } | PartialKind::OneInplace { .. } => {
+                    "finalise partial file"
+                }
             },
             #[cfg(target_os = "linux")]
             GuardStrategy::Anonymous { .. } => "finalise anonymous temp file",

--- a/crates/engine/src/local_copy/tests/partial_dir.rs
+++ b/crates/engine/src/local_copy/tests/partial_dir.rs
@@ -1528,3 +1528,139 @@ fn partial_dir_idempotent_transfer_with_existing_dest() {
     // At least one of the runs should succeed
     assert!(summary2.files_copied() + summary2.regular_files_matched() >= 1);
 }
+
+// upstream's `one_inplace`: an existing --partial-dir entry is the file the
+// reconstruction is written into, and it is renamed onto the destination on
+// commit (receiver.c:1195-1196, :1286-1300).
+
+/// Sets up `dest/pdir/<name>` holding `old`, and `source` holding `new`.
+fn one_inplace_fixture(
+    temp: &Path,
+    old: &[u8],
+    new: &[u8],
+) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
+    let source = temp.join("source.bin");
+    let dest_dir = temp.join("dest");
+    let partial_dir = dest_dir.join("pdir");
+    fs::create_dir_all(&partial_dir).expect("create partial dir");
+    let destination = dest_dir.join("source.bin");
+    let partial_entry = partial_dir.join("source.bin");
+    fs::write(&source, new).expect("write source");
+    fs::write(&partial_entry, old).expect("write partial entry");
+    (source, destination, partial_dir, partial_entry)
+}
+
+fn run_one_inplace_copy(source: &Path, destination: &Path, whole_file: bool) {
+    let operands = vec![
+        source.to_path_buf().into_os_string(),
+        destination.to_path_buf().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default()
+                .with_partial_directory(Some("pdir"))
+                .whole_file(whole_file),
+        )
+        .expect("copy succeeds");
+    assert_eq!(summary.files_copied(), 1);
+}
+
+/// Non-vacuity companion for the one_inplace staging: an ordinary
+/// `--partial-dir` resume, with nothing refusing any open, must still land the
+/// source bytes at the destination and clear the partial dir.
+///
+/// The old partial is deliberately LONGER than the source, so a staging path
+/// that reused the entry without sizing the result would leave a stale tail.
+#[test]
+fn partial_dir_one_inplace_staging_is_byte_correct() {
+    let temp = tempdir().expect("tempdir");
+    let old = vec![b'O'; 9000];
+    let new = vec![b'N'; 4096];
+    let (source, destination, partial_dir, _) = one_inplace_fixture(temp.path(), &old, &new);
+
+    run_one_inplace_copy(&source, &destination, true);
+
+    assert_eq!(fs::read(&destination).expect("read dest"), new);
+    // upstream: receiver.c:1299 - handle_partial_dir(partialptr, PDIR_DELETE)
+    // still runs under one_inplace, so the emptied relative dir goes away.
+    assert!(
+        !partial_dir.exists(),
+        "a completed one_inplace transfer removes the emptied partial dir"
+    );
+}
+
+/// The same with a delta pass rather than whole-file, so the open does not
+/// truncate and the final size comes from the transfer's own `set_len`.
+#[test]
+fn partial_dir_one_inplace_staging_is_byte_correct_with_delta() {
+    let temp = tempdir().expect("tempdir");
+    let old = vec![b'O'; 9000];
+    let new = vec![b'N'; 4096];
+    let (source, destination, partial_dir, _) = one_inplace_fixture(temp.path(), &old, &new);
+    fs::write(&destination, vec![b'D'; 7000]).expect("write existing destination");
+
+    run_one_inplace_copy(&source, &destination, false);
+
+    assert_eq!(fs::read(&destination).expect("read dest"), new);
+    assert!(!partial_dir.exists(), "partial dir removed after commit");
+}
+
+/// Anti-vacuity for the two tests above: prove the bytes travelled through the
+/// partial-dir entry rather than through a temp beside the destination.
+///
+/// `finish_transfer(fname, fnametmp, ...)` with `fnametmp == partialptr`
+/// (receiver.c:1288) is a rename, so the destination must end up wearing the
+/// inode the partial entry had. Before this staging existed the destination was
+/// a freshly created temp inode and the partial entry was unlinked, so this
+/// assertion fails on the old behaviour.
+#[cfg(unix)]
+#[test]
+fn partial_dir_one_inplace_renames_the_partial_entry_onto_the_destination() {
+    use std::os::unix::fs::MetadataExt as _;
+
+    let temp = tempdir().expect("tempdir");
+    let old = vec![b'O'; 2048];
+    let new = vec![b'N'; 2048];
+    let (source, destination, _, partial_entry) = one_inplace_fixture(temp.path(), &old, &new);
+    let staged_ino = fs::metadata(&partial_entry).expect("stat partial").ino();
+
+    run_one_inplace_copy(&source, &destination, true);
+
+    assert_eq!(
+        fs::metadata(&destination).expect("stat dest").ino(),
+        staged_ino,
+        "the committed destination must be the partial-dir entry renamed into place"
+    );
+    assert_eq!(fs::read(&destination).expect("read dest"), new);
+}
+
+/// A partial-dir leaf that is a symlink is not upstream's `partialptr`:
+/// `link_stat(partialptr, &st, 0)` is an lstat and `S_ISREG` refuses it
+/// (generator.c:2173-2179), so the transfer stays on the temp+rename path and
+/// the symlink target is never written through.
+#[cfg(unix)]
+#[test]
+fn partial_dir_symlink_leaf_is_not_a_one_inplace_target() {
+    let temp = tempdir().expect("tempdir");
+    let outside = temp.path().join("outside.bin");
+    fs::write(&outside, b"untouched").expect("write outside");
+
+    let source = temp.path().join("source.bin");
+    let dest_dir = temp.path().join("dest");
+    let partial_dir = dest_dir.join("pdir");
+    fs::create_dir_all(&partial_dir).expect("create partial dir");
+    fs::write(&source, b"payload").expect("write source");
+    std::os::unix::fs::symlink(&outside, partial_dir.join("source.bin")).expect("symlink");
+
+    let destination = dest_dir.join("source.bin");
+    run_one_inplace_copy(&source, &destination, true);
+
+    assert_eq!(fs::read(&destination).expect("read dest"), b"payload");
+    assert_eq!(
+        fs::read(&outside).expect("read outside"),
+        b"untouched",
+        "a symlinked partial-dir leaf must not receive the payload"
+    );
+}

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -28,11 +28,47 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
-use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 
-use rustix::fs::{AtFlags, FileType, Mode, OFlags};
+use rustix::fs::{Mode, OFlags};
 use rustix::io::Errno;
+
+use crate::dir_sandbox::at_syscalls;
+
+/// Issue the walk's `openat(2)` through the platform C library.
+///
+/// Every syscall this resolver makes goes through `fast_io`'s own libc-backed
+/// `*at` primitives rather than `rustix`, whose `linux_raw` backend issues the
+/// syscall instruction directly and bypasses libc entirely. Upstream's walk is
+/// plain C - `syscall.c:469` calls `openat(2)` from libc - so anything that
+/// interposes on the libc symbol (an operator's `LD_PRELOAD` shim, `fakeroot`,
+/// an audit or sandbox preload) sees upstream's resolution and, before this,
+/// did NOT see oc's. That is the same class of divergence as reading the euid
+/// from a raw syscall while upstream reads it from libc: the two answer
+/// different questions in an interposed process.
+///
+/// The `*at` form is also what the daemon's seccomp allowlist admits; see
+/// `open_start_dir` for why the no-dirfd `open(2)` is never used here.
+///
+/// `O_LARGEFILE` is added on Linux because `rustix`'s `linux_raw` backend adds
+/// it unconditionally and the plain libc `openat` symbol does not. It is a
+/// no-op on every 64-bit target, so this is not a behaviour choice - it keeps
+/// the emitted flag word identical to what this walk issued before, which is
+/// what makes the switch a backend change and nothing else.
+fn walk_openat(
+    dirfd: BorrowedFd<'_>,
+    name: &OsStr,
+    flags: OFlags,
+    mode: Mode,
+) -> io::Result<OwnedFd> {
+    #[allow(unused_mut)]
+    let mut raw_flags = flags.bits() as libc::c_int;
+    #[cfg(target_os = "linux")]
+    {
+        raw_flags |= libc::O_LARGEFILE;
+    }
+    at_syscalls::openat(dirfd, name, raw_flags, u32::from(mode.bits())).map(OwnedFd::from)
+}
 
 /// Symlink-follow budget for one walk, spent across every component.
 ///
@@ -81,8 +117,7 @@ pub fn symlink_owner_is_trusted(uid: u32) -> bool {
 /// `flags` comes from [`traversal_dir_flags`] - this descriptor is a step, not
 /// the answer.
 fn open_dir_component(dirfd: BorrowedFd<'_>, name: &OsStr, flags: OFlags) -> io::Result<OwnedFd> {
-    rustix::fs::openat(dirfd, name, flags | OFlags::NOFOLLOW, Mode::empty())
-        .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
+    walk_openat(dirfd, name, flags | OFlags::NOFOLLOW, Mode::empty())
 }
 
 /// The components a walk must step through, in order.
@@ -286,13 +321,12 @@ fn open_start_dir(absolute: bool, flags: OFlags) -> io::Result<OwnedFd> {
     // the raw `SYS_open` for the no-dirfd form, and the daemon's seccomp
     // allowlist admits only the `*at` variants, so a plain `open` is EPERM'd
     // inside a worker. `openat(AT_FDCWD, p, ..)` is the same operation.
-    rustix::fs::openat(
+    walk_openat(
         rustix::fs::CWD,
-        if absolute { "/" } else { "." },
+        OsStr::new(if absolute { "/" } else { "." }),
         flags,
         Mode::empty(),
     )
-    .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
 }
 
 /// Open the walk's final component with the caller's flags.
@@ -309,13 +343,12 @@ fn open_final(
     flags: OFlags,
     mode: Mode,
 ) -> io::Result<OwnedFd> {
-    rustix::fs::openat(
+    walk_openat(
         dirfd,
         name,
         flags | OFlags::NOFOLLOW | OFlags::CLOEXEC,
         mode,
     )
-    .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))
 }
 
 /// Walk `path` component-by-component and open its final component.
@@ -400,8 +433,7 @@ fn owner_walk_open_tracked(
             path
         };
         // `openat`/`CWD` for the same seccomp reason as `open_start_dir`.
-        return rustix::fs::openat(rustix::fs::CWD, target, flags, mode)
-            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()));
+        return walk_openat(rustix::fs::CWD, target.as_os_str(), flags, mode);
     }
 
     let mut pending = walk_components(path);
@@ -415,33 +447,34 @@ fn owner_walk_open_tracked(
         let name = pending.remove(0);
         let is_last = pending.is_empty();
 
-        let stat =
-            match rustix::fs::statat(dirfd.as_fd(), name.as_os_str(), AtFlags::SYMLINK_NOFOLLOW) {
-                Ok(stat) => stat,
-                // upstream: syscall.c:381-396 - the leaf may legitimately not exist
-                // yet under O_CREAT (the `--log-file=/tmp/dir/rsync.log` shape).
-                // Open it with O_NOFOLLOW so a leaf raced into a symlink between
-                // this failed stat and the open is still refused.
-                Err(errno)
-                    if is_last && errno == Errno::NOENT && flags.contains(OFlags::CREATE) =>
-                {
-                    // upstream: syscall.c:387-391 - the confinement is checked on
-                    // this arm too. A create is exactly where a redirected leaf
-                    // does its damage, so skipping it here would leave the
-                    // `--partial-dir`/`--temp-dir` shapes unconfined.
-                    tracker.step(&name);
-                    tracker.refuse_if_outside()?;
-                    *resolved = tracker.resolved().map(Path::to_path_buf);
-                    return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
-                }
-                Err(errno) => return Err(io::Error::from_raw_os_error(errno.raw_os_error())),
-            };
+        let stat = match at_syscalls::fstatat_nofollow(dirfd.as_fd(), name.as_os_str()) {
+            Ok(stat) => stat,
+            // upstream: syscall.c:381-396 - the leaf may legitimately not exist
+            // yet under O_CREAT (the `--log-file=/tmp/dir/rsync.log` shape).
+            // Open it with O_NOFOLLOW so a leaf raced into a symlink between
+            // this failed stat and the open is still refused.
+            Err(error)
+                if is_last
+                    && error.raw_os_error() == Some(libc::ENOENT)
+                    && flags.contains(OFlags::CREATE) =>
+            {
+                // upstream: syscall.c:387-391 - the confinement is checked on
+                // this arm too. A create is exactly where a redirected leaf
+                // does its damage, so skipping it here would leave the
+                // `--partial-dir`/`--temp-dir` shapes unconfined.
+                tracker.step(&name);
+                tracker.refuse_if_outside()?;
+                *resolved = tracker.resolved().map(Path::to_path_buf);
+                return open_final(dirfd.as_fd(), name.as_os_str(), flags, mode);
+            }
+            Err(error) => return Err(error),
+        };
 
-        if FileType::from_raw_mode(stat.st_mode as _) == FileType::Symlink {
+        if stat.is_symlink() {
             // upstream: syscall.c:406 - an other-uid symlink is the attacker's
             // and is refused; uid 0 or our own euid is the operator's own
             // layout and is followed. This arm is reached for the leaf too.
-            if !symlink_owner_is_trusted(stat.st_uid) {
+            if !symlink_owner_is_trusted(stat.uid()) {
                 return Err(io::Error::from_raw_os_error(libc::ELOOP));
             }
             if hops == 0 {
@@ -449,9 +482,7 @@ fn owner_walk_open_tracked(
             }
             hops -= 1;
 
-            let target = rustix::fs::readlinkat(dirfd.as_fd(), name.as_os_str(), Vec::new())
-                .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()))?;
-            let target = PathBuf::from(OsStr::from_bytes(target.as_bytes()));
+            let target = at_syscalls::readlinkat(dirfd.as_fd(), name.as_os_str())?;
             if target.is_absolute() {
                 // upstream: syscall.c:445 "followed an absolute target: restart from /".
                 dirfd = open_start_dir(true, traverse)?;
@@ -476,7 +507,7 @@ fn owner_walk_open_tracked(
 
         // upstream: syscall.c:479 - an interior component that is not a
         // directory is ENOTDIR, not a silent stop.
-        if FileType::from_raw_mode(stat.st_mode as _) != FileType::Directory {
+        if !stat.is_dir() {
             return Err(io::Error::from_raw_os_error(libc::ENOTDIR));
         }
         dirfd = open_dir_component(dirfd.as_fd(), name.as_os_str(), traverse)?;
@@ -493,8 +524,12 @@ fn owner_walk_open_tracked(
     // subject to the sandbox exactly as that one was.
     *resolved = tracker.resolved().map(Path::to_path_buf);
     if by_location {
-        return rustix::fs::openat(dirfd.as_fd(), ".", flags | OFlags::CLOEXEC, mode)
-            .map_err(|errno| io::Error::from_raw_os_error(errno.raw_os_error()));
+        return walk_openat(
+            dirfd.as_fd(),
+            OsStr::new("."),
+            flags | OFlags::CLOEXEC,
+            mode,
+        );
     }
     Ok(dirfd)
 }

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -67,7 +67,16 @@ fn walk_openat(
     {
         raw_flags |= libc::O_LARGEFILE;
     }
-    at_syscalls::openat(dirfd, name, raw_flags, u32::from(mode.bits())).map(OwnedFd::from)
+    // `Mode::bits()` returns `rustix::fs::RawMode`, which IS `libc::mode_t`:
+    // `u32` on Linux but `u16` on macOS. The widening is load-bearing there and
+    // reflexive here, so clippy flags it on Linux only. Both spellings lose:
+    // `u32::from(..)` trips `useless_conversion` and `.. as u32` trips
+    // `unnecessary_cast`, each on the target where the width already matches.
+    // Obeying either lint drops the conversion and breaks the macOS build, so
+    // the allow is the portable answer - same reason as the `unused_mut` above.
+    #[allow(clippy::useless_conversion)]
+    let raw_mode = u32::from(mode.bits());
+    at_syscalls::openat(dirfd, name, raw_flags, raw_mode).map(OwnedFd::from)
 }
 
 /// Symlink-follow budget for one walk, spent across every component.

--- a/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
+++ b/crates/transfer/src/disk_commit/tests_partial_interrupt_parity.rs
@@ -413,16 +413,21 @@ fn parity_partial_dir_disconnect_retains_without_mtime_zero() {
     );
 }
 
-// Why the receiver must never pick an inplace write for a --partial-dir resume.
+// Why this receiver must not report a --partial-dir resume as an inplace write.
 
-/// An inplace write (is_inplace == true, needs_rename == false) targets the live
-/// destination directly, and on interrupt the partial data is LEFT at the live
-/// destination name - it is never relocated into the partial dir. This is the
-/// exact data-integrity hazard the receiver's `resolve_use_inplace` avoids by
-/// keeping a `--partial-dir` resume a temp+rename transfer (see
-/// `crate::transfer_ops`): upstream's one_inplace writes to the partial file
-/// (partialptr), not the live destination (receiver.c:910,969), so the live name
-/// never holds a truncated file.
+/// This receiver's inplace mode (`is_inplace == true`, `needs_rename == false`)
+/// has exactly one target: the live destination. On interrupt the partial data
+/// is LEFT at the live destination name and is never relocated into the partial
+/// dir.
+///
+/// That is a property of THIS implementation, not of upstream's `one_inplace`.
+/// Upstream's in-place target under `one_inplace` is `partialptr` - the file in
+/// the partial dir - not `fname` (`rsync-3.5.0/receiver.c:1195-1196`), so the
+/// live name never holds a truncated file there either. What this test pins is
+/// that `resolve_use_inplace` must keep a `--partial-dir` resume on the
+/// temp+rename path for as long as the disk commit has no partial-dir staging
+/// target to write into; see `crate::transfer_ops` for the full reasoning and
+/// for the local-copy executor that does implement upstream's shape.
 #[test]
 fn inplace_partial_dir_would_leave_incomplete_file_at_live_dest() {
     let _registry_lock = test_support::cleanup_registry_test_guard();

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -222,37 +222,71 @@ pub struct ResponseContext<'a> {
 /// existing content (append implies inplace, and the sender only transmits the
 /// data beyond the existing length).
 ///
-/// A `--partial-dir` resume is deliberately excluded. When the `I` capability is
-/// negotiated (`inplace_partial`) and the basis is the partial-dir file
-/// (`FNAMECMP_PARTIAL_DIR`), upstream's `one_inplace` (receiver.c:910) writes the
-/// reconstruction in place to the partial file itself (`partialptr`,
-/// receiver.c:969) and renames it onto the destination only once the transfer
-/// completes, so an interrupt leaves the grown partial inside the partial dir and
-/// never a truncated file at the live destination name. oc reaches the same
-/// observable end state by reconstructing from the partial-dir basis into a temp
-/// file and renaming on commit: keeping the transfer temp+rename
-/// (`needs_rename == true`) lets the disk thread relocate the in-flight temp back
-/// into the partial dir on interrupt (`retain_partial_file`'s `PartialDir` branch,
-/// cleanup.c:105-115). Taking the inplace path for the resume would instead write
-/// the reconstruction directly to the live destination and leave a full-size but
-/// incomplete file there on interrupt - a silent data-integrity hazard.
+/// A `--partial-dir` resume returns `false` here, and the reason is narrower
+/// than an earlier revision of this comment claimed.
 ///
-/// `--inplace`/`--append` never combine with `--partial-dir` (rejected during
-/// config validation), so the exclusion only ever suppresses the `one_inplace`
-/// case; it is defensive against the two being wired together in the future.
+/// That revision argued the exclusion on data-integrity grounds: that taking the
+/// in-place path for a partial-dir resume "would write the reconstruction
+/// directly to the live destination and leave a full-size but incomplete file
+/// there on interrupt". **That misread upstream.** Upstream's in-place target
+/// under `one_inplace` is not the destination at all:
+///
+/// ```c
+/// /* receiver.c:1195-1196 */
+/// if (inplace || one_inplace)  {
+///         fnametmp = one_inplace ? partialptr : fname;
+/// ```
+///
+/// `partialptr` is the file inside the `--partial-dir`, so the reconstruction
+/// grows there and only `finish_transfer(fname, fnametmp, ...)`
+/// (`receiver.c:1288`) puts it at the destination name. An interrupt therefore
+/// leaves the grown partial in the partial dir and never a truncated file at the
+/// live name - the hazard the old rationale described was a property of writing
+/// to `fname`, which upstream does not do on this branch. It is upstream's whole
+/// design goal, not a risk it takes.
+///
+/// What is actually true is that this receiver has no third output mode. It can
+/// open the destination (`is_inplace`) or a temp it renames, and nothing else;
+/// the partial-dir path reaches it only as an interrupt destination
+/// (`retain_partial_file`) and a `--delay-updates` staging dir. Returning `true`
+/// here would therefore be wrong - not because upstream's design is unsafe, but
+/// because oc would carry out the *other* half of upstream's ternary. Until the
+/// partial-dir staging target is threaded through `BeginMessage` and the disk
+/// commit, falling back to temp+rename is the correct subset: it reaches the
+/// same observable end state, and an interrupt still relocates the in-flight
+/// temp into the partial dir (`retain_partial_file`'s `PartialDir` branch,
+/// `cleanup.c:169-170`).
+///
+/// The local-copy executor does implement upstream's shape - see
+/// `engine::local_copy`'s `WriteStrategy::InplacePartialDir` and
+/// `DestinationWriteGuard::new_one_inplace`, which open `partialptr` through the
+/// three-arm chain with `InplaceResolution::OperatorWalk` and rename it onto the
+/// destination on commit. This function is the wire receiver's half of the same
+/// gap and is still open.
+///
+/// Note that the suppression is currently unreachable either way:
+/// `inplace_partial` is only ever set alongside `--partial-dir`
+/// (`transfer/src/lib.rs`), and `--inplace`/`--append` with `--partial-dir` is
+/// rejected during config validation, so `inplace` and `one_inplace_partial_dir`
+/// cannot both be true. Do not read a green suite as evidence that this arm
+/// works.
 ///
 /// # Upstream Reference
 ///
 /// `inplace` already carries `--append`: `ServerConfig::apply_append_implies_inplace`
 /// materialises upstream's `options.c:2410` promotion before the transfer starts,
-/// so this reads the single flag exactly as `receiver.c:968` does.
+/// so this reads the single flag exactly as `receiver.c:1195` does.
 ///
-/// # Upstream Reference
-///
-/// - `receiver.c:968` - `if (inplace || one_inplace)`.
-/// - `receiver.c:910` - `one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR`.
-/// - `receiver.c:969` - `fnametmp = one_inplace ? partialptr : fname`.
-/// - `cleanup.c:105-115` - `handle_partial_dir()` moves the temp into the partial dir.
+/// - `rsync-3.5.0/receiver.c:1195` - `if (inplace || one_inplace)`.
+/// - `rsync-3.5.0/receiver.c:1137-1138` - `one_inplace = inplace_partial &&
+///   fnamecmp_type == FNAMECMP_PARTIAL_DIR && fd1 != -1`.
+/// - `rsync-3.5.0/receiver.c:1196` - `fnametmp = one_inplace ? partialptr : fname`.
+/// - `rsync-3.5.0/receiver.c:1288-1299` - `finish_transfer(fname, fnametmp, ...)`
+///   then `handle_partial_dir(partialptr, PDIR_DELETE)`, with the
+///   `do_unlink_at(partialptr)` skipped under `one_inplace`.
+/// - `rsync-3.5.0/cleanup.c:169-170` - `_exit_cleanup()` calls
+///   `handle_partial_dir(cleanup_new_fname, PDIR_CREATE)` on the abort path; that
+///   is what moves an interrupted temp into the partial dir.
 fn resolve_use_inplace(
     inplace: bool,
     inplace_partial: bool,

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -233,7 +233,7 @@ output-options pass
 ownership-depth pass
 partial pass
 partial-dir-abs-delta pass
-partial-protected-regular-retry-linux fail
+partial-protected-regular-retry-linux pass
 partial-protected-regular-retry-policy skip
 partial_nowrite pass
 password-file-symlink skip

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -233,7 +233,7 @@ output-options pass
 ownership-depth pass
 partial pass
 partial-dir-abs-delta pass
-partial-protected-regular-retry-linux fail
+partial-protected-regular-retry-linux pass
 partial-protected-regular-retry-policy skip
 partial_nowrite pass
 password-file-symlink pass


### PR DESCRIPTION
## What

Mirrors upstream's `one_inplace` in the local-copy receiver: when a `--partial-dir` entry for a file already exists as a regular file, the reconstruction is written **into that entry** and the entry is renamed onto the destination on commit.

`rsync-3.5.0/receiver.c:1195-1196`:

```c
if (inplace || one_inplace)  {
        fnametmp = one_inplace ? partialptr : fname;
```

The in-place target under `one_inplace` is `partialptr` - the file inside the partial dir - **never** the live destination. `receiver.c:1137-1138` gates it (`inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR && fd1 != -1`), `receiver.c:1204-1224` opens it through the three-arm chain with `one_inplace` threaded into **every** arm, and `receiver.c:1288-1299` renames it onto the destination and then removes the emptied partial dir - without unlinking the entry, because `finish_transfer()` already renamed it away.

Before this, oc reconstructed into a temp beside the destination and deleted the partial entry afterwards, so `pdir/<name>` was never opened at all.

Measured end to end on aarch64 Linux - an ordinary `--partial-dir` transfer, nothing refusing anything, 90000-byte stale partial replaced by a 40960-byte source:

```
openat(<mod>, "pdir", O_RDONLY|O_NOFOLLOW|O_CLOEXEC|O_PATH|O_DIRECTORY) = 5
openat(5, "victim", O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW|O_CLOEXEC, 0600) = 3
renameat(<pdir>, "victim", <mod>, "victim")                             = 0
unlinkat(AT_FDCWD, "<mod>/pdir", AT_REMOVEDIR)                          = 0
```

`rc=0`, destination byte-identical to the source, no unlink of the entry.

## `OperatorWalk` gets its first production call site

`fast_io::InplaceResolution::OperatorWalk` and the three-arm `open_inplace_output` chain were already ported and correct, but `OperatorWalk` was constructed at **zero** production sites - all 10 occurrences repo-wide were in `fast_io`'s own unit tests. `DestinationWriteGuard::new_one_inplace` is its first. No parallel resolver was written.

## The ownership walk now issues its syscalls through libc

`fast_io::owner_walk` used `rustix`, whose `linux_raw` backend issues the syscall instruction directly and bypasses libc. Upstream's walk is plain C against libc (`syscall.c:469`), so an interposition layer an operator has in place - `fakeroot`, an audit or sandbox preload - sees upstream's resolution and did **not** see oc's. Measured, driving `--exclude-from` through the walk:

| syscall | strace | LD_PRELOAD `openat` shim |
| --- | --- | --- |
| `openat(3, "cfg", …O_PATH\|O_DIRECTORY)` | seen | **not seen** |
| `openat(4, "excl", …)` | seen | **not seen** |

The walk now routes onto `fast_io`'s own libc-backed `*at` primitives (`at_syscalls::openat` / `fstatat_nofollow` / `readlinkat`), which the crate already owns and audits. Same syscalls, same flags (`O_LARGEFILE` is re-added explicitly on Linux because rustix added it), same checks - the resolver logic is untouched. This is the same class as the `am_root`/`fakeroot` divergence: a raw syscall answers a different question than upstream's libc call in an interposed process.

## The doc comment that argued the opposite

`resolve_use_inplace`'s comment argued the wire receiver's exclusion on data-integrity grounds - that taking the in-place path for a `--partial-dir` resume "would write the reconstruction directly to the live destination and leave a full-size but incomplete file there on interrupt". That read upstream's in-place target as `fname`; it is `partialptr`, so the hazard it described was a property of oc's implementation, not of upstream's design. The comment now states the real reason - this receiver has no partial-dir output mode to write into - and records that the suppression is unreachable today anyway, because `--inplace` and `--partial-dir` are rejected together during config validation. The parity test's comment is corrected to match, and a stale `cleanup.c:105-115` citation is retargeted to the `handle_partial_dir()` call at `cleanup.c:169-170`.

## Testsuite

`tools/ci/upstream-3.5.0-expect.{nonroot,root}.txt`: `partial-protected-regular-retry-linux` **fail → pass**, measured on both legs.

The cell builds an `LD_PRELOAD` shim that synthesises the `EACCES` an `fs.protected_regular` kernel raises on the `O_CREAT` open of the partial entry, swaps the partial dir for a foreign-owned symlink inside that window, and checks the retry keeps the ownership walk.

**Two independent causes**, each proven by reverting it alone and rebuilding - the cell reddens with the original `receiver did not open the existing partial file with O_CREAT`:

| mutation | cell |
| --- | --- |
| `one_inplace_partial_file` forced to `None` (staging reverted, walk kept) | FAIL |
| `walk_openat` reverted to `rustix::fs::openat` (walk backend reverted, staging kept) | FAIL |
| neither | PASS |

Upstream 3.5.0 itself passes the cell on the same host; that was the control run.

Full 3.5.0 suite against the manifests on that host: nonroot 254 pass / 5 fail / 86 skip, root 281 / 7 / 57. Expected-result mismatches: `simd-checksum` skips on aarch64 in both legs (no x86 SIMD), and the root leg's `batch-file-symlink` failed once during a run with the host at 98% disk and three other builds active - it passes 3/3 in isolation there.

## Non-vacuity companions

New engine tests: an ordinary `--partial-dir` transfer stays byte-correct with and without a delta pass and clears the partial dir; the committed destination wears the **inode the partial entry had** (a rename, not a fresh temp - this one fails on the old behaviour); a symlink at the partial leaf is refused as a staging target (`link_stat` + `S_ISREG`, `generator.c:2173-2179`) and its target is untouched; and `select_write_strategy` returns `InplacePartialDir` only when the gate is on.

## Known remaining gap

The local `--partial-dir` leaf is now a `one_inplace` staging target but is still **not** a delta basis: upstream's generator also sets `fnamecmp = partialptr` (`generator.c:2270-2273`) and lets a final `ftruncate` size the result, whereas this executor still picks its basis from the destination or a `--fuzzy` candidate only. Because nothing reads the entry back, it is opened `O_TRUNC` where upstream does not - stated in full at the call site so the compensating half is visible. The wire receiver has neither half; `resolve_use_inplace`'s comment now says so.

## One deliberate departure from upstream's precedence

`--append` keeps its own strategy even when a partial-dir entry exists, where upstream's ternary would pick `partialptr`. Upstream's append seek (`receiver.c:372-373`) takes its offset from `sx.st`, which the generator has already replaced with `partial_st` (`generator.c:2271`) - the *partial* file's length. This executor derives `append_offset` from the destination's length, which is not the file `one_inplace` writes into, so honouring it there would seek to the wrong offset in the wrong file. `--append` and `--partial-dir` are rejected together through the CLI anyway. Stated at the selector, with a unit test.
