### PR TITLE
perf(fast_io): stop waiting for the SEND_ZC notification CQE

### DIFF
--- a/crates/fast_io/src/io_uring/mod.rs
+++ b/crates/fast_io/src/io_uring/mod.rs
@@ -116,6 +116,9 @@ pub mod registered_buffers;
 pub mod renameat2;
 /// `IORING_OP_SEND_ZC` zero-copy socket-send primitive (Linux 6.0+).
 pub mod send_zc;
+/// Pipelined `IORING_OP_SEND_ZC` submission that defers the page-release
+/// notification instead of blocking on it.
+mod send_zc_pipeline;
 /// Pool of long-lived io_uring instances shared across consumers in a session.
 pub mod session_pool;
 /// Single io_uring ring shared by a reader fd and a writer fd in one session.

--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -12,10 +12,18 @@
 //!    `result()` is unused.
 //!
 //! The buffer passed to a SEND_ZC submission must remain valid and unmodified
-//! until the notification CQE arrives. This module enforces that contract by
-//! blocking on both CQEs before returning. Callers therefore see SEND_ZC as
-//! a synchronous primitive even though the kernel performs the page release
-//! asynchronously.
+//! until the notification CQE arrives. [`try_send_zc`] discharges that
+//! contract the blunt way: it blocks on both CQEs, so callers see SEND_ZC as
+//! a synchronous primitive that may be handed a borrowed slice.
+//!
+//! That is correct but slow. The kernel releases the pages only once the peer
+//! has consumed the data, so waiting for the notification couples the
+//! sender's rate to the receiver's drain rate and keeps exactly one send in
+//! flight. [`super::send_zc_pipeline::SendZcPipeline`] is the throughput
+//! path: it waits only for the transfer CQE and keeps a pool of owned buffers
+//! alive until their notifications land. Use [`try_send_zc`] when the payload
+//! is a caller-owned slice that must be released on return; use the pipeline
+//! when the payload can be moved into a buffer the sender owns.
 //!
 //! See `docs/design/iouring-send-zc.md` for the full design.
 //!
@@ -47,10 +55,10 @@ use super::config::IoUringConfig;
 use super::registered_buffers::RegisteredBufferGroup;
 
 /// CQE flag set on the transfer CQE; signals a notification CQE will follow.
-const IORING_CQE_F_MORE: u32 = 1 << 1;
+pub(super) const IORING_CQE_F_MORE: u32 = 1 << 1;
 
 /// CQE flag set on the notification CQE.
-const IORING_CQE_F_NOTIF: u32 = 1 << 3;
+pub(super) const IORING_CQE_F_NOTIF: u32 = 1 << 3;
 
 /// Sentinel `user_data` mask used to keep the SEND_ZC submission from
 /// colliding with other CQEs draining on the same ring.

--- a/crates/fast_io/src/io_uring/send_zc_pipeline.rs
+++ b/crates/fast_io/src/io_uring/send_zc_pipeline.rs
@@ -1,0 +1,562 @@
+//! Pipelined `IORING_OP_SEND_ZC` submission for the socket write path.
+//!
+//! `IORING_OP_SEND_ZC` posts two completions per submission: a **transfer**
+//! CQE ("the bytes are queued for transmit", carrying the byte count and
+//! `IORING_CQE_F_MORE` when a notification will follow) and a
+//! **notification** CQE (`IORING_CQE_F_NOTIF`, "the kernel has released its
+//! reference to your pages").
+//!
+//! [`super::send_zc::try_send_zc`] waits for both, which makes it a drop-in
+//! replacement for `send(2)` but forfeits the entire point of zero-copy: the
+//! kernel releases the pages only once the peer has consumed the data, so
+//! waiting for the notification couples the sender's rate to the receiver's
+//! drain rate and allows exactly one send in flight. Measured on a 200 MB
+//! loopback daemon pull (6400 sends of 32776 bytes), the notification wait
+//! was 75% of the time spent inside `try_send_zc` and accounted for the bulk
+//! of a 4x end-to-end regression against a plain socket write.
+//!
+//! This module splits the two waits apart:
+//!
+//! - The **transfer** CQE is still awaited synchronously. It carries the byte
+//!   count (so short sends are handled exactly as before) and any `-errno`,
+//!   and once it has been observed the bytes are in the socket's transmit
+//!   queue - which is what preserves wire ordering against every other writer
+//!   on the same fd.
+//! - The **notification** CQE is *not* awaited. The buffer it refers to stays
+//!   owned by this pipeline, unwritten and unfreed, until the notification
+//!   arrives. A pool of [`SEND_ZC_INFLIGHT_BUFFERS`] buffers lets the caller
+//!   keep filling a fresh buffer while earlier ones are still pinned, and
+//!   bounds the memory an un-reaped notification can hold.
+//!
+//! # Buffer-lifetime contract
+//!
+//! Callers hand the pipeline an **owned** buffer, never a borrowed slice:
+//! [`SendZcPipeline::send_staged`] swaps the caller's staging buffer for one
+//! the kernel has already released. There is therefore no way for a caller to
+//! observe, reuse, or free a buffer the kernel still holds. The pinned
+//! buffers outlive the submission because the pipeline owns them, and
+//! [`SendZcPipeline::drop`] drains every outstanding notification before any
+//! of them is deallocated (leaking the still-pinned buffers rather than
+//! freeing them if the drain itself fails).
+//!
+//! # Why a dedicated ring
+//!
+//! Deferred notifications mean CQEs from this pipeline stay queued across
+//! calls. Every other io_uring consumer on the calling thread
+//! ([`super::batching::submit_send_batch`] in particular) drains the shared
+//! per-thread ring's completion queue unconditionally and demultiplexes by
+//! `user_data` alone, so a stray notification left on that ring would be
+//! consumed by - and misread as - somebody else's completion. Owning a
+//! private ring makes the demux question disappear: nothing else ever submits
+//! to or reaps from it. The ring is per socket writer, i.e. per connection,
+//! not per file or per operation, so it does not reintroduce the shared-ring
+//! serialisation IUR-3 removed.
+//!
+//! oc-only: upstream rsync has no io_uring path, so there is no upstream
+//! behaviour to mirror here.
+
+use std::io;
+use std::os::unix::io::RawFd;
+
+use io_uring::{IoUring as RawIoUring, opcode, types};
+
+use super::send_zc::{IORING_CQE_F_MORE, IORING_CQE_F_NOTIF};
+
+/// Number of send buffers the pipeline keeps, and therefore the maximum
+/// number of buffers the kernel may hold pinned at once.
+///
+/// One buffer is enough for correctness but not for throughput: the caller
+/// would stall on the previous notification before it could refill. Four
+/// covers the measured loopback ratio - a 32 KiB send reaches its transfer
+/// CQE in ~12 us but its notification only ~28 us later, so roughly three
+/// sends are in flight during one notification window - and caps the
+/// pipeline's footprint at `4 * buffer_size` (256 KiB for the daemon's
+/// 64 KiB socket buffer) per connection.
+pub(super) const SEND_ZC_INFLIGHT_BUFFERS: usize = 4;
+
+/// One pooled send buffer plus the count of submissions referencing it whose
+/// page reference the kernel has not released yet.
+///
+/// `pending` is incremented when an SQE referencing `buf` is pushed and
+/// decremented exactly once per submission - either by the notification CQE,
+/// or by a transfer CQE with `IORING_CQE_F_MORE` clear, which is the kernel's
+/// way of saying no notification will follow. Counting up at submit time
+/// keeps `pending` an upper bound at every instant, so a buffer is never
+/// considered free while the kernel might still be reading it.
+struct PinnedBuffer {
+    buf: Vec<u8>,
+    pending: u32,
+}
+
+/// A private io_uring ring plus a pool of owned send buffers, submitting
+/// `IORING_OP_SEND_ZC` without waiting for the notification CQE.
+///
+/// See the module docs for the buffer-lifetime contract and the reason the
+/// ring is not shared.
+pub(super) struct SendZcPipeline {
+    ring: RawIoUring,
+    fd: RawFd,
+    slots: Vec<PinnedBuffer>,
+}
+
+impl SendZcPipeline {
+    /// Builds a pipeline for `fd` with [`SEND_ZC_INFLIGHT_BUFFERS`] buffers of
+    /// `buffer_size` bytes each.
+    ///
+    /// The caller retains ownership of `fd`; the pipeline neither closes nor
+    /// duplicates it and MUST be dropped before the fd is closed (the drain in
+    /// [`SendZcPipeline::drop`] needs the ring, not the socket, but a closed fd
+    /// would make any in-flight submission complete with an error CQE that the
+    /// drain must still observe).
+    ///
+    /// # Errors
+    ///
+    /// The `io_uring_setup(2)` error when the ring cannot be created. Callers
+    /// treat that as "no zero-copy on this writer" and fall back to the plain
+    /// send path.
+    pub(super) fn new(fd: RawFd, buffer_size: usize) -> io::Result<Self> {
+        // One transfer CQE is outstanding at a time and at most
+        // SEND_ZC_INFLIGHT_BUFFERS notifications, so a submission queue of
+        // 2 * SEND_ZC_INFLIGHT_BUFFERS (whose default completion queue is
+        // twice that again) cannot overflow.
+        let entries = (2 * SEND_ZC_INFLIGHT_BUFFERS).next_power_of_two() as u32;
+        let ring = RawIoUring::new(entries)?;
+        let slots = (0..SEND_ZC_INFLIGHT_BUFFERS)
+            .map(|_| PinnedBuffer {
+                buf: vec![0u8; buffer_size],
+                pending: 0,
+            })
+            .collect();
+        Ok(Self { ring, fd, slots })
+    }
+
+    /// Sends the first `len` bytes of `staging` and leaves `staging` holding a
+    /// buffer whose pages the kernel has already released.
+    ///
+    /// Blocks until every one of those bytes has been accepted by the kernel
+    /// (each submission's transfer CQE), so on return the data is in the
+    /// socket's transmit queue and ordered ahead of anything a later writer
+    /// submits on the same fd. It does **not** block for the notification
+    /// CQEs; the bytes stay in a pipeline-owned buffer until they arrive.
+    ///
+    /// `staging` and every pooled buffer have the same length, so the swap
+    /// leaves the caller with a buffer of unchanged capacity.
+    ///
+    /// # Errors
+    ///
+    /// - [`io::ErrorKind::WriteZero`] when the kernel reports a zero-byte
+    ///   send, matching the plain send path's treatment of a stalled socket.
+    /// - The OS error carried by a transfer CQE, or any `io_uring_enter(2)`
+    ///   error. On error the partially-sent buffer stays owned by the
+    ///   pipeline and its notifications are still drained on drop.
+    pub(super) fn send_staged(&mut self, staging: &mut Vec<u8>, len: usize) -> io::Result<()> {
+        let slot = self.acquire_free_slot()?;
+        std::mem::swap(staging, &mut self.slots[slot].buf);
+        self.send_slot(slot, len)
+    }
+
+    /// Blocks until the kernel has released every buffer this pipeline owns.
+    ///
+    /// # Errors
+    ///
+    /// Any `io_uring_enter(2)` error while waiting. The caller cannot make the
+    /// buffers safe to free after such an error; [`SendZcPipeline::drop`]
+    /// leaks them instead.
+    pub(super) fn drain(&mut self) -> io::Result<()> {
+        let Self { ring, slots, .. } = self;
+        while slots.iter().any(|slot| slot.pending > 0) {
+            reap_queued(ring, slots);
+            if slots.iter().all(|slot| slot.pending == 0) {
+                break;
+            }
+            match ring.submit_and_wait(1) {
+                Ok(_) => {}
+                // A signal interrupted `io_uring_enter(2)`. Resuming the wait
+                // is a syscall restart, not a retry policy: the notification
+                // is still coming, and giving up here would force the drop
+                // path to leak the buffers it cannot prove are free.
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    /// Number of submissions whose pages the kernel has not released yet.
+    ///
+    /// Exposed for tests and diagnostics: a non-zero value right after
+    /// [`send_staged`](Self::send_staged) returns is what distinguishes this
+    /// pipeline from the synchronous
+    /// [`try_send_zc`](super::send_zc::try_send_zc).
+    #[cfg(test)]
+    pub(super) fn pending_notifications(&self) -> u32 {
+        self.slots.iter().map(|slot| slot.pending).sum()
+    }
+
+    /// Returns the index of a buffer the kernel is not holding, blocking on
+    /// notification CQEs when every buffer is pinned.
+    fn acquire_free_slot(&mut self) -> io::Result<usize> {
+        let Self { ring, slots, .. } = self;
+        loop {
+            reap_queued(ring, slots);
+            if let Some(idx) = slots.iter().position(|slot| slot.pending == 0) {
+                return Ok(idx);
+            }
+            ring.submit_and_wait(1)?;
+        }
+    }
+
+    /// Submits `len` bytes from `slots[slot]`, resubmitting the remainder on a
+    /// short send, and waits only for each submission's transfer CQE.
+    fn send_slot(&mut self, slot: usize, len: usize) -> io::Result<()> {
+        let Self { ring, fd, slots } = self;
+        let mut sent = 0usize;
+        while sent < len {
+            let remaining = len - sent;
+            // SAFETY: `sent < len <= buf.len()`, so the offset stays inside
+            // the buffer's allocation and `remaining` bytes from it do too.
+            let ptr = unsafe { slots[slot].buf.as_ptr().add(sent) };
+            let entry = opcode::SendZc::new(types::Fd(*fd), ptr, remaining as u32)
+                .build()
+                .user_data(slot as u64);
+
+            slots[slot].pending += 1;
+            // SAFETY: `entry` points into `slots[slot].buf`, which this
+            // pipeline owns. `pending` was incremented immediately above -
+            // before the SQE could complete - and only returns to zero once
+            // the kernel has posted the notification CQE for this submission
+            // (or told us via a cleared `IORING_CQE_F_MORE` that it will not
+            // post one). No caller can observe, refill, or free a buffer with
+            // `pending > 0`: `acquire_free_slot` skips it and
+            // `SendZcPipeline::drop` drains before any deallocation. The SQE
+            // also references `fd`, which the caller keeps open for at least
+            // the pipeline's lifetime.
+            let pushed = unsafe { ring.submission().push(&entry) };
+            if pushed.is_err() {
+                slots[slot].pending -= 1;
+                return Err(io::Error::other("SEND_ZC submission queue full"));
+            }
+
+            let result = wait_for_transfer(ring, slots)?;
+            if result < 0 {
+                return Err(io::Error::from_raw_os_error(-result));
+            }
+            if result == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "SEND_ZC reported zero bytes sent",
+                ));
+            }
+            sent += result as usize;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SendZcPipeline {
+    /// Drains every outstanding notification before the pooled buffers are
+    /// deallocated.
+    ///
+    /// This is the only thing standing between a deferred notification and a
+    /// use-after-free: the kernel may still be reading pages backing
+    /// `self.slots[..].buf`, and dropping a `Vec` frees them. The drain is
+    /// unconditional - it runs on the normal path, on the error path, and
+    /// during unwinding. If the drain itself fails (an `io_uring_enter(2)`
+    /// error leaves us unable to learn when the kernel is done), the still
+    /// pinned buffers are leaked with [`std::mem::forget`]: leaking memory is
+    /// sound, freeing memory the kernel holds a reference to is not.
+    ///
+    /// Closing the ring fd is *not* a substitute. io_uring teardown is
+    /// deferred to `io_ring_exit_work`, so the kernel's page references may
+    /// outlive `close(2)` on the ring.
+    fn drop(&mut self) {
+        if self.drain().is_ok() {
+            return;
+        }
+        for slot in &mut self.slots {
+            if slot.pending > 0 {
+                std::mem::forget(std::mem::take(&mut slot.buf));
+            }
+        }
+    }
+}
+
+/// Consumes every CQE already queued, updating per-slot notification
+/// accounting, and returns the result of the transfer CQE if one was among
+/// them.
+///
+/// At most one submission is outstanding at a time, so at most one transfer
+/// CQE can appear in a single drain; every other CQE is a notification for an
+/// earlier submission.
+fn reap_queued(ring: &mut RawIoUring, slots: &mut [PinnedBuffer]) -> Option<i32> {
+    let mut transfer = None;
+    for cqe in ring.completion() {
+        let Some(slot) = slots.get_mut(cqe.user_data() as usize) else {
+            continue;
+        };
+        if cqe.flags() & IORING_CQE_F_NOTIF != 0 {
+            slot.pending = slot.pending.saturating_sub(1);
+            continue;
+        }
+        if cqe.flags() & IORING_CQE_F_MORE == 0 {
+            // The kernel is telling us no notification will follow this
+            // submission (it failed before any page was pinned), so this
+            // transfer CQE is what settles the accounting for it.
+            slot.pending = slot.pending.saturating_sub(1);
+        }
+        transfer = Some(cqe.result());
+    }
+    transfer
+}
+
+/// Blocks until the outstanding submission's transfer CQE has been observed,
+/// reaping any notification CQEs that arrive alongside it.
+fn wait_for_transfer(ring: &mut RawIoUring, slots: &mut [PinnedBuffer]) -> io::Result<i32> {
+    loop {
+        if let Some(result) = reap_queued(ring, slots) {
+            return Ok(result);
+        }
+        ring.submit_and_wait(1)?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+    use std::net::{TcpListener, TcpStream};
+    use std::os::unix::io::AsRawFd;
+    use std::thread;
+    use std::time::Duration;
+
+    /// Payload for the tests whose peer never reads. Sized to fit entirely in
+    /// the socket buffers [`widen_socket_buffers`] asks for, so the transfer
+    /// CQE cannot block waiting for a receiver that never reads.
+    ///
+    /// These tests deliberately do **not** assert that the notification is
+    /// still outstanding when `send_staged` returns. On loopback it usually is
+    /// not: the packet is handed to the receiving socket immediately, so the
+    /// kernel releases its reference and posts the notification right behind
+    /// the transfer CQE, and a single quiet send reaps both in one drain. What
+    /// the pipeline changes is that it never *waits* for the notification -
+    /// a property visible only under load, and pinned by the end-to-end
+    /// benchmark rather than by a unit test.
+    const UNREAD_CHUNK: usize = 128 * 1024;
+
+    /// What the tests request for `SO_SNDBUF`/`SO_RCVBUF`. Linux doubles the
+    /// request and caps it at `net.core.{w,r}mem_max` (212992 by default), so
+    /// the effective buffer is at least ~416 KiB - comfortably above
+    /// [`UNREAD_CHUNK`].
+    const WIDE_SOCKET_BUFFER: libc::c_int = 1024 * 1024;
+
+    fn send_zc_unavailable() -> bool {
+        !super::super::config::is_io_uring_available() || !super::super::send_zc::is_supported()
+    }
+
+    /// Requests oversized send and receive buffers on `fd` so a
+    /// [`UNREAD_CHUNK`] payload can sit in the socket with nobody reading it.
+    fn widen_socket_buffers(fd: RawFd) {
+        for opt in [libc::SO_SNDBUF, libc::SO_RCVBUF] {
+            let value = WIDE_SOCKET_BUFFER;
+            // SAFETY: `fd` is an open socket owned by the caller for the
+            // duration of this call, `value` is a live `c_int` and the length
+            // matches its size, which is what SOL_SOCKET/SO_*BUF expect. A
+            // rejected request only leaves the default buffer in place.
+            unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    opt,
+                    std::ptr::addr_of!(value).cast(),
+                    std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                );
+            }
+        }
+    }
+
+    /// Connected loopback TCP pair, both ends widened, whose receiving end is
+    /// *not* being read.
+    fn loopback_pair() -> Option<(TcpStream, TcpStream)> {
+        let listener = TcpListener::bind("127.0.0.1:0").ok()?;
+        widen_socket_buffers(listener.as_raw_fd());
+        let addr = listener.local_addr().ok()?;
+        let client = TcpStream::connect(addr).ok()?;
+        widen_socket_buffers(client.as_raw_fd());
+        let (peer, _) = listener.accept().ok()?;
+        widen_socket_buffers(peer.as_raw_fd());
+        Some((client, peer))
+    }
+
+    /// The enabling fact for deferring the notification: the buffer the kernel
+    /// is handed is **not** the buffer the caller keeps. `send_staged` swaps
+    /// rather than copies, so the caller comes back holding a different
+    /// allocation of the same size and can refill it immediately, whatever the
+    /// kernel is still doing with the one it took.
+    ///
+    /// Waiting for the notification would make this swap pointless; not
+    /// swapping would make skipping the wait unsound. The assertion is on
+    /// pointer identity, which neither depends on timing nor on whether the
+    /// kernel chose to pin or copy the pages.
+    #[test]
+    fn send_staged_hands_the_kernel_a_buffer_the_caller_no_longer_holds() {
+        if send_zc_unavailable() {
+            println!("skipping: IORING_OP_SEND_ZC unavailable on this host");
+            return;
+        }
+        let Some((client, peer)) = loopback_pair() else {
+            println!("skipping: cannot build a loopback pair");
+            return;
+        };
+        let mut pipeline = match SendZcPipeline::new(client.as_raw_fd(), UNREAD_CHUNK) {
+            Ok(p) => p,
+            Err(e) => {
+                println!("skipping: cannot build the SEND_ZC ring ({e})");
+                return;
+            }
+        };
+
+        let mut staging = vec![7u8; UNREAD_CHUNK];
+        let submitted = staging.as_ptr();
+        pipeline
+            .send_staged(&mut staging, UNREAD_CHUNK)
+            .expect("SEND_ZC accepted the payload");
+        assert_eq!(
+            staging.len(),
+            UNREAD_CHUNK,
+            "the swapped-in buffer keeps the caller's capacity"
+        );
+        assert!(
+            !std::ptr::eq(staging.as_ptr(), submitted),
+            "the caller must be left holding a different allocation from the \
+             one handed to the kernel"
+        );
+        assert!(
+            pipeline.pending_notifications() <= 1,
+            "one submission cannot leave more than one notification pending"
+        );
+
+        drop(peer);
+        drop(pipeline);
+        drop(client);
+    }
+
+    /// Round-trips more buffers than the pool holds, which forces
+    /// `acquire_free_slot` to block on notifications and recycle. Verifies
+    /// both the byte stream and that the drain settles the accounting.
+    #[test]
+    fn pipeline_recycles_buffers_across_more_sends_than_slots() {
+        if send_zc_unavailable() {
+            println!("skipping: IORING_OP_SEND_ZC unavailable on this host");
+            return;
+        }
+        let listener = match TcpListener::bind("127.0.0.1:0") {
+            Ok(l) => l,
+            Err(e) => {
+                println!("skipping: cannot bind loopback ({e})");
+                return;
+            }
+        };
+        let addr = listener.local_addr().expect("loopback addr");
+        const CHUNK: usize = 64 * 1024;
+        const ROUNDS: usize = SEND_ZC_INFLIGHT_BUFFERS * 4;
+
+        let reader = thread::spawn(move || {
+            let (mut peer, _) = listener.accept().expect("accept");
+            peer.set_read_timeout(Some(Duration::from_secs(30)))
+                .expect("read timeout");
+            let mut got = Vec::with_capacity(CHUNK * ROUNDS);
+            let mut tmp = vec![0u8; 16 * 1024];
+            while got.len() < CHUNK * ROUNDS {
+                match peer.read(&mut tmp) {
+                    Ok(0) => break,
+                    Ok(n) => got.extend_from_slice(&tmp[..n]),
+                    Err(e) => panic!("peer read failed: {e}"),
+                }
+            }
+            got
+        });
+
+        let client = TcpStream::connect(addr).expect("connect");
+        let mut pipeline = match SendZcPipeline::new(client.as_raw_fd(), CHUNK) {
+            Ok(p) => p,
+            Err(e) => {
+                println!("skipping: cannot build the SEND_ZC ring ({e})");
+                return;
+            }
+        };
+
+        let mut staging = vec![0u8; CHUNK];
+        let mut expected = Vec::with_capacity(CHUNK * ROUNDS);
+        for round in 0..ROUNDS {
+            let fill = (round & 0xff) as u8;
+            staging.fill(fill);
+            expected.resize(expected.len() + CHUNK, fill);
+            pipeline
+                .send_staged(&mut staging, CHUNK)
+                .expect("SEND_ZC accepted the payload");
+            assert_eq!(staging.len(), CHUNK, "recycled buffer keeps its capacity");
+        }
+        pipeline.drain().expect("drain observes every notification");
+        assert_eq!(
+            pipeline.pending_notifications(),
+            0,
+            "drain must leave no buffer pinned"
+        );
+        // Idempotent: `Drop` calls `drain` again after the explicit drain in
+        // `IoUringSocketWriter::drop`, and it must not block on a completion
+        // that is never coming.
+        pipeline.drain().expect("a settled drain is a no-op");
+
+        drop(pipeline);
+        drop(client);
+        let received = reader.join().expect("reader thread");
+        assert_eq!(received.len(), expected.len());
+        assert_eq!(received, expected, "round-tripped bytes must match");
+    }
+
+    /// Dropping the pipeline right after a send must run the drain and leave
+    /// the peer with every byte, rather than free buffers the kernel could
+    /// still be reading. The peer starts reading only once the drop is
+    /// already under way.
+    #[test]
+    fn drop_drains_outstanding_notifications() {
+        if send_zc_unavailable() {
+            println!("skipping: IORING_OP_SEND_ZC unavailable on this host");
+            return;
+        }
+        let Some((client, mut peer)) = loopback_pair() else {
+            println!("skipping: cannot build a loopback pair");
+            return;
+        };
+        let mut pipeline = match SendZcPipeline::new(client.as_raw_fd(), UNREAD_CHUNK) {
+            Ok(p) => p,
+            Err(e) => {
+                println!("skipping: cannot build the SEND_ZC ring ({e})");
+                return;
+            }
+        };
+        let mut staging = vec![3u8; UNREAD_CHUNK];
+        pipeline
+            .send_staged(&mut staging, UNREAD_CHUNK)
+            .expect("SEND_ZC accepted the payload");
+
+        let drainer = thread::spawn(move || {
+            peer.set_read_timeout(Some(Duration::from_secs(30)))
+                .expect("read timeout");
+            let mut tmp = vec![0u8; 16 * 1024];
+            let mut total = 0usize;
+            while total < UNREAD_CHUNK {
+                match peer.read(&mut tmp) {
+                    Ok(0) => break,
+                    Ok(n) => total += n,
+                    Err(_) => break,
+                }
+            }
+            total
+        });
+
+        drop(pipeline);
+        assert_eq!(drainer.join().expect("peer thread"), UNREAD_CHUNK);
+        drop(client);
+    }
+}

--- a/crates/fast_io/src/io_uring/socket_writer.rs
+++ b/crates/fast_io/src/io_uring/socket_writer.rs
@@ -10,8 +10,19 @@
 //! The SEND_ZC opcode dispatch is preserved: when the `iouring-send-zc` cargo
 //! feature is enabled and the running kernel advertises `IORING_OP_SEND_ZC`,
 //! payloads at or above [`SEND_ZC_MIN_BYTES`] are submitted through the
-//! zero-copy primitive on the per-thread ring; sub-threshold payloads stay on
-//! regular `IORING_OP_SEND`.
+//! zero-copy primitive; sub-threshold payloads stay on regular
+//! `IORING_OP_SEND` over the per-thread ring.
+//!
+//! SEND_ZC sends split by buffer ownership, because the opcode's page-release
+//! notification is what makes it fast or slow:
+//!
+//! - [`IoUringSocketWriter::flush_buffer`] sends from the writer's own buffer,
+//!   so it hands that buffer to [`send_zc_pipeline::SendZcPipeline`], which
+//!   waits only for the transfer CQE and lets the page-release notification
+//!   land later. This is the path the bulk of a transfer takes.
+//! - [`IoUringSocketWriter::write`] with an oversized caller slice sends
+//!   memory the caller may free the moment `write` returns, so it stays on the
+//!   synchronous [`send_zc::try_send_zc`], which waits for both CQEs.
 //!
 //! Per-ring kernel state - fixed-file registration in particular - is tied to
 //! a specific ring fd and does not survive the move to a thread-shared ring.
@@ -26,6 +37,7 @@ use super::batching::{NO_FIXED_FD, sqe_fd, submit_send_batch};
 use super::config::IoUringConfig;
 use super::per_thread_ring::with_ring;
 use super::send_zc;
+use super::send_zc_pipeline::SendZcPipeline;
 
 /// Payload-length floor below which `IORING_OP_SEND_ZC` is skipped in favour
 /// of regular `IORING_OP_SEND`.
@@ -74,6 +86,15 @@ pub struct IoUringSocketWriter {
     /// kernel advertises `IORING_OP_SEND_ZC`. Resolved once at construction
     /// so the hot path never re-probes.
     send_zc_active: bool,
+    /// Pipelined SEND_ZC submission for [`Self::flush_buffer`], built on the
+    /// first zero-copy flush. `None` until then, and permanently `None` once
+    /// its ring cannot be created (the writer then stays on plain
+    /// `IORING_OP_SEND`).
+    ///
+    /// The pipeline owns the buffers it hands the kernel, and its own `Drop`
+    /// blocks until every one of them has been released, so the writer's
+    /// `buffer` field is never the memory the kernel still holds.
+    send_zc_pipeline: Option<SendZcPipeline>,
 }
 
 impl IoUringSocketWriter {
@@ -101,6 +122,7 @@ impl IoUringSocketWriter {
             buffer_size: config.buffer_size,
             sq_entries: config.sq_entries,
             send_zc_active,
+            send_zc_pipeline: None,
         })
     }
 
@@ -112,9 +134,15 @@ impl IoUringSocketWriter {
         self.send_zc_active
     }
 
-    /// Submits `data` via SEND_ZC when policy + kernel + payload size all
-    /// agree, falling back to the batched SEND path on `Unsupported` or
-    /// when SEND_ZC is disabled. Returns the byte count actually sent.
+    /// Submits `data` - a slice this writer does **not** own - via the
+    /// synchronous SEND_ZC primitive when policy + kernel + payload size all
+    /// agree, falling back to the batched SEND path on `Unsupported` or when
+    /// SEND_ZC is disabled. Returns the byte count actually sent.
+    ///
+    /// Both branches have released every kernel reference to `data` by the
+    /// time they return, which is what lets [`Write::write`] hand a caller's
+    /// slice straight through. The buffered flush path does not come here for
+    /// its zero-copy sends; see [`Self::flush_buffer_zero_copy`].
     fn submit_send(&mut self, data: &[u8]) -> io::Result<usize> {
         if self.send_zc_active && data.len() >= SEND_ZC_MIN_BYTES {
             let fd = self.fd;
@@ -145,13 +173,30 @@ impl IoUringSocketWriter {
         with_ring(|ring| submit_send_batch(ring, fd, data, buffer_size, sq_entries, NO_FIXED_FD))
     }
 
-    /// Flushes the internal buffer via SEND_ZC or batched SEND submissions.
+    /// Flushes the internal buffer via the SEND_ZC pipeline or batched SEND
+    /// submissions.
     fn flush_buffer(&mut self) -> io::Result<()> {
         if self.buffer_pos == 0 {
             return Ok(());
         }
 
         let len = self.buffer_pos;
+        match self.flush_buffer_zero_copy(len) {
+            Ok(true) => {
+                self.buffer_pos = 0;
+                return Ok(());
+            }
+            Ok(false) => {}
+            Err(e) => {
+                // The staged bytes are no longer in `self.buffer`:
+                // `send_staged` swapped them into a pipeline-owned buffer
+                // before it failed. Forget them rather than let a later flush
+                // put the recycled buffer's stale contents on the wire.
+                self.buffer_pos = 0;
+                return Err(e);
+            }
+        }
+
         let mut sent_total = 0;
         while sent_total < len {
             // SAFETY: `as_ptr()` returns a pointer into `self.buffer`, whose
@@ -159,11 +204,13 @@ impl IoUringSocketWriter {
             // bounds are `sent_total..len`, both bounded by
             // `self.buffer_size`. We rebuild the slice on each iteration so
             // it does not alias the `&mut self` borrow consumed by
-            // `submit_send`. SEND_ZC's `try_send_zc` waits for the
-            // notification CQE before returning, so the kernel has released
-            // its page reference by the time we regain control; SEND
-            // copies bytes into kernel socket buffers synchronously and is
-            // similarly safe to call on a borrowed slice.
+            // `submit_send`. This path only reaches `submit_send_batch`,
+            // which copies the bytes into kernel socket buffers and has
+            // drained every CQE it submitted before returning, so no kernel
+            // reference to `self.buffer` outlives the call. The SEND_ZC path,
+            // which does leave a kernel page reference outstanding, never
+            // gets here: `flush_buffer_zero_copy` handled it above and moved
+            // the bytes into a buffer the pipeline owns.
             let chunk = unsafe {
                 std::slice::from_raw_parts(self.buffer.as_ptr().add(sent_total), len - sent_total)
             };
@@ -179,6 +226,39 @@ impl IoUringSocketWriter {
 
         self.buffer_pos = 0;
         Ok(())
+    }
+
+    /// Sends the first `len` buffered bytes through the SEND_ZC pipeline.
+    ///
+    /// Returns `Ok(false)` when the zero-copy path does not apply - policy or
+    /// kernel says no, the payload is below [`SEND_ZC_MIN_BYTES`], or the
+    /// pipeline's ring could not be created - leaving the buffer untouched for
+    /// the batched SEND path to handle.
+    ///
+    /// The pipeline takes the writer's buffer by swap rather than by copy, so
+    /// the bytes the kernel holds live in memory this writer no longer names.
+    /// That is what makes deferring the notification CQE sound here and not in
+    /// [`Write::write`]'s oversized-slice path.
+    fn flush_buffer_zero_copy(&mut self, len: usize) -> io::Result<bool> {
+        if !self.send_zc_active || len < SEND_ZC_MIN_BYTES {
+            return Ok(false);
+        }
+        if self.send_zc_pipeline.is_none() {
+            match SendZcPipeline::new(self.fd, self.buffer_size) {
+                Ok(pipeline) => self.send_zc_pipeline = Some(pipeline),
+                Err(_) => {
+                    // No ring, no zero-copy. Stop retrying so every later
+                    // flush goes straight to the batched SEND path.
+                    self.send_zc_active = false;
+                    return Ok(false);
+                }
+            }
+        }
+        let Some(pipeline) = self.send_zc_pipeline.as_mut() else {
+            return Ok(false);
+        };
+        pipeline.send_staged(&mut self.buffer, len)?;
+        Ok(true)
     }
 }
 
@@ -197,10 +277,14 @@ impl Write for IoUringSocketWriter {
         self.flush_buffer()?;
 
         if buf.len() >= self.buffer_size {
-            // Caller's slice is borrowed for the lifetime of this call;
-            // `submit_send` either copies via SEND or waits for the SEND_ZC
-            // notification CQE before returning, so the caller is free to
-            // reuse `buf` once we return.
+            // Caller's slice is borrowed for the lifetime of this call and may
+            // be reused or freed the moment we return, so this send must not
+            // outlive the call. `submit_send` either copies via SEND or routes
+            // through `send_zc::try_send_zc`, which waits for the notification
+            // CQE; both have surrendered every kernel reference to `buf` by
+            // the time they return. The pipelined SEND_ZC path deliberately
+            // does not apply here - it defers the notification, which is only
+            // sound for buffers the sender owns.
             let sent = self.submit_send(buf)?;
             return Ok(sent);
         }
@@ -216,7 +300,20 @@ impl Write for IoUringSocketWriter {
 }
 
 impl Drop for IoUringSocketWriter {
+    /// Flushes the buffer, then waits for the kernel to release every page the
+    /// SEND_ZC pipeline handed it.
+    ///
+    /// The drain is unconditional: `send_zc_pipeline` is dropped as part of
+    /// dropping `self` whatever happens here - including if `flush_buffer`
+    /// fails or panics - and [`SendZcPipeline::drop`] blocks until no buffer
+    /// is pinned, leaking the ones it cannot account for rather than freeing
+    /// memory the kernel may still be reading. Calling `drain` explicitly
+    /// first only makes the ordering visible at this level; it is not what
+    /// makes the drain safe.
     fn drop(&mut self) {
         let _ = self.flush_buffer();
+        if let Some(pipeline) = self.send_zc_pipeline.as_mut() {
+            let _ = pipeline.drain();
+        }
     }
 }

--- a/docs/audits/ius-2-send-zc-kernel-compat-matrix.md
+++ b/docs/audits/ius-2-send-zc-kernel-compat-matrix.md
@@ -261,6 +261,16 @@ correct but conservative:
   explicitly cites the "wait for notification CQE before returning"
   invariant.
 
+> **Superseded on the flush path.** The last bullet describes the
+> code as audited. That notification wait was measured at 75% of the
+> time spent inside `try_send_zc` and cost a 5.8x end-to-end
+> regression on a loopback daemon pull, so `flush_buffer` now routes
+> its owned buffer through
+> `crates/fast_io/src/io_uring/send_zc_pipeline.rs`, which waits only
+> for the transfer CQE. `Write::write`'s oversized-caller-slice path
+> is unchanged and still waits for both CQEs. See section 3.3 of
+> `docs/design/iouring-send-zc.md`.
+
 ### 3.4 `ZeroCopySender` wrapper (feature-gated)
 
 The higher-level wrapper exposed under `iouring-send-zc` at

--- a/docs/design/iouring-send-zc.md
+++ b/docs/design/iouring-send-zc.md
@@ -225,6 +225,49 @@ is bounded by `depth * buffer_size`: 4 x 64 KiB = 256 KiB on the
 default config, 4 x 256 KiB = 1 MiB on the `for_large_files` preset
 at `crates/fast_io/src/io_uring_common.rs:132`-`crates/fast_io/src/io_uring_common.rs:145`.
 
+### 3.3 What shipped
+
+The pool described in section 3.1 exists as
+`crates/fast_io/src/io_uring/send_zc_pipeline.rs`. It keeps the
+shape this section specifies - submit, return, pin-count per
+submission, block on a notification CQE only when the pool is
+exhausted - with three deviations, all measured rather than
+assumed:
+
+- **Owned `Vec<u8>` buffers, not `RegisteredBufferSlot`.** A
+  `RegisteredBufferGroup` is registered against one specific ring,
+  the SEND_ZC submission never sets `buf_index`, so the
+  registration would buy nothing on this path, and routing through
+  a slot forces a memcpy into it. The socket writer already owns a
+  buffer the caller filled; the pipeline takes it by
+  `mem::swap` and hands back a released one, so the pooled
+  buffers cost no copy at all.
+- **A private ring per socket writer**, not the per-thread ring
+  from #2243. Deferred notifications stay queued across calls, and
+  `batching::submit_send_batch` drains the per-thread completion
+  queue unconditionally while demultiplexing on `user_data` alone,
+  so a notification left there would be misread as one of its own
+  completions. Nothing else submits to or reaps from the
+  pipeline's ring.
+- **The transfer CQE is still awaited.** Section 3.1 says the
+  writer "submits ... and returns immediately"; the shipped
+  pipeline returns after the transfer CQE and only defers the
+  notification. That CQE carries the byte count and `-errno`,
+  which is what handles short sends, and once it has been observed
+  the bytes sit in the socket's transmit queue - which is what
+  keeps wire ordering against `submit_send_batch` and the
+  synchronous `try_send_zc` on the same fd.
+
+Depth is 4, the floor section 3.2 derives, and the measurement
+supports it: over a 200 MB loopback daemon pull (6400 sends) a free
+buffer was available with no wait in more than 90% of sends, and
+the pool held four buffers at once in 7.6% of them.
+
+`Write::write` with a caller slice at or above `buffer_size`
+(assumption 2 in section 3) is unchanged: it still blocks on both
+CQEs via `send_zc::try_send_zc`, because the caller may free that
+slice the moment `write` returns.
+
 ## 4. Kernel version gate
 
 Two-stage probe, executed lazily at writer construction in


### PR DESCRIPTION
## The regression

`ZeroCopyPolicy` reaching `IORING_OP_SEND_ZC` on the daemon-sender's socket
made a 200 MB loopback daemon pull **5.8x slower**, not faster.

| cell | median (11 alternating reps) | throughput |
|---|---|---|
| plain socket writer (no cargo feature) | 0.0866 s | 2422 MB/s |
| SEND_ZC (`iouring-send-zc`) | 0.5046 s | 416 MB/s |

## Diagnosis, measured before the fix

`try_send_zc` submits one SQE and blocks until it has seen **both**
completions: the transfer CQE ("the bytes are queued for transmit", carrying
the byte count and `IORING_CQE_F_MORE`) and the notification CQE
(`IORING_CQE_F_NOTIF`, "the kernel released your pages"). Waiting for the
second is the entire cost.

Per-call instrumentation of the daemon-sender for one 200 MB pull, recorded
in memory and dumped once at the end so the trace does not perturb the run
(traced 0.447 s vs untraced ~0.50 s):

```
send count = 6400
xfer_us:  sum=0.084 s  p50=12  p90=19  p99=36
notif_us: sum=0.249 s  p50=28  p90=51  p99=91
total_us: sum=0.333 s
waits: [(1, 10), (2, 6390)]
payload histogram: 32776 -> 6398, 32795 -> 1, 32796 -> 1
```

- The notification wait is **75%** of the time spent inside `try_send_zc`,
  and 0.249 s of the 0.41 s end-to-end gap.
- **Syscall count ruled out**: exactly two `submit_and_wait(1)` entries per
  send in 6390/6400 cases - one for each CQE, never a storm.
- **`SEND_ZC_MIN_BYTES` ruled out**: every send is 32776 bytes (a 32 KiB
  multiplex frame plus its 8-byte header). There are no sub-threshold sends
  at all, so the 16 KiB / 4 KiB threshold is not selecting anything.
- **Per-call ring construction ruled out**: a counter in
  `PerThreadRing::new` reported `per_thread_ring_builds=1` for the whole
  transfer.
- **The transfer CQE is not the problem**: 0.084 s of 0.333 s, p50 12 us,
  which is roughly what the send itself costs.

## The fix

Split the two waits.

`SendZcPipeline` still waits for the **transfer** CQE. That is what carries
the byte count, surfaces `-errno`, handles short sends by resubmitting the
remainder, and - once observed - guarantees the bytes are in the socket's
transmit queue, which is what keeps wire ordering against `submit_send_batch`
and the synchronous path on the same fd. It does **not** wait for the
notification.

### Why that is sound

Only the buffered flush path moves. The two call sites differ in who owns
the memory:

- `flush_buffer` sends from the writer's own buffer. It hands that buffer to
  the pipeline by **swap**, getting back a buffer the kernel has already
  released. No caller ever names the memory the kernel still holds, so there
  is nothing to observe, refill, or free early. A four-buffer pool keeps the
  pipe full and bounds what an un-reaped notification can hold at
  `4 * buffer_size` per connection.
- `write()` with a caller slice at or above `buffer_size` sends memory the
  caller may free the moment `write` returns. It stays on the synchronous
  `try_send_zc`. The SAFETY comments in `flush_buffer` and `write` that
  justified themselves with "try_send_zc waits for the notification CQE
  before returning" are rewritten to say which path they now describe.

Accounting: `pending` is incremented when an SQE is pushed and decremented
exactly once per submission - by the notification CQE, or by a transfer CQE
with `IORING_CQE_F_MORE` clear, which is the kernel saying no notification
will follow. Counting up at submit time keeps it an upper bound at every
instant, so a buffer is never considered free while the kernel might still
be reading it, and the drain always terminates.

### The Drop drain

`SendZcPipeline::drop` drains every outstanding notification before any
pooled buffer is deallocated. It is unconditional: the field is dropped as
part of dropping the writer on the normal path, the error path and during
unwinding. If the drain itself fails, the still-pinned buffers are leaked
with `mem::forget` - leaking memory is sound, freeing memory the kernel
holds a reference to is not. An `EINTR` from `io_uring_enter(2)` resumes the
wait (a syscall restart, not a retry policy), because abandoning it would
force that leak.

Closing the ring fd is not a substitute: io_uring teardown is deferred to
`io_ring_exit_work`, so the kernel's page references can outlive `close(2)`.

### Why a private ring

Deferred notifications stay queued across calls. Every other io_uring
consumer on the calling thread - `submit_send_batch` in particular - drains
the per-thread ring's completion queue unconditionally and demultiplexes on
`user_data` alone, so a notification left there would be consumed by, and
misread as, somebody else's completion. The pipeline owns a ring nothing
else submits to or reaps from. It is one ring per socket writer, i.e. per
connection, so it does not reintroduce the shared-ring serialisation IUR-3
removed; `tools/ci/check_shared_ring_removal.sh` still passes.

`RegisteredBufferGroup` was evaluated and rejected as the vehicle: it is
registered against one specific ring, the SEND_ZC path never sets
`buf_index` so the registration would be inert, and using it forces a memcpy
into the slot - a copy that zero-copy exists to remove.

## Results

Same host, same 200 MB source, 11 alternating reps per cell, `/dev/shm`
destination, page cache warmed once, medians reported.

| A/B | A | B | A median | B median |
|---|---|---|---|---|
| feature-only, before | plain | SEND_ZC | 0.0866 s | 0.5046 s |
| feature-only, after | plain | SEND_ZC pipelined | 0.0735 s | 0.1067 s |
| fix isolated (both feature-on) | before | after | 0.5125 s | 0.1068 s |

**The fix is a 4.8x speedup and removes the regression. It does not make
SEND_ZC beat a plain socket write on loopback** - 0.107 s vs 0.074 s, still
about 1.45x behind.

Post-fix instrumentation says the remaining gap is not pool starvation:

```
send count = 6400
send_slot (transfer CQE waits):        sum=0.046 s  p50=5 us
acquire_free_slot (pool exhaustion):   sum=0.018 s  p50=0  p90=0
pending after each send: 0->1365 1->2470 2->1352 3->724 4->488 5->1
```

Time inside the send primitive drops from 0.333 s to 0.064 s. A free buffer
was available immediately in over 90% of sends, so a deeper pool would
recover at most 0.018 s.

Loopback simply has nothing for zero-copy to amortise: the writer copies the
frame into its own buffer either way, SEND_ZC replaces the kernel's copy
with page pinning, and the receiver copies out regardless. A test that could
show SEND_ZC winning needs a real NIC with scatter-gather and checksum
offload (so the kernel copy it removes is the actual bottleneck), payloads
large enough to amortise `get_user_pages_fast`, and a link fast enough that
the copy, not the wire, is the limit.

## Verification

On the Linux host (kernel 7.0, aarch64), against this branch alone:

- `cargo fmt --all -- --check`
- `cargo clippy -p fast_io --all-targets -- -D warnings`, and again with
  `-F iouring-send-zc`
- `cargo nextest run -p fast_io` (1132 passed) and with `-F iouring-send-zc`
  (1135 passed)
- `tools/ci/check_shared_ring_removal.sh`
- A 200 MB daemon pull through the pipelined writer is byte-identical
  (`cmp` plus matching sha256).

New tests in `send_zc_pipeline`: the swap hands the kernel an allocation the
caller no longer holds; more sends than pool slots round-trip byte-exactly
and drain to zero pending (and drain is idempotent); dropping with a send
outstanding still delivers every byte.

They deliberately do not assert "the notification is still outstanding when
`send_staged` returns". On loopback it usually is not - the packet reaches
the receiving socket immediately, so the kernel posts the notification right
behind the transfer CQE and one quiet send reaps both in a single drain.
What the pipeline changes is that it never *waits*, which is visible only
under load; the A/B above is what pins it.

## Scope

oc-only: upstream rsync has no io_uring path, so there is no upstream
behaviour to mirror. The default build does not enable `iouring-send-zc`, so
the stock socket-send path is untouched.
