### PR TITLE
docs: retarget upstream citations at the pinned 3.5.0

### DIFF
--- a/crates/batch/tests/batch_integration.rs
+++ b/crates/batch/tests/batch_integration.rs
@@ -7,7 +7,7 @@
 //! - Edge cases including empty batches and large data volumes
 //!
 //! The tests are organized by functional area and follow upstream rsync's
-//! batch.c behavior as documented in `target/interop/upstream-src/rsync-3.4.1/batch.c`.
+//! batch.c behavior as documented in `target/interop/upstream-src/rsync-3.5.0/batch.c`.
 //!
 //! ## Upstream Compatibility
 //!

--- a/crates/checksums/src/rolling/checksum/neon.rs
+++ b/crates/checksums/src/rolling/checksum/neon.rs
@@ -9,7 +9,7 @@
 //! - `match.c:hash_search()` - consumer of rolling checksums during delta detection
 //!
 //! Upstream rsync has no NEON path; aarch64 falls through to the scalar loop
-//! at `target/interop/upstream-src/rsync-3.4.1/checksum.c:285-300`. The
+//! at `target/interop/upstream-src/rsync-3.5.0/checksum.c:303-318`. The
 //! vector-register-resident `s1` / `s2` pattern below mirrors the
 //! x86 SSSE3/SSE2 loop in `simd-checksum-x86_64.cpp:113-313`, adapted to
 //! NEON intrinsics.

--- a/crates/checksums/tests/rolling_signed_byte_regression.rs
+++ b/crates/checksums/tests/rolling_signed_byte_regression.rs
@@ -2,7 +2,7 @@
 //!
 //! PR #3560 fixed a sign-extension bug in the rolling checksum where bytes
 //! `>= 0x80` were treated as unsigned, diverging from upstream rsync's
-//! `schar *buf = (schar *)buf1` cast (`checksum.c:285`). The proptest in
+//! `schar *buf = (schar *)buf1` cast (`checksum.c:307`). The proptest in
 //! `rolling_simd_parity.rs` covers this via a self-contained reference, but
 //! a corrupted reference would silently mask a regression. This file pins
 //! down hand-computed expected `(s1, s2)` values for fixtures whose bytes
@@ -11,7 +11,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/checksum.c:285` casts the
+//! - `target/interop/upstream-src/rsync-3.5.0/checksum.c:307` casts the
 //!   buffer to `schar *`, so each byte contributes `(byte as i8) as i32`.
 //! - `match.c:hash_search()` consumes the rolling digest as
 //!   `(s2 << 16) | s1`, both terms masked to 16 bits.

--- a/crates/compress/src/strategy/adaptive_level.rs
+++ b/crates/compress/src/strategy/adaptive_level.rs
@@ -13,7 +13,7 @@
 //! adaptation is therefore opt-in and is never advertised as a protocol
 //! capability.
 //!
-//! Upstream rsync (`target/interop/upstream-src/rsync-3.4.1/token.c`) selects
+//! Upstream rsync (`target/interop/upstream-src/rsync-3.5.0/token.c`) selects
 //! a compression level once at session start via `do_compression_level` and
 //! does not adjust it at runtime - this strategy is a Rust-side optimisation
 //! layered on top of the upstream-compatible encoders.

--- a/crates/fast_io/src/iocp/pump.rs
+++ b/crates/fast_io/src/iocp/pump.rs
@@ -33,7 +33,7 @@
 //!
 //! # Upstream reference
 //!
-//! Upstream rsync 3.4.1 (`target/interop/upstream-src/rsync-3.4.1/`) does
+//! Upstream rsync 3.5.0 (`target/interop/upstream-src/rsync-3.5.0/`) does
 //! not use IOCP; the design space for the pump surface is open. The pump
 //! is intentionally minimal so #1898 can layer a batched-write API on top
 //! that mirrors `IoUringDiskBatch` (`crates/fast_io/src/io_uring/disk_batch.rs`).

--- a/crates/fast_io/src/iocp/socket.rs
+++ b/crates/fast_io/src/iocp/socket.rs
@@ -13,13 +13,13 @@
 //!
 //! Upstream rsync uses POSIX `read(2)` / `write(2)` against the socket fd in
 //! `safe_read` / `safe_write`
-//! (`target/interop/upstream-src/rsync-3.4.1/io.c:239` and `:312`). Windows
+//! (`target/interop/upstream-src/rsync-3.5.0/io.c:292` and `:369`). Windows
 //! has no direct equivalent because `read`/`write` on a `SOCKET` are
 //! synchronous; the closest async-capable primitive is `WSARecv` / `WSASend`
 //! with `OVERLAPPED`. The buffering and EOF semantics expected by the
 //! multiplex layer above (`crates/protocol`) are unchanged: an `Ok(0)` from a
 //! socket read means the peer cleanly closed the connection, mirroring
-//! `safe_read` exiting its loop on `n == 0` (`io.c:276`).
+//! `safe_read` exiting its loop on `n == 0` (`io.c:333`).
 //!
 //! # WSA_IO_PENDING
 //!
@@ -143,7 +143,7 @@ impl IocpSocketReader {
     /// Receives bytes from the socket, returning the number transferred.
     ///
     /// `Ok(0)` indicates a graceful peer shutdown - upstream `safe_read`
-    /// breaks its loop on `n == 0` (`io.c:276`). Connection-reset and
+    /// breaks its loop on `n == 0` (`io.c:333`). Connection-reset and
     /// shutdown-on-the-other-side errors are mapped to `Ok(0)` to mirror that
     /// EOF semantic, matching how the io_uring socket reader handles
     /// `IORING_OP_RECV` returning `0` after a peer close.
@@ -434,7 +434,7 @@ fn await_completion(
         Ok(transferred) => Ok(transferred as usize),
         // `UnexpectedEof` from the pump corresponds to STATUS_END_OF_FILE,
         // which Winsock translates to a graceful close on the recv side.
-        // upstream: io.c:276 - safe_read breaks its loop on n == 0.
+        // upstream: io.c:333 - safe_read breaks its loop on n == 0.
         Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(0),
         Err(e) => Err(e),
     }

--- a/crates/matching/src/index/sparse_match_tests.rs
+++ b/crates/matching/src/index/sparse_match_tests.rs
@@ -41,10 +41,10 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/match.c:200-345` -
+//! - `target/interop/upstream-src/rsync-3.5.0/match.c:224-378` -
 //!   `hash_search()` two-stage gate (rolling sum then strong sum).
-//! - `target/interop/upstream-src/rsync-3.4.1/rsum.c:362-366` - zsync's
-//!   bithash probe expression that this fixture pins.
+//! - zsync `librcksum/rsum.c:362-366` - the bithash probe expression
+//!   that this fixture pins.
 
 use std::io::Cursor;
 use std::num::{NonZeroU8, NonZeroU32};

--- a/crates/matching/tests/rsum_collision_fixture.rs
+++ b/crates/matching/tests/rsum_collision_fixture.rs
@@ -25,14 +25,14 @@
 //! - high-byte: `[0x80, 0x86, 0x80, 0x82]` / `[0x82, 0x80, 0x86, 0x80]`
 //!
 //! The high-byte case exercises the signed-byte path (`schar *buf` cast
-//! at upstream `checksum.c:285`); without sign-extension the s1/s2 values
+//! at upstream `checksum.c:307`); without sign-extension the s1/s2 values
 //! would diverge from upstream.
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/checksum.c:285` - signed
+//! - `target/interop/upstream-src/rsync-3.5.0/checksum.c:307` - signed
 //!   reinterpretation of buffer bytes for the rolling sum.
-//! - `target/interop/upstream-src/rsync-3.4.1/match.c:140-345` -
+//! - `target/interop/upstream-src/rsync-3.5.0/match.c:163-378` -
 //!   `hash_search()` consults strong checksum after a rolling-digest hit.
 
 use checksums::RollingChecksum;

--- a/crates/matching/tests/shifted_insertion_fixture.rs
+++ b/crates/matching/tests/shifted_insertion_fixture.rs
@@ -38,7 +38,7 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/match.c:140-345` -
+//! - `target/interop/upstream-src/rsync-3.5.0/match.c:163-378` -
 //!   `hash_search()` and the `want_i` adjacent-block hint that aligned
 //!   shifted inserts must continue to satisfy.
 

--- a/crates/matching/tests/sparse_match_fixture.rs
+++ b/crates/matching/tests/sparse_match_fixture.rs
@@ -40,15 +40,15 @@
 //!   the only block-aligned matches available are at offsets
 //!   `0, block_size, ..., (K-1) * block_size`. After matching each
 //!   planted block the generator jumps forward by `block_size` bytes
-//!   (upstream `match.c:265-310`), so non-aligned sliding windows
+//!   (upstream `match.c:297-343`), so non-aligned sliding windows
 //!   inside the planted prefix are never probed.
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/match.c:200-345` -
+//! - `target/interop/upstream-src/rsync-3.5.0/match.c:224-378` -
 //!   `hash_search()` two-stage gate (rolling sum then strong sum).
-//! - `target/interop/upstream-src/rsync-3.4.1/rsum.c:362-366` -
-//!   bithash probe before the hash-table descent (planned in #2059).
+//! - zsync `librcksum/rsum.c:362-366` - bithash probe before the
+//!   hash-table descent (planned in #2059).
 
 use std::io::Cursor;
 use std::num::{NonZeroU8, NonZeroU32};

--- a/crates/metadata/tests/atimes_crtimes_roundtrip.rs
+++ b/crates/metadata/tests/atimes_crtimes_roundtrip.rs
@@ -1,6 +1,6 @@
 //! Round-trip coverage for the `--atimes` / `--crtimes` flags.
 //!
-//! Mirrors the upstream `testsuite/atimes.test` and `testsuite/crtimes.test`
+//! Mirrors the upstream `testsuite/atimes_test.py` and `testsuite/crtimes_test.py`
 //! scenarios end-to-end through the metadata application layer that wires
 //! the IFX-8 (access time) and IFX-9 (creation time) flist fields into the
 //! receiver. The upstream scripts stamp known timestamps on a source tree
@@ -10,8 +10,10 @@
 //! atime/crtime have been read off the wire.
 //!
 //! Upstream references:
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/atimes.test`
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/crtimes.test`
+//! - `target/interop/upstream-src/rsync-3.5.0/testsuite/atimes_test.py`
+//! - `target/interop/upstream-src/rsync-3.5.0/testsuite/crtimes_test.py`
+//!   (3.5.0 replaced the 3.4.x shell `*.test` scripts with Python
+//!   rewrites of the same scenarios)
 //! - `rsync.c:set_file_attrs()` for the apply order (chown -> chmod ->
 //!   utimensat -> crtime).
 //!


### PR DESCRIPTION
## A citation naming a file that has never existed in the tree it points into

`crates/matching/tests/sparse_match_fixture.rs` and
`crates/matching/src/index/sparse_match_tests.rs` both carried:

```
//! - `target/interop/upstream-src/rsync-3.4.1/rsum.c:362-366` - zsync's
//!   bithash probe expression that this fixture pins.
```

The comment says "zsync's" and then points into the rsync tarball. `rsum.c` is
zsync's `librcksum/rsum.c`; rsync has never shipped a file of that name, at any
release. So the path is wrong in both halves - wrong project, and a version the
repo does not pin. Both files already cite the same source correctly a few lines
away (`zsync librcksum/rsum.c:362-366`, and `crates/matching/src/index/mod.rs`,
`bithash.rs`, `compact_lookup.rs` all use that form). These two sites now match it.

This is the clearest statement of why a line-count gate is not sufficient.
`xtask citations` passed this line for as long as it existed: it resolves a path
with a directory component that the 3.5.0 manifest lacks to `ForeignUpstream` and
declines to range-check it - by design, so that genuine `librcksum/` citations are
not false positives. `citation_drift_audit.py` never looked at it either; it only
inspects citations carrying a quoted C-string anchor (572 lines of 13k+). Neither
gate can tell a deliberate foreign-upstream citation from a fabricated path.

## Retargeting the rest

The other eleven sites named `rsync-3.4.1/` or `rsync-3.4.4/` paths while the pin
is 3.5.0, and the line numbers were 3.4.1-era, not merely the paths. Each was
re-derived by locating the cited *construct* in
`target/interop/upstream-src/rsync-3.5.0/`, both ends of every range, and each
mapping confirmed by comparing the line text across the two trees:

| construct | 3.4.1 | 3.5.0 |
| --- | --- | --- |
| `checksum.c` `get_checksum1()` body | 285-300 | 303-318 |
| `checksum.c` `schar *buf = (schar *)buf1` | (cited 285) | 307 |
| `match.c` `hash_search()` whole | 140-345 | 163-378 |
| `match.c` `hash_search()` two-stage gate | 200-345 | 224-378 |
| `match.c` post-match forward jump | 265-310 | 297-343 |
| `io.c` `safe_read()` | 239 | 292 |
| `io.c` `safe_write()` | 312 | 369 |
| `io.c` `safe_read` EOF break | 276 | 333 |

`batch.c`, `token.c` and the whole-tree reference in `crates/fast_io/src/iocp/pump.rs`
carry no line number and only move to 3.5.0.

### `checksum.c:285` was already wrong at 3.4.1

Three sites cite `checksum.c:285` for the `schar *` cast. At 3.4.1 line 285 is the
`uint32 get_checksum1(char *buf1, int32 len)` signature; the cast is 289. They now
name 307, which is the cast at 3.5.0.

### The atimes/crtimes fixtures moved shape, not just line

3.5.0 replaced the shell `testsuite/*.test` suite with Python `*_test.py`.
`testsuite/atimes.test` and `testsuite/crtimes.test` do not exist at the pin;
`atimes_test.py` and `crtimes_test.py` do, and each declares itself a "Python
rewrite of testsuite/atimes.test". `crates/metadata/tests/atimes_crtimes_roundtrip.rs`
now names the Python files and says why the name changed. The prose claim (stamp
known timestamps, assert preservation) still holds against the rewrites.

## Left untouched, deliberately

- **`xtask/src/commands/citations.rs:174` and `:562`.** The `rsync-3.4.1/flist.c:713`
  string is the worked example of the `ForeignUpstream` rule that gate implements -
  "a release this gate does not pin". `:562` is the test asserting that resolution.
  Retargeting either destroys the example, and `:562` is not a comment line.
- **`tools/ci/run_upstream_test_with_upstream_binary.sh:15`.** The comment documents
  the script's own default, and that default is a non-comment line still reading
  `upstream_version="${UPSTREAM_VERSION:-3.4.4}"` while `run_upstream_testsuite.sh`
  defaults to 3.5.0. Editing only the comment would make it false. Flagged for a
  separate change that moves the default.
- **`simd-checksum-x86_64.cpp:113-313`** in `crates/checksums/src/rolling/checksum/neon.rs`.
  Measured: that byte range is identical between 3.4.1 and 3.5.0 (`get_checksum1_ssse3_32`
  starts at 113 in both). Correct by coincidence, so it stays.

## Claims that changed meaning at 3.5.0 - reported, not rewritten

Neither invalidates the comment, but both are worth recording rather than quietly
absorbing:

- `hash_search()` gained a `MAX_CHAIN_LEN` (1024) per-offset chain cap at 3.5.0
  (upstream issue #217). The "two-stage gate (rolling sum then strong sum)" the two
  sparse-match fixtures describe is still there; it is now additionally bounded.
- The `want_i` adjacent-block hint gained `&& l == s->sums[want_i].len`. The claim
  in `shifted_insertion_fixture.rs` that aligned shifted inserts must satisfy the
  hint still holds, under a tighter condition.

## Gates

- `python3 tools/ci/check_rustfmt_all.py` - 3369 tracked files, clean.
- `cargo xtask citations` - 8668 names and 8668 line ranges across 5035 files, pass.
- `cargo check -p matching -p checksums -p metadata -p compress -p batch --all-targets` - clean.
- `python3 tools/ci/citation_drift_audit.py matching checksums fast_io metadata compress batch` -
  unchanged before and after, no rise in `unresolved`:

| crate | before | after |
| --- | --- | --- |
| matching | 4/0/1 | 4/0/1 |
| checksums | 2/0/0 | 2/0/0 |
| fast_io | 3/0/0 | 3/0/0 |
| metadata | 34/0/11 | 34/0/11 |
| compress | 1/0/2 | 1/0/2 |
| batch | 8/0/4 | 8/0/4 |

Comment-only: `git diff -U0` contains no changed line that is not a comment.

Scope excludes `crates/transfer`, `crates/engine`, `crates/daemon`, `crates/core`
and `crates/protocol`, which are being retargeted separately.
