### PR TITLE
fix(receiver): remove a non-regular obstacle before a file transfer

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/lstat.rs
@@ -43,6 +43,20 @@ impl LstatOutcome {
         }
     }
 
+    /// Reports whether the entry is a directory.
+    ///
+    /// The receiver's obstacle decision splits on exactly this test, so it has
+    /// to read the type from the same sandbox-anchored `fstatat` that observed
+    /// the entry rather than re-resolving the path: a swap in between would let
+    /// the removal act on a different inode from the one it classified.
+    #[must_use]
+    pub fn is_dir(&self) -> bool {
+        match self {
+            Self::At(meta) => meta.is_dir(),
+            Self::Std(meta) => meta.is_dir(),
+        }
+    }
+
     /// Inode number of the entry.
     #[must_use]
     pub fn ino(&self) -> u64 {

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -726,7 +726,7 @@ fn is_permission_error(err: &io::Error) -> bool {
 /// verbatim, with no parenthesised number to invent.
 ///
 /// upstream: `rsync-3.5.0/log.c` `rsyserr()` - `"%s: %s (%d)"`.
-fn upstream_errno_text(error: &io::Error) -> String {
+pub(crate) fn upstream_errno_text(error: &io::Error) -> String {
     let display = error.to_string();
     // A tagged failure is an `io::Error::new(kind, payload)`, i.e. the `Custom`
     // variant, whose `raw_os_error()` is `None` even though the payload wraps a

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -493,9 +493,16 @@ impl ReceiverContext {
     /// backup mechanism failed; the caller skips creating the replacement,
     /// mirroring upstream `atomic_create` returning 0 when `make_backup` fails.
     ///
+    /// This is the backup ARM of the obstacle decision, not the decision
+    /// itself: it is reached only from
+    /// [`ReceiverContext::make_way_for_replacement`], which has already ruled
+    /// out a directory. Upstream's `dir_in_the_way` (`generator.c:2469`) makes
+    /// `make_backup` unreachable for a directory in both modes, so calling this
+    /// with one would back up something upstream removes.
+    ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2018-2020` - `if (make_backups > 0 ...) if (!make_backup(fname, ...)) return 0;`
+    /// - `generator.c:2476-2478` - `if (make_backups > 0 && !dir_in_the_way) { if (!make_backup(fname, skip_atomic)) return 0; }`
     #[cfg(unix)]
     pub(in crate::receiver) fn backup_existing_before_replace(
         &self,

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -15,6 +15,8 @@ use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_f
 
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
+#[cfg(any(unix, windows))]
+use crate::receiver::directory::obstacle::MakeWayFor;
 
 impl ReceiverContext {
     /// Reports whether a received symlink's mtime should be preserved.
@@ -190,41 +192,21 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // symlink up before it is removed when --backup is set; on
-                // backup-mechanism failure upstream skips the entry.
-                match self.backup_existing_before_replace(
-                    &link_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: route the obstacle unlink through the sandbox
-                        // dirfd when the destination parent is the sandbox root,
-                        // so a TOCTOU swap on `link_path` between the readlink
-                        // above and this unlink cannot redirect the syscall to
-                        // an attacker-chosen parent. Falls back to path-based
-                        // `remove_file` otherwise.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &link_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing symlink {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // - one decision for the obstacle: rmdir a directory, back up
+                // or unlink anything else. The refusal is reported inside.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if fast_io::lstat_via_sandbox_or_fallback(
                 sandbox,
@@ -234,43 +216,22 @@ impl ReceiverContext {
             )
             .is_ok()
             {
-                // SEC-1.f: when the sandbox is plumbed and the destination
-                // parent is the sandbox root, the obstacle stat goes through
-                // `fstatat(AT_SYMLINK_NOFOLLOW)` so a TOCTOU symlink swap on
-                // `link_path` cannot redirect the probe to a different
-                // inode. Falls back to `symlink_metadata` otherwise.
-                //
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // obstacle up before removal when --backup is set.
-                match self.backup_existing_before_replace(
-                    &link_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: matching unlink also goes through the sandbox
-                        // dirfd via `unlinkat` so the obstacle-remove syscall is
-                        // anchored on the same parent the stat just observed.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &link_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing obstacle {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // for a non-symlink obstacle. The stat above only selects this
+                // arm; `make_way_for_replacement` re-reads the type through the
+                // same sandbox dirfd to decide between rmdir and backup/unlink.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if !self.config.reference_directories.is_empty() {
                 // upstream: generator.c:1978 - `else if (basis_dir[0] != NULL)`
@@ -507,42 +468,33 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // symlink up before removal when --backup is set.
-                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        let _ = fs::remove_file(&link_path);
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing symlink {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK).
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             } else if fs::symlink_metadata(&link_path).is_ok() {
-                // upstream: generator.c:2018-2020 atomic_create - back the old
-                // obstacle up before removal when --backup is set.
-                match self.backup_existing_before_replace(&link_path, relative_path, dest_dir) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        let _ = fs::remove_file(&link_path);
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing obstacle {}: {}",
-                            link_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
+                // for a non-symlink obstacle.
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &link_path,
+                        relative_path,
+                        dest_dir,
+                        MakeWayFor::Symlink,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
             }
 

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -13,7 +13,9 @@ mod creation;
 pub(in crate::receiver) mod deletion;
 mod links;
 mod missing_args;
-mod obstacle;
+// `pub(in crate::receiver)` so the regular-file candidate pass can name
+// `MakeWayFor` for its `DEL_FOR_FILE` removal (generator.c:2149).
+pub(in crate::receiver) mod obstacle;
 mod special;
 
 /// Normalizes a filename for cross-platform comparison.

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -13,6 +13,7 @@ mod creation;
 pub(in crate::receiver) mod deletion;
 mod links;
 mod missing_args;
+mod obstacle;
 mod special;
 
 /// Normalizes a filename for cross-platform comparison.

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -1,5 +1,6 @@
 //! The receiver's single decision site for an existing destination entry that
-//! stands where a symlink, FIFO, socket, or device node has to be created.
+//! stands where a regular file, symlink, FIFO, socket, or device node has to
+//! be written.
 //!
 //! Upstream makes this decision in exactly one place. `atomic_create()` sets
 //! `dir_in_the_way` when the obstacle is a directory, which also forces
@@ -11,8 +12,17 @@
 //! answer upstream's; deciding the directory case inside the backup path would
 //! leave every `--backup`-off shape decided somewhere else.
 //!
+//! The regular-file arm reaches the same `delete_item()` from its own call
+//! site rather than through `atomic_create()`: `generator.c:2149` removes a
+//! destination that is not a regular file (nor a device under
+//! `--write-devices`) before the delta is requested, then sets `statret = -1`
+//! so everything below sees an absent destination. Writing through such an
+//! obstacle - or renaming over it - is not the same operation: `--backup`
+//! never sees it, and a directory is never cleared at all.
+//!
 //! # Upstream Reference
 //!
+//! - `generator.c:2148-2153` - the `DEL_FOR_FILE` removal ahead of a regular-file transfer
 //! - `generator.c:2469` - `int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);`
 //! - `generator.c:2471-2472` - `dir_in_the_way` forces `skip_atomic = 1`
 //! - `generator.c:2477-2483` - `if (make_backups > 0 && !dir_in_the_way) make_backup(...)`
@@ -63,6 +73,8 @@ use crate::receiver::ReceiverContext;
 #[cfg(any(unix, windows))]
 #[derive(Clone, Copy)]
 pub(in crate::receiver) enum MakeWayFor {
+    /// upstream `DEL_FOR_FILE` - `"regular file"`.
+    File,
     /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
     Symlink,
     /// upstream `DEL_FOR_DEVICE` - `"device file"`.
@@ -84,6 +96,7 @@ impl MakeWayFor {
     /// upstream: `delete.c:275-279` - the `desc` assigned per `DEL_FOR_*`.
     const fn description(self) -> &'static str {
         match self {
+            Self::File => "regular file",
             Self::Symlink => "symlink",
             #[cfg(unix)]
             Self::Device => "device file",
@@ -119,8 +132,8 @@ fn is_not_empty(error: &io::Error) -> bool {
 
 #[cfg(any(unix, windows))]
 impl ReceiverContext {
-    /// Clears whatever stands at `existing` so a fresh non-regular entry can be
-    /// created there, reporting any refusal the way upstream reports it.
+    /// Clears whatever stands at `existing` so a fresh entry can be written
+    /// there, reporting any refusal the way upstream reports it.
     ///
     /// `Ok(())` means the path is free: it was already absent, it was removed,
     /// or it was moved into the backup area. `Err` means the entry must be

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -66,8 +66,16 @@ pub(in crate::receiver) enum MakeWayFor {
     /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
     Symlink,
     /// upstream `DEL_FOR_DEVICE` - `"device file"`.
+    ///
+    /// Unix only: `create_specials` is the sole constructor and Windows has
+    /// no `mknod` path, so on Windows this variant is unconstructible and
+    /// `-D warnings` rejects it as dead code.
+    #[cfg(unix)]
     Device,
     /// upstream `DEL_FOR_SPECIAL` - `"special file"`.
+    ///
+    /// Unix only, for the same reason as [`Self::Device`].
+    #[cfg(unix)]
     Special,
 }
 
@@ -77,7 +85,9 @@ impl MakeWayFor {
     const fn description(self) -> &'static str {
         match self {
             Self::Symlink => "symlink",
+            #[cfg(unix)]
             Self::Device => "device file",
+            #[cfg(unix)]
             Self::Special => "special file",
         }
     }

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -1,0 +1,425 @@
+//! The receiver's single decision site for an existing destination entry that
+//! stands where a symlink, FIFO, socket, or device node has to be created.
+//!
+//! Upstream makes this decision in exactly one place. `atomic_create()` sets
+//! `dir_in_the_way` when the obstacle is a directory, which also forces
+//! `skip_atomic`, so a directory obstacle reaches `delete_item()` whether or
+//! not `--backup` is set - the `make_backup` arm is unreachable for it in
+//! either mode. `delete_item()` then splits on the same test one level down:
+//! the `rmdir` arm for a directory, the `make_backup`/`unlink` arm in the
+//! `else`. Keeping both arms in one function here is what makes oc's structure
+//! answer upstream's; deciding the directory case inside the backup path would
+//! leave every `--backup`-off shape decided somewhere else.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:2469` - `int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);`
+//! - `generator.c:2471-2472` - `dir_in_the_way` forces `skip_atomic = 1`
+//! - `generator.c:2477-2483` - `if (make_backups > 0 && !dir_in_the_way) make_backup(...)`
+//!   `else if (skip_atomic) delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag)`
+//! - `delete.c:222-226` - the `rmdir` arm for `S_ISDIR(mode)`
+//! - `delete.c:227-238` - the `make_backup`/`unlink` arm in the `else`
+//! - `delete.c:178-181` - `cannot delete non-empty directory: %s` at `FINFO`
+//! - `delete.c:273-286` - `could not make way for %s %s: %s` at `FERROR_XFER`
+//!
+//! # Known residual: `DEL_RECURSE`
+//!
+//! `generator.c:2481` computes `int del_opts = delete_mode || force_delete ?
+//! DEL_RECURSE : 0`, so under `--delete` or `--force` upstream removes a
+//! POPULATED directory obstacle recursively and completes at exit 0. Measured
+//! against 3.5.0 over a real `--server` child: `--force`, `--delete`, and both
+//! together each give `rc=0` with the symlink in place, where this arm refuses
+//! at 23.
+//!
+//! Neither flag is reachable from here. `--force` is parsed and discarded by
+//! the server arg parser (`cli/src/frontend/server/flags.rs:615`, `"--force"
+//! => {}`) and has no field in `ParsedServerFlags`, so the receiver cannot
+//! know it was asked for. Wiring it is a server-arg and config change, not an
+//! obstacle-removal one, and is deliberately out of scope here: before this
+//! module existed the same shape aborted the whole transfer at 12 with the
+//! sibling files unsent, so the refusal below is strictly closer to upstream,
+//! not a new divergence.
+
+#[cfg(any(unix, windows))]
+use std::io;
+#[cfg(any(unix, windows))]
+use std::path::Path;
+
+#[cfg(any(unix, windows))]
+use crate::pipeline::receiver::upstream_errno_text;
+#[cfg(any(unix, windows))]
+use crate::receiver::ReceiverContext;
+
+/// The kind of item the receiver is clearing the way for.
+///
+/// Names the `DEL_FOR_*` flag upstream ORs into `delete_item`'s flags, which
+/// selects the noun in the `could not make way for new %s: %s` diagnostic.
+/// Upstream picks it from the *new* entry's type, not the obstacle's
+/// (`generator.c:2041-2047`).
+///
+/// # Upstream Reference
+///
+/// - `delete.c:275-282` - the `DEL_MAKE_ROOM` switch that picks the noun
+#[cfg(any(unix, windows))]
+#[derive(Clone, Copy)]
+pub(in crate::receiver) enum MakeWayFor {
+    /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
+    Symlink,
+    /// upstream `DEL_FOR_DEVICE` - `"device file"`.
+    Device,
+    /// upstream `DEL_FOR_SPECIAL` - `"special file"`.
+    Special,
+}
+
+#[cfg(any(unix, windows))]
+impl MakeWayFor {
+    /// upstream: `delete.c:275-279` - the `desc` assigned per `DEL_FOR_*`.
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Symlink => "symlink",
+            Self::Device => "device file",
+            Self::Special => "special file",
+        }
+    }
+}
+
+/// Reports whether `error` is the kernel's "directory is not empty" refusal.
+///
+/// Linux and the BSDs disagree on the errno `rmdir(2)` raises for a populated
+/// directory, and upstream tests only `ENOTEMPTY` because its own `rmdir` path
+/// never sees the BSD spelling. Accepting both keeps the diagnostic identical
+/// across the platforms oc builds for.
+///
+/// upstream: `delete.c:260-263` - `if (S_ISDIR(mode) && errno == ENOTEMPTY)`
+#[cfg(unix)]
+fn is_not_empty(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(libc::ENOTEMPTY) | Some(libc::EEXIST)
+    )
+}
+
+/// Windows reports a populated directory as `ERROR_DIR_NOT_EMPTY`, which `std`
+/// surfaces as a raw OS error rather than a named `io::ErrorKind`.
+#[cfg(windows)]
+fn is_not_empty(error: &io::Error) -> bool {
+    const ERROR_DIR_NOT_EMPTY: i32 = 145;
+    error.raw_os_error() == Some(ERROR_DIR_NOT_EMPTY)
+}
+
+#[cfg(any(unix, windows))]
+impl ReceiverContext {
+    /// Clears whatever stands at `existing` so a fresh non-regular entry can be
+    /// created there, reporting any refusal the way upstream reports it.
+    ///
+    /// `Ok(())` means the path is free: it was already absent, it was removed,
+    /// or it was moved into the backup area. `Err` means the entry must be
+    /// skipped; the diagnostic has already been emitted, so the caller only has
+    /// to `continue`.
+    ///
+    /// The directory arm never consults `--backup`: upstream's `dir_in_the_way`
+    /// excludes a directory obstacle from `make_backup` in both modes and sends
+    /// it to `delete_item`'s `rmdir`, which clears an empty directory and
+    /// refuses a populated one.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2469-2485` - `atomic_create()`'s `dir_in_the_way` split
+    /// - `delete.c:205-239` - `delete_item()`'s `rmdir` and `make_backup` arms
+    #[cfg(unix)]
+    pub(in crate::receiver) fn make_way_for_replacement<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        // SEC-1.f: when the sandbox is plumbed and the destination parent is
+        // the sandbox root the obstacle stat goes through
+        // `fstatat(AT_SYMLINK_NOFOLLOW)`, so a TOCTOU symlink swap on
+        // `existing` cannot redirect the probe to a different inode.
+        let Ok(metadata) =
+            fast_io::lstat_via_sandbox_or_fallback(sandbox, dest_dir, relative_path, existing)
+        else {
+            // upstream: delete.c:268-269 maps ENOENT to DR_SUCCESS and
+            // backup.c:236 returns "nothing to keep" - either way there is
+            // nothing in the way to make way for.
+            return Ok(());
+        };
+
+        if metadata.is_dir() {
+            // upstream: generator.c:2469 - dir_in_the_way, so neither the
+            // backup arm nor the atomic temp-and-rename applies.
+            return self.rmdir_obstacle(
+                writer,
+                existing,
+                relative_path,
+                dest_dir,
+                sandbox,
+                make_way_for,
+            );
+        }
+
+        // upstream: generator.c:2477 / delete.c:228-230 - the backup arm, which
+        // the `is_dir` test above has already excluded a directory from.
+        match self.backup_existing_before_replace(existing, relative_path, dest_dir, sandbox) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => return self.report_backup_failure(writer, relative_path, error),
+        }
+
+        // SEC-1.g: the obstacle unlink is anchored on the same sandbox dirfd
+        // the stat above used, so a swap between the two cannot redirect the
+        // syscall to an attacker-chosen parent.
+        //
+        // upstream: delete.c:236-237 - `what = "unlink"; ok = del_unlink(fbuf) == 0;`
+        match fast_io::unlink_via_sandbox_or_fallback(
+            sandbox,
+            dest_dir,
+            relative_path,
+            existing,
+            fast_io::UnlinkFlags::File,
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_unlink_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Windows variant: no dirfd sandbox, so the probe and the removal are
+    /// path-based, matching the Windows symlink-create path.
+    #[cfg(windows)]
+    pub(in crate::receiver) fn make_way_for_replacement<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let Ok(metadata) = std::fs::symlink_metadata(existing) else {
+            return Ok(());
+        };
+
+        if metadata.is_dir() {
+            return self.rmdir_obstacle(writer, existing, relative_path, make_way_for);
+        }
+
+        match self.backup_existing_before_replace(existing, relative_path, dest_dir) {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => return self.report_backup_failure(writer, relative_path, error),
+        }
+
+        match std::fs::remove_file(existing) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_unlink_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// The directory arm: `rmdir`, plus upstream's two-line refusal when the
+    /// directory is not empty.
+    ///
+    /// Upstream reaches `rmdir` for this shape because `atomic_create` passes
+    /// `del_opts` without `DEL_RECURSE` unless `--delete`/`--force` is in play,
+    /// so `delete_dir_contents` only probes emptiness and reports it; the
+    /// contents are never removed to make room.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:222-226` - `what = "rmdir"; ok = do_rmdir_at(fbuf) == 0;`
+    #[cfg(unix)]
+    fn rmdir_obstacle<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        dest_dir: &Path,
+        sandbox: Option<&fast_io::DirSandbox>,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        match fast_io::unlink_via_sandbox_or_fallback(
+            sandbox,
+            dest_dir,
+            relative_path,
+            existing,
+            fast_io::UnlinkFlags::Dir,
+        ) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_rmdir_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Windows variant of [`Self::rmdir_obstacle`].
+    #[cfg(windows)]
+    fn rmdir_obstacle<W>(
+        &self,
+        writer: &mut W,
+        existing: &Path,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        match std::fs::remove_dir(existing) {
+            Ok(()) => Ok(()),
+            Err(error) => self.report_rmdir_failure(writer, relative_path, make_way_for, error),
+        }
+    }
+
+    /// Renders a failed `rmdir` the way `delete_item` does.
+    ///
+    /// A vanished directory is not a failure - upstream maps `ENOENT` to
+    /// `DR_SUCCESS` and creates the replacement. A populated one gets the
+    /// `FINFO` emptiness notice before the `FERROR_XFER` refusal; any other
+    /// errno gets `delete_file: rmdir(...) failed` in its place.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:259-268` - the `ENOTEMPTY` / `rsyserr` / `ENOENT` split
+    fn report_rmdir_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        if error.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        if is_not_empty(&error) {
+            // upstream: delete.c:178-181 - delete_dir_contents() reports the
+            // emptiness probe at FINFO before delete_item() names the item it
+            // blocked. FINFO leaves the exit code alone; the FERROR_XFER line
+            // that follows is what lifts it to RERR_PARTIAL.
+            let _ = self.emit_info_line(
+                writer,
+                &format!(
+                    "cannot delete non-empty directory: {}\n",
+                    relative_path.display()
+                ),
+            );
+        } else {
+            // upstream: delete.c:264-266 - rsyserr(FERROR_XFER, errno,
+            // "delete_file: %s(%s) failed", what, fbuf).
+            let _ = self.emit_error_xfer_line(
+                writer,
+                &format!(
+                    "rsync: [receiver] delete_file: rmdir({}) failed: {}\n",
+                    relative_path.display(),
+                    upstream_errno_text(&error)
+                ),
+            );
+        }
+        self.report_make_way_failure(writer, relative_path, make_way_for, error)
+    }
+
+    /// Renders a failed obstacle `unlink` the way `delete_item` does.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:264-266` - `rsyserr(FERROR_XFER, errno, "delete_file: %s(%s) failed", ...)`
+    fn report_unlink_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        if error.kind() == io::ErrorKind::NotFound {
+            return Ok(());
+        }
+        let _ = self.emit_error_xfer_line(
+            writer,
+            &format!(
+                "rsync: [receiver] delete_file: unlink({}) failed: {}\n",
+                relative_path.display(),
+                upstream_errno_text(&error)
+            ),
+        );
+        self.report_make_way_failure(writer, relative_path, make_way_for, error)
+    }
+
+    /// Emits `could not make way for new %s: %s` and returns the error so the
+    /// caller skips the entry.
+    ///
+    /// The line is `FERROR_XFER`, which sets the peer's `got_xfer_error` and so
+    /// lifts a zero exit to `RERR_PARTIAL` (23). Reporting the same event at a
+    /// verbosity-gated `debug_log!` instead - which is what these call sites
+    /// used to do - leaves the run exiting 0 with the obstacle still standing.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:272-286` - the `DEL_MAKE_ROOM` block reached via `check_ret`
+    /// - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+    /// - `cleanup.c:217-218` - `got_xfer_error` lifts a zero exit to `RERR_PARTIAL`
+    fn report_make_way_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        make_way_for: MakeWayFor,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _ = self.emit_error_xfer_line(
+            writer,
+            &format!(
+                "could not make way for new {}: {}\n",
+                make_way_for.description(),
+                relative_path.display()
+            ),
+        );
+        Err(error)
+    }
+
+    /// Reports a backup mechanism that could not preserve the obstacle.
+    ///
+    /// Upstream is loud here and skips the entry: every `return 0` path in
+    /// `make_backup_inner()` has already called `rsyserr` (or `copy_valid_path`
+    /// has), and `atomic_create` then returns 0 without creating the
+    /// replacement. `FERROR` rather than `FERROR_XFER` matches upstream, which
+    /// leaves `got_xfer_error` clear on this arm.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `backup.c:400-401` - `rsyserr(FERROR, errno, "keep_backup failed: %s -> \"%s\"", ...)`
+    /// - `generator.c:2478-2479` - `if (!make_backup(fname, skip_atomic)) return 0;`
+    fn report_backup_failure<W>(
+        &self,
+        writer: &mut W,
+        relative_path: &Path,
+        error: io::Error,
+    ) -> io::Result<()>
+    where
+        W: crate::writer::MsgInfoSender + ?Sized,
+    {
+        let _ = self.emit_error_line(
+            writer,
+            &format!(
+                "rsync: [receiver] keep_backup failed: {}: {}\n",
+                relative_path.display(),
+                upstream_errno_text(&error)
+            ),
+        );
+        Err(error)
+    }
+}

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -37,6 +37,8 @@ use protocol::flist::{FileEntry, FileType};
 #[cfg(unix)]
 use crate::generator::ItemFlags;
 use crate::receiver::ReceiverContext;
+#[cfg(unix)]
+use crate::receiver::directory::obstacle::MakeWayFor;
 
 impl ReceiverContext {
     /// Creates FIFO, socket, and device nodes from the file list entries.
@@ -181,44 +183,31 @@ impl ReceiverContext {
                     }
                 }
 
-                // upstream: generator.c:2018-2020 atomic_create - when --backup
-                // is set and an existing item is being replaced, preserve it to
-                // the backup location before it is removed. On backup-mechanism
-                // failure upstream returns 0 from atomic_create (skips the
-                // entry); mirror that by logging and continuing.
-                match self.backup_existing_before_replace(
-                    &node_path,
-                    relative_path,
-                    dest_dir,
-                    sandbox,
-                ) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        // SEC-1.g: route the obstacle unlink through the sandbox
-                        // dirfd when the destination parent is the sandbox root
-                        // so a TOCTOU swap between the stat above and this
-                        // unlink cannot redirect the syscall. Falls back to
-                        // path-based removal otherwise. The result is
-                        // intentionally ignored: a dangling obstacle simply
-                        // surfaces as a create failure below.
-                        let _ = fast_io::unlink_via_sandbox_or_fallback(
-                            sandbox,
-                            dest_dir,
-                            relative_path,
-                            &node_path,
-                            fast_io::UnlinkFlags::File,
-                        );
-                    }
-                    Err(error) => {
-                        debug_log!(
-                            Recv,
-                            1,
-                            "failed to back up existing special file {}: {}",
-                            node_path.display(),
-                            error
-                        );
-                        continue;
-                    }
+                // upstream: generator.c:2091 atomic_create(..., del_for_flag) -
+                // one decision for the obstacle: rmdir a directory, back up or
+                // unlink anything else. The refusal is reported inside, so a
+                // blocked entry no longer exits 0 in silence.
+                //
+                // upstream: generator.c:2041-2047 - the noun in the refusal
+                // comes from the NEW entry's type, DEL_FOR_DEVICE for a device
+                // and DEL_FOR_SPECIAL for a FIFO or socket.
+                let make_way_for = if is_device {
+                    MakeWayFor::Device
+                } else {
+                    MakeWayFor::Special
+                };
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &node_path,
+                        relative_path,
+                        dest_dir,
+                        sandbox,
+                        make_way_for,
+                    )
+                    .is_err()
+                {
+                    continue;
                 }
 
                 // upstream: generator.c:1675 atomic_create -> do_mknod_at

--- a/crates/transfer/src/receiver/tests/generator_keepalive.rs
+++ b/crates/transfer/src/receiver/tests/generator_keepalive.rs
@@ -192,6 +192,8 @@ fn build_files_to_transfer_keepalive_gated_on_timeout() {
     let _ = ctx.build_files_to_transfer(
         &mut writer,
         dir.path(),
+        #[cfg(unix)]
+        None,
         &opts,
         None,
         &mut errors,
@@ -207,6 +209,8 @@ fn build_files_to_transfer_keepalive_gated_on_timeout() {
     let _ = ctx.build_files_to_transfer(
         &mut writer,
         dir.path(),
+        #[cfg(unix)]
+        None,
         &opts,
         None,
         &mut errors,

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -119,10 +119,10 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 /// This test plants a regular file where the symlink's PARENT
 /// component has to be, so the underlying `symlink` syscall returns
 /// `ENOTDIR` - a non-EACCES class. The fix must surface it as `Err`.
-/// EACCES is covered by the discrimination test in the deletion module
-/// - one fail-loud regression per site is sufficient because both
-/// sites share the same upstream-parity rule (`PermissionDenied` is
-/// the only non-fatal class).
+/// EACCES is covered by the discrimination test in the deletion
+/// module: one fail-loud regression per site is sufficient because
+/// both sites share the same upstream-parity rule (`PermissionDenied`
+/// is the only non-fatal class).
 ///
 /// ⚠ The fixture used to plant an empty DIRECTORY at the leaf and rely
 /// on `symlinkat` returning EEXIST over it. That only worked because

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -116,13 +116,23 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
 /// planted non-symlink leaf were all silently skipped while the
 /// receiver exited `rc=0` with the symlink missing.
 ///
-/// This test plants a regular file at the destination leaf so the
-/// underlying `symlink` syscall returns `AlreadyExists` (EEXIST), a
-/// non-EACCES class. The fix must surface it as `Err`. EACCES is
-/// covered by the discrimination test in the deletion module - one
-/// fail-loud regression per site is sufficient because both sites
-/// share the same upstream-parity rule (`PermissionDenied` is the
-/// only non-fatal class).
+/// This test plants a regular file where the symlink's PARENT
+/// component has to be, so the underlying `symlink` syscall returns
+/// `ENOTDIR` - a non-EACCES class. The fix must surface it as `Err`.
+/// EACCES is covered by the discrimination test in the deletion module
+/// - one fail-loud regression per site is sufficient because both
+/// sites share the same upstream-parity rule (`PermissionDenied` is
+/// the only non-fatal class).
+///
+/// ⚠ The fixture used to plant an empty DIRECTORY at the leaf and rely
+/// on `symlinkat` returning EEXIST over it. That only worked because
+/// oc had no directory arm in its obstacle removal: upstream's
+/// `atomic_create` sets `dir_in_the_way` and `delete_item` `rmdir`s an
+/// empty directory (`generator.c:2469`, `delete.c:222-226`), so the
+/// symlink lands and there is no error to surface. The old fixture's
+/// closing assertion - "the planted directory must persist" - asserted
+/// the defect. A path COMPONENT is the right vehicle: `delete_item`
+/// only ever clears the leaf, so no removal can make way for this one.
 ///
 /// upstream: generator.c:1603 atomic_create -> do_symlink - EACCES is
 /// non-fatal (increment io_error and continue); every other class is
@@ -133,20 +143,17 @@ fn create_symlinks_surfaces_non_eacces_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let dest = tmp.path();
 
-    // Plant a directory at the leaf path. `read_link` returns Err
-    // (not a symlink), `lstat` sees the directory, and the obstacle
-    // `unlink_via_sandbox_or_fallback(UnlinkFlags::File)` fails with
-    // EISDIR which is swallowed by the pre-existing `let _ = ...`
-    // obstacle-removal contract (the receiver is allowed to attempt
-    // the obstacle removal but is not required to succeed). The flow
-    // then reaches `symlinkat`, which returns AlreadyExists/EEXIST -
-    // a non-EACCES class the fix must surface.
-    std::fs::create_dir(dest.join("blocked")).expect("plant directory obstacle");
+    // A regular file standing in for the `blocked` directory component.
+    // `read_link` and `lstat` on `blocked/link` both return ENOTDIR, so
+    // the obstacle path is not entered at all; the `create_dir_all` of
+    // the parent cannot succeed either, and `symlinkat` then returns
+    // ENOTDIR - a non-EACCES class the fix must surface.
+    std::fs::write(dest.join("blocked"), b"not a directory\n").expect("plant file component");
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
     ctx.file_list = vec![FileEntry::new_symlink(
-        "blocked".into(),
+        "blocked/link".into(),
         "/etc/passwd".into(),
     )];
 
@@ -159,15 +166,15 @@ fn create_symlinks_surfaces_non_eacces_error() {
         err.kind(),
         std::io::ErrorKind::PermissionDenied,
         "EACCES is the upstream-parity non-fatal branch; this scenario \
-         plants a directory at the leaf to exercise the fail-loud branch \
-         via AlreadyExists/EEXIST",
+         plants a file where a path component belongs to exercise the \
+         fail-loud branch via ENOTDIR",
     );
-    // The on-disk obstacle must persist - the receiver did not silently
-    // delete the directory in lieu of the symlink.
+    // The on-disk obstruction must persist - the receiver did not
+    // silently consume it while reporting the symlink failure as `()`.
     assert!(
-        dest.join("blocked").is_dir(),
-        "the planted directory must persist - the receiver must not silently \
-         consume it while reporting the symlink failure as `()`",
+        dest.join("blocked").is_file(),
+        "the planted file must persist - the obstacle removal clears the \
+         leaf, never a path component",
     );
 }
 

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -20,6 +20,8 @@ use metadata::{MetadataOptions, apply_metadata_with_cached_stat, metadata_unchan
 use protocol::flist::FileEntry;
 
 use crate::receiver::directory::FailedDirectories;
+#[cfg(any(unix, windows))]
+use crate::receiver::directory::obstacle::MakeWayFor;
 use crate::receiver::quick_check::{
     BasisTrust, dest_mtime_newer, dest_type_matches_source, is_hardlink_follower,
     quick_check_matches, try_reference_dest,
@@ -83,6 +85,40 @@ fn dest_mtime(meta: &fs::Metadata) -> (i64, u32) {
             .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
             .map_or((0, 0), |d| (d.as_secs() as i64, d.subsec_nanos()))
     }
+}
+
+/// Reports whether an existing destination has to be removed before a regular
+/// file can be written over it.
+///
+/// Upstream keeps a destination in place only when it is already a regular
+/// file, or when `--write-devices` asked for the delta to be written straight
+/// into an existing device node. Everything else - a directory, a symlink, a
+/// FIFO, a socket, a device without `--write-devices` - is an obstacle that
+/// `delete_item()` clears first.
+///
+/// The metadata handed in is the follow-stat the candidate pass already took,
+/// so a symlink is classified by its target here; the removal itself re-probes
+/// with `lstat` and acts on the link, never through it.
+///
+/// # Upstream Reference
+///
+/// - `generator.c:2148` - `if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE)))`
+#[cfg(unix)]
+fn dest_blocks_regular_file(meta: &fs::Metadata, write_devices: bool) -> bool {
+    use std::os::unix::fs::FileTypeExt;
+
+    let file_type = meta.file_type();
+    if file_type.is_file() {
+        return false;
+    }
+    !(write_devices && (file_type.is_block_device() || file_type.is_char_device()))
+}
+
+/// Windows variant: there is no device node to write through, so anything that
+/// is not a regular file is an obstacle.
+#[cfg(windows)]
+fn dest_blocks_regular_file(meta: &fs::Metadata, _write_devices: bool) -> bool {
+    !meta.file_type().is_file()
 }
 
 pub(in crate::receiver) fn new_dir_count(plan: &[DryRunItem<'_>]) -> u64 {
@@ -153,6 +189,7 @@ impl ReceiverContext {
         &'a self,
         writer: &mut W,
         dest_dir: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
         metadata_opts: &MetadataOptions,
         failed_dirs: Option<&FailedDirectories>,
         metadata_errors: &mut Vec<(PathBuf, String)>,
@@ -333,7 +370,7 @@ impl ReceiverContext {
         // Pre-size for the expected minority that need transfer.
         let needs_metadata_apply = metadata_opts.requires_apply();
         let mut files_to_transfer = Vec::with_capacity(stat_results.len() / 4 + 1);
-        for (idx, file_path, dest_meta) in stat_results {
+        for (idx, file_path, mut dest_meta) in stat_results {
             // upstream: generator.c:2348-2353 generate_files() - the per-file
             // generate loop pokes maybe_send_keepalive once the I/O lull has
             // elapsed so a remote sender's --timeout does not fire while the
@@ -473,6 +510,50 @@ impl ReceiverContext {
                     continue;
                 }
             }
+            // upstream: generator.c:2148-2153 -
+            //   `if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
+            //        if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
+            //                goto cleanup;
+            //        statret = -1; stat_errno = ENOENT; }`
+            //
+            // A destination that is not a regular file is REMOVED here, before
+            // the delta is requested. Leaving it standing is not equivalent:
+            // the commit's rename replaces a FIFO or a symlink by accident and
+            // fails outright on a directory, `--backup` never sees the
+            // displaced node, and an inplace or appending write goes THROUGH
+            // the obstacle instead of over it.
+            //
+            // This is `delete_item`'s `DEL_FOR_FILE` arm, so it routes to the
+            // same `make_way_for_replacement` the symlink, FIFO, socket, and
+            // device creators use - one removal, one set of diagnostics. A
+            // refusal is reported inside; skipping the entry here is upstream's
+            // `goto cleanup`.
+            #[cfg(any(unix, windows))]
+            if dest_meta
+                .as_ref()
+                .is_some_and(|meta| dest_blocks_regular_file(meta, self.config.write.write_devices))
+            {
+                if self
+                    .make_way_for_replacement(
+                        writer,
+                        &file_path,
+                        entry.path(),
+                        dest_dir,
+                        #[cfg(unix)]
+                        sandbox,
+                        MakeWayFor::File,
+                    )
+                    .is_err()
+                {
+                    continue;
+                }
+                // upstream: generator.c:2151-2152 - `statret = -1; stat_errno =
+                // ENOENT;`. The obstacle is gone, so every decision below sees
+                // an absent destination: ITEM_IS_NEW on the itemize row and a
+                // created-file tally rather than a replacement.
+                dest_meta = None;
+            }
+
             // upstream: generator.c:511-579 itemize() - compute the base itemize
             // flags before the data transfer so the row reflects attribute
             // changes against the pre-transfer destination. A non-existent dest
@@ -1402,6 +1483,8 @@ mod itemize_order_tests {
             let files = ctx.build_files_to_transfer(
                 &mut writer,
                 dest,
+                #[cfg(unix)]
+                None,
                 &metadata::MetadataOptions::default(),
                 None,
                 &mut metadata_errors,
@@ -1472,6 +1555,8 @@ mod itemize_order_tests {
             ctx.build_files_to_transfer(
                 &mut writer,
                 dest,
+                #[cfg(unix)]
+                None,
                 &metadata::MetadataOptions::default(),
                 None,
                 &mut metadata_errors,
@@ -2152,6 +2237,8 @@ mod itemize_order_tests {
         let _ = ctx.build_files_to_transfer(
             &mut writer,
             dest,
+            #[cfg(unix)]
+            None,
             &opts,
             None,
             &mut metadata_errors,
@@ -2211,6 +2298,8 @@ mod itemize_order_tests {
         let candidates = ctx.build_files_to_transfer(
             &mut writer,
             dest,
+            #[cfg(unix)]
+            None,
             &metadata::MetadataOptions::default(),
             None,
             &mut metadata_errors,
@@ -2555,6 +2644,8 @@ mod skip_notice_tests {
         let _ = ctx.build_files_to_transfer(
             &mut writer,
             dest,
+            #[cfg(unix)]
+            None,
             &opts,
             None,
             &mut errs,

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -155,6 +155,8 @@ impl ReceiverContext {
         let files_to_transfer = self.build_files_to_transfer(
             writer,
             &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
             &setup.metadata_opts,
             None,
             &mut metadata_errors,

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -189,6 +189,8 @@ impl ReceiverContext {
         let files_to_transfer = self.build_files_to_transfer(
             writer,
             &setup.dest_dir,
+            #[cfg(unix)]
+            setup.sandbox.as_deref(),
             &setup.metadata_opts,
             Some(&failed_dirs),
             &mut metadata_errors,
@@ -567,6 +569,8 @@ mod itemize_order_tests {
         let _ = ctx.build_files_to_transfer(
             &mut writer,
             dest,
+            #[cfg(unix)]
+            None,
             &opts,
             Some(&failed_dirs),
             &mut metadata_errors,

--- a/tests/directory_obstacle_removal.rs
+++ b/tests/directory_obstacle_removal.rs
@@ -1,5 +1,6 @@
-//! A directory standing where a symlink or special file has to be created is
-//! removed, never backed up - and a populated one is refused out loud.
+//! A directory standing where a regular file, symlink, or special file has to
+//! be written is removed, never backed up - and a populated one is refused out
+//! loud.
 //!
 //! upstream `generator.c:2464-2485` `atomic_create()`:
 //!
@@ -33,6 +34,27 @@
 //! | symlink | non-empty dir | 23 + two diagnostics | 12, dir kept, sibling not transferred |
 //! | fifo    | empty dir     | 0, fifo placed | **0 in silence**, dir kept |
 //! | fifo    | non-empty dir | 23 + two diagnostics | **0 in silence**, dir kept |
+//!
+//! The regular-file source reaches the same `delete_item()` from its own call
+//! site rather than through `atomic_create()`:
+//!
+//! ```text
+//! generator.c:2148-2153
+//! if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
+//!         if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
+//!                 goto cleanup;
+//!         statret = -1;
+//!         stat_errno = ENOENT;
+//! }
+//! ```
+//!
+//! oc had no analogue there, so the destination directory survived into the
+//! commit and the rename failed against it:
+//!
+//! | src kind | obstacle | rsync 3.5.0 | oc before |
+//! |---|---|---|---|
+//! | regular | empty dir     | 0, regular file placed | 12 `server error: Is a directory (21)`, dir kept |
+//! | regular | non-empty dir | 23 + two diagnostics | 12, dir kept |
 //!
 //! and under `--backup` with a sibling backup dir, oc RENAMED the directory
 //! into the backup area - a wrong-data outcome at exit 0, where upstream
@@ -82,6 +104,10 @@ fn write_rsh_shim(dir: &Path) -> PathBuf {
 
 const SIBLING: &str = "sibling payload\n";
 
+/// The bytes a regular-file source carries, distinct from anything the
+/// destination could already hold.
+const PAYLOAD: &str = "regular payload\n";
+
 struct Fixture {
     _temp: tempfile::TempDir,
     root: PathBuf,
@@ -93,6 +119,7 @@ struct Fixture {
 enum Source {
     Symlink,
     Fifo,
+    Regular,
 }
 
 /// Builds `src/{obstacle,sibling}` and `dst/{obstacle/,sibling}`, where
@@ -122,6 +149,9 @@ fn fixture(source: Source, populate_obstacle: bool) -> Fixture {
                 .status()
                 .expect("spawn mkfifo");
             assert!(status.success(), "mkfifo failed: {status}");
+        }
+        Source::Regular => {
+            fs::write(root.join("src/obstacle"), PAYLOAD).expect("write source payload");
         }
     }
     fs::write(root.join("src/sibling"), SIBLING).expect("write src sibling");
@@ -343,5 +373,133 @@ fn a_populated_directory_obstacle_under_backup_is_refused_not_backed_up() {
     assert!(
         !fx.root.join("dst/bak/obstacle").exists(),
         "and no part of it is moved into the backup area"
+    );
+}
+
+/// The regular-file headline for `--backup` off: an EMPTY directory is
+/// `rmdir`'d and the file's data lands in its place, at exit 0.
+///
+/// Nothing masks this one. A rename over a symlink, FIFO, or socket replaces
+/// the node by accident, which is why the plain-mode cells for those shapes
+/// looked correct; `rename()` onto a directory is `EISDIR`, so oc surfaced
+/// `server error: Is a directory (21)` and stopped the whole run at 12 with
+/// the sibling unsent.
+///
+/// The `-i` row is part of the expectation: `statret = -1` is what makes the
+/// entry `ITEM_IS_NEW`, so 3.5.0 prints `<f+++++++++ a` for a cleared
+/// obstacle. Measured against 3.5.0, not read off the source.
+///
+/// upstream: `generator.c:2149` - `delete_item(fname, sx.st.st_mode,
+/// del_opts | DEL_FOR_FILE)`, then `statret = -1`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_regular_file() {
+    let fx = fixture(Source::Regular, false);
+
+    let (status, stdout, stderr) = push(&fx, &["-i"]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "rsync 3.5.0 rmdir's the empty directory and writes the file at exit \
+         0; oc reported `server error: Is a directory (21)` and stopped. \
+         stderr was: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(obstacle(&fx)).expect("obstacle must now be a regular file"),
+        PAYLOAD,
+        "the file has to actually replace the directory, with the sender's \
+         bytes - a still-standing directory means the removal never ran"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "the rest of the transfer must still land"
+    );
+    assert!(
+        stdout.contains("+++++++++ obstacle"),
+        "upstream prints `<f+++++++++ a` for a cleared obstacle: the removal \
+         sets `statret = -1`, so the entry is ITEM_IS_NEW rather than a \
+         replacement of the directory it displaced. stdout was: {stdout}"
+    );
+}
+
+/// A POPULATED directory is refused for a regular file too, with upstream's
+/// two lines and `RERR_PARTIAL` - and the noun is `regular file`, which is the
+/// `DEL_FOR_FILE` arm of the same switch that says `symlink` and `special
+/// file` above.
+///
+/// upstream: `delete.c:276` - `case DEL_FOR_FILE: desc = "regular file";`.
+#[test]
+fn a_populated_directory_obstacle_is_refused_for_a_regular_file() {
+    let fx = fixture(Source::Regular, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(23),
+        "rsync 3.5.0 exits 23 for this shape; oc exited 12. stdout: {stdout} \
+         stderr: {stderr}"
+    );
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("cannot delete non-empty directory: obstacle"),
+        "output was: {output}"
+    );
+    assert!(
+        output.contains("could not make way for new regular file: obstacle"),
+        "the noun comes from the NEW entry's type, so a regular-file source \
+         says `regular file` where a symlink says `symlink`. output was: \
+         {output}"
+    );
+    assert!(
+        obstacle(&fx).is_dir(),
+        "`del_opts` carries no DEL_RECURSE here, so the contents stay put"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "a refused obstacle skips its own entry only; oc used to abandon the \
+         rest of the batch at 12"
+    );
+}
+
+/// The non-vacuity companion: with NO obstacle, an ordinary regular-file
+/// replacement still lands byte-for-byte at exit 0 AND is still reported as a
+/// replacement, not as a creation.
+///
+/// The removal above sits directly in front of every regular-file transfer, so
+/// a gate one type too wide would unlink the existing destination first. The
+/// bytes alone do not catch that - `-I` re-sends the whole file either way, so
+/// a delete-then-create still produces the right content at exit 0. The `-i`
+/// row does: an unlinked destination itemizes `+++++++++` where 3.5.0 prints
+/// `<f..T......` for a file it kept and wrote over. That glyph is exactly what
+/// `statret = -1` controls, so this cell is the mirror of the assertion above.
+#[test]
+fn a_regular_file_destination_with_no_obstacle_still_transfers() {
+    let fx = fixture(Source::Regular, false);
+    // Replace the directory obstacle with an ordinary stale file, which is
+    // upstream's `stype == FT_REG` leg: kept in place and written over.
+    fs::remove_dir_all(obstacle(&fx)).expect("clear the obstacle");
+    fs::write(obstacle(&fx), "stale destination bytes\n").expect("plant stale destination");
+
+    let (status, stdout, stderr) = push(&fx, &["-i"]);
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    assert_eq!(
+        fs::read_to_string(obstacle(&fx)).expect("read replaced file"),
+        PAYLOAD,
+        "an ordinary replace must still carry the sender's bytes"
+    );
+    assert!(
+        !stdout.contains("+++++++++ obstacle"),
+        "`stype == FT_REG` is upstream's keep-it leg: the destination is \
+         written over, never removed, so its row is a change and not a \
+         creation. A `+++++++++` here means the obstacle removal fired one \
+         type too wide. stdout was: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING
     );
 }

--- a/tests/directory_obstacle_removal.rs
+++ b/tests/directory_obstacle_removal.rs
@@ -1,0 +1,347 @@
+//! A directory standing where a symlink or special file has to be created is
+//! removed, never backed up - and a populated one is refused out loud.
+//!
+//! upstream `generator.c:2464-2485` `atomic_create()`:
+//!
+//! ```text
+//! int skip_atomic, dir_in_the_way = del_for_flag && S_ISDIR(sxp->st.st_mode);
+//! if (!del_for_flag || dir_in_the_way || tmpdir || !get_tmpname(tmpname, fname, True))
+//!         skip_atomic = 1;
+//! ...
+//! if (make_backups > 0 && !dir_in_the_way) {
+//!         if (!make_backup(fname, skip_atomic))
+//!                 return 0;
+//! } else if (skip_atomic) {
+//!         int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
+//!         if (delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag) != 0)
+//!                 return 0;
+//! }
+//! ```
+//!
+//! `dir_in_the_way` forces `skip_atomic`, so a directory obstacle reaches
+//! `delete_item()` in BOTH modes: the `make_backup` arm is unreachable for it
+//! whether or not `--backup` is set. `delete_item()` then splits the same way
+//! one level down - the `rmdir` arm at `delete.c:222-226`, the
+//! `make_backup`/`unlink` arm in the `else` at `delete.c:227-238`.
+//!
+//! That is why the removal and the reporting are one change and not two. oc
+//! had no directory arm at all, so:
+//!
+//! | src kind | obstacle | rsync 3.5.0 | oc before |
+//! |---|---|---|---|
+//! | symlink | empty dir     | 0, symlink placed | 12, dir kept, sibling not transferred |
+//! | symlink | non-empty dir | 23 + two diagnostics | 12, dir kept, sibling not transferred |
+//! | fifo    | empty dir     | 0, fifo placed | **0 in silence**, dir kept |
+//! | fifo    | non-empty dir | 23 + two diagnostics | **0 in silence**, dir kept |
+//!
+//! and under `--backup` with a sibling backup dir, oc RENAMED the directory
+//! into the backup area - a wrong-data outcome at exit 0, where upstream
+//! removes it.
+//!
+//! Measured against rsync 3.5.0 (protocol 32) over a real `--server` child on
+//! both ends. Every cell below was run against that binary first; the
+//! expectations are its output, not a reading of the source.
+//!
+//! ⚠ These must run over a REAL `--server` process. A local transfer takes the
+//! engine's local-copy executor, which refuses a directory obstacle in its own
+//! error type (`local_copy/error.rs:427`, "cannot replace existing directory
+//! with symbolic link") and exercises none of the receiver path under test.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn oc_rsync_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// `rsync` invokes `$RSYNC_RSH <host> <command...>`; drop the host and exec the
+/// command locally, so the receiver really is a separate `--server` process.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let script = dir.join("fake_rsh.sh");
+    fs::write(
+        &script,
+        "#!/bin/sh\n\
+         while [ $# -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         -*) shift ;;\n\
+         *) break ;;\n\
+         esac\n\
+         done\n\
+         shift || true\n\
+         exec \"$@\"\n",
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&script).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).expect("chmod shim");
+    script
+}
+
+const SIBLING: &str = "sibling payload\n";
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    shim: PathBuf,
+}
+
+/// What the source names `obstacle`.
+#[derive(Clone, Copy)]
+enum Source {
+    Symlink,
+    Fifo,
+}
+
+/// Builds `src/{obstacle,sibling}` and `dst/{obstacle/,sibling}`, where
+/// `dst/obstacle` is a directory and `src/obstacle` is the non-regular entry
+/// that has to replace it.
+///
+/// `sibling` is load-bearing: upstream keeps transferring it when the obstacle
+/// is refused, so it separates "the obstacle entry was skipped" from "the whole
+/// transfer stopped". oc did the latter.
+fn fixture(source: Source, populate_obstacle: bool) -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::create_dir_all(root.join("dst/obstacle")).expect("create dst obstacle");
+    fs::create_dir_all(root.join("outside")).expect("create outside");
+
+    match source {
+        Source::Symlink => {
+            std::os::unix::fs::symlink("../outside", root.join("src/obstacle"))
+                .expect("plant source symlink");
+        }
+        Source::Fifo => {
+            // Same `mkfifo(1)` shell-out as tests/drop_devices.rs, rather than
+            // a new unsafe libc call in the test tree.
+            let status = std::process::Command::new("mkfifo")
+                .arg(root.join("src/obstacle"))
+                .status()
+                .expect("spawn mkfifo");
+            assert!(status.success(), "mkfifo failed: {status}");
+        }
+    }
+    fs::write(root.join("src/sibling"), SIBLING).expect("write src sibling");
+    if populate_obstacle {
+        fs::write(root.join("dst/obstacle/occupant"), "occupant\n").expect("populate obstacle");
+    }
+
+    let shim = write_rsh_shim(&root);
+    Fixture {
+        _temp: temp,
+        root,
+        shim,
+    }
+}
+
+/// Pushes `src/` to `dst/` through the shim against an external `--server`
+/// receiver. `extra` carries the `--backup` flags where a cell needs them.
+fn push(fx: &Fixture, extra: &[&str]) -> (Option<i32>, String, String) {
+    let binary = oc_rsync_binary();
+    let out = test_support::OcRsyncCliRunner::new()
+        .binary(&binary)
+        // -l keeps symlinks as symlinks, -D materialises the fifo, -I defeats
+        // the quick check so the obstacle entry is always reconsidered.
+        .args(["-rlDI"])
+        .args(extra)
+        .arg("--rsh")
+        .arg(&fx.shim)
+        .arg("--rsync-path")
+        .arg(&binary)
+        .arg(format!("{}/src/", fx.root.display()))
+        .arg(format!("obshost:{}/dst/", fx.root.display()))
+        .run()
+        .expect("push did not finish");
+    (
+        out.status,
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn obstacle(fx: &Fixture) -> PathBuf {
+    fx.root.join("dst/obstacle")
+}
+
+/// The headline for `--backup` off: an EMPTY directory is `rmdir`'d and the
+/// symlink takes its place, at exit 0.
+///
+/// upstream: `delete.c:222-226` - the `rmdir` arm of `delete_item()`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_symlink() {
+    let fx = fixture(Source::Symlink, false);
+
+    let (status, _stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "rsync 3.5.0 rmdir's the empty directory and creates the symlink at \
+         exit 0; oc reported `server error: File exists` and stopped. \
+         stderr was: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside"),
+        "the symlink has to actually replace the directory - a still-standing \
+         directory means the removal never ran"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "the rest of the transfer must still land"
+    );
+}
+
+/// Same for a FIFO, which is the shape oc failed SILENTLY on: it reported exit
+/// 0 while leaving the directory in place and never creating the node.
+///
+/// This cell is the one that distinguishes "the removal works" from "the
+/// removal now fails loudly instead of silently" - every other cell here would
+/// pass under a change that only added diagnostics.
+///
+/// upstream: `generator.c:2091` `atomic_create(file, fname, NULL, NULL, rdev,
+/// &sx, dest_existed ? del_for_flag : 0)`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_fifo() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let fx = fixture(Source::Fifo, false);
+
+    let (status, _stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    let meta = fs::symlink_metadata(obstacle(&fx)).expect("obstacle must still exist");
+    assert!(
+        meta.file_type().is_fifo(),
+        "oc reported exit 0 here while leaving the directory standing and \
+         never creating the fifo - silent data loss, not a loud failure. \
+         The obstacle is now: {meta:?}"
+    );
+}
+
+/// A POPULATED directory is refused, and the refusal is audible: upstream's
+/// two lines plus `RERR_PARTIAL`.
+///
+/// This is the reporting half. Before the change the same shape exited 0 (fifo)
+/// or 12 (symlink) and printed nothing an operator could act on, because the
+/// failure went to a verbosity-gated `debug_log!`.
+///
+/// upstream: `delete.c:178-181` `cannot delete non-empty directory: %s` at
+/// `FINFO`, then `delete.c:283-285` `could not make way for %s %s: %s` at
+/// `FERROR_XFER`, whose `got_xfer_error` lifts the exit to 23
+/// (`log.c:310-311`, `cleanup.c:217-218`).
+#[test]
+fn a_populated_directory_obstacle_is_refused_at_23() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(23),
+        "rsync 3.5.0 exits 23 for this shape. stdout: {stdout} stderr: {stderr}"
+    );
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("cannot delete non-empty directory: obstacle"),
+        "upstream reports the emptiness probe at FINFO before naming the item \
+         it blocked. output was: {output}"
+    );
+    assert!(
+        output.contains("could not make way for new symlink: obstacle"),
+        "upstream's FERROR_XFER line is what makes the run exit non-zero; \
+         without it the obstacle is skipped in silence. output was: {output}"
+    );
+    assert!(
+        obstacle(&fx).is_dir(),
+        "the contents are never removed to make room - `del_opts` carries no \
+         DEL_RECURSE here"
+    );
+    assert_eq!(
+        fs::read_to_string(fx.root.join("dst/sibling")).expect("read sibling"),
+        SIBLING,
+        "a refused obstacle skips its own entry only; upstream keeps going, \
+         and oc used to abandon the rest of the batch"
+    );
+}
+
+/// The noun in the refusal comes from the NEW entry's type, not the obstacle's.
+///
+/// upstream: `generator.c:2041-2047` picks `DEL_FOR_DEVICE` or
+/// `DEL_FOR_SPECIAL`; `delete.c:275-282` turns it into the printed noun.
+#[test]
+fn the_refusal_names_the_new_entrys_kind() {
+    let fx = fixture(Source::Fifo, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("could not make way for new special file: obstacle"),
+        "a FIFO is DEL_FOR_SPECIAL, so upstream says `special file` here and \
+         `symlink` in the cell above. output was: {output}"
+    );
+}
+
+/// The non-vacuity companion, and the reason the two halves ship together.
+///
+/// `dir_in_the_way` excludes a directory from `make_backup` in BOTH modes, so
+/// under `--backup` the empty directory is still `rmdir`'d and the symlink
+/// still lands at exit 0. oc instead RENAMED the directory into the backup
+/// area - a wrong-data outcome that exited 0, so no exit-code assertion could
+/// have caught it.
+///
+/// Reporting the obstacle failure loudly WITHOUT this removal would turn this
+/// cell from a wrong-data pass into a hard failure on a shape upstream
+/// completes at 0. That is what makes the halves inseparable.
+///
+/// upstream: `generator.c:2476` - `if (make_backups > 0 && !dir_in_the_way)`.
+#[test]
+fn a_directory_obstacle_is_removed_not_backed_up_under_backup() {
+    let fx = fixture(Source::Symlink, false);
+    fs::create_dir_all(fx.root.join("dst/bak")).expect("create backup dir");
+
+    let (status, _stdout, stderr) = push(&fx, &["-b", "--backup-dir=bak"]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "upstream completes this shape at exit 0. stderr was: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside"),
+        "the symlink must land under --backup exactly as it does without it"
+    );
+    assert!(
+        !fx.root.join("dst/bak/obstacle").exists(),
+        "upstream never backs a directory obstacle up - dir_in_the_way keeps \
+         it out of make_backup in both modes. oc renamed it into the backup \
+         area, which is a data outcome no exit code reports"
+    );
+}
+
+/// The same `--backup` run, with the obstacle populated: still refused, still
+/// audible, and still not copied into the backup area.
+#[test]
+fn a_populated_directory_obstacle_under_backup_is_refused_not_backed_up() {
+    let fx = fixture(Source::Symlink, true);
+    fs::create_dir_all(fx.root.join("dst/bak")).expect("create backup dir");
+
+    let (status, stdout, stderr) = push(&fx, &["-b", "--backup-dir=bak"]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    assert!(
+        obstacle(&fx).join("occupant").exists(),
+        "the populated directory and its contents stay put"
+    );
+    assert!(
+        !fx.root.join("dst/bak/obstacle").exists(),
+        "and no part of it is moved into the backup area"
+    );
+}


### PR DESCRIPTION
### Stacked on #7597

⚠ This branch is **stacked on #7597** (`fix/obstacle-dir-removal`), not on `master`. Stack: `1faf3c46f` -> `0dac95a43` (#7597) -> this PR. #7597 must land first. It created `make_way_for_replacement`, which owns both of `delete_item()`'s arms — this PR only routes a sixth call site onto it.

### The gap

Upstream removes whatever stands at the destination before it requests the delta for a regular file:

```c
/* generator.c:2148-2153 */
if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
        if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
                goto cleanup;
        statret = -1;
        stat_errno = ENOENT;
}
```

oc had no analogue at that site, so the obstacle survived into the commit. A `rename()` over a symlink, FIFO, or socket replaces the node by accident — which is why the plain-mode cells for those shapes looked correct — but `rename()` onto a directory is `EISDIR`, and there the whole run stopped.

### Measured

rsync 3.5.0 (protocol 32) over a real `--server` child on both ends, source a regular file, obstacle at `dst/a`, sibling file present, each cell carrying a control that proved the removal was permitted (`removable` in all cells, so a surviving node means *not attempted*, never *attempted and refused*):

| obstacle | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|
| empty dir | `rc=0`, `<f+++++++++ a`, regular file placed | `rc=12` `server error: Is a directory (os error 21)`, dir kept, sibling unsent | `rc=0`, `<f+++++++++ a`, regular file placed |
| non-empty dir | `rc=23`, `could not make way for new regular file: a` + `cannot delete non-empty directory: a`, dir kept | `rc=12`, same abort | `rc=23`, both lines, dir kept, sibling written |

Both `before` rows were re-measured on this branch's parent, not quoted from an earlier report. The four symlink/FIFO rows #7597 fixed are unchanged, and the full six-shape sweep (symlink, fifo, regular x empty, non-empty) now matches 3.5.0 in exit code, itemize row, and diagnostic text.

### What changed

A **routing change**, not a second mechanism. `make_way_for_replacement` already owns the `rmdir`-with-`ENOTEMPTY`-refusal arm and the backup-else-unlink arm, and already emits `could not make way for %s %s`. The regular-file site now calls it with a new `DEL_FOR_FILE` noun (`"regular file"`, `delete.c:276`). No removal and no diagnostic is written twice.

The gate is upstream's own test: a destination is kept only when it is already a regular file, or when `--write-devices` asked for the delta to go straight into an existing device node. On success `dest_meta` is cleared, which is `statret = -1`: 3.5.0 itemizes a cleared obstacle `<f+++++++++`, not as a replacement of the node it displaced.

### Proofs

Three independent mutations, each killing exactly one cell:

1. routing disabled -> **both** rows redden at 12, reproducing the measured `Is a directory (os error 21)` text verbatim;
2. `dest_meta = None` dropped -> the empty-dir cell reddens **on the itemize row alone** (`<f.sT......` where 3.5.0 prints `<f+++++++++`);
3. the gate widened one type, so an ordinary regular destination is unlinked too -> the **no-obstacle companion** reddens. Bytes alone do not catch that (`-I` re-sends the file either way, so a delete-then-create still lands the right content at exit 0); the `-i` row does. The companion was inert against this mutation until it asserted on the row, which is why it now does.

### Manifests

No row moves. The 3.5.0 python suite, all 345 cells, nonroot, against this branch's binary: 8 `FAIL`, of which 6 are exactly the rows `tools/ci/upstream-3.5.0-expect.nonroot.txt` already names. The other two (`daemon-copylinks-parent-escape`, `daemon-scan-cwd-desync`) pass 3/3 when re-run in isolation against the same binary — host contention inside the 25-cell chunk, not a moved row. No manifest is edited.

### Residuals, unchanged and out of scope

- A destination symlink whose target is a regular file, and a dangling destination symlink, are still classified by the candidate pass's follow-`stat`, so they are renamed over rather than removed and `--backup` does not see them. Neither can reach the new branch (`dest_meta` is `Some(is_file)` / `None` respectively), so this PR leaves both exactly as they were. Measured: the dangling-symlink-under-`--backup` cell is the one row in that sweep where oc still differs from 3.5.0.
- `--force`/`DEL_RECURSE` stays unreachable while the server arg parser discards `--force` (`cli/src/frontend/server/flags.rs:615`).