### PR TITLE
docs(engine,daemon,core,protocol): retarget citations at rsync 3.5.0

### DIFF
--- a/crates/core/tests/daemon_client_interop.rs
+++ b/crates/core/tests/daemon_client_interop.rs
@@ -9,8 +9,8 @@
 //! 3. Verify protocol negotiation, file transfers, and metadata preservation
 //!
 //! Upstream reference:
-//! - `target/interop/upstream-src/rsync-3.4.1/clientserver.c` - daemon protocol
-//! - `target/interop/upstream-src/rsync-3.4.1/main.c:1267-1384` - client_run()
+//! - `target/interop/upstream-src/rsync-3.5.0/clientserver.c` - daemon protocol
+//! - `target/interop/upstream-src/rsync-3.5.0/main.c:1323-1440` - client_run()
 
 mod common;
 

--- a/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
+++ b/crates/core/tests/upstream_client_to_oc_daemon_interop.rs
@@ -9,8 +9,8 @@
 //! 3. Verify protocol negotiation, file transfers, and metadata preservation
 //!
 //! Upstream reference:
-//! - `target/interop/upstream-src/rsync-3.4.1/clientserver.c` - client protocol
-//! - `target/interop/upstream-src/rsync-3.4.1/main.c:1267-1384` - client_run()
+//! - `target/interop/upstream-src/rsync-3.5.0/clientserver.c` - client protocol
+//! - `target/interop/upstream-src/rsync-3.5.0/main.c:1323-1440` - client_run()
 //!
 //! oc-rsync reference:
 //! - `crates/daemon/src/daemon/` - daemon implementation

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -27,7 +27,7 @@ pub(crate) struct RuntimeOptions {
     /// than picking one. The accept-loop interprets this as "iterate IPv6
     /// then IPv4, surface per-family bind failures as warnings, succeed as
     /// long as at least one family bound." See
-    /// `target/interop/upstream-src/rsync-3.4.4/socket.c:402-499`
+    /// `target/interop/upstream-src/rsync-3.5.0/socket.c:552-650`
     /// (`open_socket_in`) for the family-iteration loop oc-rsync reproduces.
     pub(crate) dual_stack: bool,
     bind_address_overridden: bool,

--- a/crates/daemon/src/tests/chunks/daemon_max_connections_wire_bytes_match_upstream.rs
+++ b/crates/daemon/src/tests/chunks/daemon_max_connections_wire_bytes_match_upstream.rs
@@ -17,7 +17,7 @@
 // template + `{limit}` + `\n` shape, so pinning the template plus the
 // substituted bytes locks both call sites against drift.
 //
-// upstream: target/interop/upstream-src/rsync-3.4.1/clientserver.c:752
+// upstream: target/interop/upstream-src/rsync-3.5.0/clientserver.c:799
 
 #[test]
 fn daemon_max_connections_wire_bytes_match_upstream() {

--- a/crates/daemon/src/tests/chunks/daemon_per_module_cap_wire_bytes_match_global_path.rs
+++ b/crates/daemon/src/tests/chunks/daemon_per_module_cap_wire_bytes_match_global_path.rs
@@ -19,7 +19,7 @@
 // to each other plus to the upstream literal, guarding against drift
 // in either call site.
 //
-// upstream: target/interop/upstream-src/rsync-3.4.1/clientserver.c:752
+// upstream: target/interop/upstream-src/rsync-3.5.0/clientserver.c:799
 
 #[test]
 fn daemon_per_module_cap_wire_bytes_match_global_path() {

--- a/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_per_module_cap_overrides_global_max_connections.rs
@@ -7,7 +7,7 @@
 // per-module cap allows, the second is refused with the upstream
 // literal even though the daemon-global cap (10) is nowhere near hit.
 //
-// upstream: target/interop/upstream-src/rsync-3.4.1/clientserver.c:744
+// upstream: target/interop/upstream-src/rsync-3.5.0/clientserver.c:791
 // applies `lp_max_connections(i)` via `claim_connection()` per module;
 // the per-module value binds independently of any daemon-wide limit.
 

--- a/crates/daemon/src/tests/chunks/runtime_options_per_module_max_connections_overrides_global.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_per_module_max_connections_overrides_global.rs
@@ -3,9 +3,9 @@
 // per-module value is what `ModuleRuntime` enforces for connections to
 // that module, regardless of the higher global cap.
 //
-// upstream: target/interop/upstream-src/rsync-3.4.1/loadparm.c associates
+// upstream: target/interop/upstream-src/rsync-3.5.0/loadparm.c associates
 // `max connections` with each `[modulename]` section (Locals: in
-// `daemon-parm.txt:48`). Upstream has no daemon-global cap; oc-rsync's
+// `daemon-parm.txt:50`). Upstream has no daemon-global cap; oc-rsync's
 // `--max-connections` is an additional daemon-level admission limit and
 // must not override the per-module value when the module sets its own
 // (a per-module value of 1 must still cap that module at 1 even when

--- a/crates/engine/src/delete/cohort_batcher.rs
+++ b/crates/engine/src/delete/cohort_batcher.rs
@@ -56,9 +56,9 @@
 //!
 //! # Upstream reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`): per-cohort dispatch order the batcher preserves.
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-360`
 //!   (`delete_in_dir`): one cohort per destination parent directory.
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/crates/engine/src/delete/cohort_index.rs
+++ b/crates/engine/src/delete/cohort_index.rs
@@ -34,13 +34,13 @@
 //!
 //! # Upstream reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/hlink.c:59-65`
+//! - `target/interop/upstream-src/rsync-3.5.0/hlink.c:59-65`
 //!   (`init_hard_links`): builds the dev/ino table before the delete
 //!   sweep runs.
-//! - `target/interop/upstream-src/rsync-3.4.1/hlink.c:186-208`
+//! - `target/interop/upstream-src/rsync-3.5.0/hlink.c:200-222`
 //!   (`match_hard_links`): freezes leader assignments before
 //!   `do_delete_pass`.
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`): the dispatch is unconditional `do_unlink`; the
 //!   kernel reconciles ref counts. Our [`CohortIndex`] therefore exists
 //!   to power itemize tagging and cohort-aware diagnostics, not to skip
@@ -192,7 +192,7 @@ impl CohortIndex {
     /// should be tagged as "last ref" or as one of several. The count
     /// reflects source-side membership only - destination-side ref
     /// counts are the kernel's responsibility, mirroring upstream
-    /// `delete.c:130-225` where every unlink is unconditional.
+    /// `delete.c:191-288` where every unlink is unconditional.
     #[must_use]
     pub fn surviving_refs_in_cohort(&self, cohort: HardlinkCohortId) -> u32 {
         self.cohort_sizes.get(&cohort).copied().unwrap_or(0)

--- a/crates/engine/src/delete/emitter/mod.rs
+++ b/crates/engine/src/delete/emitter/mod.rs
@@ -30,18 +30,18 @@
 //!
 //! # Upstream reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:48-122`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:91-183`
 //!   (`delete_dir_contents`): recursive directory peel used when an
 //!   `rmdir` would fail with `ENOTEMPTY`.
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`): dispatch by `S_ISDIR` / `S_ISLNK` / `IS_DEVICE` /
 //!   `IS_SPECIAL`, with `do_rmdir` for directories and `robust_unlink`
 //!   for everything else; `ENOTEMPTY` recurses, other errors are logged
 //!   and reported via `DR_FAILURE`.
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-360`
 //!   (`delete_in_dir`): reverse iteration over the sorted destination
 //!   listing, one `delete_item` call per non-matched entry.
-//! - `target/interop/upstream-src/rsync-3.4.1/errcode.h`: `RERR_PARTIAL`
+//! - `target/interop/upstream-src/rsync-3.5.0/errcode.h`: `RERR_PARTIAL`
 //!   (23) and `RERR_VANISHED` (24).
 
 use std::io;
@@ -89,7 +89,7 @@ pub struct DeleteEmitter<F: DeleteFs> {
     /// segment. When `Some`, every successful delete dispatch records a
     /// cohort-tagged trace so callers can attach cohort information to
     /// itemize lines without re-statting. The dispatch itself is
-    /// unchanged - matching upstream `delete.c:130-225`, every extras
+    /// unchanged - matching upstream `delete.c:191-288`, every extras
     /// path is unlinked unconditionally and the kernel reconciles ref
     /// counts. The snapshot is wrapped in [`Arc`] so the same value can
     /// be shared with phase-1 workers.
@@ -212,7 +212,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// every dispatch.
     ///
     /// Wiring a [`CohortIndex`] does not change which paths get
-    /// unlinked - upstream `delete.c:130-225` always issues
+    /// unlinked - upstream `delete.c:191-288` always issues
     /// `do_unlink`, and the kernel reconciles ref counts. The snapshot
     /// powers the emitter's cohort log (see [`Self::cohort_records`]),
     /// which downstream itemize formatting consumes to tag deletions
@@ -312,7 +312,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// [`EmitterErrorPolicy::continue_on_error`] is `false` and a per-entry
     /// failure occurs. Under the default policy every failure other than
     /// ENOENT and dir-ENOTEMPTY sets [`Self::io_error`] and the drain
-    /// continues, matching upstream `delete.c:86-210` which never aborts the
+    /// continues, matching upstream `delete.c:141-273` which never aborts the
     /// pass on a per-entry errno.
     pub fn emit_all(&mut self) -> io::Result<()> {
         loop {
@@ -337,7 +337,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     /// configured [`EmitterErrorPolicy`]. Used by both the top-level
     /// drain and the ENOTEMPTY recursive fallback so a nested directory
     /// gets the same continue-on-error semantics as a top-level one,
-    /// matching upstream `delete_dir_contents` (`delete.c:86-109`) which
+    /// matching upstream `delete_dir_contents` (`delete.c:141-164`) which
     /// iterates the dirlist and keeps going after each per-entry
     /// failure.
     fn drain_plan(&mut self, plan: &DeletePlan) -> io::Result<()> {
@@ -430,10 +430,10 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                     // it prints an FINFO notice once per such directory and
                     // neither records an I/O error nor counts the directory as
                     // deleted, so the exit code stays 0.
-                    // upstream: delete.c:117-119 (delete_dir_contents) and
-                    // delete.c:197-199 (delete_item) both
+                    // upstream: delete.c:178-180 (delete_dir_contents) and
+                    // delete.c:260-262 (delete_item) both
                     // `rprintf(FINFO, "cannot delete non-empty directory: %s\n", ...)`.
-                    // FINFO renders at the default verbosity (log.c:317-320,
+                    // FINFO renders at the default verbosity (log.c:344-347,
                     // shown unless `--quiet`); oc's only info category present
                     // at verbose level 0 is `NONREG` (info_verbosity[0]), the
                     // same channel the sibling "skipping non-regular file"
@@ -450,7 +450,7 @@ impl<F: DeleteFs> DeleteEmitter<F> {
                     );
                     return Ok(());
                 }
-                // upstream: delete.c:86-210 `delete_dir_contents` /
+                // upstream: delete.c:141-273 `delete_dir_contents` /
                 // `delete_item` never abort the pass on a per-entry errno.
                 // Every failure other than ENOENT (idempotent) and
                 // dir-ENOTEMPTY (DR_NOT_EMPTY) is logged via FERROR_XFER,
@@ -530,11 +530,11 @@ impl<F: DeleteFs> DeleteEmitter<F> {
     }
 
     /// Handles a directory entry. Tries `rmdir` first (upstream
-    /// `delete.c:161-163`); on [`io::ErrorKind::DirectoryNotEmpty`] takes
+    /// `delete.c:222-226`); on [`io::ErrorKind::DirectoryNotEmpty`] takes
     /// the nested directory's published plan and drains it through the
     /// shared [`Self::drain_plan`] loop, or falls back to
     /// [`DeleteFs::remove_dir_all`] when no plan was published (upstream
-    /// `delete.c:48-122 delete_dir_contents`). The retried `rmdir` after
+    /// `delete.c:91-183 delete_dir_contents`). The retried `rmdir` after
     /// a successful drain matches `delete_item`'s second pass.
     #[cfg(unix)]
     fn dispatch_dir(

--- a/crates/engine/src/delete/extras.rs
+++ b/crates/engine/src/delete/extras.rs
@@ -18,12 +18,12 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-360`
 //!   (`delete_in_dir`): scans `get_dirlist(fbuf, ...)` then for every
 //!   item calls `flist_find_ignore_dirness(cur_flist, fp) < 0` to decide
 //!   whether to delete. We perform the same set subtraction in pure
 //!   Rust: hash the segment's basenames, then walk the dest directory.
-//! - `target/interop/upstream-src/rsync-3.4.1/flist.c:flist_find`
+//! - `target/interop/upstream-src/rsync-3.5.0/flist.c:flist_find`
 //!   (basename-keyed lookup against the active flist).
 
 use std::collections::HashSet;
@@ -85,7 +85,7 @@ pub fn compute_extras(
 /// the supplied [`CohortIndex`].
 ///
 /// The cohort tag has no effect on the unlink decision itself; matching
-/// upstream `delete.c:130-225`, every extras path is still unlinked
+/// upstream `delete.c:191-288`, every extras path is still unlinked
 /// unconditionally and the kernel reconciles ref counts. The tag exists
 /// so the [`super::DeleteEmitter`] can emit cohort-aware itemize lines
 /// without re-statting and so future diagnostics can distinguish a

--- a/crates/engine/src/delete/mod.rs
+++ b/crates/engine/src/delete/mod.rs
@@ -24,11 +24,11 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-387`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-400`
 //!   (`delete_in_dir`, `do_delete_pass`).
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:82-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`).
-//! - `target/interop/upstream-src/rsync-3.4.1/flist.c:3217-3343`
+//! - `target/interop/upstream-src/rsync-3.5.0/flist.c:3554-3671`
 //!   (`f_name_cmp`).
 
 mod cohort_batcher;

--- a/crates/engine/src/delete/parallel_consumer.rs
+++ b/crates/engine/src/delete/parallel_consumer.rs
@@ -40,9 +40,9 @@
 //!
 //! # Upstream reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:130-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`): per-cohort dispatch order the consumer preserves.
-//! - `target/interop/upstream-src/rsync-3.4.1/main.c:225-247`
+//! - `target/interop/upstream-src/rsync-3.5.0/main.c:229-251`
 //!   (`write_del_stats` / `read_del_stats`): the goodbye-phase frame the
 //!   wire ordering invariant protects. The consumer never emits the frame
 //!   itself; it preserves cohort identity so the unchanged generator-side
@@ -488,7 +488,7 @@ fn dispatch_cohort<F: DeleteFs + Sync + Send>(
                 }
             }
             Err(err) => {
-                // upstream: delete.c:86-210 never aborts the pass on a
+                // upstream: delete.c:141-273 never aborts the pass on a
                 // per-entry errno; record it and keep going under the
                 // default continue-on-error policy.
                 accumulate_nonfatal(&mut summary.io_error, policy, &err);

--- a/crates/engine/src/delete/reorder_buffer.rs
+++ b/crates/engine/src/delete/reorder_buffer.rs
@@ -62,11 +62,12 @@
 //!
 //! # Upstream reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/del.c` (NDX_DEL_STATS
+//! - `target/interop/upstream-src/rsync-3.5.0/main.c:229-251`
+//!   (`write_del_stats` / `read_del_stats`; NDX_DEL_STATS
 //!   semantics: exactly one frame per goodbye cohort, carrying five
 //!   varints; the buffer never emits the frame itself, it only
 //!   preserves the cohort identity the goodbye writer reads).
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-360`
 //!   (`delete_in_dir`: one cohort per destination parent directory).
 //! - DEL-1.a audit: `docs/design/del-1a-upstream-ordering-audit.md`.
 

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -53,9 +53,9 @@ fn normalize_filename_for_compare(name: &OsStr) -> OsString {
 ///
 /// # Upstream Reference
 ///
-/// - `flist.c:1344` - `one_file_system && st.st_dev != filesystem_dev` sets
+/// - `flist.c:1490` - `one_file_system && st.st_dev != filesystem_dev` sets
 ///   `FLAG_MOUNT_DIR` on the dest dirlist entry.
-/// - `generator.c:331` - `delete_in_dir()` skips a `FLAG_MOUNT_DIR` directory.
+/// - `generator.c:337` - `delete_in_dir()` skips a `FLAG_MOUNT_DIR` directory.
 #[cfg(unix)]
 fn crosses_mount_boundary(boundary_dev: u64, entry_dev: u64) -> bool {
     entry_dev != boundary_dev
@@ -176,7 +176,7 @@ where
     //    mid-traversal once the limit is reached. The emitter removes an
     //    extraneous directory wholesale and counts it as a single deletion,
     //    silently exceeding the cap for directory subtrees. The leaf executor
-    //    matches upstream delete.c:156/181 (guard-before-delete,
+    //    matches upstream delete.c:217/244 (guard-before-delete,
     //    increment-on-success).
     // 2. `--one-file-system`: a mount point nested inside an otherwise-doomed
     //    subtree must be preserved, but `remove_dir_all` recurses across the
@@ -186,7 +186,7 @@ where
     //    `--max-delete` the cap is absent, so `cap_reached` is always false and
     //    the pass never reports a limit hit.
     // 3. `--backup`: every extraneous file must be backed up before removal
-    //    (upstream delete.c:165-171 `make_backup` inside `delete_item`, invoked
+    //    (upstream delete.c:228-234 `make_backup` inside `delete_item`, invoked
     //    for each entry `delete_dir_contents` recurses over). The emitter peels
     //    a directory wholesale with `remove_dir_all`, which never backs up the
     //    contents - a silent data-loss gap. The leaf executor recurses
@@ -232,7 +232,7 @@ where
     // run at all: it would recurse across a mount boundary nested inside a
     // doomed subtree and destroy the mounted filesystem. Under --backup it would
     // peel a directory's contents without backing them up (upstream
-    // delete.c:165-171 backs up every entry `delete_dir_contents` recurses
+    // delete.c:228-234 backs up every entry `delete_dir_contents` recurses
     // over). Route the already-built plan through the leaf executor, which
     // preserves a mount, pins its parent, and backs up each file before removal.
     // The immediate `--delete*` modes reach the leaf executor via the dispatch
@@ -297,7 +297,7 @@ where
         // The emitter never aborts on a per-entry errno; a swallowed
         // unlink/rmdir error surfaces as exit code 23 in the outcome. Fold
         // it into the copy context so the run finishes RERR_PARTIAL while the
-        // pass keeps deleting the rest of the tree (upstream delete.c:86-210
+        // pass keeps deleting the rest of the tree (upstream delete.c:141-273
         // FERROR_XFER + `io_error |= IOERR_GENERAL`).
         if outcome.exit_code == EMITTER_PARTIAL_EXIT_CODE {
             context.record_delete_io_error();
@@ -315,7 +315,7 @@ where
 /// upstream: generator.c:351 `delete_during == 2` calls `remember_delete(fp, ...)`
 /// from inside `delete_in_dir` - the decision (including
 /// `change_local_filter_dir`) happens during the walk, only the unlink is
-/// postponed to `do_delayed_deletions()` (generator.c:2419). Deciding at flush
+/// postponed to `do_delayed_deletions()` (generator.c:2900). Deciding at flush
 /// time instead would wrongly consult the by-then-present merge files.
 pub(crate) fn decide_and_defer_delayed_deletions<S: AsRef<OsStr>>(
     context: &mut CopyContext,
@@ -363,9 +363,9 @@ pub(crate) fn execute_decided_deletion(
 /// (see `remove_entry_capped`), counting only successful deletions - exactly
 /// mirroring upstream `delete.c:delete_item`/`delete_dir_contents` where
 /// `stats.deleted_files` is compared against `max_delete` before every entry
-/// and incremented only on a successful removal (`delete.c:156` guard,
-/// `delete.c:181` increment), and a mount point pins its parent
-/// (`delete.c:89-97`). With no `--max-delete` the cap is absent, so
+/// and incremented only on a successful removal (`delete.c:217` guard,
+/// `delete.c:244` increment), and a mount point pins its parent
+/// (`delete.c:144-152`). With no `--max-delete` the cap is absent, so
 /// `cap_reached` is always false and the pass never reports a limit hit.
 ///
 /// The global running count is `context.summary().items_deleted()`, which the
@@ -384,7 +384,7 @@ fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
 
     // --one-file-system boundary device threaded through the recursion so a
     // mount point nested inside a doomed subtree is preserved and pins its
-    // parent, matching upstream delete.c:89-97. `build_plan_for_directory`
+    // parent, matching upstream delete.c:144-152. `build_plan_for_directory`
     // already excluded direct-child mounts, so this guards the deeper levels.
     let boundary_dev = delete_boundary_device(context, destination);
 
@@ -413,7 +413,7 @@ fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
     }
 
     if skipped > 0 {
-        // upstream: generator.c:2431 emits one warning after the pass with
+        // upstream: generator.c:2905 emits one warning after the pass with
         // the total number of entries skipped because of the limit; the run
         // then exits RERR_DEL_LIMIT (25).
         info_log!(
@@ -430,10 +430,10 @@ fn delete_extraneous_entries_capped<S: AsRef<OsStr>>(
 
 /// Orders two directory children the way upstream `get_dirlist` sorts them
 /// for a delete pass: protocol-29 `f_name_cmp` places non-directories before
-/// directories (t_ITEM before t_PATH, upstream: flist.c:3223), then by name.
+/// directories (t_ITEM before t_PATH, upstream: flist.c:3560), then by name.
 /// Callers `reverse()` the sorted slice to reproduce upstream's reverse
-/// dirlist iteration (`for (i = dirlist->used; i--; )`, delete.c:85 /
-/// generator.c:326), so directories are visited first, then files - the
+/// dirlist iteration (`for (i = dirlist->used; i--; )`, delete.c:141 /
+/// generator.c:333), so directories are visited first, then files - the
 /// order that decides which entries survive a `--max-delete` cap and the
 /// order deletion log lines are emitted.
 fn cmp_child_delete_order(a: (&OsStr, bool), b: (&OsStr, bool)) -> std::cmp::Ordering {
@@ -448,10 +448,10 @@ fn cmp_child_delete_order(a: (&OsStr, bool), b: (&OsStr, bool)) -> std::cmp::Ord
 /// depth-first (`delete_dir_contents`, reverse-sorted iteration), then the
 /// now-empty directory is itself subject to the same guard before its own
 /// removal. `skipped` accumulates the count reported to the user, matching
-/// upstream's `skipped_deletes` (`delete.c:157`).
+/// upstream's `skipped_deletes` (`delete.c:218`).
 ///
 /// `nested` distinguishes a directory reached during the recursion (upstream's
-/// `delete_item(..., DEL_DIR_IS_EMPTY)` call at `delete.c:107`) from a
+/// `delete_item(..., DEL_DIR_IS_EMPTY)` call at `delete.c:162`) from a
 /// top-level extraneous entry (upstream's initial `delete_item` without
 /// `DEL_DIR_IS_EMPTY`). Only the former counts a cap-saturated non-empty
 /// directory toward `skipped` - see the `!all_children_removed` branch below.
@@ -479,7 +479,7 @@ fn remove_entry_capped(
         }
     };
 
-    // upstream: generator.c:331 / delete.c:89-97 - a mount point is never
+    // upstream: generator.c:337 / delete.c:144-152 - a mount point is never
     // deleted and pins its enclosing directory as non-empty. Under
     // --one-file-system a directory on a different device than the transfer
     // root is that mount point: preserve it and return `false` so the caller
@@ -532,7 +532,7 @@ fn remove_entry_capped(
             let child_path = path.join(&child_name);
             let child_relative = entry_relative.join(&child_name);
             // Children are reached via the recursion, mirroring upstream's
-            // `delete_item(..., DEL_DIR_IS_EMPTY)` at delete.c:107; mark them
+            // `delete_item(..., DEL_DIR_IS_EMPTY)` at delete.c:162; mark them
             // `nested` so a cap-saturated non-empty subdir is counted.
             if !remove_entry_capped(
                 context,
@@ -548,9 +548,9 @@ fn remove_entry_capped(
 
         if !all_children_removed {
             // Contents survived because the cap was reached, so the directory
-            // cannot be removed. upstream: delete.c:117 prints this once per
+            // cannot be removed. upstream: delete.c:178 prints this once per
             // non-empty directory without flagging an I/O error. upstream
-            // delete.c:117 prints the transfer-relative name (`f_name`), not the
+            // delete.c:178 prints the transfer-relative name (`f_name`), not the
             // absolute destination path.
             info_log!(
                 Nonreg,
@@ -559,18 +559,18 @@ fn remove_entry_capped(
                 entry_relative.display().to_string().replace('\\', "/")
             );
             // A NESTED non-empty directory is still reached by upstream's
-            // `delete_item(..., DEL_DIR_IS_EMPTY)` (delete.c:107): with
-            // DEL_DIR_IS_EMPTY set, delete.c:144 is skipped and control falls
-            // straight to the max_delete guard (delete.c:156), which does
+            // `delete_item(..., DEL_DIR_IS_EMPTY)` (delete.c:162): with
+            // DEL_DIR_IS_EMPTY set, delete.c:205 is skipped and control falls
+            // straight to the max_delete guard (delete.c:217), which does
             // `skipped_deletes++` because the cap is saturated. The TOP-LEVEL
             // directory instead enters `delete_item` WITHOUT DEL_DIR_IS_EMPTY,
             // so its survived contents take the `goto check_ret` path
-            // (delete.c:151-152) and it is never counted. Count the nested case
+            // (delete.c:212-213) and it is never counted. Count the nested case
             // to match upstream's skipped total exactly (issue #212).
             //
             // Only count it when the cap is the reason the contents survived. A
             // directory that survived solely because it pins a `--one-file-system`
-            // mount point is upstream's DR_NOT_EMPTY (delete.c:95-96), which does
+            // mount point is upstream's DR_NOT_EMPTY (delete.c:150-151), which does
             // not touch `skipped_deletes`; counting it would falsely trip
             // RERR_DEL_LIMIT. `cap_reached` is true exactly when a cap skip
             // occurred, so it distinguishes the two without changing the
@@ -623,14 +623,14 @@ fn delete_leaf(
 ) -> Result<(), LocalCopyError> {
     let is_dir = file_type.is_dir();
 
-    // upstream: delete.c:165 - back up an extraneous file before deletion only
+    // upstream: delete.c:228 - back up an extraneous file before deletion only
     // when `backup_dir || !is_backup_file(fbuf)`.
     if !context.mode().is_dry_run()
         && !is_dir
         && let Some(name) = path.file_name()
         && context.options().should_backup_before_delete(name)
     {
-        // upstream: delete.c:167 - the delete pass calls `make_backup(fbuf,
+        // upstream: delete.c:230 - the delete pass calls `make_backup(fbuf,
         // True)`, skipping the hard-link tier since the item is unlinked
         // outright right after regardless of which strategy placed it.
         context.backup_existing_entry(path, Some(entry_relative), file_type, true)?;
@@ -639,7 +639,7 @@ fn delete_leaf(
     // A directory can survive its own delete when in-place suffix backups
     // (`--backup` without `--backup-dir`) renamed its contents to `name~`,
     // leaving it non-empty. Upstream `delete_dir_contents` reports this as the
-    // benign `DR_NOT_EMPTY` (delete.c:117): print the notice, keep the
+    // benign `DR_NOT_EMPTY` (delete.c:178): print the notice, keep the
     // directory, do not flag an I/O error or count a deletion. The rmdir must
     // therefore run before the deletion is recorded so the `*deleting` event is
     // only emitted for a directory that is actually removed.
@@ -649,7 +649,7 @@ fn delete_leaf(
                 Ok(()) => {}
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                 Err(error) if is_dir_not_empty(&error) => {
-                    // upstream delete.c:117 prints the transfer-relative name
+                    // upstream delete.c:178 prints the transfer-relative name
                     // (`f_name`), not the absolute destination path.
                     info_log!(
                         Nonreg,
@@ -723,11 +723,11 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
     relative: Option<&Path>,
     source_entries: &[S],
 ) -> Result<Option<DeletePlan>, LocalCopyError> {
-    // upstream: delete.c:63 / generator.c:308 - the delete pass calls
+    // upstream: delete.c:106 / generator.c:314 - the delete pass calls
     // `change_local_filter_dir(fbuf, F_DEPTH(file))` with the destination
     // directory so the receiver applies any per-dir merge rules found in the
     // directory being scanned, INHERITING an ancestor directory's rules into
-    // subdirectories (exclude.c:801 keeps them in `lp->head`). Advancing the
+    // subdirectories (exclude.c:900 keeps them in `lp->head`). Advancing the
     // persistent, depth-keyed delete-filter chain keeps ancestor frames alive
     // (rather than popping each directory's rules immediately), which is what
     // lets a parent `.rsync-filter` protect a subdirectory's entries. During a
@@ -798,13 +798,13 @@ fn build_plan_for_directory<S: AsRef<OsStr>>(
             )
         })?;
 
-        // upstream: generator.c:331-336 delete_in_dir() skips a dest directory
+        // upstream: generator.c:337-342 delete_in_dir() skips a dest directory
         // flagged FLAG_MOUNT_DIR ("cannot delete mount point"). Under
         // --one-file-system a destination directory on a different device than
         // the transfer root is that mount point: exclude it from the plan so it
         // is neither unlinked nor `remove_dir_all`'d. Its parent is the
         // source-present scanned directory, which is never a deletion candidate,
-        // so the parent is left in place (delete.c:89-97 parent pinning).
+        // so the parent is left in place (delete.c:144-152 parent pinning).
         if is_delete_mount_point(boundary_dev, &destination.join(&name_path), file_type) {
             info_log!(
                 Mount,
@@ -920,7 +920,7 @@ fn classify_kind(file_type: fs::FileType) -> DeleteEntryKind {
 ///
 /// Directories recurse into their contents so per-entry counters match
 /// upstream's `delete_in_dir` walk (one count per leaf, mirroring
-/// `target/interop/upstream-src/rsync-3.4.1/generator.c:272-347`).
+/// `target/interop/upstream-src/rsync-3.5.0/generator.c:285-360`).
 fn apply_delete_side_effects(
     context: &mut CopyContext,
     destination: &Path,
@@ -956,7 +956,7 @@ fn apply_delete_side_effects(
             record_directory_subtree(context, &mut subtree_path, &mut subtree_relative)?;
         }
 
-        // upstream: delete.c:165 - back up an extraneous file before deletion
+        // upstream: delete.c:228 - back up an extraneous file before deletion
         // only when `backup_dir || !is_backup_file(fbuf)`. A name that already
         // ends in the backup suffix is unlinked directly (no re-backup to
         // `<name><suffix><suffix>`); the emitter below performs that unlink.
@@ -965,7 +965,7 @@ fn apply_delete_side_effects(
                 .options()
                 .should_backup_before_delete(entry.name.as_os_str())
         {
-            // upstream: delete.c:167 - prefer_rename=True; the item is
+            // upstream: delete.c:230 - prefer_rename=True; the item is
             // unlinked outright right after, so skip the hard-link tier.
             context.backup_existing_entry(
                 &path,
@@ -1087,7 +1087,7 @@ pub(crate) fn record_directory_subtree(
 /// # Upstream Reference
 ///
 /// - `sender.c:395` `successful_send()`
-/// - `log.c:311` / `main.c:1630` `got_xfer_error` -> `RERR_PARTIAL`
+/// - `log.c:338` / `main.c:1683` `got_xfer_error` -> `RERR_PARTIAL`
 pub(crate) fn remove_source_entry_if_requested(
     context: &mut CopyContext,
     source: &Path,
@@ -1323,7 +1323,7 @@ mod mount_boundary_tests {
     /// point that must be preserved.
     ///
     /// upstream: flist.c:1490 (`st.st_dev != filesystem_dev` -> FLAG_MOUNT_DIR),
-    /// generator.c:331 (delete_in_dir skips it).
+    /// generator.c:337 (delete_in_dir skips it).
     #[test]
     fn mount_boundary_predicate_distinguishes_devices() {
         const ROOT_DEV: u64 = 0x10;
@@ -1388,7 +1388,7 @@ mod mount_boundary_tests {
                     "a same-device directory must remain deletable",
                 );
                 // A non-directory on a foreign device is not a mount point:
-                // upstream restricts FLAG_MOUNT_DIR to S_ISDIR (flist.c:1341).
+                // upstream restricts FLAG_MOUNT_DIR to S_ISDIR (flist.c:1487).
                 assert!(
                     !is_delete_mount_point(Some(ROOT_DEV), &foreign_file, file_ft),
                     "only directories can be mount points",

--- a/crates/engine/tests/delete_determinism_property.rs
+++ b/crates/engine/tests/delete_determinism_property.rs
@@ -26,10 +26,10 @@
 //!
 //! # Upstream Reference
 //!
-//! - `target/interop/upstream-src/rsync-3.4.1/generator.c:272-387`
+//! - `target/interop/upstream-src/rsync-3.5.0/generator.c:285-400`
 //!   (`delete_in_dir`, `do_delete_pass`) - emits unlinks per directory in
 //!   reverse `f_name_cmp` order.
-//! - `target/interop/upstream-src/rsync-3.4.1/delete.c:82-225`
+//! - `target/interop/upstream-src/rsync-3.5.0/delete.c:191-288`
 //!   (`delete_item`) - dispatches the actual `unlink`/`rmdir` syscall.
 
 #![cfg(unix)]

--- a/crates/protocol/tests/flist_sort_keys_rp28h.rs
+++ b/crates/protocol/tests/flist_sort_keys_rp28h.rs
@@ -3,7 +3,7 @@
 //!
 //! Upstream `flist.c:f_name_cmp()` picks its sort key at runtime via
 //! `t_path = protocol_version >= 29 ? t_PATH : t_ITEM`
-//! (upstream: `flist.c:3223` in `target/interop/upstream-src/rsync-3.4.1`).
+//! (upstream: `flist.c:3560` in `target/interop/upstream-src/rsync-3.5.0`).
 //!
 //! - `t_PATH` (protocol >= 29) introduces the file-before-directory rule at
 //!   each path level and treats directories as if they carry an implicit

--- a/crates/protocol/tests/flist_wire_flags_rp28g.rs
+++ b/crates/protocol/tests/flist_wire_flags_rp28g.rs
@@ -14,8 +14,8 @@
 //! # Upstream Reference
 //!
 //! The flag-byte encoding is implemented in upstream
-//! `flist.c:send_file_entry()` between lines 544 and 563 of
-//! `target/interop/upstream-src/rsync-3.4.1/flist.c`:
+//! `flist.c:send_file_entry()` between lines 639 and 658 of
+//! `target/interop/upstream-src/rsync-3.5.0/flist.c`:
 //!
 //! ```c
 //! if (xfer_flags_as_varint)

--- a/crates/protocol/tests/zlib_codec_proto_lt_31.rs
+++ b/crates/protocol/tests/zlib_codec_proto_lt_31.rs
@@ -8,8 +8,8 @@
 //!
 //! # Upstream reference
 //!
-//! upstream: `token.c:send_deflated_token()` lines 463-484 in
-//! `target/interop/upstream-src/rsync-3.4.1/token.c`:
+//! upstream: `token.c:send_deflated_token()` lines 475-511 in
+//! `target/interop/upstream-src/rsync-3.5.0/token.c`:
 //!
 //! ```c
 //! } else if (token != -2 && do_compression == CPRES_ZLIB) {
@@ -20,10 +20,12 @@
 //!         tx_strm.avail_in = n1;
 //!         if (protocol_version >= 31) /* Newer protocols avoid a data-duplicating bug */
 //!             offset += n1;
-//!         tx_strm.next_out = (Bytef *) obuf;
-//!         tx_strm.avail_out = AVAIL_OUT_SIZE(CHUNK_SIZE);
-//!         r = deflate(&tx_strm, Z_INSERT_ONLY);
-//!         ...
+//!         do {
+//!             tx_strm.next_out = (Bytef *) obuf;
+//!             tx_strm.avail_out = AVAIL_OUT_SIZE(CHUNK_SIZE);
+//!             r = deflate(&tx_strm, Z_INSERT_ONLY);
+//!             ...
+//!         } while (tx_strm.avail_in != 0 || tx_strm.avail_out == 0);
 //!     } while (toklen > 0);
 //! }
 //! ```


### PR DESCRIPTION
The pinned upstream oracle is rsync **3.5.0**, but citations across
`crates/{engine,daemon,core,protocol}` still carried 3.4.1- and 3.4.4-era line
numbers. These are not cosmetically-stale paths: the numbers point at the wrong
code.

Comment-only. No behaviour change.

## Before / after: what the old number actually says at 3.5.0

| citation | claim in the comment | 3.4.1/3.4.4 line | what that line is **at 3.5.0** | retargeted to |
|---|---|---|---|---|
| `delete.c:130-225` (6 files) | `delete_item` | `enum delret delete_item(...)` | `* delete recursively.` — a comment fragment | `delete.c:191-288` |
| `generator.c:272-347` (5 files) | `delete_in_dir` | `static void delete_in_dir(...)` | `lseek(deldelay_fd, 0, 0);` inside `flush_delete_delay()` | `generator.c:285-360` |
| `clientserver.c:752` (2 files) | the `@ERROR: max connections (%d) reached` reply | that `io_printf` line | `int ret, pre_exec_arg_fd = -1, ...` — a variable declaration | `clientserver.c:799` |
| `flist.c:3217-3343` | `f_name_cmp` | `int f_name_cmp(...)` | `return ndx;` inside `flist_find_ignore_dirness()` | `flist.c:3554-3671` |
| `main.c:1267-1384` (2 files) | `client_run()` | `int client_run(...)` | `rprintf(FERROR, "Your options have been rejected...")` | `main.c:1323-1440` |
| `hlink.c:186-208` | `match_hard_links` | `void match_hard_links(...)` | `if (inc_recurse && CVAL(node->data, 0) == 0) {` | `hlink.c:200-222` |

## Method

Every site was resolved by locating the **named construct** in
`target/interop/upstream-src/rsync-3.5.0`, never by arithmetic, and **both ends**
of every `START-END` range were re-derived independently. Ranges that repeat
across files (`delete.c:130-225`, `generator.c:272-347`, …) were resolved once
and applied consistently.

## Findings that are not retargets

**`del.c` does not exist — in any version.** `crates/engine/src/delete/reorder_buffer.rs:65`
cited `rsync-3.4.1/del.c` for NDX_DEL_STATS semantics. There is no `del.c` at
3.4.1 or 3.5.0. The described construct (one frame, five varints) is
`main.c:write_del_stats()` / `read_del_stats()`; the citation now names those
functions at `main.c:229-251`.

**Two pre-existing over-spans, corrected rather than shifted.**
`delete.c:82-225 (delete_item)` in `delete/mod.rs` and
`delete_determinism_property.rs`: at 3.4.1, line 82 is inside
`delete_dir_contents` (`/* We do our own recursion... */`), not `delete_item`
(130). `flist.c:3217-3343 (f_name_cmp)` in `delete/mod.rs`: `f_name_cmp` ends at
3334 at 3.4.1; 3343 is inside `f_name_has_prefix`. Both were narrowed to the
labelled function's true 3.5.0 bounds. `socket.c:402-499 (open_socket_in)` at
3.4.4 likewise stopped one line short of the function (`500`).

**Claims whose named helpers no longer exist upstream — prose left alone.**
`emitter/mod.rs` says `delete_item` uses "`do_rmdir` for directories and
`robust_unlink` for everything else"; `cohort_index.rs` says "the dispatch is
unconditional `do_unlink`". At 3.5.0 the directory arm is
`del_held_dfd()` + `do_unlink_atfd(dfd, leaf, AT_REMOVEDIR)` (falling back to
`do_rmdir_at`), and the file arm is `del_unlink()`. The **policy** is unchanged
(rmdir for dirs, unconditional unlink otherwise), so the ranges were retargeted
and the prose left as-is rather than rewritten to match 3.5.0. Flagging it here
so a reviewer can decide.

Separately, `emitter/mod.rs`'s `delete_item` bullet says "`ENOTEMPTY` recurses".
It does not, at either version: the recursion happens in `delete_dir_contents`
*before* the rmdir, and `delete_item`'s `ENOTEMPTY` arm only sets
`DR_NOT_EMPTY`. Pre-existing, not version drift; left untouched.

**One quoted C excerpt had to move with its range.**
`zlib_codec_proto_lt_31.rs` quotes (elided) `send_deflated_token`. 3.5.0
restructured that loop: the `deflate()` call now sits inside a nested drain loop
(bundled-zlib `Z_INSERT_ONLY` vs system-zlib `Z_SYNC_FLUSH` fallback, upstream
#951). The `protocol_version >= 31` offset advance the test actually pins is
byte-identical. The elision was updated so the quote is faithful to the lines it
now cites (475-511). The `send_file_entry` flag prelude quoted in
`flist_wire_flags_rp28g.rs` is byte-identical at 3.5.0 — path and range only.

**One citation coincides across versions.** `hlink.c:59-65` (`init_hard_links`)
is at the same lines in both trees; only the path changed. Being in the stale set
did not mean it had moved.

**`cleanup.rs` carried three eras side by side.** 3.4.1-era, 3.4.4-era, and
already-3.5.0 citations in the same file. Verified-correct-at-3.5.0 and therefore
left untouched: `delete.c:217`, `generator.c:351`, `flist.c:1490`, and the whole
`sender.c` block (`145`, `176-177`, `395`, `426-428`, `429-430`, `433-440`,
`434-439`, `442`, `442-451`, `453`, `454`, `456-457`, `457-458`).

## Deliberately not touched

`crates/core/tests/common/mod.rs:428` names `rsync-3.4.4/rsync` — an **interop
binary path** this repo builds, not a source citation. Same shape at
`.github/workflows/_interop.yml:87`.

## Stale citations found outside this PR's scope

Reported, not changed here:

- `crates/daemon/src/daemon/sections/server_runtime/{accept_loop.rs:199,
  listener.rs:370, listener.rs:463, tests.rs:1234, tests.rs:1490}` — all cite
  `socket.c::open_socket_in` at 3.4.1 `428-498` / 3.4.4 `432-498` /
  `socket.c:463-465`. **This PR moved `runtime_options/types.rs` to
  `rsync-3.5.0/socket.c:552-650` for the same function**, so those five sites are
  now the odd ones out. They sit in an area under active change, hence the split.
- `crates/core/src/client/remote/output_option.rs:3` — `options.c` at
  `rsync-3.4.4:354`
- `crates/core/tests/exit_code_comprehensive.rs:1139` — `rsync-3.4.1/errcode.h`
- `crates/protocol/tests/iconv_golden_bytes.rs:7` — `rsync-3.4.1/flist.c`

## Gates

| gate | result |
|---|---|
| `python3 tools/ci/check_rustfmt_all.py` | 3369 tracked `.rs` files checked at edition 2024 — clean |
| `cargo xtask citations` | 8668 names / 8668 line ranges across 5035 files — pass |

`python3 tools/ci/citation_drift_audit.py engine daemon core protocol`:

| crate | before (anchored / drift / unresolved) | after |
|---|---|---|
| engine | 39 / 0 / 35 | **41** / 0 / 35 |
| daemon | 88 / 2 / 43 | **90** / 2 / **42** |
| core | 60 / 0 / 61 | 60 / 0 / 61 |
| protocol | 60 / 0 / 27 | 60 / 0 / 27 |

`unresolved` does not rise anywhere; `string-anchored` rises by 2 in engine and
daemon and daemon's `unresolved` drops by 1 — retargeted anchors that now resolve
against the 3.5.0 tree. The 2 daemon drift rows are pre-existing and untouched.

Verified comment-only: every added and removed line in the diff begins with
`//`, `///`, or `//!`.
