### PR TITLE
docs(transfer): retarget upstream citations at the pinned 3.5.0

### DIFF
--- a/crates/transfer/src/delta_transfer.rs
+++ b/crates/transfer/src/delta_transfer.rs
@@ -433,7 +433,7 @@
 //! # References
 //!
 //! - **Upstream rsync**: <https://github.com/RsyncProject/rsync>
-//! - **Protocol spec**: `target/interop/upstream-src/rsync-3.4.1/csprotocol.txt`
+//! - **Protocol spec**: `csprotocol.txt`
 //! - **Engine documentation**: [`engine::delta`]
 //! - **Wire format**: [`protocol::wire`]
 //! - **Metadata**: `metadata::apply`

--- a/crates/transfer/tests/acl_negotiation_missing_remote.rs
+++ b/crates/transfer/tests/acl_negotiation_missing_remote.rs
@@ -3,13 +3,13 @@
 //!
 //! Upstream rsync gates ACL transfer on two layers:
 //!
-//! 1. **Protocol-version gate** (`compat.c:655-661`): if the negotiated
+//! 1. **Protocol-version gate** (`compat.c:667-673`): if the negotiated
 //!    protocol is `< 30`, the sender errors out with
 //!    `"--acls requires protocol 30 or higher (negotiated %d)."`.
-//! 2. **Local-binary feature gate** (`options.c:1842-1857`): when the
+//! 2. **Local-binary feature gate** (`options.c:1965-1980`): when the
 //!    server-side rsync was compiled without `--enable-acl-support`
 //!    (`#ifdef SUPPORT_ACLS`), the entire `acls.c` compilation unit
-//!    is empty (acls.c:25,1141) and the resulting binary will never
+//!    is empty (acls.c:29,1510) and the resulting binary will never
 //!    advertise `-A` in the compact server flag string emitted from
 //!    `options.c`. There is no dedicated capability bit for ACLs on
 //!    the wire - the absence of `-A` in the server flags is the
@@ -25,9 +25,9 @@
 //! - sending ACL bytes on the wire when the peer cannot decode them.
 //!
 //! Upstream references:
-//! - `target/interop/upstream-src/rsync-3.4.1/compat.c:655-661`
-//! - `target/interop/upstream-src/rsync-3.4.1/options.c:1842-1857`
-//! - `target/interop/upstream-src/rsync-3.4.1/acls.c:25,1141`
+//! - `compat.c:667-673`
+//! - `options.c:1965-1980`
+//! - `acls.c:29,1510`
 
 #![deny(unsafe_code)]
 
@@ -44,9 +44,9 @@ const SERVER_FLAGS_NO_ACL_NO_XATTR: &str = "-logDtpre.iLsfxC";
 
 /// Compact flag string from a modern peer that DOES support ACLs and xattrs.
 ///
-/// `A` and `X` sit BEFORE the `e`: upstream emits them at options.c:2695-2703,
+/// `A` and `X` sit BEFORE the `e`: upstream emits them at options.c:2861-2869,
 /// well ahead of `maybe_add_e_option`, which appends the `e.<caps>` suffix last
-/// (options.c:2727). The `-e` argument is the tail of the bundle by
+/// (options.c:2894). The `-e` argument is the tail of the bundle by
 /// construction, so no peer - upstream or oc - ever places a transfer letter
 /// after it. `crates/core/.../flags.rs` emits the same order.
 const SERVER_FLAGS_WITH_ACL_AND_XATTR: &str = "-logDtpAXre.iLsfxC";
@@ -92,7 +92,7 @@ fn server_flag_string_with_a_and_x_yields_acls_and_xattrs_true() {
 /// only gets cleared by the wire-flag layer when parsing the server's
 /// reply.
 ///
-/// This mirrors upstream `compat.c:655-661`, which is conditional on
+/// This mirrors upstream `compat.c:667-673`, which is conditional on
 /// `protocol_version < 30` and entirely silent for newer protocols.
 #[test]
 fn protocol_30_plus_does_not_reject_acls_at_restriction_layer() {
@@ -165,7 +165,7 @@ fn end_to_end_remote_without_acl_support_at_protocol_32() {
 /// but the negotiated protocol is `< 30`. The restriction layer must
 /// reject this with the exact upstream error message format.
 ///
-/// upstream: compat.c:655-661
+/// upstream: compat.c:667-673
 /// ```c
 /// if (preserve_acls && !local_server) {
 ///     rprintf(FERROR, "--acls requires protocol 30 or higher "
@@ -187,13 +187,13 @@ fn end_to_end_protocol_below_30_rejects_acls_with_upstream_message() {
         let expected = format!("--acls requires protocol 30 or higher (negotiated {version}).");
         assert_eq!(
             message, expected,
-            "error message must match upstream compat.c:657-659 format byte-for-byte",
+            "error message must match upstream compat.c:668-670 format byte-for-byte",
         );
     }
 }
 
 /// Local-server transfers (no remote at all) bypass the protocol-version
-/// gate for ACLs. This matches upstream `compat.c:655` which guards the
+/// gate for ACLs. This matches upstream `compat.c:667` which guards the
 /// error with `!local_server`.
 ///
 /// Even at protocol 27, a `--acls` local copy proceeds because there is

--- a/crates/transfer/tests/daemon_push_refused_file_reports_error.rs
+++ b/crates/transfer/tests/daemon_push_refused_file_reports_error.rs
@@ -5,13 +5,13 @@
 //! Upstream's receiver-side generator checks every entry against
 //! `daemon_filter_list` and, on a match, reports
 //! `ERROR: daemon refused to receive file "<name>"` as `FERROR_XFER`
-//! (`generator.c:1275-1287`) before dropping the entry. Three consequences
+//! (`generator.c:1664-1676`) before dropping the entry. Three consequences
 //! follow, and all three are asserted here:
 //!
 //! 1. The pushing client renders the line. `FERROR_XFER` from a server is
-//!    framed as `MSG_ERROR_XFER` (`log.c:330-346`) instead of being written to
+//!    framed as `MSG_ERROR_XFER` (`log.c:357-373`) instead of being written to
 //!    the daemon's own stderr, so the message travels to whoever ran the push.
-//! 2. The push exits 23. `log.c:310-311` sets `got_xfer_error` on the frame and
+//! 2. The push exits 23. `log.c:337-338` sets `got_xfer_error` on the frame and
 //!    `cleanup.c:217-218` lifts a zero exit to `RERR_PARTIAL`. A silent skip
 //!    would exit 0 and tell the user nothing was wrong while the module kept
 //!    none of the refused files.
@@ -33,12 +33,12 @@
 //!
 //! # Upstream References
 //!
-//! - `generator.c:1273-1287` - `check_filter(&daemon_filter_list, ...)` and the
+//! - `generator.c:1662-1676` - `check_filter(&daemon_filter_list, ...)` and the
 //!   `ERROR: daemon refused to receive %s "%s"` report
-//! - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
-//! - `log.c:330-346` - `am_server` frames the text instead of printing it
+//! - `log.c:337-338` - `case FERROR_XFER: got_xfer_error = 1;`
+//! - `log.c:357-373` - `am_server` frames the text instead of printing it
 //! - `cleanup.c:217-218` - `got_xfer_error` -> `RERR_PARTIAL` (23)
-//! - `clientserver.c:874-893` - `rsync_module()` builds `daemon_filter_list`
+//! - `clientserver.c:933-952` - `rsync_module()` builds `daemon_filter_list`
 //!   from the module's `exclude` / `include` / `filter` directives
 
 #![cfg(unix)]
@@ -54,13 +54,13 @@ use tempfile::{TempDir, tempdir};
 
 /// The exact upstream text, minus the trailing newline.
 ///
-/// upstream: generator.c:1281-1283.
+/// upstream: generator.c:1670-1672.
 const REFUSAL: &str = r#"ERROR: daemon refused to receive file "top.secret""#;
 
 /// Writes an `rsyncd.conf` with one writable module that excludes `*.secret`.
 ///
 /// `use chroot = false` keeps the daemon runnable unprivileged. `exclude` is
-/// the directive that feeds `daemon_filter_list` (clientserver.c:891).
+/// the directive that feeds `daemon_filter_list` (clientserver.c:950).
 fn write_daemon_config(
     config_path: &Path,
     pid_path: &Path,
@@ -259,13 +259,13 @@ fn assert_push_is_refused(client: &Path, extra: &[&str]) {
 
     assert!(
         stderr.contains(REFUSAL),
-        "the client must render the daemon's refusal (upstream generator.c:1281-1283); \
+        "the client must render the daemon's refusal (upstream generator.c:1670-1672); \
          a silent skip leaves the user with no diagnostic at all.\nargs: {args:?}\nstderr:\n{stderr}",
     );
     assert_eq!(
         code, 23,
         "a refused file must exit 23 (RERR_PARTIAL): FERROR_XFER sets got_xfer_error \
-         (log.c:310-311) and cleanup.c:217-218 lifts the zero exit.\nargs: {args:?}\nstderr:\n{stderr}",
+         (log.c:337-338) and cleanup.c:217-218 lifts the zero exit.\nargs: {args:?}\nstderr:\n{stderr}",
     );
     assert!(
         scratch.module.join("allowed.txt").is_file(),
@@ -280,7 +280,7 @@ fn assert_push_is_refused(client: &Path, extra: &[&str]) {
     assert!(
         !daemon_stderr.contains("daemon refused"),
         "the refusal must be framed to the client, not written to the daemon's own \
-         stderr (upstream log.c:330-346 returns after send_msg under am_server)\n\
+         stderr (upstream log.c:357-373 returns after send_msg under am_server)\n\
          daemon stderr:\n{daemon_stderr}",
     );
 }

--- a/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
+++ b/crates/transfer/tests/upstream_compat_daemon_gzip_goodbye.rs
@@ -1,4 +1,4 @@
-//! NXT-2: upstream-compat port of `testsuite/daemon-gzip-download.test`.
+//! NXT-2: upstream-compat port of `testsuite/daemon-gzip-download_test.py`.
 //!
 //! Pairs an upstream rsync client (3.4.4 by default) against an oc-rsync
 //! daemon over a real TCP socket. The transfer pulls a ~1 MB fixture with
@@ -19,11 +19,11 @@
 //!
 //! # Upstream references
 //!
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/daemon-gzip-download.test`
+//! - `testsuite/daemon-gzip-download_test.py`
 //!   - upstream script this port replaces.
-//! - `main.c:983` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
+//! - `main.c:998` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
 //!   return; contract pinned by UTS-9.
-//! - `options.c:2002` - `-zz` -> `compress_choice = "zlibx"` mapping.
+//! - `options.c:2122-2123` - `-zz` -> `compress_choice = "zlibx"` mapping.
 //!
 //! # Gating
 //!
@@ -79,7 +79,7 @@ impl Drop for DaemonGuard {
 /// for it to accept connections.
 fn spawn_oc_rsync_daemon(bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
     // Race-free free port: the default daemon binds SO_REUSEADDR only (upstream
-    // socket.c:447), so a collision is a clean EADDRINUSE exit the helper
+    // socket.c:597), so a collision is a clean EADDRINUSE exit the helper
     // retries. See `test_support::daemon_port`.
     let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
         Command::new(bin)

--- a/crates/transfer/tests/uts_atimes_preserve.rs
+++ b/crates/transfer/tests/uts_atimes_preserve.rs
@@ -1,12 +1,12 @@
-//! Nextest port of upstream `testsuite/atimes.test` (local-copy leg).
+//! Nextest port of upstream `testsuite/atimes_test.py` (local-copy leg).
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/atimes.test`.
+//! `testsuite/atimes_test.py`.
 //!
 //! # Background
 //!
 //! `-U` / `--atimes` tells rsync to preserve each file's access time in
-//! addition to its modification time. Upstream's atimes.test backdates
+//! addition to its modification time. Upstream's atimes_test.py backdates
 //! `$fromdir/foo`'s atime to a fixed timestamp, runs `rsync -rtUgvvv`, and
 //! `checkit()` confirms the destination tree matches with atimes compared.
 //!
@@ -26,7 +26,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/atimes.test` - the upstream script this file ports.
+//! - `testsuite/atimes_test.py` - the upstream script this file ports.
 //! - `rsync.c` / `generator.c` - `--atimes` restores `st_atime` alongside
 //!   `st_mtime` when the receiver commits the file.
 

--- a/crates/transfer/tests/uts_backup_suffix_and_dir.rs
+++ b/crates/transfer/tests/uts_backup_suffix_and_dir.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the upstream `testsuite/backup.test` scenario.
+//! Nextest port of the upstream `testsuite/backup_test.py` scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/backup.test`.
+//! `testsuite/backup_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `backup.test` verifies `--backup`: before overwriting a changed
+//! Upstream's `backup_test.py` verifies `--backup`: before overwriting a changed
 //! destination file, rsync preserves the old version. Two placement modes
 //! exist and this test pins both:
 //!
@@ -25,7 +25,7 @@
 //! breaks scripts that parse the backup log. The suffix-vs-directory split is
 //! two genuinely different placement paths in the generator, so both are
 //! exercised. The `backed up X to Y` wording must match upstream byte-for-byte
-//! (`backup.c:353`) because tooling greps for it.
+//! (`backup.c:433`) because tooling greps for it.
 //!
 //! # What this test pins
 //!
@@ -37,8 +37,8 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/backup.test` - the upstream script this file ports.
-//! - `backup.c:353` - `rprintf(FINFO, "backed up %s to %s\n", fname, buf)`.
+//! - `testsuite/backup_test.py` - the upstream script this file ports.
+//! - `backup.c:433` - `rprintf(FINFO, "backed up %s to %s\n", fname, buf)`.
 //! - `options.c` - `--backup` / `--backup-dir` / `--suffix` wiring.
 
 #![cfg(unix)]

--- a/crates/transfer/tests/uts_chmod_option.rs
+++ b/crates/transfer/tests/uts_chmod_option.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the local legs of upstream `testsuite/chmod-option.test`.
+//! Nextest port of the local legs of upstream `testsuite/chmod-option_test.py`.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/chmod-option.test`.
+//! `testsuite/chmod-option_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `chmod-option.test` verifies that `--chmod` rewrites permission
+//! Upstream's `chmod-option_test.py` verifies that `--chmod` rewrites permission
 //! bits on the fly during a transfer, applying the same symbolic-mode grammar
 //! `chmod(1)` uses, with rsync's `F`/`D` file/directory qualifiers. Two of its
 //! legs are pure local transfers with a deterministic outcome:
@@ -35,7 +35,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/chmod-option.test` - the upstream script this file ports.
+//! - `testsuite/chmod-option_test.py` - the upstream script this file ports.
 //! - `chmod.c` - `parse_chmod()` symbolic-mode grammar and `F`/`D` qualifiers.
 //! - `generator.c` - receiver-side application of the parsed chmod modes.
 
@@ -205,7 +205,7 @@ fn chmod_file_only_clears_world_execute() {
 /// Deliverable #1: a `--chmod` that strips the transfer-root directory's own
 /// owner-execute bit self-locks it.
 ///
-/// upstream: generator.c:1503-1520 - the generator chmods the transfer root
+/// upstream: generator.c:1895-1912 - the generator chmods the transfer root
 /// ("dst/.") to its tweaked mode and then tries to re-add owner-`rwx` so it can
 /// write the root's contents. Resolving `.` inside the now owner-non-executable
 /// root fails with `EACCES` ("failed to modify permissions on dst/."), the
@@ -270,8 +270,8 @@ fn chmod_transfer_root_self_locks_without_owner_execute() {
 /// by `--chmod` regains owner-execute; owner-non-writable ones keep the strict
 /// mode.
 ///
-/// upstream: generator.c:1512-1520 raises a directory to owner-`rwx` while its
-/// contents are written, and generator.c:2107-2145 `touch_up_dirs()` restores
+/// upstream: generator.c:1904-1912 raises a directory to owner-`rwx` while its
+/// contents are written, and generator.c:2579-2617 `touch_up_dirs()` restores
 /// the tweaked mode ONLY when the owner would otherwise lack write. A subdir is
 /// addressed by name (not "./"), so the re-add chmod always succeeds; the net
 /// on-disk mode therefore keeps the transient owner bits when the owner is

--- a/crates/transfer/tests/uts_clean_fname_underflow.rs
+++ b/crates/transfer/tests/uts_clean_fname_underflow.rs
@@ -1,7 +1,7 @@
-//! Nextest port of upstream `testsuite/clean-fname-underflow.test`.
+//! Nextest port of upstream `testsuite/clean-fname-underflow_test.py`.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/clean-fname-underflow.test`.
+//! `testsuite/clean-fname-underflow_test.py`.
 //!
 //! # Background
 //!
@@ -31,7 +31,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/clean-fname-underflow.test` - the upstream script this file
+//! - `testsuite/clean-fname-underflow_test.py` - the upstream script this file
 //!   ports.
 //! - `util1.c` - `clean_fname()` in-place `.`/`..` collapsing.
 

--- a/crates/transfer/tests/uts_dd_symlink_dirlink_basis_topologies.rs
+++ b/crates/transfer/tests/uts_dd_symlink_dirlink_basis_topologies.rs
@@ -1,7 +1,7 @@
 //! Regression coverage for the eight `symlink-dirlink-basis` topologies the
 //! upstream rsync 3.4.4 testsuite exercises against `-K`/`--keep-dirlinks`.
 //!
-//! Upstream test: `testsuite/symlink-dirlink-basis.test`. Issue #715. The
+//! Upstream test: `testsuite/symlink-dirlink-basis_test.py`. Issue #715. The
 //! scenarios update a destination file whose parent directory is a symlink to
 //! the real directory. With `--keep-dirlinks` the receiver must follow the
 //! parent symlink at chmod time instead of refusing it through the
@@ -20,10 +20,10 @@
 //! receiver's path through the bypass.
 //!
 //! Upstream sources of truth:
-//!   - `target/interop/upstream-src/rsync-3.4.4/testsuite/symlink-dirlink-basis.test`
-//!   - `target/interop/upstream-src/rsync-3.4.1/options.c:688` (`-K` mapping)
-//!   - `target/interop/upstream-src/rsync-3.4.1/generator.c:1344`
-//!     (`link_stat(fname, &sx.st, keep_dirlinks && is_dir)`)
+//!   - `testsuite/symlink-dirlink-basis_test.py`
+//!   - `options.c:702` (`-K` mapping)
+//!   - `generator.c:1745`
+//!     (`gen_entry_stat(fname, file, &sx.st, keep_dirlinks && is_dir)`)
 
 use metadata::MetadataOptions;
 use transfer::flags::ParsedServerFlags;

--- a/crates/transfer/tests/uts_delay_updates_atomic.rs
+++ b/crates/transfer/tests/uts_delay_updates_atomic.rs
@@ -1,14 +1,14 @@
-//! Nextest port of upstream `testsuite/delay-updates.test` (local-copy leg).
+//! Nextest port of upstream `testsuite/delay-updates_test.py` (local-copy leg).
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/delay-updates.test`.
+//! `testsuite/delay-updates_test.py`.
 //!
 //! # Background
 //!
 //! `--delay-updates` stages every updated file under a `.~tmp~` scratch
 //! directory in the destination and only renames them into place at the end of
 //! the transfer, so an interrupted run never leaves half-written files visible.
-//! Upstream's delay-updates.test runs `rsync -aiv --delay-updates` and
+//! Upstream's delay-updates_test.py runs `rsync -aiv --delay-updates` and
 //! `checkit()` confirms the destination matches - and, implicitly, that the
 //! `.~tmp~` staging directory does not survive a successful run.
 //!
@@ -33,7 +33,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/delay-updates.test` - the upstream script this file ports.
+//! - `testsuite/delay-updates_test.py` - the upstream script this file ports.
 //! - `receiver.c` / `generator.c` - `--delay-updates` stages into `partialptr`
 //!   under `.~tmp~` and renames at `finish_transfer()` time.
 

--- a/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
+++ b/crates/transfer/tests/uts_duplicate_source_names_copied_once.rs
@@ -1,7 +1,7 @@
 //! Port of the upstream rsync 3.4.4 testsuite `duplicates.test`.
 //!
 //! Upstream source of truth:
-//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/duplicates.test`
+//!   `testsuite/duplicates_test.py`
 //!   `flist.c` `clean_flist()` - the dedup pass that collapses repeated names.
 //!
 //! Why this matters: a user can name the same source more than once on the

--- a/crates/transfer/tests/uts_executability_flag_transfer.rs
+++ b/crates/transfer/tests/uts_executability_flag_transfer.rs
@@ -1,7 +1,7 @@
 //! Port of the upstream rsync 3.4.4 testsuite `executability.test`.
 //!
 //! Upstream source of truth:
-//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/executability.test`
+//!   `testsuite/executability_test.py`
 //!   `rsync.c` `dest_mode()` - when `-E` is set without `-p`, only the
 //!   executability bits transfer from source to destination.
 //!
@@ -64,7 +64,7 @@ fn attr_only_fixture(from: &Path, to: &Path) {
 
 /// Asserts the upstream `dest_mode()` outcome for [`attr_only_fixture`].
 ///
-/// upstream: rsync.c:449-473 dest_mode() - existing dest keeps its perm bits;
+/// upstream: rsync.c:464-487 dest_mode() - existing dest keeps its perm bits;
 /// with `-E` a non-executable source strips 0111, an executable source grants
 /// exec to every class that can read, and a dest that already has any exec
 /// bit is left verbatim.
@@ -86,7 +86,7 @@ fn assert_attr_only_outcome(to: &Path) {
     );
 }
 
-/// Full three-phase replay of the upstream `executability.test`: a plain
+/// Full three-phase replay of the upstream `executability_test.py`: a plain
 /// recursive copy leaves destination modes alone, and only `-E` transfers the
 /// executability bits without disturbing the read/write bits.
 #[test]
@@ -200,9 +200,9 @@ fn executability_flag_transfers_only_exec_bits() {
 /// `metadata_unchanged` never consulted `--executability`, leaving the
 /// destination at its old mode while the itemized output claimed a `p` change.
 ///
-/// upstream: generator.c:418-426 perms_differ() feeds unchanged_attrs(), so an
+/// upstream: generator.c:424-432 perms_differ() feeds unchanged_attrs(), so an
 /// executability-presence mismatch forces set_file_attrs() on the skip path
-/// (generator.c:1827).
+/// (generator.c:2246).
 #[test]
 fn executability_applies_on_up_to_date_files_over_rsh_push() {
     require_binaries!("oc-rsync", LSH_STUB_BIN);
@@ -232,7 +232,7 @@ fn executability_applies_on_up_to_date_files_over_rsh_push() {
 /// Regression: `-rtE` over a remote shell (pull) must chmod up-to-date files.
 ///
 /// Same attribute-only scenario as the push test, but the local client is the
-/// receiver. Note `-E` never rides the wire on a pull (options.c:2692 packs
+/// receiver. Note `-E` never rides the wire on a pull (options.c:2858 packs
 /// 'E' only when `am_sender`); the local receiver must honour its own flag.
 #[test]
 fn executability_applies_on_up_to_date_files_over_rsh_pull() {
@@ -264,8 +264,8 @@ fn executability_applies_on_up_to_date_files_over_rsh_pull() {
 /// source mode copied exactly, including the read/write bits `-E` alone would
 /// leave untouched.
 ///
-/// upstream: options.c:2690-2693 - the server arg string carries 'p', never
-/// 'E', when both are set; generator.c:418-421 perms_differ() compares the
+/// upstream: options.c:2856-2859 - the server arg string carries 'p', never
+/// 'E', when both are set; generator.c:424-427 perms_differ() compares the
 /// full mode under preserve_perms.
 #[test]
 fn executability_is_noop_when_perms_active_over_rsh() {

--- a/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
+++ b/crates/transfer/tests/uts_fuzzy_local_basis_reuse.rs
@@ -1,13 +1,13 @@
-//! Nextest port of upstream `testsuite/fuzzy.test` (local-copy legs).
+//! Nextest port of upstream `testsuite/fuzzy_test.py` (local-copy legs).
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/fuzzy.test`.
+//! `testsuite/fuzzy_test.py`.
 //!
 //! # Background
 //!
 //! `--fuzzy` lets the receiver reuse a same-content, differently-named file
 //! already present in the destination directory as the delta basis for a new
-//! transfer, instead of sending the whole file. Upstream's fuzzy.test seeds
+//! transfer, instead of sending the whole file. Upstream's fuzzy_test.py seeds
 //! `$todir/rsync2.c` with the exact bytes of `$fromdir/rsync.c`, then runs
 //! `rsync -avvi --no-whole-file --fuzzy` and asserts the resulting tree
 //! matches - which only holds if the basis was actually reused.
@@ -42,7 +42,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/fuzzy.test` - the upstream script this file ports.
+//! - `testsuite/fuzzy_test.py` - the upstream script this file ports.
 //! - `generator.c` - `find_fuzzy()` selects the fuzzy basis in the receiver's
 //!   destination directory.
 

--- a/crates/transfer/tests/uts_missing_args.rs
+++ b/crates/transfer/tests/uts_missing_args.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the upstream `testsuite/missing.test` scenario.
+//! Nextest port of the upstream `testsuite/missing_test.py` scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/missing.test`.
+//! `testsuite/missing_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `missing.test` guards bugs Wayne Davison fixed when he reworked
+//! Upstream's `missing_test.py` guards bugs Wayne Davison fixed when he reworked
 //! the generator's `missing_below` logic (the state that suppresses per-file
 //! work under a directory that a dry run has decided not to create):
 //!
@@ -34,7 +34,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/missing.test` - the upstream script this file ports.
+//! - `testsuite/missing_test.py` - the upstream script this file ports.
 //! - `generator.c` - `missing_below` handling and the `--ignore-non-existing`
 //!   skip path (`skipping non-existent destination file`).
 //! - `delete.c` - the `--delete-after` deletion pass that must still run.

--- a/crates/transfer/tests/uts_mkpath_create_dest_path.rs
+++ b/crates/transfer/tests/uts_mkpath_create_dest_path.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the upstream `testsuite/mkpath.test` scenario.
+//! Nextest port of the upstream `testsuite/mkpath_test.py` scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/mkpath.test`.
+//! `testsuite/mkpath_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `mkpath.test` verifies the `--mkpath` option, which tells rsync
+//! Upstream's `mkpath_test.py` verifies the `--mkpath` option, which tells rsync
 //! to create any missing leading components of the destination path before
 //! transferring. Without `--mkpath`, rsync only creates the final destination
 //! directory (or none at all for a single-file copy); a multi-level missing
@@ -39,7 +39,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/mkpath.test` - the upstream script this file ports.
+//! - `testsuite/mkpath_test.py` - the upstream script this file ports.
 //! - `options.c` - `--mkpath` option wiring (`mkpath_dest_arg`).
 //! - `generator.c` - destination-prefix directory materialization.
 

--- a/crates/transfer/tests/uts_multi_source_merge.rs
+++ b/crates/transfer/tests/uts_multi_source_merge.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the upstream `testsuite/merge.test` scenario.
+//! Nextest port of the upstream `testsuite/merge_test.py` scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/merge.test`.
+//! `testsuite/merge_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `merge.test` verifies that rsync can merge files from multiple
+//! Upstream's `merge_test.py` verifies that rsync can merge files from multiple
 //! source directories (and bare file arguments) into a single destination in
 //! one invocation. The canonical command is:
 //!
@@ -33,14 +33,14 @@
 //! # What this test pins
 //!
 //! The transfer exits 0 and the destination tree is byte-for-byte the union
-//! upstream `merge.test` builds in its `chk/` reference tree: every disjoint
+//! upstream `merge_test.py` builds in its `chk/` reference tree: every disjoint
 //! file present with its own payload, every overlapping name carrying the
 //! shared payload, nested `sub1`/`sub2` merged, and `dir-and-not-dir`
 //! resolved to the directory form holding `inside`.
 //!
 //! # Upstream References
 //!
-//! - `testsuite/merge.test` - the upstream script this file ports.
+//! - `testsuite/merge_test.py` - the upstream script this file ports.
 //! - `flist.c` - multi-root file-list construction (`send_file_list`).
 //! - `generator.c` - per-directory reconciliation of merged entries.
 
@@ -61,7 +61,7 @@ fn write(path: &Path, contents: &str) {
 }
 
 /// Build the three source directories plus the two bare-file arguments,
-/// mirroring the upstream `merge.test` fixture block verbatim (dropping only
+/// mirroring the upstream `merge_test.py` fixture block verbatim (dropping only
 /// the never-referenced `from3/six` payload asymmetries - kept faithful here).
 fn build_sources(root: &Path) {
     write(&root.join("from1/one"), "one\n");

--- a/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
+++ b/crates/transfer/tests/uts_nextest_chdir_symlink_race.rs
@@ -1,10 +1,10 @@
 //! UTS-NEXTEST-EDGE.i: nextest port of the upstream
-//! `testsuite/chdir-symlink-race.test` security scenario.
+//! `testsuite/chdir-symlink-race_test.py` security scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/chdir-symlink-race.test`
-//! (the same scenario also lives in rsync-3.4.3 / 3.4.2 / 3.4.1; the 3.4.4
-//! file is the canonical upstream copy).
+//! `testsuite/chdir-symlink-race_test.py`
+//! (3.5.0 rewrote the shell `.test` scripts as Python; the scenario is
+//! carried over unchanged from the 3.4.x `chdir-symlink-race.test`).
 //!
 //! The upstream scenario probes the chdir-symlink-race TOCTOU class of
 //! bug at the receiver: after CVE-2026-29518's fix to

--- a/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_delete_stats.rs
@@ -1,14 +1,15 @@
 //! UTS-NEXTEST-EDGE.g: nextest port of the `daemon-delete-stats` scenario.
 //!
 //! Upstream scenario lineage:
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/delete.test` -
-//!   canonical upstream delete sweep coverage; the daemon-mode
-//!   `NDX_DEL_STATS` exchange is not a standalone upstream script but
-//!   is exercised by the same `--delete --stats` invocation under
-//!   `runtests.py` daemon mode.
-//! - `del.c::do_delete_pass()` - the full-tree delete sweep that
-//!   populates the per-type counters.
-//! - `generator.c:2376-2398` and `main.c:225-238` (3.4.4 `write_del_stats`):
+//! - `testsuite/delete_test.py` - canonical upstream delete sweep
+//!   coverage.
+//! - `testsuite/daemon-delete-stats_test.py` - at the pinned 3.5.0 the
+//!   daemon-mode `NDX_DEL_STATS` exchange has its own script; through
+//!   3.4.x it was only exercised by the same `--delete --stats`
+//!   invocation under `runtests.py` daemon mode.
+//! - `generator.c:364` `do_delete_pass()` - the full-tree delete sweep
+//!   that populates the per-type counters.
+//! - `generator.c:2850-2872` and `main.c:229-242` (`write_del_stats`):
 //!   the `NDX_DEL_STATS` wire frame contract gated on `delete_mode ||
 //!   force_delete || read_batch` plus `INFO_GTE(STATS, 2)`.
 //!
@@ -69,11 +70,11 @@
 //!
 //! # Upstream References
 //!
-//! - `del.c::do_delete_pass()` - delete sweep loop.
-//! - `generator.c:2376-2398` - `write_del_stats()` early emission gate
+//! - `generator.c:364` `do_delete_pass()` - delete sweep loop.
+//! - `generator.c:2850-2872` - `write_del_stats()` early emission gate
 //!   (`delete_mode || force_delete || read_batch`).
-//! - `main.c:225-238` - `write_del_stats()` wire format.
-//! - `rsync.c:337-342` - sender-side `read_ndx_and_attrs()` consumes
+//! - `main.c:229-242` - `write_del_stats()` wire format.
+//! - `rsync.c:338-343` - sender-side `read_ndx_and_attrs()` consumes
 //!   the `NDX_DEL_STATS` frame and accumulates the counters.
 //! - `crates/protocol/src/stats/delete.rs::DeleteStats::write_to` /
 //!   `read_from` - oc-rsync side of the wire format.
@@ -145,7 +146,7 @@ impl Drop for DaemonGuard {
 /// until it accepts connections.
 fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
     // Acquire a race-free free port and start the daemon on it. Because the
-    // default daemon binds with SO_REUSEADDR only (upstream socket.c:447), a
+    // default daemon binds with SO_REUSEADDR only (upstream socket.c:597), a
     // port collision is a clean EADDRINUSE daemon exit - never a silent
     // SO_REUSEPORT co-bind - so the helper simply retries with a fresh port.
     // See `test_support::daemon_port`.

--- a/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
+++ b/crates/transfer/tests/uts_nextest_daemon_gzip_zz.rs
@@ -1,19 +1,19 @@
-//! UTS-NEXTEST-EDGE.e: nextest port of the upstream `testsuite/daemon-gzip-
-//! download.test` and `testsuite/daemon-gzip-upload.test` `-zz` codec
-//! scenarios.
+//! UTS-NEXTEST-EDGE.e: nextest port of the upstream
+//! `testsuite/daemon-gzip-download_test.py` and
+//! `testsuite/daemon-gzip-upload_test.py` `-zz` codec scenarios.
 //!
 //! Upstream test sources:
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/daemon-gzip-download.test`
-//! - `target/interop/upstream-src/rsync-3.4.4/testsuite/daemon-gzip-upload.test`
+//! - `testsuite/daemon-gzip-download_test.py`
+//! - `testsuite/daemon-gzip-upload_test.py`
 //!
-//! (The identical scenarios also live in 3.4.3 / 3.4.2 / 3.4.1; the 3.4.4
-//! files are the canonical upstream copies.)
+//! (3.5.0 rewrote the shell `.test` scripts as Python; the scenarios are
+//! carried over unchanged from the 3.4.x `daemon-gzip-*.test` pair.)
 //!
 //! # Background
 //!
 //! Both upstream tests exercise `-zz` against a daemon transfer in both
 //! directions. `-zz` selects the new-style per-block codec (zlibx; upstream
-//! `options.c:2002` flips `compress_choice = "zlibx"` when the count of
+//! `options.c:2122-2123` flips `compress_choice = "zlibx"` when the count of
 //! `-z` flags is `>= 2` and no explicit `--compress-choice` was given).
 //! The negotiation surface lives in `crates/protocol` (capability advertise
 //! and `compress` capability bit) and the codec implementation in
@@ -61,11 +61,11 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/daemon-gzip-download.test` - upstream download script.
-//! - `testsuite/daemon-gzip-upload.test` - upstream upload script.
-//! - `options.c:2002` - `-zz` -> `compress_choice = "zlibx"` mapping.
+//! - `testsuite/daemon-gzip-download_test.py` - upstream download script.
+//! - `testsuite/daemon-gzip-upload_test.py` - upstream upload script.
+//! - `options.c:2122-2123` - `-zz` -> `compress_choice = "zlibx"` mapping.
 //! - `compat.c::setup_compress()` - codec negotiation across the wire.
-//! - `main.c:983` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
+//! - `main.c:998` `do_server_sender()` - `io_flush(FULL_FLUSH)` before
 //!   return; the contract pinned by UTS-9.
 //! - `crates/transfer/src/generator/transfer/orchestrator.rs` - matching
 //!   flush on the oc-rsync sender side.
@@ -118,7 +118,7 @@ impl DaemonGuard {
 ///
 /// Delegates port acquisition to [`test_support::spawn_daemon_on_free_port`]:
 /// it allocates a candidate port, starts the daemon on it, and - because the
-/// default daemon binds with `SO_REUSEADDR` only (upstream `socket.c:447`) - a
+/// default daemon binds with `SO_REUSEADDR` only (upstream `socket.c:597`) - a
 /// port collision is a clean `EADDRINUSE` daemon exit rather than a silent
 /// `SO_REUSEPORT` co-bind, so a losing attempt simply retries with a fresh
 /// port. No two daemons ever share a port, eliminating the cross-talk that
@@ -309,7 +309,8 @@ fn read_all(path: &Path) -> Vec<u8> {
 
 /// UTS-NEXTEST-EDGE.e.1 - download direction.
 ///
-/// Mirrors upstream `daemon-gzip-download.test`:
+/// Mirrors upstream `daemon-gzip-download_test.py`, quoted here in the 3.4.x
+/// `daemon-gzip-download.test` shell form it was rewritten from:
 ///
 /// ```sh
 /// $RSYNC -avvvvzz localhost::test-from/ '$todir/'
@@ -395,7 +396,8 @@ fn daemon_gzip_zz_download_byte_identical() {
 
 /// UTS-NEXTEST-EDGE.e.2 - upload direction.
 ///
-/// Mirrors upstream `daemon-gzip-upload.test`:
+/// Mirrors upstream `daemon-gzip-upload_test.py`, quoted here in the 3.4.x
+/// `daemon-gzip-upload.test` shell form it was rewritten from:
 ///
 /// ```sh
 /// $RSYNC -avvvvzz '$fromdir/' localhost::test-to/
@@ -471,7 +473,7 @@ fn daemon_gzip_zz_upload_byte_identical() {
 /// UTS-NEXTEST-EDGE.e.3 - `-z` and `-zz` both engage compression on a daemon pull.
 ///
 /// `-z` requests default zlib; `-zz` requests the "new" codec (upstream
-/// `options.c:2002` maps it to `zlibx`). oc-rsync implements a single
+/// `options.c:2122-2123` maps it to `zlibx`). oc-rsync implements a single
 /// deflate codec for both (`protocol::CompressionAlgorithm::{Zlib, ZlibX}`
 /// both resolve to `compress::algorithm::CompressionAlgorithm::Zlib`), so
 /// the two flags produce the same compressed wire stream by design - rsync
@@ -560,7 +562,7 @@ fn daemon_gzip_z_vs_zz_negotiation() {
 /// the wrong daemon (upload landing in a different module root, or a reset when
 /// the sibling was torn down). That was only possible because oc set
 /// `SO_REUSEPORT` on the *default* listener, letting a second daemon co-bind.
-/// Upstream (`socket.c:447`) sets only `SO_REUSEADDR`, so a second daemon on an
+/// Upstream (`socket.c:597`) sets only `SO_REUSEADDR`, so a second daemon on an
 /// in-use port is refused with `EADDRINUSE`.
 ///
 /// This test pins that behaviour deterministically: with the fixture daemon
@@ -719,8 +721,8 @@ fn concurrent_fixtures_get_distinct_ports_and_do_not_cross_talk() {
 /// `dont compress = gz` therefore desynced the token stream and aborted the
 /// transfer with a `protocol incompatibility` / out-of-range file-list index.
 ///
-/// Upstream never does this: `token.c:1065 send_token()` dispatches purely on
-/// the global `do_compression` codec, and `token.c:225 set_compression()`'s
+/// Upstream never does this: `token.c:1068 send_token()` dispatches purely on
+/// the global `do_compression` codec, and `token.c:232 set_compression()`'s
 /// per-file suffix lookup is compiled out under `#if 0` ("No compression
 /// algorithms currently allow mid-stream changing of the level."). The daemon's
 /// `dont compress` suffix list builds a suffix tree (`init_set_compression()`)

--- a/crates/transfer/tests/uts_nextest_hardlinks_inc_recurse.rs
+++ b/crates/transfer/tests/uts_nextest_hardlinks_inc_recurse.rs
@@ -1,14 +1,14 @@
-//! UTS-NEXTEST-EDGE.j: nextest port of the upstream `testsuite/hardlinks.test`
+//! UTS-NEXTEST-EDGE.j: nextest port of the upstream `testsuite/hardlinks_test.py`
 //! INC_RECURSE end-to-end scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/hardlinks.test` (the
-//! identical scenario also lives in 3.4.3 / 3.4.2 / 3.4.1; the 3.4.4 file is
-//! the canonical upstream copy).
+//! `testsuite/hardlinks_test.py` (3.5.0 rewrote the shell `.test` scripts as
+//! Python; the scenario is carried over unchanged from the 3.4.x
+//! `hardlinks.test`).
 //!
 //! # Background
 //!
-//! Upstream's `hardlinks.test` exercises `-aH` (preserve hard links) under
+//! Upstream's `hardlinks_test.py` exercises `-aH` (preserve hard links) under
 //! incremental recursion (INC_RECURSE) with three escalating shapes:
 //!
 //! 1. A simple flat hardlink pair (`name1` + `name2` in the same directory)
@@ -22,7 +22,7 @@
 //! oc-rsync ships INC_RECURSE on both the sender and the receiver under
 //! ISI.h (sender default flipped back on under PR #5085 after the V61D-1
 //! regression was triaged) and IFX-7 (hardlink wire encoding parity). The
-//! runtests.py harness exercises the upstream `hardlinks.test` script
+//! runtests.py harness exercises the upstream `hardlinks_test.py` script
 //! through `continue-on-error: true` CI plumbing - a per-test regression on
 //! that path does not block a PR. The UTS-NEXTEST-EDGE family lifts the
 //! upstream scenario into a native nextest integration test so it runs as
@@ -53,7 +53,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/hardlinks.test` - the upstream script this file ports.
+//! - `testsuite/hardlinks_test.py` - the upstream script this file ports.
 //! - `hlink.c::match_hard_links()` - leader/follower assignment after the
 //!   file list sort that the INC_RECURSE path relies on (see also
 //!   `crates/daemon/src/tests/chunks/daemon_hardlinks_relative_receive.rs`).
@@ -115,7 +115,8 @@ fn trailing_slash(dir: &Path) -> std::ffi::OsString {
 
 /// Scenario 1: two-file flat hardlink pair.
 ///
-/// Mirrors the opening block of upstream `hardlinks.test`:
+/// Mirrors the opening block of upstream `hardlinks_test.py`, quoted here in
+/// the 3.4.x `hardlinks.test` shell form it was rewritten from:
 ///
 /// ```sh
 /// echo "This is the file" > "$name1"
@@ -223,7 +224,8 @@ fn flat_hardlink_pair_survives_inc_recurse_roundtrip() {
 
 /// Scenario 2: hardlink spanning a deep subdirectory under INC_RECURSE.
 ///
-/// Mirrors the middle block of upstream `hardlinks.test`:
+/// Mirrors the middle block of upstream `hardlinks_test.py`, quoted here in
+/// the 3.4.x `hardlinks.test` shell form it was rewritten from:
 ///
 /// ```sh
 /// makepath "$fromdir/subdir/down/deep"
@@ -336,7 +338,8 @@ fn deep_subdir_hardlink_survives_inc_recurse_roundtrip() {
 
 /// Scenario 3: `--link-dest` re-run hardlinks every locally-inherited entry.
 ///
-/// Mirrors the `--link-dest` block of upstream `hardlinks.test`:
+/// Mirrors the `--link-dest` block of upstream `hardlinks_test.py`, quoted
+/// here in the 3.4.x `hardlinks.test` shell form it was rewritten from:
 ///
 /// ```sh
 /// $RSYNC -aH                          "$fromdir/" "$todir/"

--- a/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
+++ b/crates/transfer/tests/uts_symlink_ignore_no_links_flag.rs
@@ -1,7 +1,7 @@
 //! Port of the upstream rsync 3.4.4 testsuite `symlink-ignore.test`.
 //!
 //! Upstream source of truth:
-//!   `target/interop/upstream-src/rsync-3.4.4/testsuite/symlink-ignore.test`
+//!   `testsuite/symlink-ignore_test.py`
 //!
 //! Why this matters: rsync's default symlink policy is to *not* copy symlinks
 //! at all. A symlink is only transferred when the user opts in with `-l`

--- a/crates/transfer/tests/uts_trimslash_source_arg.rs
+++ b/crates/transfer/tests/uts_trimslash_source_arg.rs
@@ -1,11 +1,11 @@
-//! Nextest port of the upstream `testsuite/trimslash.test` scenario.
+//! Nextest port of the upstream `testsuite/trimslash_test.py` scenario.
 //!
 //! Upstream test source:
-//! `target/interop/upstream-src/rsync-3.4.4/testsuite/trimslash.test`.
+//! `testsuite/trimslash_test.py`.
 //!
 //! # Background
 //!
-//! Upstream's `trimslash.test` exercises rsync's tiny trailing-slash trimmer
+//! Upstream's `trimslash_test.py` exercises rsync's tiny trailing-slash trimmer
 //! (upstream `util1.c:trim_trailing_slashes`) via a standalone `trimslash`
 //! helper. The rule it enforces: any run of trailing slashes on a path
 //! collapses to the semantics of a single trailing slash, except that a path
@@ -38,7 +38,7 @@
 //!
 //! # Upstream References
 //!
-//! - `testsuite/trimslash.test` - the upstream script this file ports.
+//! - `testsuite/trimslash_test.py` - the upstream script this file ports.
 //! - `util1.c` - `trim_trailing_slashes()`, the function under test.
 //! - `flist.c` - trailing-slash handling of source args (`send_file_list`).
 


### PR DESCRIPTION
`crates/transfer` cited upstream rsync by `target/interop/upstream-src/rsync-3.4.1/...` and `rsync-3.4.4/...` paths. The interop pin is **3.5.0**. These were not cosmetically-stale paths: the line numbers are 3.4.x-era numbers, and at 3.5.0 most of them land on unrelated code.

## What the old line numbers actually say at 3.5.0

| citation | what it claims | at its 3.4.x baseline | at 3.5.0, same number | retargeted to |
|---|---|---|---|---|
| `compat.c:655-661` | the `--acls requires protocol 30 or higher` gate | that gate (3.4.4) | `if (preallocate_files && !am_sender) { ... "preallocation is not supported" }` | `compat.c:667-673` |
| `log.c:310-311` | `case FERROR_XFER: got_xfer_error = 1;` | that case (3.4.4) | `if (code == FCLIENT) code = FINFO;` | `log.c:337-338` |
| `generator.c:1275-1287` | `check_filter(&daemon_filter_list, ...)` and the `ERROR: daemon refused to receive` report | that block (3.4.4) | a comment fragment inside the hard-link fallback (`* as a build without the macro does -- the caller creates`) | `generator.c:1664-1676` |
| `backup.c:353` | `rprintf(FINFO, "backed up %s to %s\n", fname, buf)` | that line (3.4.4) | `close(bfd);` | `backup.c:433` |
| `generator.c:2107-2145` | `touch_up_dirs()` restoring tweaked dir perms | that loop (3.4.4) | the `ftype != FT_REG` / `max_size` skip block in `recv_generator()` | `generator.c:2579-2617` |

Neither existing gate can see this. `cargo xtask citations` only checks that the cited line number is `<=` the file's length at 3.5.0, which is true by coincidence for all of them; `tools/ci/citation_drift_audit.py` only inspects citations carrying a quoted C-string anchor, and it scans `crates/*/src/**` only - 21 of the 22 files here live in `tests/`.

## Method

Every citation was retargeted **by construct, never by arithmetic**: read the claim, locate that function / branch / message / struct field in `target/interop/upstream-src/rsync-3.5.0/`, and re-derive **both ends** of every range there independently. Paths drop the version directory in favour of the bare form the rest of the crate already uses (there are no `rsync-3.5.0/`-prefixed citations anywhere in `crates/`).

Two of the citations turned out to be already-correct at 3.5.0 and were left alone: `cleanup.c:217-218` (`got_xfer_error` -> `RERR_PARTIAL`) is byte-identical at both versions, and `chmod.c:92` (`bits = (where * what) & ~orig_umask`) sits at line 77 in 3.4.1/3.4.4 and at 92 in 3.5.0 - it already names the pin. Coincidence is real here, so every site was checked rather than assumed to have moved.

## The testsuite rename

3.5.0 rewrote the shell testsuite scripts as Python. Every one of the 19 cited `testsuite/<name>.test` files is gone at the pin and has a `testsuite/<name>_test.py` counterpart whose header reads `# Python rewrite of testsuite/<name>.test`, verified for all 19. Those locators move accordingly.

Prose that quotes the shell form verbatim keeps it and is now qualified as the 3.4.x form - e.g. `Mirrors the opening block of upstream hardlinks_test.py, quoted here in the 3.4.x hardlinks.test shell form it was rewritten from:` above a ```` ```sh ```` block. Sentences that record provenance ("Port of the upstream rsync 3.4.4 testsuite `duplicates.test`", "Verified against upstream rsync 3.4.4") are historical statements and are left as written.

## Claims that changed, not just moved

- **`generator.c:1344`** cited `link_stat(fname, &sx.st, keep_dirlinks && is_dir)`. At 3.5.0 that call site is `generator.c:1745` and reads `gen_entry_stat(fname, file, &sx.st, keep_dirlinks && is_dir)`. `gen_entry_stat` (`generator.c:1389`) is a thin dispatcher to `link_stat_at` on a held dirfd or `link_stat` otherwise, so the `keep_dirlinks && is_dir` follow-decision the comment is about is unchanged; only the quoted call text is updated.
- **`uts_nextest_daemon_delete_stats.rs`** claimed the daemon-mode `NDX_DEL_STATS` exchange "is not a standalone upstream script". False at the pin: `testsuite/daemon-delete-stats_test.py` exists at 3.5.0. The reference list now names it and scopes the old statement to 3.4.x.
- Same file cited `del.c::do_delete_pass()`. There is no `del.c` in 3.4.4 or 3.5.0; `do_delete_pass()` is `static` in `generator.c` (3.4.4:358, 3.5.0:364). Corrected to `generator.c:364`.
- Three citations were **already wrong at their own 3.4.x baseline**, not merely drifted: `options.c:2695-2703` and `options.c:2727` in `acl_negotiation_missing_remote.rs` (they pointed at `relative_paths`/`one_file_system` and at `args[ac++] = NULL`, not at the `A`/`X` emission and `maybe_add_e_option`), and `options.c:2002` in the two `-zz` files (the `compress_choice = "zlibx"` assignment is at 3.4.4:2011-2012). All three now point at the construct at 3.5.0.

No construct cited by the 22 files is absent from 3.5.0.

## Deliberately not changed

`daemon_push_refused_file_reports_error.rs:183-184` builds the runtime lookup path for an upstream binary (`target/interop/upstream-install/3.4.4/bin/rsync`, `target/interop/upstream-src/rsync-3.4.4/rsync`). That is executable code selecting which peer the interop leg runs against, not a citation - retargeting it would change behaviour, so it is left for whoever owns the interop binary pin. The same applies to the 3.4.4 gating prose in `upstream_compat_daemon_gzip_goodbye.rs`, which describes that binary.

## Gates

- `python3 tools/ci/check_rustfmt_all.py` - clean, 3369 tracked `.rs` files at edition 2024.
- `cargo xtask citations` - passes; 8668 names and 8668 line ranges across 5035 files.
- `python3 tools/ci/citation_drift_audit.py transfer` - `string-anchored=152 suspected-drift=6 (4%) unresolved=78`, **identical to the pre-change baseline**. That is not evidence of correctness: the audit globs `crates/transfer/src/**/*.rs` only, and 21 of these 22 files are under `tests/`. It confirms no regression, nothing more. No entry in its output names any file this PR touches.

Comment-only. Four changed lines are not comments: they are `assert!` failure-message string literals in `acl_negotiation_missing_remote.rs` and `daemon_push_refused_file_reports_error.rs` that quote the same citations inline (`"error message must match upstream compat.c:657-659 format byte-for-byte"`). Leaving them would print a stale line number to whoever reads the failure. No predicate, comparison value, or control flow changed.

## Out of scope, and still stale

The `unresolved=78` population in the drift audit is concentrated in `crates/transfer/src/`, outside the 22 files this PR covers, and those citations carry no version prefix so the enumerating grep does not reach them. Spot-checked, they are 3.4.4-era and mostly wrong at the pin:

- `receiver/directory/backup.rs`: `generator.c:2018` -> `generator.c:2477-2478`; its quoted `make_backup(fname, False)` is a paraphrase of `if (!make_backup(fname, skip_atomic))` at both versions. `backup.c:191` (`if (!prefer_rename)`) -> `backup.c:230`.
- `receiver/basis.rs`: `generator.c:720-721` (`if (block_size) blength = block_size;`) is **correct at 3.5.0** - it was 714-715 at 3.4.4. The audit reports it `unresolved` only because the quoted anchor spans two upstream lines, a documented false-negative class of the tool.

`basis.rs`, `quick_check.rs` and `directory/backup.rs` alone carry 181 citation lines across ~120 distinct sites; construct-level re-derivation of those is a separate piece of work, not a rider on this one. `uts_2_efg_ssh_alt_dest_verification.rs` and `uts_files_from_ssh_push_relative.rs` also still cite `testsuite/alt-dest.test` and `testsuite/files-from.test`, both gone at the pin.
