### PR TITLE
fix(daemon): pin the module root before the privilege drop

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -152,6 +152,32 @@ fn apply_privilege_restrictions_with_upstream_errors(
         }
     }
 
+    // upstream: clientserver.c:1059-1065 - `change_dir(module_chdir, CD_NORMAL)`
+    // and `module_dirfd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC)` both
+    // run here, ABOVE the setgid/setuid at clientserver.c:1093+. The ordering
+    // is the whole mechanism: after the drop, every lookup that names the
+    // module by its absolute path re-traverses the module's ancestors as the
+    // module uid, so a module under a directory that uid cannot search (the
+    // 0700-home shape, `path = /home/backup/data`) fails with EACCES even
+    // though the module itself is world-readable. Publishing the root here
+    // rather than after the drop also means its canonicalisation still runs
+    // privileged.
+    let module_root = inner_module_path.as_deref().unwrap_or(&module.path);
+    publish_module_confinement(module, module_root, chroot_applied);
+    if let Err(err) = fast_io::confinement::pin_session_root_fd(module_root) {
+        // Upstream leaves `module_dirfd` at -1 and carries on with the
+        // absolute path (`clientserver.c:1063-1066` has no error arm), so a
+        // failed pin is not fatal here either - it only means the lookups
+        // below fall back to the absolute form they used before. Say so, since
+        // it is the difference between the module being sandboxed and not.
+        let text = format!(
+            "module '{}': could not pin the module root before the privilege drop: {err}; lookups fall back to the absolute module path",
+            module.name,
+        );
+        let message = rsync_warning!(text).with_role(Role::Daemon);
+        log_message(log_sink, &message);
+    }
+
     if let Some(target) = drop_target {
         if target.uid.is_some() || !target.gids.is_empty() {
             if let Err(err) = drop_privileges(target.uid, &target.gids, log_sink) {
@@ -179,12 +205,6 @@ fn apply_privilege_restrictions_with_upstream_errors(
             }
         }
     }
-
-    publish_module_confinement(
-        module,
-        inner_module_path.as_deref().unwrap_or(&module.path),
-        chroot_applied,
-    );
 
     Ok(Some(PrivilegeOutcome {
         chroot_applied,

--- a/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs
@@ -164,6 +164,13 @@ fn apply_privilege_restrictions_with_upstream_errors(
     // privileged.
     let module_root = inner_module_path.as_deref().unwrap_or(&module.path);
     publish_module_confinement(module, module_root, chroot_applied);
+    // The pin itself is unix-only: `pin_session_root_fd` and the rest of the
+    // held-dirfd family are `#[cfg(unix)]` in `fast_io::confinement`, because
+    // there is no dirfd to hold and no setgid/setuid drop to precede on
+    // Windows. The policy half above is cross-platform and still runs. A
+    // no-op Windows arm returning `Ok(())` would report a pin that never
+    // happened - the opposite of what the warning below exists to say.
+    #[cfg(unix)]
     if let Err(err) = fast_io::confinement::pin_session_root_fd(module_root) {
         // Upstream leaves `module_dirfd` at -1 and carries on with the
         // absolute path (`clientserver.c:1063-1066` has no error arm), so a

--- a/crates/fast_io/src/confined_open.rs
+++ b/crates/fast_io/src/confined_open.rs
@@ -280,13 +280,14 @@ mod imp {
             // Open the module root as the anchoring dirfd. The root is an
             // absolute, operator-trusted path, so a plain open (following any
             // symlinks in the root itself) matches upstream's
-            // `openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY)`.
+            // `openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY)`. Routed
+            // through `open_trusted_dir` rather than opened here so this arm
+            // gets the same `dup(module_dirfd)` shortcut the walk arm below
+            // gets: re-opening the absolute root after a daemon's privilege
+            // drop `EACCES`es on an unsearchable ancestor.
+            // upstream: `syscall.c:85-90` `open_anchor_dirfd()`.
             use std::os::fd::AsFd;
-            use std::os::unix::fs::OpenOptionsExt;
-            let root_dir = std::fs::OpenOptions::new()
-                .read(true)
-                .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC)
-                .open(root)?;
+            let root_dir = crate::secure_dir::open_trusted_dir(root)?;
             if let Some(file) = linux::openat2_confined(root_dir.as_fd(), trimmed, leaf, noatime)? {
                 return Ok(file);
             }

--- a/crates/fast_io/src/confined_readdir.rs
+++ b/crates/fast_io/src/confined_readdir.rs
@@ -46,12 +46,32 @@ pub fn read_dir_confined(root: &Path, relative: &Path) -> io::Result<Vec<OsStrin
     imp::read_dir_confined(root, relative)
 }
 
+/// Enumerates an already-open directory descriptor.
+///
+/// The descriptor is borrowed, never consumed: `fdopendir` takes ownership of
+/// whatever it is handed and `closedir` releases it, so this hands over a
+/// duplicate and leaves the caller's own descriptor untouched.
+///
+/// Shared with [`crate::pinned_root::read_dir`], which anchors the scan on the
+/// daemon's pinned module root rather than on a confined walk - the same
+/// enumeration of a descriptor either way, so it is written once.
+///
+/// # Errors
+///
+/// The `dup`/`fdopendir` error. A `readdir` error is indistinguishable from
+/// end-of-stream and is treated as the end, matching upstream's
+/// `while ((di = readdir(d)) != NULL)` scan loop (`flist.c` `send_directory()`).
+#[cfg(unix)]
+pub(crate) fn read_dir_names_at(dirfd: std::os::fd::BorrowedFd<'_>) -> io::Result<Vec<OsString>> {
+    imp::read_names(dirfd)
+}
+
 #[cfg(unix)]
 mod imp {
     use super::*;
 
     use std::ffi::CStr;
-    use std::os::fd::IntoRawFd;
+    use std::os::fd::{BorrowedFd, IntoRawFd};
     use std::os::unix::ffi::OsStrExt;
 
     use crate::dir_sandbox::{ConfinePolicy, DirSandbox};
@@ -64,22 +84,17 @@ mod imp {
             relative,
             ConfinePolicy::operator_trusted(),
         )?;
-        read_names(&sandbox)
+        read_names(sandbox.root_dirfd())
     }
 
-    /// Enumerates the sandbox's resolved directory from its descriptor.
-    ///
-    /// `fdopendir` takes ownership of the descriptor it is handed and
-    /// `closedir` releases it, while the sandbox keeps its own for the
-    /// caller's later use - so this hands over a duplicate, never the
-    /// sandbox's.
+    /// Enumerates `dirfd` from a duplicate of it.
     #[allow(unsafe_code)]
-    fn read_names(sandbox: &DirSandbox) -> io::Result<Vec<OsString>> {
-        let duplicate = sandbox.root_dirfd().try_clone_to_owned()?;
+    pub(super) fn read_names(dirfd: BorrowedFd<'_>) -> io::Result<Vec<OsString>> {
+        let duplicate = dirfd.try_clone_to_owned()?;
         let raw = duplicate.into_raw_fd();
 
         // SAFETY: `raw` is an open directory descriptor this function solely
-        // owns, freshly duplicated above and not shared with the sandbox.
+        // owns, freshly duplicated above and not shared with the caller's.
         // `fdopendir` takes that ownership on success; on failure it does not,
         // which is why the error arm closes `raw` itself.
         let dir = unsafe { libc::fdopendir(raw) };

--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -73,6 +73,12 @@ static SESSION_OPTOUT: AtomicBool = AtomicBool::new(false);
 /// caller is without making it invent values for fields its arm ignores.
 pub fn install_session(activation: &Activation) {
     SESSION_OPTOUT.store(activation.optout_allowed(), Ordering::Relaxed);
+    // The pinned descriptor names the PREVIOUS root, so it stops being an
+    // answer the moment the root changes. Dropping it here keeps one
+    // invariant - the pin, when present, is always this root's - instead of
+    // letting a stale descriptor answer for a root it never named.
+    #[cfg(unix)]
+    clear_session_root_fd();
     *SESSION_ROOT
         .write()
         .unwrap_or_else(std::sync::PoisonError::into_inner) = activation.root().map(physical_root);
@@ -113,6 +119,174 @@ fn physical_root(root: &Path) -> PathBuf {
 /// is the failure mode this exists to prevent. The value is a property of the
 /// session, not of the call - unlike [`PathKind`], which is.
 static SESSION_ROOT: RwLock<Option<PathBuf>> = RwLock::new(None);
+
+/// The session's root pinned *by identity* - the second half of
+/// [`SESSION_ROOT`], not a second root.
+///
+/// [`SESSION_ROOT`] answers *where* the boundary is. This answers *which
+/// directory* it is, as a descriptor obtained while the process could still
+/// reach it. The two are always the same directory: [`install_session`] drops
+/// the descriptor whenever it replaces the path, so a pin that is present is
+/// always this session's.
+///
+/// # Why a descriptor is needed at all
+///
+/// A daemon resolves the module root while privileged and then drops to the
+/// module's uid. Every later operation that re-walks the *absolute* module
+/// path re-traverses the module's ancestors as the dropped uid, so a module
+/// under a directory that uid cannot search (`path = /home/backup/data` with a
+/// 0700 home) fails with `EACCES` even though the module itself is
+/// world-readable. A descriptor opened before the drop is immune: the kernel
+/// checks the ancestors once, at open time.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:1059-1065` - `change_dir(module_chdir, CD_NORMAL)` then
+///   `module_dirfd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC)`, both
+///   above the `setgid`/`setuid` at `clientserver.c:1093+`.
+/// - `flist.c:2035-2059` `secure_opendir()` - the scan anchors on it.
+/// - `sender.c:293-295` - the content open anchors on it.
+/// - `syscall.c:85-90` `open_anchor_dirfd()` - `dup(module_dirfd)` instead of
+///   re-resolving the absolute root.
+#[cfg(unix)]
+static SESSION_ROOT_FD: RwLock<Option<PinnedRoot>> = RwLock::new(None);
+
+/// The pinned root: the descriptor, plus the spelling it was pinned under.
+///
+/// Two spellings of one directory, not two roots. [`SESSION_ROOT`] holds the
+/// *physical* one, because judging whether a resolved path landed outside the
+/// boundary has to compare in one namespace. The sender's absolute source
+/// paths are built from the *literal* one - the module path as the operator
+/// wrote it in `rsyncd.conf` - and the two differ wherever an ancestor is a
+/// symlink (`/var` -> `/private/var` on macOS, `/home` -> `/usr/home` on
+/// FreeBSD, any bind-mounted or symlinked module root). Keeping the literal
+/// here is what lets a lookup on such a deployment recognise its own root;
+/// without it the anchoring silently never fires and the module is back to the
+/// `EACCES` this exists to remove.
+#[cfg(unix)]
+#[derive(Clone)]
+struct PinnedRoot {
+    literal: PathBuf,
+    fd: std::sync::Arc<std::os::fd::OwnedFd>,
+}
+
+/// Pin `root` by identity.
+///
+/// Call while the process can still reach it - for a daemon that means after
+/// `chroot` and before the `setgid`/`setuid` drop, exactly where upstream
+/// opens `module_dirfd`. Calling it later still succeeds when the ancestors
+/// happen to be searchable, and fails with the same `EACCES` the pin exists to
+/// avoid when they are not.
+///
+/// `root` is the root as the caller names it; it should be the same value the
+/// caller published through [`install_session`], and both spellings of it are
+/// then recognised (see [`PinnedRoot`]).
+///
+/// # Errors
+///
+/// The `open(2)` error from opening the root as a directory, or `ELOOP` when
+/// the ownership walk refuses a component symlink owned by neither uid 0 nor
+/// our euid. A caller that cannot pin must fall back to the absolute path -
+/// which is what it did before a pin existed - and must not treat the pin as a
+/// confinement it can skip re-checking.
+#[cfg(unix)]
+pub fn pin_session_root_fd(root: &Path) -> std::io::Result<()> {
+    // upstream: clientserver.c:1065 - `open(".", O_RDONLY | O_DIRECTORY |
+    // O_CLOEXEC)`. A working directory descriptor, not `O_PATH`: `openat`
+    // anchoring, the `dup` in [`crate::open_trusted_dir`], and the Landlock
+    // rule all take it as-is, and `O_PATH` cannot serve the first two.
+    //
+    // Through the OWNERSHIP WALK, not a plain open, because upstream's `.` is
+    // already the directory `change_dir()` entered and `change_dir()` enters a
+    // non-chrooted daemon's module root with
+    // `open_no_attacker_symlinks(dir, O_RDONLY | O_DIRECTORY, 0)`
+    // (`util1.c:1254-1263`). A plain open here would resolve a symlink an
+    // attacker planted at a component of the configured `path =`, and the pin
+    // would then answer `link_stat(".")` with the escape target's directory -
+    // turning the ancestor-traversal fix into a module-root escape. The
+    // operator's own `/backup -> /mnt/disk` is still followed; only a
+    // foreign-owned one is refused.
+    let fd = crate::owner_walk::operator_open_dir(root)?;
+    *SESSION_ROOT_FD
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(PinnedRoot {
+        literal: root.to_path_buf(),
+        fd: std::sync::Arc::new(fd),
+    });
+    Ok(())
+}
+
+/// Drop the pinned root descriptor.
+#[cfg(unix)]
+pub fn clear_session_root_fd() {
+    *SESSION_ROOT_FD
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+}
+
+/// The pinned root descriptor when `path` names the pinned root itself, under
+/// either spelling of it.
+///
+/// This is the question [`crate::open_trusted_dir`] asks, and upstream asks it
+/// as `strcmp(path, module_dir)` (`syscall.c:87`).
+#[cfg(unix)]
+#[must_use]
+pub fn pinned_root_fd_for(path: &Path) -> Option<std::sync::Arc<std::os::fd::OwnedFd>> {
+    let (fd, relative) = pinned_root_relative(path)?;
+    (relative == Path::new(".")).then_some(fd)
+}
+
+/// Whether this session pinned a root at all.
+#[cfg(unix)]
+#[must_use]
+pub fn session_root_is_pinned() -> bool {
+    SESSION_ROOT_FD
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .is_some()
+}
+
+/// Split `path` into the pinned root descriptor and the remainder to resolve
+/// beneath it, so a caller can reach `path` without re-walking the root's
+/// ancestors.
+///
+/// Returns `None` - meaning "resolve `path` the ordinary way" - when no root
+/// is pinned, or when `path` does not lie beneath the pinned root. A path
+/// equal to the root yields `.`, which is the name upstream's post-`change_dir`
+/// code uses for the same directory (`flist.c:2059`).
+#[cfg(unix)]
+#[must_use]
+pub fn pinned_root_relative(
+    path: &Path,
+) -> Option<(std::sync::Arc<std::os::fd::OwnedFd>, PathBuf)> {
+    let pinned = SESSION_ROOT_FD
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()?;
+    let relative = path
+        .strip_prefix(&pinned.literal)
+        .ok()
+        .or_else(|| path.strip_prefix(session_confinement_root()?).ok())?;
+    // A `..` in the remainder would be resolved from the pin rather than from
+    // `/`, and `strip_prefix` is lexical so it cannot say where that lands.
+    // Upstream refuses the same component up front
+    // (`syscall.c` `path_has_dotdot_component`); here the answer is simply
+    // "not anchorable", which leaves the caller on the absolute path it used
+    // before. Anchoring is an optimisation of reach, never of policy, so
+    // declining is always a correct answer.
+    if relative
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
+        return None;
+    }
+    let relative = if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative.to_path_buf()
+    };
+    Some((pinned.fd, relative))
+}
 
 /// Whether an already-resolved absolute path must be refused for landing
 /// outside the session's confinement root.

--- a/crates/fast_io/src/landlock.rs
+++ b/crates/fast_io/src/landlock.rs
@@ -121,6 +121,11 @@ pub fn is_supported() -> bool {
 ///
 /// Call exactly once per daemon connection, after privilege drop and any
 /// chroot have completed, before any user-controlled file operation begins.
+/// A root that names the session's pinned module root
+/// ([`pin_session_root_fd`](crate::confinement::pin_session_root_fd)), or lies
+/// beneath it, is opened through that descriptor - the rule path open runs
+/// post-drop, and re-resolving the absolute path there is what makes the
+/// ruleset fail to install on a module under an unsearchable ancestor.
 /// All roots must be absolute and must already exist - the helper does not
 /// create them. An empty `allowed_roots` slice denies every filesystem write
 /// once `restrict_self()` engages, which is the correct posture for a
@@ -158,9 +163,18 @@ pub fn restrict_to_module_paths(allowed_roots: &[&Path]) -> LandlockOutcome {
     };
 
     for root in allowed_roots {
-        let fd = match PathFd::new(root) {
+        // The rule path is opened HERE, which is after the daemon's privilege
+        // drop - so opening the module root by its absolute path re-traverses
+        // the module's ancestors as the dropped uid and returns `EACCES`
+        // whenever one of them is unsearchable (a 0700 home). The caller only
+        // warns on failure, so the module would then be served with no sandbox
+        // at all: the hardening would disappear on precisely the layout it
+        // exists for. Anchoring the open on the root the daemon pinned while
+        // still privileged (`clientserver.c:1059-1065`) is what keeps the rule
+        // installable there.
+        let fd = match crate::pinned_root::open_o_path(root) {
             Ok(fd) => fd,
-            Err(err) => return LandlockOutcome::Error(io::Error::other(err.to_string())),
+            Err(err) => return LandlockOutcome::Error(err),
         };
         created = match created.add_rule(PathBeneath::new(fd, access)) {
             Ok(c) => c,

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -145,6 +145,8 @@ pub mod page_aligned;
 pub mod parallel;
 /// Total physical memory detection (for the buffer pool's RAM-derived cap).
 pub mod physical_memory;
+/// Source lookups anchored on the daemon's pinned module root.
+pub mod pinned_root;
 /// Unix-only: read-only in-place recovery, mirroring upstream
 /// `open_readonly_inplace` (`receiver.c:200`).
 #[cfg(unix)]
@@ -418,7 +420,7 @@ pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
     operator_create_dir_all, operator_link, operator_link_confined, operator_mkdir,
-    operator_open_append, operator_open_create_new, operator_open_read,
+    operator_open_append, operator_open_create_new, operator_open_dir, operator_open_read,
     operator_open_read_confined, operator_open_recv, operator_open_rw_create,
     operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
     operator_rename, operator_rename_confined, operator_symlink_metadata, owner_trusted_parent,

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -820,6 +820,37 @@ fn operator_open_kind(
     owner_walk_open(path, flags, mode, kind).map(std::fs::File::from)
 }
 
+/// Open an operator-supplied DIRECTORY through the ownership walk.
+///
+/// This is upstream's `open_no_attacker_symlinks(dir, O_RDONLY | O_DIRECTORY,
+/// 0)`, and its one load-bearing caller is `change_dir()`: a non-chrooted
+/// daemon enters its module root through this walk rather than a plain
+/// `chdir`, so a symlink an attacker planted at any component of the
+/// configured `path =` is refused while the operator's own
+/// `/backup -> /mnt/disk` is still followed. The trust signal is authority
+/// (owned by uid 0 or our euid), not location, because an operator path may
+/// legitimately point anywhere.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/syscall.c:540` `open_no_attacker_symlinks()`
+/// - `rsync-3.5.0/util1.c:1254-1263` `change_dir()` - the `am_daemon &&
+///   !am_chrooted` arm, which opens the module root this way and `fchdir`s to
+///   the result.
+///
+/// # Errors
+///
+/// See `operator_open_with`; additionally `ENOTDIR` when the path does not
+/// name a directory.
+pub fn operator_open_dir(path: &Path) -> io::Result<OwnedFd> {
+    owner_walk_open(
+        path,
+        OFlags::RDONLY | OFlags::DIRECTORY,
+        Mode::empty(),
+        crate::confinement::PathKind::Ancillary,
+    )
+}
+
 /// Open an operator-supplied path read-only through the ownership walk.
 ///
 /// The read-side counterpart for the operator paths rsync only consumes -

--- a/crates/fast_io/src/pinned_root.rs
+++ b/crates/fast_io/src/pinned_root.rs
@@ -1,0 +1,281 @@
+//! Source-scan filesystem lookups anchored on the pinned session root.
+//!
+//! Upstream's sender never names the module by its absolute path after the
+//! daemon drops privilege. It `change_dir()`s into the module root while still
+//! privileged, pins that directory as `module_dirfd`
+//! (`clientserver.c:1059-1065`), and every later lookup is either relative to
+//! the resulting cwd or explicitly anchored on that descriptor
+//! (`flist.c:2035-2059` for the scan, `sender.c:293-295` for the content
+//! open). oc keeps source paths absolute instead, which is fine until the
+//! module sits under a directory the dropped uid cannot search: then every
+//! `stat`/`opendir` on an absolute in-module path re-traverses that ancestor
+//! and fails with `EACCES`, even though the module itself is world-readable.
+//!
+//! These helpers restore upstream's position without giving up absolute paths.
+//! Each one asks
+//! [`pinned_root_relative`](crate::confinement::pinned_root_relative) whether
+//! the path lies beneath the pinned root; if it does the lookup is issued
+//! `*at`-style against the pinned descriptor, and if it does not - no daemon,
+//! no pin, or a path outside the module - it is the ordinary `std::fs` call it
+//! has always been. The two arms are the same lookup of the same directory
+//! entry; only the starting point differs.
+//!
+//! # What makes the pinned answer trustworthy
+//!
+//! Answering `lstat(<module root>)` from the pin means answering it about the
+//! directory the pin names, so the pin has to be the directory the module
+//! resolves to and nothing else. It is:
+//! [`pin_session_root_fd`](crate::confinement::pin_session_root_fd) opens the
+//! root through the ownership walk, which is what upstream's `change_dir()`
+//! does for a non-chrooted daemon (`util1.c:1254-1263`), so a symlink an
+//! attacker planted at a component of the configured `path =` is refused and
+//! no pin is taken at all. Every helper here then falls back to the absolute
+//! path, which is where the sender's own foreign-symlink refusal still lives.
+//!
+//! # Platform
+//!
+//! The directory scan anchors on every Unix - `openat(O_RDONLY|O_DIRECTORY)`
+//! plus `fdopendir` is portable. The *stat* is Linux-only, because anchoring
+//! it needs an open that reports a directory entry's metadata without
+//! requiring read access to it and without following a symlinked leaf, and
+//! `O_PATH` is the only open that does both. Elsewhere the stat takes the
+//! ordinary path-based arm, which is what it did before this module existed -
+//! the anchoring is an added capability, never a weakened one, so a target
+//! without it is exactly as confined as it was.
+//!
+//! # Upstream Reference
+//!
+//! - `clientserver.c:1059-1065` - the pin, taken before the privilege drop.
+//! - `flist.c:2028-2059` `secure_opendir()` - the scan anchored on it.
+//! - `flist.c:1362-1370` `link_stat()` - the per-entry stat the scan drives.
+
+use std::fs::Metadata;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// `lstat` for a source path, anchored on the pinned root when it applies.
+///
+/// Equivalent to [`std::fs::symlink_metadata`] in every observable way; see
+/// the module docs for what "anchored" buys.
+///
+/// # Errors
+///
+/// The underlying `lstat`/`openat` error.
+pub fn symlink_metadata(path: &Path) -> io::Result<Metadata> {
+    match anchored_metadata(path, false) {
+        Some(result) => result,
+        None => std::fs::symlink_metadata(path),
+    }
+}
+
+/// `stat` for a source path, anchored on the pinned root when it applies.
+///
+/// Equivalent to [`std::fs::metadata`] in every observable way.
+///
+/// # Errors
+///
+/// The underlying `stat`/`openat` error.
+pub fn metadata(path: &Path) -> io::Result<Metadata> {
+    match anchored_metadata(path, true) {
+        Some(result) => result,
+        None => std::fs::metadata(path),
+    }
+}
+
+/// `opendir` + `readdir` for a source directory, anchored on the pinned root
+/// when it applies.
+///
+/// The iterator yields absolute child paths built by joining each name onto
+/// `path`, so callers see exactly what [`std::fs::read_dir`] would have given
+/// them. `.` and `..` are skipped by both arms.
+///
+/// # Errors
+///
+/// The `opendir` error, reported here; per-entry errors are reported by the
+/// iterator, matching [`std::fs::ReadDir`].
+pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
+    #[cfg(unix)]
+    if let Some((fd, relative)) = crate::confinement::pinned_root_relative(path) {
+        use std::os::fd::AsFd;
+        let dir = imp::open_dir_at(fd.as_fd(), &relative)?;
+        let names = crate::confined_readdir::read_dir_names_at(dir.as_fd())?;
+        return Ok(ReadDir(Source::Names {
+            dir: path.to_path_buf(),
+            names: names.into_iter(),
+        }));
+    }
+    Ok(ReadDir(Source::Std(std::fs::read_dir(path)?)))
+}
+
+/// Open `path` as an `O_PATH` descriptor, anchored on the pinned root when it
+/// applies.
+///
+/// This is what a Landlock rule needs: the kernel wants the directory the rule
+/// covers as a descriptor, and building that descriptor by re-opening the
+/// absolute module path runs *after* the privilege drop. Anchoring it on the
+/// pin is the difference between the module being sandboxed and the sandbox
+/// silently failing to install on exactly the layout it was added for.
+///
+/// # Errors
+///
+/// The underlying `open`/`openat` error.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn open_o_path(path: &Path) -> io::Result<std::os::fd::OwnedFd> {
+    use std::os::fd::AsFd;
+    match crate::confinement::pinned_root_relative(path) {
+        Some((fd, relative)) => imp::open_o_path_at(fd.as_fd(), &relative),
+        None => imp::open_o_path_at_cwd(path),
+    }
+}
+
+/// Iterator over a directory's children as absolute paths.
+///
+/// Produced by [`read_dir`]; the variant it wraps depends on whether the
+/// directory was reachable through the pinned root.
+pub struct ReadDir(Source);
+
+enum Source {
+    Std(std::fs::ReadDir),
+    #[cfg(unix)]
+    Names {
+        dir: PathBuf,
+        names: std::vec::IntoIter<std::ffi::OsString>,
+    },
+}
+
+impl Iterator for ReadDir {
+    type Item = io::Result<PathBuf>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            Source::Std(entries) => entries.next().map(|entry| entry.map(|e| e.path())),
+            #[cfg(unix)]
+            Source::Names { dir, names } => names.next().map(|name| Ok(dir.join(name))),
+        }
+    }
+}
+
+/// `Some(result)` when the lookup was anchored, `None` when the caller should
+/// issue the ordinary path-based call.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn anchored_metadata(path: &Path, follow: bool) -> Option<io::Result<Metadata>> {
+    use std::os::fd::AsFd;
+    let (fd, relative) = crate::confinement::pinned_root_relative(path)?;
+    Some(imp::metadata_at(fd.as_fd(), &relative, follow))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn anchored_metadata(_path: &Path, _follow: bool) -> Option<io::Result<Metadata>> {
+    // No `O_PATH`: see the module docs. The caller takes the path-based arm.
+    None
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+
+    use std::ffi::CString;
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    use std::fs::File;
+    use std::os::fd::{BorrowedFd, FromRawFd, OwnedFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    /// `stat`/`lstat` `relative` beneath `dirfd`.
+    ///
+    /// `O_PATH` is what makes this a stat and not a read: the kernel resolves
+    /// the name and hands back a descriptor that refers to it without granting
+    /// - or requiring - any access to its contents, so an unreadable file, a
+    /// FIFO with no writer, and a device all report their metadata the way
+    /// `lstat` does. `fstat` on such a descriptor has been supported since
+    /// Linux 3.6. With `O_NOFOLLOW` it names the symlink itself, which is
+    /// exactly `lstat`; without it the symlink is followed, which is `stat`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) fn metadata_at(
+        dirfd: BorrowedFd<'_>,
+        relative: &Path,
+        follow: bool,
+    ) -> io::Result<Metadata> {
+        let mut flags = libc::O_PATH | libc::O_CLOEXEC;
+        if !follow {
+            flags |= libc::O_NOFOLLOW;
+        }
+        let fd = openat(dirfd, relative, flags)?;
+        File::from(fd).metadata()
+    }
+
+    /// Open `relative` beneath `dirfd` as a directory for enumeration.
+    pub(super) fn open_dir_at(dirfd: BorrowedFd<'_>, relative: &Path) -> io::Result<OwnedFd> {
+        openat(
+            dirfd,
+            relative,
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    }
+
+    /// Open `relative` beneath `dirfd` as an `O_PATH` descriptor.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) fn open_o_path_at(dirfd: BorrowedFd<'_>, relative: &Path) -> io::Result<OwnedFd> {
+        openat(dirfd, relative, libc::O_PATH | libc::O_CLOEXEC)
+    }
+
+    /// Open `path` as an `O_PATH` descriptor with no anchor.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) fn open_o_path_at_cwd(path: &Path) -> io::Result<OwnedFd> {
+        // `AT_FDCWD` is the documented "resolve from the process cwd"
+        // sentinel, not a descriptor, and an absolute path ignores it
+        // entirely. Wrapping it as a `BorrowedFd` would misstate ownership, so
+        // the raw form is passed straight through and this arm does not go
+        // through `openat` above.
+        let c_path = c_path(path)?;
+        // SAFETY: `c_path` is a valid NUL-terminated C string that outlives
+        // the call. `openat` is a thread-safe syscall wrapper returning either
+        // a fresh owned descriptor or -1 with `errno` set; ownership of any
+        // non-negative fd transfers immediately to `OwnedFd::from_raw_fd`,
+        // which is its only owner and closes it on drop.
+        #[allow(unsafe_code)]
+        let raw = unsafe {
+            libc::openat(
+                libc::AT_FDCWD,
+                c_path.as_ptr(),
+                libc::O_PATH | libc::O_CLOEXEC,
+            )
+        };
+        owned_or_errno(raw)
+    }
+
+    fn openat(dirfd: BorrowedFd<'_>, relative: &Path, flags: i32) -> io::Result<OwnedFd> {
+        use std::os::fd::AsRawFd;
+
+        let c_path = c_path(relative)?;
+        // SAFETY: `dirfd` is a live borrowed descriptor for the duration of
+        // the call and `c_path` is a valid NUL-terminated C string that
+        // outlives it. `openat` is a thread-safe syscall wrapper returning
+        // either a fresh owned descriptor or -1 with `errno` set; ownership of
+        // any non-negative fd transfers immediately to `OwnedFd::from_raw_fd`,
+        // which is its only owner and closes it on drop.
+        #[allow(unsafe_code)]
+        let raw = unsafe { libc::openat(dirfd.as_raw_fd(), c_path.as_ptr(), flags) };
+        owned_or_errno(raw)
+    }
+
+    fn owned_or_errno(raw: i32) -> io::Result<OwnedFd> {
+        if raw < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: `raw` is a non-negative descriptor just returned by
+        // `openat(2)` with `O_CLOEXEC`, not duplicated or retained anywhere
+        // else, so this is its sole owner.
+        #[allow(unsafe_code)]
+        let fd = unsafe { OwnedFd::from_raw_fd(raw) };
+        Ok(fd)
+    }
+
+    fn c_path(path: &Path) -> io::Result<CString> {
+        CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "path contains interior null byte",
+            )
+        })
+    }
+}

--- a/crates/fast_io/src/pinned_root.rs
+++ b/crates/fast_io/src/pinned_root.rs
@@ -183,10 +183,10 @@ mod imp {
     /// `stat`/`lstat` `relative` beneath `dirfd`.
     ///
     /// `O_PATH` is what makes this a stat and not a read: the kernel resolves
-    /// the name and hands back a descriptor that refers to it without granting
-    /// - or requiring - any access to its contents, so an unreadable file, a
-    /// FIFO with no writer, and a device all report their metadata the way
-    /// `lstat` does. `fstat` on such a descriptor has been supported since
+    /// the name and hands back a descriptor that refers to it without
+    /// granting - or requiring - any access to its contents, so an unreadable
+    /// file, a FIFO with no writer, and a device all report their metadata the
+    /// way `lstat` does. `fstat` on such a descriptor has been supported since
     /// Linux 3.6. With `O_NOFOLLOW` it names the symlink itself, which is
     /// exactly `lstat`; without it the symlink is followed, which is `stat`.
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/crates/fast_io/src/secure_dir.rs
+++ b/crates/fast_io/src/secure_dir.rs
@@ -93,7 +93,25 @@ pub fn secure_open_dir(path: &Path) -> io::Result<OwnedFd> {
 /// Ordinary `open(2)` errors only: `ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`.
 /// Unlike [`secure_open_dir`] this never fails with `ELOOP` or `EXDEV`
 /// merely because a component is a symlink.
+///
+/// # The pinned session root is duplicated, not re-resolved
+///
+/// When `path` names the root a daemon pinned by identity before its
+/// privilege drop
+/// ([`pin_session_root_fd`](crate::confinement::pin_session_root_fd)), this
+/// hands back a duplicate of that descriptor instead of re-opening the
+/// absolute path. Functionally identical - same inode, same ordinary symlink
+/// resolution, already performed - but it does not re-traverse the root's
+/// ancestors as the dropped uid, which `EACCES`es whenever the module sits
+/// under a directory that uid cannot search (a 0700 home).
+///
+/// upstream: `syscall.c:85-90` `open_anchor_dirfd()` - `dup(module_dirfd)`
+/// under exactly this condition, plain `openat(AT_FDCWD, ...)` otherwise.
 pub fn open_trusted_dir(path: &Path) -> io::Result<OwnedFd> {
+    if let Some(pinned) = crate::confinement::pinned_root_fd_for(path) {
+        use std::os::fd::AsFd;
+        return pinned.as_fd().try_clone_to_owned();
+    }
     imp::open_trusted_dir(path)
 }
 

--- a/crates/fast_io/tests/landlock_rule_under_unsearchable_parent.rs
+++ b/crates/fast_io/tests/landlock_rule_under_unsearchable_parent.rs
@@ -1,0 +1,128 @@
+//! The Landlock allowlist must still INSTALL for a module under an
+//! unsearchable ancestor.
+//!
+//! `restrict_to_module_paths` opens each rule path to hand the kernel a
+//! descriptor, and it runs after the daemon's privilege drop. Opening the
+//! module by its absolute path there re-traverses the module's ancestors under
+//! the dropped identity, so a module beneath a directory that identity cannot
+//! search (`path = /home/backup/data` under a 0700 home) fails with `EACCES`
+//! before a single rule is added.
+//!
+//! The caller only WARNS on that failure and serves the connection anyway
+//! (`crates/daemon/.../transfer/sandbox.rs`, the `LandlockOutcome::Error`
+//! arm), which is the part that makes this worth its own cell: the module is
+//! then served with no kernel sandbox at all, and the hardening disappears on
+//! exactly the layout it was added for. "The transfer succeeded" cannot see
+//! that - it succeeds either way - so the outcome value is asserted directly.
+//!
+//! The barrier is built with `chmod 0` rather than a uid drop: the kernel rule
+//! is search permission on an ancestor, and a uid is only the usual way of
+//! losing it. Root is exempt from both, so the cell skips there.
+//!
+//! upstream: `clientserver.c:1059-1065` - the pin, taken before the drop.
+
+#![cfg(all(target_os = "linux", feature = "landlock"))]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::thread;
+
+use fast_io::confinement::{
+    ModuleInsecureLinks, ModuleState, clear_session_root_fd, install_daemon_session,
+    pin_session_root_fd,
+};
+use fast_io::landlock::{LandlockOutcome, is_supported, restrict_to_module_paths};
+
+/// Ask the kernel to install the allowlist for `module`, on a thread of its
+/// own.
+///
+/// Landlock restricts the calling THREAD irreversibly, so a scenario that
+/// succeeds must not leave the test's own thread sandboxed - it still has a
+/// fixture to tear down, and a restricted thread cannot unlink its own parent
+/// directory.
+fn install_on_a_worker(module: &Path, drop_pin_first: bool) -> Result<LandlockOutcome, String> {
+    let module: PathBuf = module.to_path_buf();
+    thread::Builder::new()
+        .name("landlock-pinned-root".into())
+        .spawn(move || {
+            if drop_pin_first {
+                clear_session_root_fd();
+            }
+            restrict_to_module_paths(&[module.as_path()])
+        })
+        .map_err(|e| format!("spawn worker: {e}"))?
+        .join()
+        .map_err(|_| "worker thread panicked".to_owned())
+}
+
+#[test]
+fn the_ruleset_installs_for_a_module_whose_parent_is_unsearchable() {
+    // SAFETY: `geteuid(2)` is a pure read of the calling process's
+    // credentials. It takes no pointers and has no failure mode.
+    #[allow(unsafe_code)]
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 || !is_supported() {
+        return;
+    }
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let private = temp.path().join("private");
+    let module = private.join("mod");
+    fs::create_dir_all(module.join("sub")).expect("mkdir module");
+    fs::write(module.join("sub").join("file"), b"served\n").expect("write payload");
+    fs::set_permissions(&module, fs::Permissions::from_mode(0o755)).expect("chmod module");
+
+    let seal = |mode: u32| {
+        fs::set_permissions(&private, fs::Permissions::from_mode(mode)).expect("chmod parent");
+    };
+    let publish_and_pin = || {
+        install_daemon_session(ModuleState {
+            root: Some(module.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::default(),
+        });
+        pin_session_root_fd(&module).expect("pin the module root");
+    };
+
+    // Every outcome is collected first and asserted at the end, so a failure
+    // never leaves the fixture sealed shut and untearable-down.
+
+    // 1. Non-vacuity: an ordinary, traversable parent, no pin at all. A change
+    //    that broke the everyday deployment would otherwise be invisible here.
+    clear_session_root_fd();
+    let ordinary = install_on_a_worker(&module, false);
+
+    // 2. The mutation: the barrier up, the pin dropped. This is what the code
+    //    did before the pin existed.
+    publish_and_pin();
+    seal(0o000);
+    let unpinned = install_on_a_worker(&module, true);
+    seal(0o755);
+
+    // 3. The assertion: the same call, same barrier, with the pin taken while
+    //    the parent was still searchable.
+    publish_and_pin();
+    seal(0o000);
+    let pinned = install_on_a_worker(&module, false);
+    seal(0o755);
+    clear_session_root_fd();
+
+    assert!(
+        matches!(ordinary, Ok(LandlockOutcome::Enforced(_))),
+        "an unpinned module under a traversable parent must still be sandboxed: {ordinary:?}"
+    );
+    match unpinned {
+        Ok(LandlockOutcome::Error(err)) if err.raw_os_error() == Some(libc::EACCES) => {}
+        other => panic!(
+            "without the pin the rule path open must EACCES on the sealed parent, got {other:?}"
+        ),
+    }
+    assert!(
+        matches!(pinned, Ok(LandlockOutcome::Enforced(_))),
+        "the ruleset must install for a module under an unsearchable parent: {pinned:?}"
+    );
+
+    drop(temp);
+}

--- a/crates/fast_io/tests/pinned_module_root_under_unsearchable_parent.rs
+++ b/crates/fast_io/tests/pinned_module_root_under_unsearchable_parent.rs
@@ -1,0 +1,344 @@
+//! A daemon must serve a module whose ancestors it can no longer traverse.
+//!
+//! Upstream never re-walks the absolute module path after the privilege drop:
+//! `clientserver.c:1059-1065` `change_dir()`s into the module root and pins it
+//! as `module_dirfd` while still privileged, and the scan
+//! (`flist.c:2035-2059`), the content open (`sender.c:293-295`) and the anchor
+//! helper (`syscall.c:85-90`, `dup(module_dirfd)`) all resolve against that
+//! descriptor afterwards. oc keeps absolute source paths, so without the same
+//! pin every one of those lookups re-traverses the module's ancestors under
+//! the dropped identity and fails with `EACCES` on an unsearchable one - the
+//! `path = /home/backup/data` under a 0700 home shape.
+//!
+//! # How the barrier is built without root
+//!
+//! The kernel rule is search permission on an ancestor; `uid` is only how a
+//! daemon usually loses it. `chmod 0` on a parent takes it away from the
+//! current user just as effectively, and root is exempt from both - so the
+//! cell asserts its own barrier first and skips as root, where no barrier can
+//! be built.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use fast_io::confinement::{
+    ModuleInsecureLinks, ModuleState, clear_session_root_fd, install_daemon_session,
+    pin_session_root_fd, session_root_is_pinned,
+};
+
+/// The fixture: `<tmp>/private/mod/{sub/file, link}`, plus `<tmp>/outside`.
+struct Fixture {
+    _temp: tempfile::TempDir,
+    private: PathBuf,
+    module: PathBuf,
+}
+
+impl Fixture {
+    fn build() -> io::Result<Self> {
+        let temp = tempfile::tempdir()?;
+        let private = temp.path().join("private");
+        let module = private.join("mod");
+        let sub = module.join("sub");
+        fs::create_dir_all(&sub)?;
+        fs::write(sub.join("file"), b"served\n")?;
+        std::os::unix::fs::symlink("sub/file", module.join("link"))?;
+        fs::set_permissions(&module, fs::Permissions::from_mode(0o755))?;
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o755))?;
+        Ok(Self {
+            _temp: temp,
+            private,
+            module,
+        })
+    }
+
+    /// Take away search permission on the module's parent.
+    fn seal(&self) -> io::Result<()> {
+        fs::set_permissions(&self.private, fs::Permissions::from_mode(0o000))
+    }
+
+    /// Give it back, so the fixture can be torn down.
+    fn unseal(&self) -> io::Result<()> {
+        fs::set_permissions(&self.private, fs::Permissions::from_mode(0o755))
+    }
+
+    /// Publish the module as the session root and pin it by identity, the way
+    /// the daemon does between its chroot and its `setuid`.
+    fn publish_and_pin(&self) -> io::Result<()> {
+        install_daemon_session(ModuleState {
+            root: Some(self.module.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::default(),
+        });
+        pin_session_root_fd(&self.module)
+    }
+}
+
+/// Sorted child names, so the two arms are compared as sets and not as
+/// whatever order the filesystem happened to return.
+fn child_names(entries: fast_io::pinned_root::ReadDir) -> io::Result<Vec<OsString>> {
+    let mut names = entries
+        .map(|entry| entry.map(|path| path.file_name().unwrap_or_default().to_owned()))
+        .collect::<io::Result<Vec<_>>>()?;
+    names.sort();
+    Ok(names)
+}
+
+fn eacces(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::EACCES)
+}
+
+/// Everything the sender does to a module path, with the module's parent
+/// sealed shut and the root pinned beforehand.
+///
+/// One test function on purpose: the pin and the session root are process
+/// globals (as they are upstream), so these assertions are an ordered sequence
+/// against one installed session, not independent cells that could interleave.
+#[test]
+fn a_pinned_module_root_survives_an_unsearchable_parent() {
+    if unsafe_geteuid() == 0 {
+        // Root is exempt from the search-permission check, so no barrier can
+        // be built here and every arm below would pass without proving
+        // anything. The equivalent root-only cell is upstream's own
+        // `testsuite/daemon-module-private-parent_test.py`.
+        return;
+    }
+
+    let fixture = Fixture::build().expect("fixture");
+    let module = fixture.module.clone();
+    let sub_file = module.join("sub").join("file");
+
+    // ---- Non-vacuity: an ordinary, traversable parent still works, with and
+    // ---- without a pin. A fix that broke the ordinary path would sail past
+    // ---- every assertion below it.
+    clear_session_root_fd();
+    let unpinned_meta = fast_io::pinned_root::symlink_metadata(&module).expect("unpinned lstat");
+    assert!(unpinned_meta.is_dir(), "the module root is a directory");
+    let unpinned_names =
+        child_names(fast_io::pinned_root::read_dir(&module).expect("unpinned scan"))
+            .expect("unpinned entries");
+    assert_eq!(
+        unpinned_names,
+        vec![OsString::from("link"), OsString::from("sub")],
+        "the unpinned scan must list the module's children"
+    );
+
+    fixture.publish_and_pin().expect("publish and pin");
+    assert!(
+        session_root_is_pinned(),
+        "publishing a module root and pinning it must leave a descriptor behind"
+    );
+    let pinned_names = child_names(fast_io::pinned_root::read_dir(&module).expect("pinned scan"))
+        .expect("pinned entries");
+    assert_eq!(
+        pinned_names, unpinned_names,
+        "the pinned scan must see exactly what the unpinned one saw"
+    );
+
+    // ---- The barrier goes up. Everything from here on runs with the module's
+    // ---- parent unsearchable, which is the state a daemon reaches by
+    // ---- dropping to the module uid.
+    fixture.seal().expect("seal the parent");
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        sealed_assertions(&module, &sub_file);
+    }));
+    fixture.unseal().expect("unseal the parent");
+    clear_session_root_fd();
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+
+    an_operator_owned_symlink_at_the_module_root_is_followed_and_pinned();
+}
+
+fn sealed_assertions(module: &Path, sub_file: &Path) {
+    // The barrier is real: assert it before relying on it. Without this the
+    // whole cell could pass on a filesystem or platform where `chmod 0` on a
+    // directory does not stop a descendant lookup, and would be proving
+    // nothing at all.
+    let control = fs::symlink_metadata(module).expect_err("a sealed parent must block lstat");
+    assert!(
+        eacces(&control),
+        "expected EACCES through the sealed parent, got {control}"
+    );
+    let control = fs::read_dir(module).expect_err("a sealed parent must block opendir");
+    assert!(
+        eacces(&control),
+        "expected EACCES through the sealed parent, got {control}"
+    );
+
+    // Consumer 1: the walk's `link_stat`. This is the exact lookup that
+    // produced `link_stat "." (in m) failed: Permission denied`.
+    sealed_stat_assertions(module, sub_file);
+
+    // Consumer 2: the walk's `read_dir` and the per-child stat it drives.
+    let names = child_names(
+        fast_io::pinned_root::read_dir(module)
+            .expect("the pinned scan must not re-walk the sealed parent"),
+    )
+    .expect("pinned entries");
+    assert_eq!(names, vec![OsString::from("link"), OsString::from("sub")]);
+
+    // Consumer 3: the anchor every confined source open resolves against.
+    // `open_trusted_dir` is oc's `open_anchor_dirfd()` (syscall.c:85-90), and
+    // it is what `SourceOpen::open` and `read_source_link` re-open on every
+    // call.
+    fast_io::open_trusted_dir(module)
+        .expect("the trusted anchor open must duplicate the pin, not re-resolve the path");
+    let mut file = fast_io::open_source_confined(
+        module,
+        Path::new("sub/file"),
+        fast_io::LeafPolicy::Nofollow,
+        false,
+    )
+    .expect("the confined content open must resolve against the pin");
+    let mut body = String::new();
+    io::Read::read_to_string(&mut file, &mut body).expect("read the served file");
+    assert_eq!(body, "served\n");
+    let followed = fast_io::open_source_confined(
+        module,
+        Path::new("link"),
+        fast_io::LeafPolicy::FollowConfined,
+        false,
+    );
+    assert!(
+        followed.is_ok(),
+        "the --copy-links content open must resolve against the pin too: {followed:?}"
+    );
+    let target = fast_io::read_link_confined(module, Path::new("link"))
+        .expect("the confined readlink must resolve against the pin");
+    assert_eq!(target, Path::new("sub/file"));
+
+    // The mutation, in-process: with the pin dropped, every one of the above
+    // is back to re-walking the absolute module path, and the sealed parent
+    // stops it. Without this the cell could pass because the sealed parent
+    // never blocked anything.
+    clear_session_root_fd();
+    let regressed = fast_io::open_trusted_dir(module)
+        .expect_err("without the pin the anchor open must re-resolve the path and fail");
+    assert!(
+        eacces(&regressed),
+        "expected EACCES without the pin, got {regressed}"
+    );
+    let regressed = fast_io::pinned_root::read_dir(module)
+        .err()
+        .expect("without the pin the scan must re-walk the sealed parent and fail");
+    assert!(
+        eacces(&regressed),
+        "expected EACCES without the pin, got {regressed}"
+    );
+    sealed_stat_mutation(module);
+}
+
+/// The stat half of the anchoring, which exists only where `O_PATH` does.
+///
+/// `O_PATH` is the only open that reports a directory entry's metadata without
+/// requiring access to it and without following a symlinked leaf, so the
+/// anchored stat is Linux-only by construction; elsewhere it is the ordinary
+/// path-based `lstat`/`stat` it has always been, and the sealed parent stops
+/// it exactly as it always did. See `fast_io::pinned_root`'s Platform section.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn sealed_stat_assertions(module: &Path, sub_file: &Path) {
+    let meta = fast_io::pinned_root::symlink_metadata(module)
+        .expect("the pinned lstat of the module root must not re-walk the sealed parent");
+    assert!(meta.is_dir(), "the module root is still a directory");
+    let meta = fast_io::pinned_root::metadata(sub_file)
+        .expect("the pinned stat of an in-module file must not re-walk the sealed parent");
+    assert_eq!(meta.len(), b"served\n".len() as u64);
+
+    // A symlink must be lstat'ed as a symlink and stat'ed as its target: the
+    // anchored arm must not collapse the two, which is the one way an
+    // `O_PATH`-based stat could silently change meaning.
+    let link = module.join("link");
+    assert!(
+        fast_io::pinned_root::symlink_metadata(&link)
+            .expect("pinned lstat of the symlink")
+            .file_type()
+            .is_symlink(),
+        "the pinned lstat must report the symlink itself"
+    );
+    assert!(
+        fast_io::pinned_root::metadata(&link)
+            .expect("pinned stat of the symlink")
+            .is_file(),
+        "the pinned stat must follow the symlink to its target"
+    );
+}
+
+/// The stat half of the mutation. Runs with the pin already dropped.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn sealed_stat_mutation(module: &Path) {
+    let regressed = fast_io::pinned_root::symlink_metadata(module)
+        .expect_err("without the pin the lstat must re-walk the sealed parent and fail");
+    assert!(
+        eacces(&regressed),
+        "expected EACCES without the pin, got {regressed}"
+    );
+}
+
+/// No `O_PATH` here, so there is no anchored stat to assert on.
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn sealed_stat_assertions(_module: &Path, _sub_file: &Path) {}
+
+/// No `O_PATH` here, so there is no anchored stat to mutate away.
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn sealed_stat_mutation(_module: &Path) {}
+
+/// A module root the operator reached through their OWN symlink still pins.
+///
+/// The pin goes through the ownership walk, because upstream's `.` is the
+/// directory `change_dir()` entered and a non-chrooted daemon enters it with
+/// `open_no_attacker_symlinks()` (`util1.c:1254-1263`). That walk refuses a
+/// component symlink owned by a foreign uid and FOLLOWS one owned by uid 0 or
+/// our euid - the `/backup -> /mnt/disk` administrative pattern. Hardening the
+/// pin into a blanket `O_NOFOLLOW` would refuse that pattern too, and this is
+/// the half that would go quiet if it did.
+///
+/// The refusing half needs a symlink owned by a uid we are not, so it needs
+/// root; upstream's own `testsuite/daemon-module-chdir-symlink_test.py` is that
+/// cell, and `symlink_owner_is_trusted` pins the predicate.
+///
+/// A phase of the one test rather than a `#[test]` of its own: the session and
+/// its pin are process globals, so two cells installing sessions concurrently
+/// would answer each other's questions.
+fn an_operator_owned_symlink_at_the_module_root_is_followed_and_pinned() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let real = temp.path().join("real");
+    fs::create_dir(&real).expect("mkdir real");
+    fs::write(real.join("payload"), b"served\n").expect("write payload");
+    let linked = temp.path().join("linked");
+    std::os::unix::fs::symlink(&real, &linked).expect("symlink the module root");
+
+    install_daemon_session(ModuleState {
+        root: Some(linked.clone()),
+        chrooted: false,
+        selected: true,
+        insecure_links: ModuleInsecureLinks::default(),
+    });
+    pin_session_root_fd(&linked).expect("an operator-owned symlinked module root must still pin");
+
+    let names = child_names(fast_io::pinned_root::read_dir(&linked).expect("scan through the pin"))
+        .expect("entries");
+    clear_session_root_fd();
+    assert_eq!(
+        names,
+        vec![OsString::from("payload")],
+        "the pin must resolve the operator's own symlink, not refuse it"
+    );
+}
+
+/// `geteuid` has no safe wrapper in std; it takes no arguments, reads no
+/// memory, and cannot fail.
+fn unsafe_geteuid() -> u32 {
+    // SAFETY: `geteuid(2)` is a pure read of the calling process's credentials.
+    // It takes no pointers, has no failure mode, and is async-signal-safe.
+    #[allow(unsafe_code)]
+    unsafe {
+        libc::geteuid()
+    }
+}

--- a/crates/transfer/src/generator/file_list/batch_stat.rs
+++ b/crates/transfer/src/generator/file_list/batch_stat.rs
@@ -27,10 +27,9 @@ pub(in crate::generator) struct StatResult {
 
 /// Collects `read_dir()` entries into paths and batch-resolves their metadata.
 ///
-/// When `follow_symlinks` is true, uses `fs::metadata()` (follows symlinks).
-/// Otherwise uses `fs::symlink_metadata()` (lstat). The caller is responsible
-/// for applying more nuanced symlink resolution (e.g. `--copy-unsafe-links`)
-/// after receiving the raw metadata.
+/// When `follow_symlinks` is true this stats (follows symlinks); otherwise it
+/// lstats. The caller is responsible for applying more nuanced symlink
+/// resolution (e.g. `--copy-unsafe-links`) after receiving the raw metadata.
 ///
 /// Uses [`map_blocking`] which dispatches to rayon's work-stealing pool when
 /// the entry count meets the configured stat threshold from [`ParallelThresholds`],
@@ -41,10 +40,14 @@ pub(in crate::generator) fn batch_stat_dir_entries(
     thresholds: &ParallelThresholds,
 ) -> Vec<StatResult> {
     map_blocking(paths, thresholds.for_op(ParallelOp::Stat), move |path| {
+        // Anchored on the daemon's pinned module root when the entry lies
+        // beneath it, so the per-child stat does not re-walk the module's
+        // ancestors as the dropped uid. The ordinary `lstat`/`stat` otherwise.
+        // upstream: `flist.c:2035-2059` `secure_opendir()`.
         let metadata = if follow_symlinks {
-            fs::metadata(&path)
+            fast_io::pinned_root::metadata(&path)
         } else {
-            fs::symlink_metadata(&path)
+            fast_io::pinned_root::symlink_metadata(&path)
         };
         StatResult { path, metadata }
     })

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -300,7 +300,7 @@ impl GeneratorContext {
         // upstream: flist.c:send_file_list() - scan directory before recording entry
         let should_recurse = metadata.is_dir() && self.config.flags.recursive;
         let dir_read = if should_recurse {
-            match std::fs::read_dir(&path) {
+            match fast_io::pinned_root::read_dir(&path) {
                 Ok(entries) => Some(entries),
                 Err(e) => {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
@@ -400,7 +400,7 @@ impl GeneratorContext {
     ///
     /// - `flist.c:send_directory()` - reads directory and stats each child
     fn scan_directory_batched(&mut self, base: &Path, dir_path: &Path) -> io::Result<()> {
-        match std::fs::read_dir(dir_path) {
+        match fast_io::pinned_root::read_dir(dir_path) {
             Ok(entries) => self.process_dir_entries_batched(base, dir_path, entries),
             Err(e) => {
                 // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
@@ -424,13 +424,13 @@ impl GeneratorContext {
         &mut self,
         base: &Path,
         dir_path: &Path,
-        entries: std::fs::ReadDir,
+        entries: fast_io::pinned_root::ReadDir,
     ) -> io::Result<()> {
         // Phase 1: collect child paths from readdir
         let mut child_paths = Vec::new();
         for entry in entries {
             match entry {
-                Ok(de) => child_paths.push(de.path()),
+                Ok(child) => child_paths.push(child),
                 Err(e) => {
                     // upstream: flist.c:2195 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     let text = format!(
@@ -469,7 +469,7 @@ impl GeneratorContext {
                     // directories are followed; symlinks to files stay
                     // symlinks (distinct from --copy-links, which follows all).
                     if !follow && self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
-                        if let Ok(followed) = std::fs::metadata(&path) {
+                        if let Ok(followed) = fast_io::pinned_root::metadata(&path) {
                             if followed.file_type().is_dir() {
                                 meta = followed;
                             }
@@ -498,7 +498,7 @@ impl GeneratorContext {
                                     path.display(),
                                     target.display()
                                 );
-                                match std::fs::metadata(&path) {
+                                match fast_io::pinned_root::metadata(&path) {
                                     Ok(followed) => meta = followed,
                                     Err(e) => {
                                         self.log_stat_error(&path, &e);
@@ -558,10 +558,20 @@ impl GeneratorContext {
     ///   the transfer tree (converting them to regular files)
     /// - Default: use lstat (preserve symlinks as symlinks)
     ///
+    /// Every stat here goes through
+    /// [`fast_io::pinned_root`](fast_io::pinned_root), which anchors the
+    /// lookup on the module root a daemon pinned while still privileged when
+    /// the path lies beneath it. Upstream is already positioned there - it
+    /// `change_dir()`s into the module before the drop - so `link_stat(".")`
+    /// costs it nothing; oc keeps absolute paths, and without the anchor the
+    /// stat re-walks the module's ancestors as the dropped uid and `EACCES`es
+    /// on an unsearchable one.
+    ///
     /// # Upstream Reference
     ///
     /// - `flist.c:217-244` - `readlink_stat()`
     /// - `flist.c:227` - `copy_unsafe_links && unsafe_symlink(linkbuf, path)`
+    /// - `clientserver.c:1059-1065` - the pin the anchoring reads.
     pub(in crate::generator) fn resolve_symlink_metadata(
         &self,
         path: &Path,
@@ -587,10 +597,10 @@ impl GeneratorContext {
         };
 
         if self.config.flags.copy_links {
-            return std::fs::metadata(path);
+            return fast_io::pinned_root::metadata(path);
         }
 
-        let meta = std::fs::symlink_metadata(path)?;
+        let meta = fast_io::pinned_root::symlink_metadata(path)?;
 
         // upstream: flist.c:1362-1370 link_stat() - with follow_dirlinks a
         // symlink whose target is a directory is transmitted as a real
@@ -619,13 +629,20 @@ impl GeneratorContext {
         // `--copy-dirlinks` is an explicit client request over a client-named
         // tree and keeps its existing meaning untouched.
         //
+        // When the daemon PINNED its module root the stat above already comes
+        // from the pinned directory, so `.` is a directory here and this gate
+        // has nothing to decide - which is upstream's position exactly, and is
+        // sound for the same reason: the pin is taken through the ownership
+        // walk (`util1.c:1254-1263`), so a foreign-uid symlink at the module
+        // root is refused before a pin exists and this gate is back in force.
+        //
         // upstream: `rsync-3.5.0/syscall.c:406` - a symlink owned by uid 0 or
         // our euid is the operator's own layout and is followed; any other uid
         // is an attacker's plant and is refused.
         let follow_dirlinks = self.config.flags.copy_dirlinks
             || (is_dotdir && symlink_target_is_operator_owned(&meta));
         if follow_dirlinks && meta.file_type().is_symlink() {
-            if let Ok(followed) = std::fs::metadata(path) {
+            if let Ok(followed) = fast_io::pinned_root::metadata(path) {
                 if followed.file_type().is_dir() {
                     return Ok(followed);
                 }
@@ -647,7 +664,7 @@ impl GeneratorContext {
                     path.display(),
                     target.display()
                 );
-                return std::fs::metadata(path);
+                return fast_io::pinned_root::metadata(path);
             }
         }
 

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -100,7 +100,7 @@ daemon-link-dest-escape pass
 daemon-max-alloc-zero skip
 daemon-module-chdir-symlink pass
 daemon-module-options skip
-daemon-module-private-parent fail
+daemon-module-private-parent pass
 daemon-munge pass
 daemon-namecvt-empty-response skip
 daemon-namecvt-newline-token skip


### PR DESCRIPTION
## The gap

A daemon module whose path sits under a directory the served uid cannot search - `path = /home/backup/data` under a 0700 home - could not be served at all. The sender re-walked the **absolute** module path after `setuid`, so every lookup re-traversed the unsearchable ancestor:

```
rsync: [sender] link_stat "." (in m) failed: Permission denied (13)
statx(AT_FDCWD, "/tmp/dmpp/private/mod", AT_STATX_SYNC_AS_STAT|AT_SYMLINK_NOFOLLOW, ...) = -1 EACCES
```

Upstream 3.5.0 serves the same module fine. It avoids this by **ordering**, not by permissions.

## The upstream shape being mirrored

`clientserver.c:1059-1065` enters the module with `change_dir(module_chdir, CD_NORMAL)` and then pins it,

```c
module_dirfd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
```

both **above** the `setgid`/`setuid` at `:1093`. Three consumers resolve against that descriptor: `flist.c:2035-2059` (the directory scan), `sender.c:293-295` (the content open), and `syscall.c:85-90` `open_anchor_dirfd()`, which `dup(module_dirfd)`s rather than re-resolving the absolute root.

oc had neither half - `server_config.rs:289` recorded the reason ("oc has no chdir, so it keeps the absolute form").

## What changed

- **`fast_io::confinement`** gains `SESSION_ROOT_FD` beside the existing `SESSION_ROOT`: the same root, as a descriptor. `install_session` drops it whenever it replaces the path, so a pin that is present is always this session's. It stores the root's literal spelling as well as the physical one, because the sender's absolute paths are built from the former and the two differ wherever an ancestor is a symlink.
- **The pin goes through the ownership walk**, not a plain open. Upstream's `.` is the directory `change_dir()` entered, and a non-chrooted daemon enters it with `open_no_attacker_symlinks()` (`util1.c:1254-1263`). A plain open would let a foreign-uid symlink planted at the configured `path =` redirect the pin - measured: it turns `daemon-module-chdir-symlink` red, an ancestor-traversal fix becoming a module-root escape.
- **`fast_io::pinned_root`** (new) issues the sender's `lstat` / `stat` / `opendir` against the pin when the path lies beneath it, and is the ordinary `std::fs` call otherwise. A `..` remainder declines to anchor. The stat arm needs `O_PATH` and is therefore Linux-only; the scan anchors on every Unix.
- **`open_trusted_dir`** duplicates the pin when asked for the pinned root - `open_anchor_dirfd()` exactly. That is what fixes `SourceOpen::open` and `read_source_link`, which reconstructed a module-relative path but then re-opened the root by absolute path on every call, plus the `openat2` fast path in `open_source_confined`.

### The three consumers, as fixed

| consumer | upstream | here |
|---|---|---|
| walk `lstat`/`stat` (`walk.rs:593`) | `flist.c:1362` `link_stat()` on `.` after `change_dir` | `pinned_root::{symlink_metadata,metadata}` |
| walk `read_dir` + per-child stat | `flist.c:2028-2059` `secure_opendir()` | `pinned_root::read_dir`, `batch_stat_dir_entries` |
| `SourceOpen::open`, `read_source_link` | `sender.c:293-295`, `syscall.c:87-88` | `open_trusted_dir` dups the pin |

## Second symptom, same cause, security-relevant

The Landlock rule-path open ran post-drop too, so `restrict_to_module_paths` failed with `EACCES` before adding a single rule. The caller only **warns** and serves the connection anyway, so the module was served with no kernel sandbox at all - the hardening disappeared on exactly the layout it was added for. The rule path is now opened through the pin.

Measured on the same fixture:

```
before: oc-rsync warning: module 'm': landlock setup failed for root /tmp/dmpp/private/mod: Permission denied
after:  module 'm': landlock fully enforced over 1 root(s)
```

## Evidence

Linux 7.0 aarch64, upstream testsuite 3.5.0, root/pipe leg.

- **Upstream control** - `testsuite/daemon-module-private-parent_test.py` passes against a real 3.5.0 build.
- **Baseline** - the cell fails on `master` (its manifest row said `fail`).
- **After** - it passes, so `tools/ci/upstream-3.5.0-expect.root.txt` flips to `pass` in this commit. The only remaining mismatches on this host, `batch-file-symlink` and `simd-checksum`, reproduce identically on an unmodified `master` build.
- **Mutation** - removing *only* the `pin_session_root_fd` call and rebuilding restores both symptoms: the `link_stat` EACCES and `landlock setup failed`.
- **Ownership-walk half** - `daemon-module-chdir-symlink` is red with a plain-open pin and green with the walk.

The TCP manifest row stays `fail`. There the cell opens a second connection, and oc's threaded daemon has already applied a process-wide `setuid` where upstream forks per connection, so the second connection reports `@ERROR: module 'm' path does not exist`. That is a separate defect and is not touched here.

## Tests

Two new cells build the barrier with `chmod 0` on the parent rather than a uid drop, so they need no root (and skip as root, where no barrier can exist):

- `pinned_module_root_under_unsearchable_parent` - asserts the barrier is real first, then that every anchored lookup crosses it, and that each reverts to `EACCES` with the pin dropped. Includes a traversable-parent companion and an operator-owned-symlink module root, so a change that broke the ordinary deployment or hardened the pin into a blanket `O_NOFOLLOW` cannot hide.
- `landlock_rule_under_unsearchable_parent` - asserts the ruleset **installs** (`Enforced`), which is a distinct claim from "the transfer succeeded": the transfer succeeds either way. Carries the same mutation (`Error`/`EACCES` without the pin) and the same traversable-parent companion.
