### PR TITLE
test(transfer): pin the backup ladder's destination anchor

### DIFF
--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -32,7 +32,7 @@ pub(super) use self::file_ops::{process_file, process_whole_file};
 #[cfg(test)]
 pub(crate) use self::commit::ForceExdev;
 #[cfg(all(test, unix))]
-use self::commit::rename_config_sandboxed;
+use self::commit::{commit_file, rename_config_sandboxed};
 #[cfg(test)]
 use self::commit::{
     delay_updates_staging_path, is_cross_device, make_backup_copy, rename_with_io_uring_fallback,

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -1009,3 +1009,523 @@ fn truncate_for_whole_file_sparse_noop_when_no_basis() {
     assert_eq!(preallocated_len, 0);
     assert_eq!(file.metadata().unwrap().len(), 0);
 }
+
+/// Builds the `--backup-dir` fixture the metadata-option cells share and
+/// returns `(tempdir, dest_dir, backup_dir, file_path, inherited_mode)`.
+///
+/// `inherited_mode` is picked so a plainly-created directory under the current
+/// umask can NEVER carry it: the mode a bare `mkdir` produces is measured
+/// first, and the destination subdirectory is given a different one. Without
+/// that step a umask of 077 would make "the backup subdir did not inherit
+/// 0700" true by coincidence and the cell inert.
+#[cfg(unix)]
+fn backup_dir_mode_fixture() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf, u32) {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let probe = dir.path().join("umask_probe");
+    fs::create_dir(&probe).expect("create probe dir");
+    let plain_mode = fs::metadata(&probe)
+        .expect("stat probe")
+        .permissions()
+        .mode()
+        & 0o777;
+    let inherited_mode = if plain_mode == 0o700 { 0o711 } else { 0o700 };
+
+    let dest_dir = dir.path().join("dst");
+    let sub = dest_dir.join("sub");
+    fs::create_dir_all(&sub).expect("create dst/sub");
+    let file_path = sub.join("payload.bin");
+    fs::write(&file_path, b"pre-image").expect("write pre-image");
+    fs::set_permissions(&sub, fs::Permissions::from_mode(inherited_mode)).expect("chmod dst/sub");
+
+    let backup_dir = dir.path().join("bak");
+    (dir, dest_dir, backup_dir, file_path, inherited_mode)
+}
+
+#[cfg(unix)]
+fn dir_mode(path: &Path) -> u32 {
+    use std::os::unix::fs::PermissionsExt as _;
+    fs::metadata(path).expect("stat").permissions().mode() & 0o777
+}
+
+/// The `metadata_opts` the commit configuration carries must reach the
+/// `--backup-dir` attribute copy rather than being replaced by a default.
+///
+/// `create_backup_path_parents` does
+/// `env.metadata_opts.cloned().unwrap_or_default()`, and
+/// `MetadataOptions::default()` preserves permissions - so
+/// [`make_backup_backup_dir_subdir_inherits_source_mode`], which asks for
+/// `preserve_permissions(true)`, passes identically whether the field is
+/// threaded or dropped: the default agrees with it. This cell asks for
+/// `preserve_permissions(false)`, which no default can supply, so the freshly
+/// created backup subdirectory must keep the plain `mkdir` mode instead of the
+/// destination directory's.
+///
+/// The two cells are each other's companions: this one proves the caller's
+/// options are consulted, that one proves the attribute copy runs at all.
+///
+/// upstream: `backup.c:173` `set_file_attrs(backup_dir_buf, file, NULL, NULL, 0)`
+/// applies the run's own preserve flags to each new backup subdirectory; it does
+/// not pick its own.
+#[cfg(unix)]
+#[test]
+fn make_backup_backup_dir_parent_honours_the_supplied_metadata_options() {
+    use std::ffi::OsString;
+
+    let (_dir, dest_dir, backup_dir, file_path, inherited_mode) = backup_dir_mode_fixture();
+
+    let config = BackupConfig {
+        dest_dir: dest_dir.clone(),
+        backup_dir: Some(backup_dir.clone()),
+        suffix: OsString::new(),
+    };
+    let disk_config = DiskCommitConfig {
+        metadata_opts: Some(::metadata::MetadataOptions::new().preserve_permissions(false)),
+        ..DiskCommitConfig::default()
+    };
+
+    make_backup(&file_path, &config, disk_config.backup_env())
+        .expect("make_backup succeeds")
+        .expect("notice produced for the backed-up file");
+
+    let backup_sub = backup_dir.join("sub");
+    assert!(backup_sub.is_dir(), "backup subdirectory must be created");
+    assert!(
+        backup_sub.join("payload.bin").exists(),
+        "the fixture must actually place a backup under the new subdirectory"
+    );
+    let mode = dir_mode(&backup_sub);
+    assert_ne!(
+        mode, inherited_mode,
+        "preserve_permissions(false) must reach the backup-dir attribute copy; \
+         a dropped metadata_opts falls back to a default that DOES preserve \
+         permissions, got {mode:o}"
+    );
+}
+
+/// Fixture for the `--backup` destination-anchor pins: a destination root whose
+/// PATH was swapped for a symlink to an out-of-tree directory *after* the
+/// receiver's [`fast_io::DirSandbox`] pinned its dirfd.
+///
+/// Deterministic by program order - no threads, no sleeps. `open_root` captures
+/// the real inode first; the swap happens afterwards, leaving exactly the state
+/// an attacker who flips `dest` between the sandbox open and the backup would
+/// produce. Every path handed to the ladder afterwards is the pre-swap
+/// `dest/<leaf>` string, which is what the receiver actually holds.
+///
+/// The two wirings are then distinguishable by PLACEMENT: an `*at()` call
+/// anchored on `sandbox.current_dirfd()` lands in `pinned`, while any
+/// path-based resolution of the same string lands in `outside`. The ownership
+/// walk in the fallback follows the swapped symlink by design - it is owned by
+/// our own euid (`syscall.c:270-272`) - which is why the dirfd anchor, not the
+/// walk, is what keeps the backup inside the tree here.
+#[cfg(unix)]
+struct SwappedDestRoot {
+    _temp: tempfile::TempDir,
+    /// The destination root string the ladder is given; now a symlink.
+    dest_dir: PathBuf,
+    /// The real directory the sandbox dirfd pins.
+    pinned: PathBuf,
+    /// Out-of-tree directory the swapped path resolves to.
+    outside: PathBuf,
+    sandbox: std::sync::Arc<fast_io::DirSandbox>,
+}
+
+#[cfg(unix)]
+fn swapped_dest_root() -> SwappedDestRoot {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let staging = fs::canonicalize(temp.path()).expect("canon");
+    let dest_dir = staging.join("dest");
+    let pinned = staging.join("dest.pinned");
+    let outside = staging.join("outside");
+    fs::create_dir(&dest_dir).expect("create dest");
+    fs::create_dir(&outside).expect("create outside");
+
+    let sandbox = std::sync::Arc::new(fast_io::DirSandbox::open_root(&dest_dir).expect("sandbox"));
+
+    fs::rename(&dest_dir, &pinned).expect("move the real dest aside");
+    std::os::unix::fs::symlink(&outside, &dest_dir).expect("plant the dest symlink");
+
+    SwappedDestRoot {
+        _temp: temp,
+        dest_dir,
+        pinned,
+        outside,
+        sandbox,
+    }
+}
+
+/// The [`BackupEnv`](super::super::config::BackupEnv) sandbox/`dest_dir` pair
+/// must reach the hard-link tier: the backup's NEW endpoint is resolved against
+/// the pinned dirfd, so a destination root swapped for a symlink cannot carry
+/// the pre-image out of the tree.
+///
+/// upstream: `backup.c:437-448` `make_backup()` raises `operator_path_resolve`
+/// around the whole ladder, and `link_or_rename()` (`backup.c:239`) runs
+/// `do_link_at()` FIRST - so confining only the rename would leave the escape
+/// wide open on every platform where the link succeeds. oc's SEC-1.h equivalent
+/// is `linkat_via_sandbox_or_fallback`, reached only when `env.sandbox` and
+/// `env.dest_dir` are both threaded through.
+///
+/// Observable difference, not a call count: with the anchor the backup file is
+/// at `pinned/payload.bin~`; without it, at `outside/payload.bin~`. See
+/// [`make_backup_without_the_destination_anchor_follows_the_root_swap`] for the
+/// non-vacuity companion that runs the same fixture unanchored.
+#[cfg(unix)]
+#[test]
+fn make_backup_hardlink_tier_anchors_the_backup_on_the_pinned_destination() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    // The pre-image the ladder reaches through the swapped path.
+    fs::write(fx.outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+    let config = DiskCommitConfig {
+        sandbox: Some(fx.sandbox.clone()),
+        dest_dir: Some(fx.dest_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+    let backup_config = BackupConfig {
+        dest_dir: fx.dest_dir.clone(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+
+    let notice = make_backup(
+        &fx.dest_dir.join("payload.bin"),
+        &backup_config,
+        config.backup_env(),
+    )
+    .expect("anchored backup succeeds")
+    .expect("notice produced for the backed-up file");
+
+    assert!(
+        !fx.outside.join("payload.bin~").exists(),
+        "the backup must not be placed out of tree through the swapped destination root"
+    );
+    assert!(
+        fx.pinned.join("payload.bin~").exists(),
+        "the anchored link must place the backup inside the pinned destination"
+    );
+    assert_eq!(
+        fs::read(fx.pinned.join("payload.bin~")).unwrap(),
+        b"pre-transfer bytes",
+        "the backup must carry the destination's pre-transfer bytes verbatim"
+    );
+    assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
+}
+
+/// Non-vacuity companion for
+/// [`make_backup_hardlink_tier_anchors_the_backup_on_the_pinned_destination`]:
+/// the SAME fixture with `env.sandbox`/`env.dest_dir` absent resolves the backup
+/// name by path and therefore DOES follow the swap.
+///
+/// This is what stops the anchored cell reading as a pass for the wrong reason.
+/// If the fixture simply could not produce a backup - a missing pre-image, a
+/// ladder that bailed out early - this test would fail too, because it asserts a
+/// backup file was written (out of tree).
+#[cfg(unix)]
+#[test]
+fn make_backup_without_the_destination_anchor_follows_the_root_swap() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    fs::write(fx.outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+    let config = DiskCommitConfig::default();
+    assert!(config.sandbox.is_none() && config.dest_dir.is_none());
+    let backup_config = BackupConfig {
+        dest_dir: fx.dest_dir.clone(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+
+    make_backup(
+        &fx.dest_dir.join("payload.bin"),
+        &backup_config,
+        config.backup_env(),
+    )
+    .expect("unanchored backup still succeeds")
+    .expect("notice produced for the backed-up file");
+
+    let escaped_backup = fx.outside.join("payload.bin~");
+    assert!(
+        escaped_backup.exists(),
+        "the fixture must be able to produce a backup at all; nothing was written"
+    );
+    assert_eq!(
+        fs::read(&escaped_backup).unwrap(),
+        b"pre-transfer bytes",
+        "without the anchor the ladder resolves the backup name by path and \
+         follows the swap - the fixture can and does produce a backup, so the \
+         anchored cell's placement assertion is discriminating, not vacuous"
+    );
+    assert!(
+        !fx.pinned.join("payload.bin~").exists(),
+        "nothing reaches the pinned directory when no dirfd anchor is supplied"
+    );
+}
+
+/// The sandbox/`dest_dir` pair must reach the RENAME tier too: both endpoints
+/// resolve against the pinned dirfd, so the pre-image that moves is the one
+/// inside the real destination and the out-of-tree file is left alone.
+///
+/// [`ForceExdev`] knocks out the hard-link tier exactly as a real `--backup-dir`
+/// on another mount does (`link(2)` fails `EXDEV` before `rename(2)` can), which
+/// is the documented purpose of the guard. It also proves the anchored rename is
+/// the leg that ran: the guard is consulted only by `backup_rename_syscall`,
+/// which the sandbox leg bypasses. Drop `dest_dir` and the injected `EXDEV`
+/// instead diverts the ladder onto the copy tier, which path-resolves both
+/// endpoints and lands the backup out of tree.
+///
+/// upstream: `backup.c:249` `do_rename_at()` under `operator_path_resolve`;
+/// `syscall.c:1918-1923` confines each side independently.
+#[cfg(unix)]
+#[test]
+fn make_backup_rename_tier_anchors_both_endpoints_on_the_pinned_destination() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    // The real pre-image, reachable only through the pinned dirfd.
+    fs::write(fx.pinned.join("payload.bin"), b"pinned pre-image").unwrap();
+    // The out-of-tree file the swapped PATH resolves to. Deliberately a
+    // different length so a byte comparison cannot agree by coincidence.
+    fs::write(
+        fx.outside.join("payload.bin"),
+        b"out-of-tree decoy contents",
+    )
+    .unwrap();
+
+    let config = DiskCommitConfig {
+        sandbox: Some(fx.sandbox.clone()),
+        dest_dir: Some(fx.dest_dir.clone()),
+        ..DiskCommitConfig::default()
+    };
+    let backup_config = BackupConfig {
+        dest_dir: fx.dest_dir.clone(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+
+    {
+        let _force = ForceExdev::new();
+        make_backup(
+            &fx.dest_dir.join("payload.bin"),
+            &backup_config,
+            config.backup_env(),
+        )
+        .expect("anchored rename succeeds without consulting the EXDEV guard")
+        .expect("notice produced for the backed-up file");
+    }
+
+    let anchored_backup = fx.pinned.join("payload.bin~");
+    assert!(
+        anchored_backup.exists(),
+        "the anchored rename must place the backup inside the pinned destination"
+    );
+    assert_eq!(
+        fs::read(&anchored_backup).unwrap(),
+        b"pinned pre-image",
+        "the anchored rename must move the pre-image held by the pinned dirfd"
+    );
+    assert!(
+        !fx.pinned.join("payload.bin").exists(),
+        "a rename moves the pre-image; the copy tier would have left it in place"
+    );
+    assert!(
+        !fx.outside.join("payload.bin~").exists(),
+        "no backup may be written out of tree through the swapped root"
+    );
+    assert_eq!(
+        fs::read(fx.outside.join("payload.bin")).unwrap(),
+        b"out-of-tree decoy contents",
+        "the out-of-tree file the swapped PATH names must be untouched"
+    );
+}
+
+/// `create_dir_all_sandboxed` is the third `BackupEnv` reader: the
+/// `--backup-dir` root is a single component under `dest_dir`, so its `mkdir` is
+/// anchored on the pinned dirfd and cannot be redirected by the swapped root.
+///
+/// The ladder then FAILS CLOSED: the link/rename tiers see a backup name two
+/// components deep, outside the SEC-1.h single-leaf shape, so they path-resolve
+/// into `outside/bak` - which does not exist, because the anchored `mkdir`
+/// created the real one inside the pinned root. Nothing is written out of tree.
+/// Without the anchor the same fixture creates `outside/bak` and completes the
+/// backup there; see
+/// [`make_backup_backup_dir_without_the_anchor_escapes_the_swapped_root`].
+///
+/// upstream: `backup.c:206` `make_path(dirbuf, 0)` ensures the backup root, run
+/// under the `operator_path_resolve` that `make_backup()` raises.
+#[cfg(unix)]
+#[test]
+fn make_backup_backup_dir_root_mkdir_anchors_on_the_pinned_destination() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    fs::write(fx.outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+    let config = DiskCommitConfig {
+        sandbox: Some(fx.sandbox.clone()),
+        dest_dir: Some(fx.dest_dir.clone()),
+        metadata_opts: Some(::metadata::MetadataOptions::new().preserve_permissions(true)),
+        ..DiskCommitConfig::default()
+    };
+    let backup_config = BackupConfig {
+        dest_dir: fx.dest_dir.clone(),
+        backup_dir: Some(PathBuf::from("bak")),
+        // upstream: options.c - the default suffix is cleared once a backup
+        // directory is named.
+        suffix: OsString::new(),
+    };
+
+    let result = make_backup(
+        &fx.dest_dir.join("payload.bin"),
+        &backup_config,
+        config.backup_env(),
+    );
+
+    assert!(
+        fx.pinned.join("bak").is_dir(),
+        "the --backup-dir root mkdir must be anchored on the pinned destination"
+    );
+    assert!(
+        !fx.outside.join("bak").exists(),
+        "no part of the backup tree may be created out of tree through the swap"
+    );
+    assert!(
+        result.is_err(),
+        "with the backup root anchored inside the pinned tree the path-resolved \
+         link/rename tiers find no parent, so the backup fails closed rather \
+         than escaping"
+    );
+    assert!(
+        !fx.outside.join("payload.bin~").exists() && !fx.pinned.join("payload.bin~").exists(),
+        "a --backup-dir backup never lands beside the destination"
+    );
+}
+
+/// Non-vacuity companion for
+/// [`make_backup_backup_dir_root_mkdir_anchors_on_the_pinned_destination`]: with
+/// `env.sandbox`/`env.dest_dir` absent the same fixture creates the whole backup
+/// tree out of tree and completes the backup there, so the anchored cell's
+/// "`outside/bak` must not exist" is a real discrimination and its `is_err()` is
+/// not a fixture that merely cannot back anything up.
+#[cfg(unix)]
+#[test]
+fn make_backup_backup_dir_without_the_anchor_escapes_the_swapped_root() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    fs::write(fx.outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+    let config = DiskCommitConfig {
+        metadata_opts: Some(::metadata::MetadataOptions::new().preserve_permissions(true)),
+        ..DiskCommitConfig::default()
+    };
+    let backup_config = BackupConfig {
+        dest_dir: fx.dest_dir.clone(),
+        backup_dir: Some(PathBuf::from("bak")),
+        suffix: OsString::new(),
+    };
+
+    make_backup(
+        &fx.dest_dir.join("payload.bin"),
+        &backup_config,
+        config.backup_env(),
+    )
+    .expect("unanchored --backup-dir backup succeeds")
+    .expect("notice produced for the backed-up file");
+
+    let escaped_backup = fx.outside.join("bak/payload.bin");
+    assert!(
+        escaped_backup.exists(),
+        "the fixture must be able to produce a --backup-dir backup at all; \
+         nothing was written"
+    );
+    assert_eq!(
+        fs::read(&escaped_backup).unwrap(),
+        b"pre-transfer bytes",
+        "unanchored, the whole backup tree follows the swap - the fixture is \
+         fully capable of producing a --backup-dir backup"
+    );
+    assert!(
+        !fx.pinned.join("bak").exists(),
+        "nothing reaches the pinned directory when no dirfd anchor is supplied"
+    );
+}
+
+/// The ORDINARY commit path must hand the ladder its own anchor too:
+/// `commit_file` builds the [`BackupEnv`](super::super::config::BackupEnv) from
+/// the same `DiskCommitConfig` that carries the sandbox, so the pre-transfer
+/// destination is backed up inside the pinned tree and the received file is
+/// committed on top of it.
+///
+/// The `--delay-updates` sweep is pinned separately
+/// (`receiver::transfer::tests`); this cell covers the immediate commit, which
+/// is the caller upstream reaches through `finish_transfer()`
+/// (`rsync.c:897` `make_backup(fname, False)`). Either call site can be
+/// downgraded to a default env without the other noticing, so both are pinned.
+#[cfg(unix)]
+#[test]
+fn commit_file_backup_anchors_on_the_pinned_destination() {
+    use std::ffi::OsString;
+
+    let fx = swapped_dest_root();
+    // The received temp file lives beside the final name inside the PINNED
+    // directory, which is where the receiver created it before the swap.
+    fs::write(fx.pinned.join(".tmp.payload"), b"received content").unwrap();
+    // The pre-transfer destination the ladder reaches through the swapped path.
+    fs::write(fx.outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+    let config = DiskCommitConfig {
+        sandbox: Some(fx.sandbox.clone()),
+        dest_dir: Some(fx.dest_dir.clone()),
+        backup: Some(BackupConfig {
+            dest_dir: fx.dest_dir.clone(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        }),
+        ..DiskCommitConfig::default()
+    };
+
+    let begin = BeginMessage {
+        file_path: fx.dest_dir.join("payload.bin"),
+        target_size: 16,
+        file_entry_index: 0,
+        checksum_verifier: None,
+        is_device_target: false,
+        is_inplace: false,
+        append_offset: 0,
+        xattr_list: None,
+        xattr_basis: None,
+        file_entry: None,
+    };
+    let mut guard = crate::temp_guard::TempFileGuard::new(fx.dest_dir.join(".tmp.payload"));
+
+    let outcome = commit_file(&begin, &config, &mut guard, true, 16, None)
+        .expect("the anchored commit must succeed");
+
+    assert!(
+        outcome.backup_notice.is_some(),
+        "an existing destination must produce a backup notice"
+    );
+    assert!(
+        !fx.outside.join("payload.bin~").exists(),
+        "the commit path must not place the backup out of tree through the \
+         swapped destination root"
+    );
+    assert_eq!(
+        fs::read(fx.pinned.join("payload.bin~")).unwrap(),
+        b"pre-transfer bytes",
+        "the backup must hold the destination's pre-transfer bytes verbatim"
+    );
+    // Non-vacuity: the commit really ran, so the backup assertions are not
+    // passing on a fixture where nothing happened.
+    assert_eq!(
+        fs::read(fx.pinned.join("payload.bin")).unwrap(),
+        b"received content",
+        "the received file must be committed onto the pinned destination"
+    );
+}

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -1582,4 +1582,173 @@ mod tests {
         assert_eq!(fs::read_to_string(&final_a).unwrap(), "staged-a");
         assert_eq!(fs::read_to_string(&final_b).unwrap(), "staged-b");
     }
+
+    /// The delayed sweep is a second CALLER of the backup ladder, so it must
+    /// hand the ladder the receiver's destination anchor - not a default,
+    /// unanchored [`BackupEnv`].
+    ///
+    /// Every other sweep test in this module passes `BackupEnv::default()`, so
+    /// none of them can tell a threaded env from a dropped one. This one can:
+    /// the destination root PATH is swapped for a symlink to an out-of-tree
+    /// directory after the [`fast_io::DirSandbox`] pinned its dirfd (program
+    /// order, no threads, no sleeps), which makes the two wirings differ by
+    /// observable PLACEMENT. Anchored, the pre-image is linked into the pinned
+    /// directory; unanchored, the path-based resolver follows the swap and the
+    /// pre-image leaves the tree.
+    ///
+    /// upstream: `receiver.c:694` - `if (make_backups > 0 && !make_backup(fname,
+    /// False)) continue;`. This is the same `make_backup()` `finish_transfer()`
+    /// calls, and `make_backup()` (`backup.c:437-448`) raises
+    /// `operator_path_resolve` for its whole body whichever caller entered it.
+    #[cfg(unix)]
+    #[test]
+    fn delayed_sweep_threads_the_destination_anchor_into_the_backup_ladder() {
+        use std::ffi::OsString;
+
+        let dir = test_support::create_tempdir();
+        let staging = fs::canonicalize(dir.path()).expect("canon");
+
+        let dest_dir = staging.join("dest");
+        let pinned = staging.join("dest.pinned");
+        let outside = staging.join("outside");
+        fs::create_dir(&dest_dir).unwrap();
+        fs::create_dir(&outside).unwrap();
+
+        // Pin the real destination inode BEFORE the swap.
+        let sandbox = fast_io::DirSandbox::open_root(&dest_dir).expect("sandbox");
+        fs::rename(&dest_dir, &pinned).expect("move the real dest aside");
+        std::os::unix::fs::symlink(&outside, &dest_dir).expect("plant the dest symlink");
+
+        // The pre-transfer destination the sweep must back up, reached through
+        // the swapped path exactly as the receiver's stored path string does.
+        let final_path = dest_dir.join("payload.bin");
+        fs::write(outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+        let staged_dir = staging.join("staged");
+        fs::create_dir(&staged_dir).unwrap();
+        let staged_path = staged_dir.join("payload.bin");
+        fs::write(&staged_path, b"replacement bytes, a different length").unwrap();
+
+        let backup_config = crate::disk_commit::BackupConfig {
+            dest_dir: dest_dir.clone(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        };
+        let env = BackupEnv {
+            sandbox: Some(&sandbox),
+            dest_dir: Some(&dest_dir),
+            metadata_opts: None,
+        };
+
+        let io_error = handle_delayed_updates(
+            &[(staged_path, final_path.clone())],
+            Some(backup_config),
+            env,
+            None,
+        );
+        assert_eq!(io_error, 0, "the sweep itself must succeed");
+
+        assert!(
+            !outside.join("payload.bin~").exists(),
+            "the sweep must not carry the pre-image out of tree through the \
+             swapped destination root"
+        );
+        let anchored_backup = pinned.join("payload.bin~");
+        assert!(
+            anchored_backup.exists(),
+            "the sweep must pass the destination anchor to make_backup; with a \
+             default BackupEnv the backup follows the swap instead"
+        );
+        assert_eq!(
+            fs::read(&anchored_backup).unwrap(),
+            b"pre-transfer bytes",
+            "the backup must carry the destination's pre-transfer bytes verbatim"
+        );
+
+        // Non-vacuity: the sweep really did run its rename, so "the backup is
+        // in the pinned directory" cannot be passing because nothing happened.
+        assert_eq!(
+            fs::read(outside.join("payload.bin")).unwrap(),
+            b"replacement bytes, a different length",
+            "the delayed rename must still land after a successful backup"
+        );
+    }
+
+    /// The receiver entry point that OWNS the anchor must put it in the
+    /// [`BackupEnv`] it builds: `finalize_delayed_updates_and_hardlinks`
+    /// receives `dest_dir` and the destination `sandbox` as parameters, and
+    /// those are exactly what the ladder needs.
+    ///
+    /// Same swapped-root fixture as
+    /// [`delayed_sweep_threads_the_destination_anchor_into_the_backup_ladder`],
+    /// one level up: that cell pins the sweep passing its `env` on to
+    /// `make_backup`, this one pins the caller constructing a real `env` from
+    /// its own arguments instead of a default. Both are needed - either half
+    /// alone can be dropped without the other cell noticing.
+    ///
+    /// upstream: `receiver.c:694-695` - `handle_delayed_updates()` runs at
+    /// `phase == 2` inside the receiver, with the same ambient
+    /// `operator_path_resolve` state `make_backup()` sets for itself
+    /// (`backup.c:437-448`).
+    #[cfg(unix)]
+    #[test]
+    fn delayed_update_finalizer_builds_the_backup_env_from_its_anchor() {
+        let dir = test_support::create_tempdir();
+        let staging = fs::canonicalize(dir.path()).expect("canon");
+
+        let dest_dir = staging.join("dest");
+        let pinned = staging.join("dest.pinned");
+        let outside = staging.join("outside");
+        fs::create_dir(&dest_dir).unwrap();
+        fs::create_dir(&outside).unwrap();
+
+        let sandbox = fast_io::DirSandbox::open_root(&dest_dir).expect("sandbox");
+        fs::rename(&dest_dir, &pinned).expect("move the real dest aside");
+        std::os::unix::fs::symlink(&outside, &dest_dir).expect("plant the dest symlink");
+
+        let final_path = dest_dir.join("payload.bin");
+        fs::write(outside.join("payload.bin"), b"pre-transfer bytes").unwrap();
+
+        let staged_dir = staging.join("staged");
+        fs::create_dir(&staged_dir).unwrap();
+        let staged_path = staged_dir.join("payload.bin");
+        fs::write(&staged_path, b"replacement bytes, a different length").unwrap();
+
+        let mut ctx = replay_client_ctx();
+        ctx.config.flags.backup = true;
+
+        let mut writer = crate::writer::DiscardSink::new();
+        ctx.finalize_delayed_updates_and_hardlinks(
+            &dest_dir,
+            Some(&sandbox),
+            &[(staged_path, final_path)],
+            &mut writer,
+        )
+        .expect("the delayed-update finalizer must complete");
+
+        assert!(
+            !outside.join("payload.bin~").exists(),
+            "the finalizer must not let the pre-image leave the tree through \
+             the swapped destination root"
+        );
+        let anchored_backup = pinned.join("payload.bin~");
+        assert!(
+            anchored_backup.exists(),
+            "the finalizer must build the BackupEnv from the dest_dir and \
+             sandbox it was handed, not a default one"
+        );
+        assert_eq!(
+            fs::read(&anchored_backup).unwrap(),
+            b"pre-transfer bytes",
+            "the backup must carry the destination's pre-transfer bytes verbatim"
+        );
+
+        // Non-vacuity: the finalizer really did sweep, so the placement
+        // assertion is not passing on an untouched fixture.
+        assert_eq!(
+            fs::read(outside.join("payload.bin")).unwrap(),
+            b"replacement bytes, a different length",
+            "the delayed rename must still land after a successful backup"
+        );
+    }
 }


### PR DESCRIPTION
## Why

`make_backup` and its hard-link / rename / copy tiers read three things from the commit configuration through `BackupEnv`: the receiver's destination sandbox, the destination root that sandbox is anchored on, and the metadata options applied when a `--backup-dir` parent has to be created. **Nothing pinned that any of them were actually threaded through.**

- Every existing `handle_delayed_updates` test passes `BackupEnv::default()`, so none of them can tell a threaded env from a dropped one.
- `make_backup_backup_dir_subdir_inherits_source_mode` asks for `preserve_permissions(true)`, which `MetadataOptions::default()` already supplies, so it agrees with a dropped `metadata_opts` field.

Recent work reshaped `make_backup` and its rename tier and routed the delayed sweep through `make_backup` rather than a second implementation, so the wiring matters and had no coverage.

## Method

Read `rsync-3.5.0/backup.c` first. `make_backup()` (`backup.c:437-448`) raises `operator_path_resolve` around its whole body, and `link_or_rename()` runs `do_link_at()` FIRST (`backup.c:239`) before `do_rename_at()` (`backup.c:249`); `get_backup_name()` ensures the `--backup-dir` root with `make_path()` (`backup.c:206`) and `copy_valid_path()` applies the run's own preserve flags to each new subdirectory with `set_file_attrs()` (`backup.c:173`). Confining only the rename would leave the escape open on every platform where the link succeeds, so all three sites need pinning.

Each new cell swaps the destination root's PATH for a symlink to an out-of-tree directory **after** the `DirSandbox` has pinned its dirfd - program order, no threads, no sleeps. The two wirings then differ by observable placement and byte-fidelity: an anchored `*at()` lands the backup in the pinned directory, a path-based resolution follows the swap. (The ownership walk in the fallback follows that symlink by design - it is owned by our own euid, `syscall.c:270-272` - which is exactly why the dirfd anchor, not the walk, is what keeps the backup inside the tree here.)

Every pin is paired with a non-vacuity companion that runs the same fixture unanchored and asserts a backup IS produced out of tree, so a fixture that cannot make a backup at all does not read as a pass.

## Decision points covered

| Consumer of `BackupEnv` | Observable difference |
| --- | --- |
| `backup_hardlink_syscall` (`backup.c:239`) | backup at `pinned/payload.bin~` vs `outside/payload.bin~` |
| `backup_rename_sandboxed` (`backup.c:249`) | the pre-image the pinned dirfd holds moves; the out-of-tree file is untouched |
| `create_dir_all_sandboxed` for the `--backup-dir` root (`backup.c:206`) | `pinned/bak` created, `outside/bak` absent, ladder fails closed |
| `metadata_opts` (`backup.c:173`) | `preserve_permissions(false)` keeps the plain `mkdir` mode instead of the destination dir's |
| `commit_file` call site | backup placement plus the received file committed onto the pinned destination |
| `handle_delayed_updates` call site | backup placement plus the delayed rename landing |
| `finalize_delayed_updates_and_hardlinks` (builds the env) | same, one level up |

The mode cell measures a bare `mkdir`'s mode under the current umask first and picks a destination mode that differs from it, so a umask of 077 cannot make the assertion true by coincidence.

## Mutation matrix

Each mutation was applied to production code, the suite run, then reverted.

| Mutation | Reddened |
| --- | --- |
| `backup_env()` -> `dest_dir: None` | hardlink, rename and `--backup-dir` mkdir anchor cells (3 of 2419) |
| `backup_env()` -> `sandbox: None` | the same 3 |
| `backup_rename_sandboxed` anchor predicate disabled | rename anchor cell only |
| `backup_hardlink_syscall` anchor predicate disabled | hardlink anchor cell only |
| `create_dir_all_sandboxed` anchor predicate disabled | `--backup-dir` mkdir anchor cell only |
| `handle_delayed_updates` -> `make_backup(..., BackupEnv::default())` | the sweep cell only (1 of 2417) |
| `finalize_delayed_updates_and_hardlinks` -> passes `BackupEnv::default()` | the finalizer cell only (1 of 2418) |
| `commit_file` -> `make_backup(..., BackupEnv::default())` | the commit cell only (1 of 2420) |
| `backup_env()` -> `metadata_opts: None` | **survived** before this PR; now reddens the metadata-options cell only |

That last row is the point: the pre-existing attribute-inheritance test could not kill it.

## Gates

- `cargo build -p bin --bin oc-rsync`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
- `cargo nextest run -p transfer -p engine` - 7781 passed
- `cargo nextest run -p bin -E 'binary(/^integration_/)'` - 214 passed
- `cargo nextest run -p bin` backup suites (`integration_delete_backup`, `delay_updates_backup_failure`, `commit_backup_failure_is_fatal`, `server_backup_temp_dir`) - 52 passed

Test-only. No production behaviour is changed; the sole non-test edit is a `#[cfg(all(test, unix))] use` so the tests can reach `commit_file`.
