### PR TITLE
fix(server): send the server's exit code to the peer via MSG_ERROR_EXIT

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -604,11 +604,25 @@ where
     // FD (lsh.sh, the parent shell, still holds an inherited copy), so the
     // peer never sees EOF and the drain loops forever. Match upstream and
     // let process exit do the work.
+    //
+    // upstream: cleanup.c:282 `_exit_cleanup()` exits with the `RERR_*` the
+    // failing site handed `exit_cleanup()`, never a flat 1. oc carries one
+    // `io::Error` up instead of a per-site code, so the class is recovered with
+    // the same mapping the client applies to its own local failures. The peer
+    // learns the code from the `MSG_ERROR_EXIT` the transfer body already sent
+    // (transfer::announce_error_exit); this is the process status the remote
+    // shell reports on top of it.
     match run_server_stdio(config, &mut stdin, stdout, None) {
         Ok(_stats) => 0,
         Err(e) => {
-            write_server_error(stderr, program_brand, format!("server error: {e}"));
-            1
+            let exit_code = core::exit_code::ExitCode::from_io_error(&e);
+            write_server_error_with_code(
+                stderr,
+                program_brand,
+                exit_code,
+                format!("server error: {e}"),
+            );
+            exit_code.as_i32()
         }
     }
 }
@@ -916,8 +930,22 @@ fn apply_value_flags<Err: Write>(
 }
 
 fn write_server_error<Err: Write>(stderr: &mut Err, brand: Brand, text: impl fmt::Display) {
+    write_server_error_with_code(stderr, brand, core::exit_code::ExitCode::Syntax, text);
+}
+
+/// Renders a server-side `rsync error:` trailer carrying an explicit `RERR_*`.
+///
+/// upstream: log.c:912 `log_exit()` prints the code the process is exiting with,
+/// so a transfer-body failure must not be labelled `(code 1)` while the process
+/// leaves with a different status.
+fn write_server_error_with_code<Err: Write>(
+    stderr: &mut Err,
+    brand: Brand,
+    code: core::exit_code::ExitCode,
+    text: impl fmt::Display,
+) {
     let mut sink = MessageSink::with_brand(stderr, brand);
-    let mut message = rsync_error!(1, "{}", text);
+    let mut message = rsync_error!(code.as_i32(), "{}", text);
     message = message.with_role(Role::Server);
     if super::super::write_message(&message, &mut sink).is_err() {
         let _ = writeln!(sink.writer_mut(), "{text}");

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -287,14 +287,7 @@ fn map_server_transfer_error(error: std::io::Error, role: Role) -> ClientError {
 /// [`transfer::RemoteExitError`], returning the peer-supplied exit code when the
 /// failure originated from a remote `MSG_ERROR_EXIT` frame.
 fn remote_exit_code(error: &std::io::Error) -> Option<i32> {
-    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error.get_ref()?);
-    while let Some(err) = source {
-        if let Some(remote) = err.downcast_ref::<crate::server::RemoteExitError>() {
-            return Some(remote.code);
-        }
-        source = err.source();
-    }
-    None
+    crate::server::remote_exit_code(error)
 }
 
 /// Builds a `HandshakeResult` for daemon transfers where the protocol version

--- a/crates/core/src/client/remote/ssh_transfer/drive.rs
+++ b/crates/core/src/client/remote/ssh_transfer/drive.rs
@@ -463,6 +463,15 @@ fn run_server_over_ssh_connection(
             }
         }
         Err(transfer_error) => {
+            // upstream: io.c:1892 - a received `MSG_ERROR_EXIT` ends in the
+            // NORETURN `_exit_cleanup(val)`, so the peer's code IS the client's
+            // exit code; upstream never reaches the child-status comparison
+            // below on that path. Without this arm the abort surfaces as a
+            // local `ConnectionAborted` and reports RERR_SOCKETIO (10) whatever
+            // the server actually exited with.
+            if let Some(code) = crate::server::remote_exit_code(&transfer_error) {
+                return Err(remote_exit_error(ExitCode::from_raw(code), local_role));
+            }
             let transfer_exit = ExitCode::from_io_error(&transfer_error);
             if child_exit_code.as_i32() > transfer_exit.as_i32() {
                 Err(remote_exit_error(child_exit_code, local_role))

--- a/crates/core/src/exit_code/codes.rs
+++ b/crates/core/src/exit_code/codes.rs
@@ -340,63 +340,13 @@ impl ExitCode {
     /// [`ExitCode::Protocol`]; every other `InvalidData`/`UnexpectedEof`
     /// (truncated stream, corrupt frame, unexpected EOF) stays
     /// [`ExitCode::StreamIo`] (12), matching upstream's `RERR_STREAMIO`.
+    ///
+    /// The mapping itself lives in [`transfer::error::rerr_for_io_error`], one
+    /// crate below this one, because the server half needs the identical answer
+    /// when it writes the `MSG_ERROR_EXIT` payload that tells the peer which
+    /// `RERR_*` it is exiting with (upstream: cleanup.c:250).
     #[must_use]
     pub fn from_io_error(error: &std::io::Error) -> Self {
-        use std::io::ErrorKind;
-
-        // upstream: errcode.h RERR_PROTOCOL=2 - a tagged protocol violation
-        // outranks the generic InvalidData=>StreamIo(12) mapping below.
-        if error
-            .get_ref()
-            .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>())
-        {
-            return Self::Protocol;
-        }
-
-        // upstream: errcode.h RERR_SYNTAX=1 - an option-usage refusal is tagged
-        // at its call site, exactly as the protocol-violation class above;
-        // without the tag it would fall through to the `_ => FileIo` arm.
-        if error
-            .get_ref()
-            .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>())
-        {
-            return Self::Syntax;
-        }
-
-        // upstream: rsync.c:900 - `finish_transfer()` answers a failed
-        // `make_backup()` with `exit_cleanup(RERR_FILEIO)` whatever the errno
-        // was, so a denied backup must not be graded by `ErrorKind` like the
-        // per-file open failures below. Without this arm the usual `EACCES`
-        // reaches the `PermissionDenied => FileSelect` arm and reports 3.
-        if matches!(
-            transfer::temp_guard::commit_op_failure(error),
-            Some((transfer::temp_guard::CommitOp::Backup, _))
-        ) {
-            return Self::FileIo;
-        }
-
-        match error.kind() {
-            ErrorKind::NotFound | ErrorKind::PermissionDenied | ErrorKind::AlreadyExists => {
-                Self::FileSelect
-            }
-
-            ErrorKind::ConnectionRefused
-            | ErrorKind::ConnectionReset
-            | ErrorKind::ConnectionAborted
-            | ErrorKind::BrokenPipe
-            | ErrorKind::AddrInUse
-            | ErrorKind::AddrNotAvailable
-            | ErrorKind::NotConnected => Self::SocketIo,
-
-            ErrorKind::TimedOut => Self::Timeout,
-
-            ErrorKind::UnexpectedEof | ErrorKind::InvalidData => Self::StreamIo,
-
-            ErrorKind::Interrupted => Self::Signal,
-
-            ErrorKind::Unsupported => Self::Unsupported,
-
-            _ => Self::FileIo,
-        }
+        Self::from_i32(transfer::error::rerr_for_io_error(error)).unwrap_or(Self::FileIo)
     }
 }

--- a/crates/transfer/src/error.rs
+++ b/crates/transfer/src/error.rs
@@ -248,6 +248,90 @@ pub fn flush_retry<W: Write>(writer: &mut W) -> io::Result<()> {
     }
 }
 
+/// Maps a fatal transfer failure onto the upstream `errcode.h` `RERR_*` value
+/// that `exit_cleanup()` would have been called with at the failing site.
+///
+/// Upstream picks the code per call site (`exit_cleanup(RERR_FILEIO)` and
+/// friends); oc carries one `io::Error` up the stack instead, so the class is
+/// recovered here from the error's tag or `ErrorKind`. This lives in `transfer`,
+/// below `core`, because both the client's `ExitCode::from_io_error` and the
+/// server's `MSG_ERROR_EXIT` producer need the same answer, and the server half
+/// runs inside this crate.
+///
+/// # Mapping Rules
+///
+/// - a tagged [`protocol::ProtocolViolation`] - `RERR_PROTOCOL` (2)
+/// - a tagged [`protocol::SyntaxViolation`] - `RERR_SYNTAX` (1)
+/// - a failed commit-path backup - `RERR_FILEIO` (11), whatever the errno
+/// - `NotFound`, `PermissionDenied`, `AlreadyExists` - `RERR_FILESELECT` (3)
+/// - the connection-class kinds - `RERR_SOCKETIO` (10)
+/// - `TimedOut` - `RERR_TIMEOUT` (30)
+/// - `UnexpectedEof`, other `InvalidData` - `RERR_STREAMIO` (12)
+/// - `Interrupted` - `RERR_SIGNAL` (20)
+/// - `Unsupported` - `RERR_UNSUPPORTED` (4)
+/// - everything else - `RERR_FILEIO` (11)
+///
+/// # Upstream Reference
+///
+/// - `errcode.h` - the `RERR_*` values.
+/// - `rsync.c:900` - `finish_transfer()` answers a failed `make_backup()` with
+///   `exit_cleanup(RERR_FILEIO)` whatever the errno was.
+#[must_use]
+pub fn rerr_for_io_error(error: &io::Error) -> i32 {
+    // upstream: errcode.h RERR_PROTOCOL=2 - a tagged protocol violation
+    // outranks the generic InvalidData => RERR_STREAMIO mapping below.
+    if error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<protocol::ProtocolViolation>())
+    {
+        return 2;
+    }
+
+    // upstream: errcode.h RERR_SYNTAX=1 - an option-usage refusal is tagged at
+    // its call site, exactly as the protocol-violation class above; without the
+    // tag it would fall through to the `_ => RERR_FILEIO` arm.
+    if error
+        .get_ref()
+        .is_some_and(|inner| inner.is::<protocol::SyntaxViolation>())
+    {
+        return 1;
+    }
+
+    // upstream: rsync.c:900 - a denied backup must not be graded by `ErrorKind`
+    // like the per-file open failures below. Without this arm the usual `EACCES`
+    // reaches the `PermissionDenied => RERR_FILESELECT` arm and reports 3.
+    if matches!(
+        crate::temp_guard::commit_op_failure(error),
+        Some((crate::temp_guard::CommitOp::Backup, _))
+    ) {
+        return 11;
+    }
+
+    match error.kind() {
+        io::ErrorKind::NotFound
+        | io::ErrorKind::PermissionDenied
+        | io::ErrorKind::AlreadyExists => 3,
+
+        io::ErrorKind::ConnectionRefused
+        | io::ErrorKind::ConnectionReset
+        | io::ErrorKind::ConnectionAborted
+        | io::ErrorKind::BrokenPipe
+        | io::ErrorKind::AddrInUse
+        | io::ErrorKind::AddrNotAvailable
+        | io::ErrorKind::NotConnected => 10,
+
+        io::ErrorKind::TimedOut => 30,
+
+        io::ErrorKind::UnexpectedEof | io::ErrorKind::InvalidData => 12,
+
+        io::ErrorKind::Interrupted => 20,
+
+        io::ErrorKind::Unsupported => 4,
+
+        _ => 11,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -1029,68 +1029,185 @@ pub fn run_server_with_handshake_adopting<W: Write>(
     // receiver reports the sender's transmitted counters, not its own wire tally.
     let client_mode = config.connection.client_mode;
 
-    match config.role {
-        ServerRole::Receiver => {
-            let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
-            // upstream: flist.c:2615/2789 - recv_file_list() measures its span
-            // against the raw read counter to accumulate stats.flist_size.
-            ctx.set_raw_read_counter(std::sync::Arc::clone(&bytes_received_counter));
-            // upstream: io.c:859 - stats.total_written tracking
-            let mut counting_writer = writer::CountingWriter::new(&mut writer);
-            let mut stats = ctx.run(chained_reader, &mut counting_writer, progress)?;
-            stats.flist_size = ctx.flist_size();
-            stats.bytes_sent = counting_writer.bytes_written();
-            // upstream: io.c:820 - stats.total_read counts raw bytes read off the
-            // socket (mux frames + compressed tokens), below decompression. Source
-            // bytes_received from the wire counter so --stats reports compressed
-            // wire bytes, not the post-decompression literal byte total.
-            stats.bytes_received =
-                bytes_received_counter.load(std::sync::atomic::Ordering::Relaxed);
+    // Captured before `handshake` is borrowed by the role context: the
+    // `MSG_ERROR_EXIT` gate below needs it after the dispatch has ended.
+    let negotiated_protocol = handshake.protocol.as_u8();
 
-            // upstream: main.c:325-372 handle_stats() - the sender is the only
-            // process with the authoritative byte totals. A client receiver reads
-            // the sender's cached raw counters over the wire (main.c:365-372) and
-            // swaps their meaning: it prints the sender's total_read as "Total
-            // bytes sent" and the sender's total_written as "Total bytes received".
-            // Its own wire tally diverges by the trailing stats/goodbye bytes the
-            // sender wrote after sampling, so prefer the transmitted figures.
-            // Absent (empty file list, no stats trailer) keeps the local tally,
-            // matching upstream's `if (f < 0 && !am_sender)` no-op (main.c:363).
-            if client_mode && let Some(sender_stats) = ctx.sender_stats() {
-                stats.bytes_sent = sender_stats.total_read;
-                stats.bytes_received = sender_stats.total_written;
-            }
+    let outcome: ServerResult = 'dispatch: {
+        match config.role {
+            ServerRole::Receiver => {
+                let mut ctx = ReceiverContext::new(&handshake, config, pipeline);
+                // upstream: flist.c:2615/2789 - recv_file_list() measures its span
+                // against the raw read counter to accumulate stats.flist_size.
+                ctx.set_raw_read_counter(std::sync::Arc::clone(&bytes_received_counter));
+                // upstream: io.c:859 - stats.total_written tracking
+                let mut counting_writer = writer::CountingWriter::new(&mut writer);
+                let mut stats = match ctx.run(chained_reader, &mut counting_writer, progress) {
+                    Ok(stats) => stats,
+                    Err(error) => break 'dispatch Err(error),
+                };
+                stats.flist_size = ctx.flist_size();
+                stats.bytes_sent = counting_writer.bytes_written();
+                // upstream: io.c:820 - stats.total_read counts raw bytes read off the
+                // socket (mux frames + compressed tokens), below decompression. Source
+                // bytes_received from the wire counter so --stats reports compressed
+                // wire bytes, not the post-decompression literal byte total.
+                stats.bytes_received =
+                    bytes_received_counter.load(std::sync::atomic::Ordering::Relaxed);
 
-            // A custom `--out-format` on a pull buffered its per-file rows as
-            // metadata events (the receiver suppressed its own stdout). Hand each
-            // one to the client callback in flist-index order so the CLI renders
-            // the user's template - mirroring how the push sender feeds the same
-            // callback. No-op unless the client set `out_format_active`.
-            if let Some(cb) = itemize {
-                for row in ctx.drain_event_rows() {
-                    cb.on_itemize_row(&row.as_row());
+                // upstream: main.c:325-372 handle_stats() - the sender is the only
+                // process with the authoritative byte totals. A client receiver reads
+                // the sender's cached raw counters over the wire (main.c:365-372) and
+                // swaps their meaning: it prints the sender's total_read as "Total
+                // bytes sent" and the sender's total_written as "Total bytes received".
+                // Its own wire tally diverges by the trailing stats/goodbye bytes the
+                // sender wrote after sampling, so prefer the transmitted figures.
+                // Absent (empty file list, no stats trailer) keeps the local tally,
+                // matching upstream's `if (f < 0 && !am_sender)` no-op (main.c:363).
+                if client_mode && let Some(sender_stats) = ctx.sender_stats() {
+                    stats.bytes_sent = sender_stats.total_read;
+                    stats.bytes_received = sender_stats.total_written;
                 }
+
+                // A custom `--out-format` on a pull buffered its per-file rows as
+                // metadata events (the receiver suppressed its own stdout). Hand each
+                // one to the client callback in flist-index order so the CLI renders
+                // the user's template - mirroring how the push sender feeds the same
+                // callback. No-op unless the client set `out_format_active`.
+                if let Some(cb) = itemize {
+                    for row in ctx.drain_event_rows() {
+                        cb.on_itemize_row(&row.as_row());
+                    }
+                }
+
+                Ok(ServerStats::Receiver(stats))
             }
+            ServerRole::Generator => {
+                let mut paths = Vec::with_capacity(config.args.len());
+                paths.extend(config.args.iter().map(std::path::PathBuf::from));
 
-            Ok(ServerStats::Receiver(stats))
+                let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
+                ctx.batch_stats_sink = batch_stats_sink;
+                // upstream: io.c:820/859 - the sender's handle_stats() reports the raw
+                // descriptor counters. Hand the generator the transport-level wire
+                // counters so it samples total_written/total_read at its handle_stats
+                // point (main.c:979-980), below multiplex framing, matching upstream.
+                ctx.set_wire_counters(
+                    std::sync::Arc::clone(&bytes_sent_counter),
+                    std::sync::Arc::clone(&bytes_received_counter),
+                );
+                let stats = match ctx.run(chained_reader, &mut writer, &paths, progress, itemize) {
+                    Ok(stats) => stats,
+                    Err(error) => break 'dispatch Err(error),
+                };
+
+                Ok(ServerStats::Generator(stats))
+            }
         }
-        ServerRole::Generator => {
-            let mut paths = Vec::with_capacity(config.args.len());
-            paths.extend(config.args.iter().map(std::path::PathBuf::from));
+    };
 
-            let mut ctx = GeneratorContext::new(&handshake, config, pipeline);
-            ctx.batch_stats_sink = batch_stats_sink;
-            // upstream: io.c:820/859 - the sender's handle_stats() reports the raw
-            // descriptor counters. Hand the generator the transport-level wire
-            // counters so it samples total_written/total_read at its handle_stats
-            // point (main.c:979-980), below multiplex framing, matching upstream.
-            ctx.set_wire_counters(
-                std::sync::Arc::clone(&bytes_sent_counter),
-                std::sync::Arc::clone(&bytes_received_counter),
-            );
-            let stats = ctx.run(chained_reader, &mut writer, &paths, progress, itemize)?;
-
-            Ok(ServerStats::Generator(stats))
+    match outcome {
+        Ok(stats) => Ok(stats),
+        Err(error) => {
+            announce_error_exit(&mut writer, &error, negotiated_protocol);
+            Err(error)
         }
     }
+}
+
+/// Tells the peer which `RERR_*` this side is exiting with, so it exits with the
+/// same code instead of inferring one from the connection dropping.
+///
+/// This is upstream's `_exit_cleanup()` tail, ported arm for arm:
+///
+/// ```c
+/// if (exit_code && exit_code != RERR_SOCKETIO && exit_code != RERR_STREAMIO
+///  && exit_code != RERR_SIGNAL1 && exit_code != RERR_TIMEOUT && !shutting_down) {
+///         if (protocol_version >= 31 || am_receiver) {
+///                 if (line > 0)
+///                         send_msg_int(MSG_ERROR_EXIT, exit_code);
+///                 ...
+/// ```
+///
+/// The four excluded codes are the ones whose own failure mode is the transport,
+/// so writing another frame down it is pointless. `line > 0` is upstream's guard
+/// against echoing an exit that a *received* `MSG_ERROR_EXIT` caused
+/// (io.c:1892 re-enters `_exit_cleanup` with a negative line); oc's equivalent
+/// is a [`RemoteExitError`] anywhere in the failure's source chain.
+///
+/// Upstream's gate reads `protocol_version >= 31 || am_receiver`, but only the
+/// first half is a *wire* condition. `am_receiver` is true in the forked
+/// receiver child, whose `send_msg()` buffers into the sibling message channel
+/// its parent generator drains - not into the socket the client reads. oc runs
+/// one process with no sibling channel, so porting `am_receiver` as a wire
+/// exemption would emit the frame where upstream emits nothing. Measured against
+/// rsync 3.5.0 over a remote shell, a server-receiver failure that reports 3 to
+/// the client at protocol 32 reports 12 at `--protocol=30`, which is the gate
+/// this port has to reproduce: protocol 31 and up, both roles.
+///
+/// A non-multiplexed writer has no frame to carry the code; `send_error_exit`
+/// reports that as an error which is deliberately dropped, exactly as upstream's
+/// `io_flush()` is a no-op with no multiplexed output active.
+///
+/// # Upstream Reference
+///
+/// - `cleanup.c:242-258` - the gate and `send_msg_int(MSG_ERROR_EXIT, exit_code)`.
+/// - `errcode.h` - `RERR_SOCKETIO`/`RERR_STREAMIO`/`RERR_SIGNAL1`/`RERR_TIMEOUT`.
+fn announce_error_exit<W: Write>(
+    writer: &mut writer::ServerWriter<W>,
+    error: &io::Error,
+    protocol_version: u8,
+) {
+    // upstream: cleanup.c:245 `line > 0` - never echo an exit the peer asked for.
+    if remote_exit_code(error).is_some() {
+        return;
+    }
+
+    let exit_code = crate::error::rerr_for_io_error(error);
+
+    // upstream: cleanup.c:242-243 - a transport-class failure is not announced over
+    // that same transport.
+    const RERR_SOCKETIO: i32 = 10;
+    const RERR_STREAMIO: i32 = 12;
+    const RERR_SIGNAL1: i32 = 19;
+    const RERR_TIMEOUT: i32 = 30;
+    if exit_code == 0
+        || matches!(
+            exit_code,
+            RERR_SOCKETIO | RERR_STREAMIO | RERR_SIGNAL1 | RERR_TIMEOUT
+        )
+    {
+        return;
+    }
+
+    // upstream: cleanup.c:244 `protocol_version >= 31 || am_receiver` - see the
+    // doc comment for why the `am_receiver` half is a sibling-channel condition
+    // and not a wire one.
+    if protocol_version < 31 {
+        return;
+    }
+
+    if writer.send_error_exit(exit_code).is_ok() {
+        let _ = writer.flush_all_pending();
+    }
+}
+
+/// Walks the source chain of an `io::Error` looking for a [`RemoteExitError`],
+/// which marks a failure that a peer's own `MSG_ERROR_EXIT` produced.
+///
+/// upstream: io.c:1892 - the handler re-enters `_exit_cleanup` with a negative
+/// line so the same code is not sent straight back out.
+///
+/// The client side reads the same chain to exit with the peer's code rather than
+/// with whatever local `ErrorKind` the aborted read produced.
+#[must_use]
+pub fn remote_exit_code(error: &io::Error) -> Option<i32> {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error.get_ref()?);
+    while let Some(err) = source {
+        if let Some(remote) = err.downcast_ref::<RemoteExitError>() {
+            return Some(remote.code);
+        }
+        source = err.source();
+    }
+    None
 }

--- a/crates/transfer/src/tests/error_exit_gate.rs
+++ b/crates/transfer/src/tests/error_exit_gate.rs
@@ -1,0 +1,77 @@
+//! Gate coverage for the `MSG_ERROR_EXIT` producer.
+//!
+//! upstream: cleanup.c:242-258 - `_exit_cleanup()` writes the exit code onto the
+//! multiplexed stream only when the code is not one of the four transport-class
+//! failures, the peer negotiated protocol 31 or later, and this exit was not
+//! itself caused by a `MSG_ERROR_EXIT` the peer sent.
+
+use std::io;
+
+use protocol::{MPLEX_BASE, MessageCode};
+
+use crate::RemoteExitError;
+use crate::announce_error_exit;
+use crate::writer::ServerWriter;
+
+/// Runs the producer over a multiplexed writer and returns the bytes it emitted.
+fn emitted(error: &io::Error, protocol_version: u8) -> Vec<u8> {
+    let mut wire = Vec::new();
+    {
+        let mut writer = ServerWriter::new_plain(&mut wire)
+            .activate_multiplex()
+            .expect("activate multiplex");
+        announce_error_exit(&mut writer, error, protocol_version);
+    }
+    wire
+}
+
+/// The frame upstream's `send_msg_int(MSG_ERROR_EXIT, code)` produces: the
+/// tag/length header followed by the 4-byte little-endian code.
+fn expected_frame(code: i32) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(8);
+    frame.extend_from_slice(&[4, 0, 0, MPLEX_BASE + MessageCode::ErrorExit.as_u8()]);
+    frame.extend_from_slice(&code.to_le_bytes());
+    frame
+}
+
+#[test]
+fn a_file_select_failure_is_announced_at_protocol_31() {
+    let error = io::Error::from(io::ErrorKind::PermissionDenied);
+    assert_eq!(emitted(&error, 31), expected_frame(3));
+    assert_eq!(emitted(&error, 32), expected_frame(3));
+}
+
+/// upstream: cleanup.c:244 - below protocol 31 nothing is written to the wire;
+/// the surviving `am_receiver` arm routes to the forked receiver's sibling
+/// channel, which a single-process port does not have.
+#[test]
+fn protocol_30_announces_nothing() {
+    let error = io::Error::from(io::ErrorKind::PermissionDenied);
+    assert!(emitted(&error, 30).is_empty());
+}
+
+/// upstream: cleanup.c:242-243 - `RERR_SOCKETIO`, `RERR_STREAMIO`, `RERR_SIGNAL1`
+/// and `RERR_TIMEOUT` are the transport-class codes; announcing one down the
+/// transport that just failed is pointless, so upstream skips the send.
+#[test]
+fn transport_class_codes_are_not_announced() {
+    for kind in [
+        io::ErrorKind::ConnectionReset, // RERR_SOCKETIO
+        io::ErrorKind::UnexpectedEof,   // RERR_STREAMIO
+        io::ErrorKind::TimedOut,        // RERR_TIMEOUT
+    ] {
+        let error = io::Error::from(kind);
+        assert!(
+            emitted(&error, 32).is_empty(),
+            "{kind:?} is transport-class and must not be announced"
+        );
+    }
+}
+
+/// upstream: io.c:1892 - receipt of `MSG_ERROR_EXIT` re-enters `_exit_cleanup`
+/// with a negative line precisely so the code is not echoed straight back.
+#[test]
+fn an_exit_the_peer_asked_for_is_not_echoed_back() {
+    let error = io::Error::other(RemoteExitError { code: 3 });
+    assert!(emitted(&error, 32).is_empty());
+}

--- a/crates/transfer/src/tests/mod.rs
+++ b/crates/transfer/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod allow_inc_recurse;
 mod bwlimit_wiring;
 mod compress_off_level;
 mod config;
+mod error_exit_gate;
 mod filter_list_gate;
 mod multiplex_protocol_version;
 mod negotiated_algorithms;

--- a/crates/transfer/src/writer/server.rs
+++ b/crates/transfer/src/writer/server.rs
@@ -311,6 +311,29 @@ impl<W: Write> ServerWriter<W> {
         self.send_message(MessageCode::IoError, &io_error.to_le_bytes())
     }
 
+    /// Sends a `MSG_ERROR_EXIT` message carrying the `RERR_*` code this side is
+    /// about to exit with, so the peer exits with the same code instead of
+    /// inferring one from the connection dropping.
+    ///
+    /// The payload is the bare 4-byte little-endian exit code upstream's
+    /// `send_msg_int()` writes; a zero-length body is upstream's sibling
+    /// handshake reply, which oc never originates.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `cleanup.c:250`: `send_msg_int(MSG_ERROR_EXIT, exit_code)` from
+    ///   `_exit_cleanup()`, under `protocol_version >= 31 || am_receiver`.
+    /// - `io.c:1854-1892`: the peer's `read_a_msg()` handler ends in the
+    ///   NORETURN `_exit_cleanup(val, __FILE__, 0 - __LINE__)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the writer is not in multiplex mode or the underlying
+    /// I/O operation fails.
+    pub fn send_error_exit(&mut self, exit_code: i32) -> io::Result<()> {
+        self.send_message(MessageCode::ErrorExit, &exit_code.to_le_bytes())
+    }
+
     /// Attaches a batch recorder for capturing compressed protocol data.
     ///
     /// The recorder is always attached to the `MultiplexWriter` so it captures

--- a/tests/server_error_exit_code_reaches_client.rs
+++ b/tests/server_error_exit_code_reaches_client.rs
@@ -1,0 +1,229 @@
+//! A server-side fatal error must reach the client as the server's own
+//! `RERR_*` code, carried by `MSG_ERROR_EXIT`.
+//!
+//! Upstream's `_exit_cleanup()` writes the code it is about to exit with onto
+//! the multiplexed stream before the process ends (cleanup.c:242-258), and the
+//! peer's `read_a_msg()` turns receipt of that frame into the NORETURN
+//! `_exit_cleanup(val, __FILE__, 0 - __LINE__)` (io.c:1854-1892). The client
+//! therefore exits with the *server's* code, not with whatever the connection
+//! dropping happened to look like locally.
+//!
+//! oc had neither half on the remote-shell path: the `--server` entry point
+//! collapsed every transfer failure to a flat `1` and sent no frame, so an
+//! oc client saw only EOF and reported `RERR_STREAMIO` (12).
+//!
+//! Measured against the pinned upstream rsync 3.5.0 over a remote shell, for a
+//! push whose server receiver cannot create the destination root:
+//!
+//! | client | server | protocol | client-observed exit |
+//! |--------|--------|----------|----------------------|
+//! | rsync  | rsync  | 32       | 3                    |
+//! | rsync  | rsync  | 30       | 12                   |
+//!
+//! The protocol split is upstream's gate. `cleanup.c:244` reads
+//! `protocol_version >= 31 || am_receiver`, but `am_receiver` selects the forked
+//! receiver child's *sibling* message channel, not the socket; a single-process
+//! port must gate on the protocol version alone, which is exactly what the two
+//! rows above show on the wire.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+
+const RUN_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Locates the binary under test. `CARGO_BIN_EXE_oc-rsync` is a compile-time
+/// variable, so it must be read with `env!`, never `env::var_os`: at run time it
+/// is unset and the lookup would fall through to a stale `target/debug` build.
+fn oc_rsync_binary() -> PathBuf {
+    let built = PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"));
+    assert!(
+        built.is_file(),
+        "oc-rsync binary missing at {}; refusing to fall back to a stale build",
+        built.display()
+    );
+    built
+}
+
+/// Effective-UID probe used as a skip gate. Shells out to `id -u` rather than
+/// linking `libc::geteuid` so the test stays free of FFI. Root ignores the
+/// directory mode the fixture relies on, so the fatal path would never fire.
+fn is_root() -> bool {
+    match Command::new("id").arg("-u").output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse::<u32>()
+            .map(|uid| uid == 0)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Writes an executable `--rsh` shim that drops the host operand and runs
+/// oc-rsync as the remote `--server`, giving a real two-process transfer with no
+/// sshd.
+fn write_rsh_shim(dir: &Path) -> PathBuf {
+    let path = dir.join("rsh.sh");
+    fs::write(
+        &path,
+        format!(
+            "#!/bin/sh\nshift\nexec {} \"$@\"\n",
+            oc_rsync_binary().display()
+        ),
+    )
+    .expect("write rsh shim");
+    let mut perms = fs::metadata(&path).expect("stat shim").permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).expect("chmod shim");
+    path
+}
+
+fn run_with_timeout(mut command: Command) -> Output {
+    let mut child = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn oc-rsync");
+    let deadline = Instant::now() + RUN_TIMEOUT;
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                panic!("oc-rsync did not exit within {RUN_TIMEOUT:?}");
+            }
+            None => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+    child.wait_with_output().expect("collect output")
+}
+
+/// Restores the fixture's directory mode however the test leaves.
+struct ModeGuard(PathBuf);
+
+impl Drop for ModeGuard {
+    fn drop(&mut self) {
+        if let Ok(meta) = fs::metadata(&self.0) {
+            let mut perms = meta.permissions();
+            perms.set_mode(0o755);
+            let _ = fs::set_permissions(&self.0, perms);
+        }
+    }
+}
+
+/// Pushes into `<dst>/sub/` where `<dst>` is not writable, so the *server*
+/// receiver fails to create the destination root. Returns the client's exit
+/// code and its combined output.
+fn push_into_unwritable_parent(extra: &[&str]) -> (i32, String) {
+    let scratch = TempDir::new().expect("tempdir");
+    let src = scratch.path().join("src");
+    let dst = scratch.path().join("dst");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::create_dir_all(&dst).expect("mkdir dst");
+    fs::write(src.join("f.txt"), b"payload").expect("write source file");
+
+    let shim = write_rsh_shim(scratch.path());
+
+    let guard = ModeGuard(dst.clone());
+    let mut perms = fs::metadata(&dst).expect("stat dst").permissions();
+    perms.set_mode(0o555);
+    fs::set_permissions(&dst, perms).expect("chmod dst");
+
+    let mut command = Command::new(oc_rsync_binary());
+    command.arg("-e").arg(&shim);
+    command.args(extra);
+    command.arg("-r");
+    command.arg(format!("{}/", src.display()));
+    command.arg(format!("host:{}/sub/", dst.display()));
+
+    let output = run_with_timeout(command);
+    drop(guard);
+
+    let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+    text.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.code().unwrap_or(-1), text)
+}
+
+/// The regression. At the negotiated default protocol the server receiver's
+/// `RERR_FILESELECT` must arrive as the client's own exit code.
+///
+/// Before the fix the server exited a flat `1` with no `MSG_ERROR_EXIT`, so the
+/// client only saw the stream end and reported `RERR_STREAMIO` (12).
+///
+/// upstream: cleanup.c:250 `send_msg_int(MSG_ERROR_EXIT, exit_code)`;
+/// io.c:1892 `_exit_cleanup(val, __FILE__, 0 - __LINE__)`.
+#[test]
+fn server_fatal_exit_code_reaches_the_client() {
+    if is_root() {
+        eprintln!("skip: running as root, the unwritable-destination path cannot fire");
+        return;
+    }
+
+    let (code, text) = push_into_unwritable_parent(&[]);
+    assert_eq!(
+        code, 3,
+        "the client must exit with the server's RERR_FILESELECT, not a \
+         locally-inferred code; output was:\n{text}"
+    );
+}
+
+/// The gate's companion: below protocol 31 upstream sends nothing, and the
+/// client is left inferring `RERR_STREAMIO` (12) from the closed stream. This
+/// row is green both before and after the fix, so a blanket "always propagate"
+/// change would redden it.
+///
+/// upstream: cleanup.c:244 `protocol_version >= 31`.
+#[test]
+fn protocol_30_keeps_the_stream_io_code() {
+    if is_root() {
+        eprintln!("skip: running as root, the unwritable-destination path cannot fire");
+        return;
+    }
+
+    let (code, text) = push_into_unwritable_parent(&["--protocol=30"]);
+    assert_eq!(
+        code, 12,
+        "protocol 30 is below upstream's MSG_ERROR_EXIT gate, so the client \
+         must still report RERR_STREAMIO; output was:\n{text}"
+    );
+}
+
+/// A transfer that succeeds keeps exiting 0 over the same remote-shell path, so
+/// the new producer cannot be firing on the happy path.
+#[test]
+fn a_successful_remote_shell_push_still_exits_zero() {
+    let scratch = TempDir::new().expect("tempdir");
+    let src = scratch.path().join("src");
+    let dst = scratch.path().join("dst");
+    fs::create_dir_all(&src).expect("mkdir src");
+    fs::create_dir_all(&dst).expect("mkdir dst");
+    fs::write(src.join("f.txt"), b"payload").expect("write source file");
+
+    let shim = write_rsh_shim(scratch.path());
+
+    let mut command = Command::new(oc_rsync_binary());
+    command.arg("-e").arg(&shim);
+    command.arg("-r");
+    command.arg(format!("{}/", src.display()));
+    command.arg(format!("host:{}/", dst.display()));
+
+    let output = run_with_timeout(command);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "a clean push must still exit 0; stderr was:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read(dst.join("f.txt")).expect("destination file"),
+        b"payload",
+        "the payload must land"
+    );
+}


### PR DESCRIPTION
## The gap

A `--server` process that failed mid-transfer told the client nothing. `run_server_mode()` collapsed every `run_server_stdio()` error to a flat `1` and dropped the connection, so the peer only ever saw the stream end and had to guess a code.

Measured over a remote shell against the pinned rsync 3.5.0, for a push whose server receiver cannot create its destination root:

| client | server | protocol | client-observed exit | |
|--------|--------|----------|----------------------|---|
| rsync  | rsync  | 32       | 3                    | reference |
| rsync  | oc     | 32       | 12                   | server sent no code |
| oc     | oc     | 32       | 12                   | server sent no code |
| oc     | rsync  | 32       | 10                   | code received, then discarded |
| rsync  | rsync  | 30       | 12                   | reference, below the gate |

## Upstream

`MSG_ERROR_EXIT` (`rsync.h:305`, tag 86) carries a 4-byte little-endian `RERR_*`. There are four write sites:

- `cleanup.c:250` - `_exit_cleanup()` originates the code it is about to exit with.
- `io.c:1872`, `io.c:1881`, `io.c:1887` - three relay arms inside the `read_a_msg()` handler that keep a forked sibling pair in step. None originates a code.

Only the first applies to a peer with no forked siblings, so only it is ported.

The read side is `io.c:1854-1890`: the handler ends in the NORETURN `_exit_cleanup(val, __FILE__, 0 - __LINE__)`, so the receiving process exits with the peer's code, and the negative line suppresses both a duplicate diagnostic and an echo of the frame.

`cleanup.c:243-256` gates the send on: a non-zero code that is not one of `RERR_SOCKETIO` / `RERR_STREAMIO` / `RERR_SIGNAL1` / `RERR_TIMEOUT`, `!shutting_down`, `line > 0`, and `protocol_version >= 31 || am_receiver`.

## The `am_receiver` half of the gate is not a wire condition

`am_receiver` is true in the forked receiver **child**, whose `send_msg()` buffers into the sibling message channel its parent generator drains - not into the socket the client reads. oc runs one process with no sibling channel, so porting `am_receiver` as a wire exemption would emit the frame where upstream emits nothing. The wire agrees: the same server-receiver failure reports 3 to the client at protocol 32 and 12 at `--protocol=30`. The port therefore gates on the protocol version alone, for both roles.

## The change

- `transfer::announce_error_exit` writes the frame from the role dispatch in `run_server_with_handshake_adopting`, while the multiplexed writer is still alive, under upstream's gate. `ServerWriter::send_error_exit` is the `send_msg_int(MSG_ERROR_EXIT, code)` equivalent.
- `run_server_mode()` exits with the `RERR_*` the failure maps to instead of `1`, and its `rsync error:` trailer carries the same code rather than a hardcoded `(code 1)`.
- The SSH client honours a peer's `MSG_ERROR_EXIT` the way the daemon client already did. Without it the abort surfaced as a local `ConnectionAborted` and reported `RERR_SOCKETIO` (10) whatever the server had exited with.
- The `io::Error` to `RERR_*` mapping moves from `ExitCode::from_io_error` down into `transfer::error::rerr_for_io_error`, one crate below, so the client and the server producer cannot answer differently. `from_io_error` delegates to it; behaviour is unchanged.

## After

All four combinations report 3 at protocol 32 and 12 at `--protocol=30`, matching upstream row for row.

## Tests

`tests/server_error_exit_code_reaches_client.rs` drives a real two-process transfer through an `--rsh` shim and asserts on the exit code the **client process** reports:

- `server_fatal_exit_code_reaches_the_client` - 3, the regression.
- `protocol_30_keeps_the_stream_io_code` - 12, the gate's companion.
- `a_successful_remote_shell_push_still_exits_zero` - 0, the happy path.

`crates/transfer/src/tests/error_exit_gate.rs` pins the emitted frame bytes and each arm of the gate: announced at 31/32, silent at 30, silent for the four transport-class codes, silent for an exit a peer asked for.

Mutation proof, run twice:

- Producer disabled (`announce_error_exit` returns early): the regression test reddens with `left: 12, right: 3`; both companions stay green.
- Consumer disabled (the SSH client's `remote_exit_code` arm): the regression test reddens with `left: 10, right: 3`; both companions stay green.

## Out of scope

Two neighbours are left untouched, both belonging to the in-flight IOBUF work:

- oc has no `noop_io_until_death()` (`cleanup.c:252`), so after announcing the code the server exits rather than lingering until the peer dies.
- The `@ERROR: ` payload-prefix divergence.

Separately, a pull whose server **sender** cannot chdir into the source reports 23 in oc against upstream's 12. That is a different failure classification, unchanged by this PR, and needs its own measurement.
