### PR TITLE
perf(fast_io): write small batches positionally instead of through io_uring

### DIFF
--- a/crates/fast_io/src/io_uring/batching.rs
+++ b/crates/fast_io/src/io_uring/batching.rs
@@ -1,6 +1,9 @@
 //! Batched SQE submission helpers for io_uring file and socket I/O.
 
+use std::fs::File;
 use std::io;
+use std::os::unix::fs::FileExt;
+use std::os::unix::io::AsRawFd;
 
 use io_uring::{IoUring as RawIoUring, opcode, types};
 
@@ -43,16 +46,88 @@ pub(super) fn try_register_fd(ring: &RawIoUring, raw_fd: i32, register: bool) ->
     }
 }
 
+/// Smallest batch, in write SQEs, for which an io_uring round trip pays.
+///
+/// [`submit_write_batch`] pushes a batch, blocks in `submit_and_wait` until
+/// every SQE in it has completed, then drains the completion queue before the
+/// next batch is built. Nothing is in flight across batches, so the only
+/// concurrency io_uring can add is *within* one batch. A batch of a single
+/// chunk therefore buys nothing: it costs SQE construction, a ring transition,
+/// a CQE drain and per-slot bookkeeping on top of exactly the blocking wait a
+/// plain `pwrite(2)` would have done.
+///
+/// The value is the smallest one measured to remove the whole cost. On a
+/// 10,000-file / 313 MB loopback daemon pull (9000x1 KiB + 800x100 KiB +
+/// 200x1 MiB, aarch64, 4 cores) the receiver issues 10,600 write batches, and
+/// the count reaching the ring falls 10,600 -> 1,600 -> 800 -> 0 as this
+/// constant goes 1 -> 2 -> 4 -> 8; no batch on that workload is 8 chunks or
+/// larger. Wall clock tracks it: at 1 the pull costs ~4.8x the
+/// io_uring-disabled floor, at 2 ~1.6x, and at 8 it sits on the floor.
+/// Batches at or above this size keep the ring, because nothing measured says
+/// they are worse there.
+///
+/// Setting this to `1` disables the bypass; the ring then sees every write, as
+/// it did before.
+pub(super) const MIN_RING_BATCH_CHUNKS: usize = 8;
+
+/// Number of write SQEs the next batch over `remaining` bytes would submit.
+///
+/// Mirrors the batch sizing in [`submit_write_batch`]: `chunk_size`-sized
+/// pieces, capped at the ring's `max_sqes` submission-queue depth.
+pub(super) fn next_batch_chunks(remaining: usize, chunk_size: usize, max_sqes: usize) -> usize {
+    remaining.div_ceil(chunk_size).min(max_sqes)
+}
+
+/// Whether that batch should go to [`write_all_positional`] instead of the ring.
+pub(super) fn batch_bypasses_ring(remaining: usize, chunk_size: usize, max_sqes: usize) -> bool {
+    next_batch_chunks(remaining, chunk_size, max_sqes) < MIN_RING_BATCH_CHUNKS
+}
+
+/// Writes all of `data` at `base_offset` with positional writes.
+///
+/// The fallback [`submit_write_batch`] takes for batches too small to amortise
+/// a ring round trip. Byte-for-byte equivalent to the ring path: the same
+/// offsets, the same short-write resubmission, and the same `WriteZero` error
+/// when the kernel accepts nothing. `EINTR` is retried rather than surfaced --
+/// the ring path never reports it either, since a completed `IORING_OP_WRITE`
+/// carries the byte count, not the signal.
+pub(super) fn write_all_positional(
+    file: &File,
+    data: &[u8],
+    base_offset: u64,
+) -> io::Result<usize> {
+    let mut done = 0usize;
+    while done < data.len() {
+        match file.write_at(&data[done..], base_offset + done as u64) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "write returned 0 bytes",
+                ));
+            }
+            Ok(n) => done += n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(done)
+}
+
 /// Submits a batch of write SQEs from contiguous `data` and collects completions.
 ///
 /// Splits `data` into `chunk_size`-sized pieces, submitting up to `max_sqes` at
 /// a time. Handles short writes by resubmitting the remainder.
 ///
+/// A batch of fewer than [`MIN_RING_BATCH_CHUNKS`] chunks is written with
+/// [`write_all_positional`] instead: the ring is drained between batches, so
+/// such a batch would block exactly as long as a `pwrite(2)` while adding the
+/// submission and completion work on top.
+///
 /// When `fixed_fd_slot` is not `NO_FIXED_FD`, SQEs use the registered fixed-file
 /// index and set `IOSQE_FIXED_FILE`.
 pub(super) fn submit_write_batch(
     ring: &mut RawIoUring,
-    fd: types::Fd,
+    file: &File,
     data: &[u8],
     base_offset: u64,
     chunk_size: usize,
@@ -63,13 +138,20 @@ pub(super) fn submit_write_batch(
         return Ok(0);
     }
 
+    let fd = sqe_fd(file.as_raw_fd(), fixed_fd_slot);
     let total = data.len();
     let mut global_done = 0usize;
 
     while global_done < total {
         let remaining = total - global_done;
 
-        let n_chunks = remaining.div_ceil(chunk_size).min(max_sqes);
+        if batch_bypasses_ring(remaining, chunk_size, max_sqes) {
+            global_done +=
+                write_all_positional(file, &data[global_done..], base_offset + global_done as u64)?;
+            continue;
+        }
+
+        let n_chunks = next_batch_chunks(remaining, chunk_size, max_sqes);
         // Per-chunk tracking: (chunk_start_in_data, chunk_len, bytes_written_so_far).
         let mut slots: Vec<(usize, usize, usize)> = Vec::with_capacity(n_chunks);
         for i in 0..n_chunks {

--- a/crates/fast_io/src/io_uring/disk_batch.rs
+++ b/crates/fast_io/src/io_uring/disk_batch.rs
@@ -210,13 +210,12 @@ impl IoUringDiskBatch {
             )
         })?;
 
-        let fd = sqe_fd(active.file.as_raw_fd(), NO_FIXED_FD);
         let len = self.buffer_pos;
         let offset = active.bytes_written;
 
         let written = submit_write_batch(
             &mut self.ring,
-            fd,
+            &active.file,
             &self.buffer[..len],
             offset,
             self.config.buffer_size,

--- a/crates/fast_io/src/io_uring/file_writer.rs
+++ b/crates/fast_io/src/io_uring/file_writer.rs
@@ -30,7 +30,11 @@ use crate::traits::FileWriter;
 ///
 /// Incoming writes are buffered internally. On `flush()` (or when the buffer
 /// fills), the buffered data is submitted as a batch of write SQEs -- up to
-/// `sq_entries` concurrent writes per `submit_and_wait` call.
+/// `sq_entries` of them, which the kernel may run concurrently *within* that
+/// one `submit_and_wait` call. Batches do not overlap: the ring is drained to
+/// empty before the next one is built, so a batch of a single chunk gains no
+/// concurrency at all. Those go to a positional write instead; see
+/// [`super::batching::MIN_RING_BATCH_CHUNKS`].
 ///
 /// Submissions are issued against the calling thread's per-thread ring (see
 /// [`super::per_thread_ring`]). Fixed-file registration and registered-buffer
@@ -167,13 +171,19 @@ impl IoUringWriter {
     /// Submits up to `sq_entries` writes per `submit_and_wait` call on the
     /// per-thread ring.
     pub fn write_all_batched(&mut self, data: &[u8], offset: u64) -> io::Result<()> {
-        let raw_fd = self.file.as_raw_fd();
-        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
         let buffer_size = self.buffer_size;
         let sq_entries = self.sq_entries as usize;
 
         let written = with_ring(|ring| {
-            submit_write_batch(ring, fd, data, offset, buffer_size, sq_entries, NO_FIXED_FD)
+            submit_write_batch(
+                ring,
+                &self.file,
+                data,
+                offset,
+                buffer_size,
+                sq_entries,
+                NO_FIXED_FD,
+            )
         })?;
         if written != data.len() {
             return Err(io::Error::new(
@@ -218,8 +228,6 @@ impl IoUringWriter {
             return Ok(());
         }
 
-        let raw_fd = self.file.as_raw_fd();
-        let fd = sqe_fd(raw_fd, NO_FIXED_FD);
         let len = self.buffer_pos;
         let offset = self.bytes_written;
         let buffer_size = self.buffer_size;
@@ -228,7 +236,7 @@ impl IoUringWriter {
         let written = with_ring(|ring| {
             submit_write_batch(
                 ring,
-                fd,
+                &self.file,
                 &self.buffer[..len],
                 offset,
                 buffer_size,

--- a/crates/fast_io/src/io_uring/tests.rs
+++ b/crates/fast_io/src/io_uring/tests.rs
@@ -1630,3 +1630,128 @@ fn test_registered_buffer_disabled_still_works() {
         assert_eq!(read_back, data);
     }
 }
+
+/// The routing decision itself, tabulated. A batch smaller than
+/// [`MIN_RING_BATCH_CHUNKS`] chunks goes to the positional write; anything at
+/// or above it keeps the ring.
+///
+/// The rows are the shapes the receiver actually produces on a daemon pull:
+/// `flush_buffer` passes `chunk_size == buffer_size` with at most a full
+/// buffer of data, so it can only ever build a single chunk, while
+/// `write_all_batched` is the one caller that can exceed one chunk.
+#[test]
+fn small_batches_bypass_the_ring_and_large_ones_do_not() {
+    use super::batching::{MIN_RING_BATCH_CHUNKS, batch_bypasses_ring, next_batch_chunks};
+
+    let chunk = 4096usize;
+    let sq = 64usize;
+
+    // A single chunk buys no concurrency: the ring is drained before the next
+    // batch is built, so this is a blocking round trip with extra bookkeeping.
+    assert_eq!(next_batch_chunks(1024, chunk, sq), 1);
+    assert!(batch_bypasses_ring(1024, chunk, sq));
+    assert!(batch_bypasses_ring(chunk, chunk, sq));
+
+    // Just under the threshold still bypasses.
+    let under = (MIN_RING_BATCH_CHUNKS - 1) * chunk;
+    assert_eq!(
+        next_batch_chunks(under, chunk, sq),
+        MIN_RING_BATCH_CHUNKS - 1
+    );
+    assert!(batch_bypasses_ring(under, chunk, sq));
+
+    // At the threshold and above, the ring keeps the batch.
+    let at = MIN_RING_BATCH_CHUNKS * chunk;
+    assert_eq!(next_batch_chunks(at, chunk, sq), MIN_RING_BATCH_CHUNKS);
+    assert!(!batch_bypasses_ring(at, chunk, sq));
+    assert!(!batch_bypasses_ring(at + 1, chunk, sq));
+
+    // The submission-queue depth caps the batch, so a shallow ring can never
+    // reach the threshold and always takes the positional write.
+    assert_eq!(next_batch_chunks(1 << 20, chunk, 2), 2);
+    assert!(batch_bypasses_ring(1 << 20, chunk, 2));
+}
+
+/// Both routes must land the same bytes at the same offsets. Payloads either
+/// side of the threshold go through the same entry point and are compared
+/// against what was asked for, including a non-zero base offset.
+#[test]
+fn both_write_routes_produce_identical_bytes_at_the_same_offsets() {
+    use std::fs::File;
+
+    use super::batching::MIN_RING_BATCH_CHUNKS;
+    use super::per_thread_ring::with_ring;
+
+    if with_ring(|_| Ok(())).is_err() {
+        return;
+    }
+
+    let dir = tempdir().expect("tempdir");
+    let chunk = 4096usize;
+
+    // Payloads below the threshold (positional route) and above it (ring
+    // route), each with and without a partial trailing chunk.
+    let sizes = [
+        1024usize,
+        chunk,
+        (MIN_RING_BATCH_CHUNKS - 1) * chunk + 17,
+        MIN_RING_BATCH_CHUNKS * chunk,
+        (MIN_RING_BATCH_CHUNKS + 3) * chunk + 91,
+    ];
+
+    for (i, len) in sizes.iter().copied().enumerate() {
+        let payload: Vec<u8> = (0..len).map(|b| (b % 251) as u8).collect();
+        let path = dir.path().join(format!("route-{i}.bin"));
+        let offset = 8192u64;
+
+        let file = File::create(&path).expect("create");
+        let mut writer = IoUringWriter::with_ring(file, chunk, 64, -1, false, 0);
+        writer
+            .write_all_batched(&payload, offset)
+            .expect("batched write");
+        drop(writer);
+
+        let written = std::fs::read(&path).expect("read back");
+        assert_eq!(
+            written.len() as u64,
+            offset + len as u64,
+            "len {len}: file must end exactly at offset + payload"
+        );
+        assert_eq!(
+            &written[offset as usize..],
+            &payload[..],
+            "len {len}: payload bytes must match at the requested offset"
+        );
+        assert!(
+            written[..offset as usize].iter().all(|&b| b == 0),
+            "len {len}: nothing may be written before the requested offset"
+        );
+    }
+}
+
+/// `write_all_positional` on its own: every byte lands at `base_offset`, and an
+/// empty slice is a no-op rather than a zero-length write.
+#[test]
+fn positional_write_places_every_byte_at_the_requested_offset() {
+    use std::fs::File;
+
+    use super::batching::write_all_positional;
+
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().join("positional.bin");
+    let file = File::create(&path).expect("create");
+
+    assert_eq!(write_all_positional(&file, b"", 0).expect("empty"), 0);
+
+    let payload: Vec<u8> = (0..9_973u32).map(|b| (b % 251) as u8).collect();
+    assert_eq!(
+        write_all_positional(&file, &payload, 4096).expect("write"),
+        payload.len()
+    );
+    drop(file);
+
+    let written = std::fs::read(&path).expect("read back");
+    assert_eq!(written.len(), 4096 + payload.len());
+    assert_eq!(&written[4096..], &payload[..]);
+    assert!(written[..4096].iter().all(|&b| b == 0));
+}


### PR DESCRIPTION
## The defect

`submit_write_batch` pushes a batch of write SQEs, blocks in `submit_and_wait`
until every one has completed, then drains the completion queue before building
the next batch (`crates/fast_io/src/io_uring/batching.rs`). Nothing is ever in
flight across batches, so the only concurrency io_uring can add is *within* one
batch - and a batch of a single chunk has none. For such a batch the ring
performs exactly the blocking wait a `pwrite(2)` would have done, plus SQE
construction, a ring transition, a CQE drain and per-slot bookkeeping.

A receiver pulling many small files hits that case on every file: the whole file
fits the writer's buffer, so each flush is a one-chunk batch and each file costs
one `io_uring_enter` round trip that buys nothing.

The doc comment on `IoUringWriter` claimed "`sq_entries` concurrent writes per
`submit_and_wait` call". That is true within a batch, but the batch is drained
before the next is built, so it overstated what the layer delivers. Corrected in
the same commit.

## Measurement

10,000 files / 313 MB over a loopback `rsync://` daemon pull; aarch64, 4 cores,
kernel 7.0.0. Three iterations, arms interleaved, every row `rc=0` and
`files=10000`. Load average was *falling* across the run (1.64 -> 1.08), so the
fast arms are not flattered by a quieting host.

| arm | 1 | 2 | 3 | mean |
|---|---|---|---|---|
| upstream rsync 3.5.0 | 1145 | 937 | 946 | ~941 ms |
| oc before, io_uring ON | 1110 | 1110 | 1099 | **1106 ms** |
| oc after, io_uring ON | 443 | 441 | 465 | **450 ms** |
| oc before, `OC_RSYNC_DISABLE_IOURING=1` | 444 | 451 | 484 | 460 ms |

io_uring cost **2.47x** on this workload. After the change the io_uring-ON arm
sits on the disabled-path floor, and oc is 2.1x faster than upstream.

## The change

A batch below `MIN_RING_BATCH_CHUNKS` goes to `write_all_positional`, which
keeps the ring path's contract byte for byte: same offsets, same short-write
resubmission, same `WriteZero` on a zero-length accept, and `EINTR` retried
rather than surfaced (a completed `IORING_OP_WRITE` carries the byte count, not
the signal). Batches at or above the threshold keep the ring, since no
measurement says they are worse there.

`submit_write_batch` now takes `&File` rather than a bare `types::Fd` so it can
reach `FileExt::write_at`. The SQE fd is derived inside from the same handle, so
registered-file behaviour is unchanged and no `unsafe` is added.

The threshold is measured, not guessed. On this workload the receiver issues
10,600 write batches, and the count reaching the ring falls 10,600 -> 1,600 ->
800 -> 0 as the constant goes 1 -> 2 -> 4 -> 8; wall clock tracks it (~4.8x the
floor at 1, ~1.6x at 2, on the floor at 8). No batch on this workload is 8
chunks or larger, and the doc comment says so explicitly rather than implying
the value is bounded from above by evidence.

## Verification

- **Data correctness**: full 10,000-file / 313 MB pull through the new path,
  `md5sum` over every file compared source vs destination - identical
  (`9a00464040860872dd272a575bcb9a7d` both sides). A file count alone would not
  have caught corruption on a write-path change.
- **Non-vacuity**: setting `MIN_RING_BATCH_CHUNKS` back to `1` reddens
  `small_batches_bypass_the_ring_and_large_ones_do_not`
  (`assertion failed: batch_bypasses_ring(1024, chunk, sq)`).
- `cargo fmt --all -- --check` - clean.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings` - clean.
- `cargo nextest run --locked -p fast_io --all-features --no-fail-fast` - 1168 run, 1168 passed, 1 skipped.

## Deliberately unchanged

`IoUringWriter::write_at` still issues a single blocking SQE. It is the same
shape, but it has no production caller on the io_uring path (only its own
definition and tests), so routing it would be a change without a workload.
