### PR TITLE
refactor(transfer): make the directory walk resumable, and scan one level with it

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -363,14 +363,10 @@ impl GeneratorContext {
     ///
     /// - `rsync.c:424` - `i = ndx - cur_flist->ndx_start`
     pub(crate) fn wire_to_flat_ndx(&self, wire_ndx: i32) -> usize {
-        let segments = &self.incremental.ndx_segments;
+        let map = &self.incremental.ndx_map;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
-        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
-        let seg_idx = segments
-            .partition_point(|&(_, ndx_start)| ndx_start <= wire_ndx)
-            .saturating_sub(1);
-        let (flat_start, ndx_start) = segments[seg_idx];
-        flat_start + (wire_ndx - ndx_start) as usize
+        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(map.len()), Ordering::Relaxed);
+        map.wire_to_flat(wire_ndx)
     }
 
     /// Resolves a wire NDX read back from the receiver to the flat `file_list`
@@ -397,20 +393,7 @@ impl GeneratorContext {
     /// - `generator.c:2306-2313` - each sub-list (including the initial list
     ///   whose `parent_ndx >= 0`) itemizes its owning directory at `ndx_start - 1`.
     pub(crate) fn resolve_itemize_ndx(&self, wire_ndx: i32) -> usize {
-        let segments = &self.incremental.ndx_segments;
-        // A gap NDX `g` satisfies `g + 1 == ndx_start` for exactly one sub-list;
-        // no regular entry's NDX can equal a sub-list start minus one (the +1
-        // gap is reserved, flist.c:2966). Binary search is valid because
-        // `ndx_start` values are strictly increasing.
-        if let Ok(seg_idx) =
-            segments.binary_search_by(|&(_, ndx_start)| ndx_start.cmp(&(wire_ndx + 1)))
-        {
-            let parent_flat = self.incremental.segment_parent_flat[seg_idx];
-            if parent_flat >= 0 {
-                return parent_flat as usize;
-            }
-        }
-        self.wire_to_flat_ndx(wire_ndx)
+        self.incremental.ndx_map.resolve_itemize(wire_ndx)
     }
 
     /// Converts a flat file list array index to a wire NDX value.
@@ -427,12 +410,10 @@ impl GeneratorContext {
     /// - `generator.c:2338` - `ndx = i + cur_flist->ndx_start`
     #[cfg(test)]
     pub(crate) fn flat_to_wire_ndx(&self, flat_idx: usize) -> i32 {
-        let segments = &self.incremental.ndx_segments;
+        let map = &self.incremental.ndx_map;
         NDX_CONVERT_CALLS.fetch_add(1, Ordering::Relaxed);
-        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(segments.len()), Ordering::Relaxed);
-        let seg_idx = segments.partition_point(|&(start, _)| start <= flat_idx) - 1;
-        let (flat_start, ndx_start) = segments[seg_idx];
-        ndx_start + (flat_idx - flat_start) as i32
+        NDX_CONVERT_CMPS.fetch_add(partition_point_depth(map.len()), Ordering::Relaxed);
+        map.flat_to_wire(flat_idx)
     }
 
     /// Returns the negotiated protocol version.
@@ -1188,16 +1169,10 @@ impl GeneratorContext {
     /// - `flist.c:2980 flist_free()` - frees completed file list segments
     /// - `sender.c:248` - `flist_free(first_flist)` in sender transfer loop
     pub(crate) fn reclaim_oldest_segment(&mut self) {
-        let segments = &self.incremental.ndx_segments;
-        let first = self.incremental.first_segment_idx;
-
-        // Must have at least 2 segments to reclaim (keep the current one).
-        if first + 1 >= segments.len() {
+        let Some((start, end)) = self.incremental.ndx_map.reclaimable_range() else {
             return;
-        }
-
-        let start = segments[first].0;
-        let end = segments[first + 1].0;
+        };
+        let first = self.incremental.ndx_map.first_live();
 
         logging::debug_log!(
             Flist,
@@ -1214,7 +1189,7 @@ impl GeneratorContext {
         for base in &mut self.source_bases[start..end] {
             *base = Arc::clone(&empty);
         }
-        self.incremental.first_segment_idx += 1;
+        self.incremental.ndx_map.advance_reclaimed();
     }
 }
 

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -37,11 +37,7 @@ impl GeneratorContext {
         // upstream: hlink.c:match_hard_links() stores flist->ndx_start + i
         // as the leader's gnum. Followers reference this wire NDX value so the
         // receiver can look up the leader at (received_value - ndx_start).
-        let ndx_start = self
-            .incremental
-            .ndx_segments
-            .first()
-            .map_or(0, |&(_, start)| start) as u32;
+        let ndx_start = self.incremental.ndx_map.first_ndx_start() as u32;
 
         for i in 0..self.file_list.len() {
             let entry = &self.file_list[i];

--- a/crates/transfer/src/generator/file_list/inc_recurse.rs
+++ b/crates/transfer/src/generator/file_list/inc_recurse.rs
@@ -297,12 +297,13 @@ impl GeneratorContext {
         // first sorted entry's basename differs from ".", in which case the root
         // has no directory row. `.` is always the first initial entry (flat 0)
         // when present, so resolve its slot to flat 0; otherwise leave it -1.
-        self.incremental.segment_parent_flat[0] =
+        self.incremental.ndx_map.set_initial_parent_flat(
             if self.file_list.get(0).is_some_and(|e| e.name() == ".") {
                 0
             } else {
                 -1
-            };
+            },
+        );
     }
 }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -66,6 +66,61 @@ enum WalkStep {
     LeaveDir(filters::DirFilterGuard),
 }
 
+/// What the driver does when it reaches a subdirectory.
+///
+/// upstream: `flist.c:send_directory()` takes a flags word, and
+/// `send_extra_file_list()` passes `FLAG_DIVERT_DIRS` so a subdirectory found
+/// while scanning a sub-list is recorded and diverted rather than descended
+/// into. That single flag is why upstream never materialises the whole tree:
+/// one call scans one level, and the diverted directories become the work list
+/// for later calls.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Descent {
+    /// Descend into every subdirectory, so one drive produces the whole tree.
+    Recurse,
+    /// Emit a subdirectory's own entry and stop there - its children belong to
+    /// a later scan. upstream: `FLAG_DIVERT_DIRS`.
+    DivertDirs,
+}
+
+/// The two things every walk step needs that are not part of the step itself:
+/// the base the wire-side relative name is computed against, and how deep to go.
+///
+/// Carried as one value rather than two parameters so adding the policy does
+/// not widen every signature in the driver.
+#[derive(Clone, Copy)]
+struct WalkScope<'a> {
+    base: &'a Path,
+    descent: Descent,
+}
+
+impl<'a> WalkScope<'a> {
+    /// The whole-tree walk every existing caller performs.
+    fn recursive(base: &'a Path) -> Self {
+        Self {
+            base,
+            descent: Descent::Recurse,
+        }
+    }
+
+    /// One level only. upstream: `FLAG_DIVERT_DIRS`.
+    fn one_level(base: &'a Path) -> Self {
+        Self {
+            base,
+            descent: Descent::DivertDirs,
+        }
+    }
+
+    /// Whether a subdirectory reached under this scope is descended into.
+    ///
+    /// The transfer root is not governed by this: `send_file_list()` always
+    /// scans the root it was pointed at, whichever flags it carries. Only
+    /// directories found *inside* a scan are diverted.
+    fn descends_into_subdirs(self) -> bool {
+        matches!(self.descent, Descent::Recurse)
+    }
+}
+
 impl GeneratorContext {
     /// Pre-checks a top-level source entry and walks it if it exists.
     ///
@@ -237,7 +292,7 @@ impl GeneratorContext {
             metadata,
             is_top_level,
         }];
-        self.drive_walk(base, &mut stack)
+        self.drive_walk(WalkScope::recursive(base), &mut stack)
     }
 
     /// Runs the explicit walk stack to exhaustion.
@@ -246,17 +301,18 @@ impl GeneratorContext {
     /// scans first and releases its filter scope after - the same nesting the
     /// recursion produced. An error abandons the remaining steps, which is what
     /// the `?` in the recursive version did by unwinding.
-    fn drive_walk(&mut self, base: &Path, stack: &mut Vec<WalkStep>) -> io::Result<()> {
+    fn drive_walk(&mut self, scope: WalkScope<'_>, stack: &mut Vec<WalkStep>) -> io::Result<()> {
         while let Some(step) = stack.pop() {
             match step {
                 WalkStep::Visit {
                     path,
                     metadata,
                     is_top_level,
-                } => self.visit_walk_entry(base, path, metadata, is_top_level, stack)?,
+                } => self.visit_walk_entry(scope, path, metadata, is_top_level, stack)?,
                 WalkStep::VisitChild(result) => {
-                    if let Some((path, metadata)) = self.resolve_child_metadata(base, result) {
-                        self.visit_walk_entry(base, path, metadata, false, stack)?;
+                    if let Some((path, metadata)) = self.resolve_child_metadata(scope.base, result)
+                    {
+                        self.visit_walk_entry(scope, path, metadata, false, stack)?;
                     }
                 }
                 WalkStep::ScanChildren { dir, opened } => {
@@ -275,13 +331,13 @@ impl GeneratorContext {
     /// recursive calls replaced by pushes onto `stack`.
     fn visit_walk_entry(
         &mut self,
-        base: &Path,
+        scope: WalkScope<'_>,
         path: PathBuf,
         metadata: std::fs::Metadata,
         is_top_level: bool,
         stack: &mut Vec<WalkStep>,
     ) -> io::Result<()> {
-        let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
+        let relative = path.strip_prefix(scope.base).unwrap_or(&path).to_path_buf();
 
         // upstream: flist.c:2338-2349 - non-relative single-file sources split
         // on the last `/` so the wire-side relative name is just the basename
@@ -391,7 +447,12 @@ impl GeneratorContext {
         }
 
         // upstream: flist.c:send_file_list() - scan directory before recording entry
-        let should_recurse = metadata.is_dir() && self.config.flags.recursive;
+        //
+        // Under `FLAG_DIVERT_DIRS` the entry is still emitted; only the descent
+        // is withheld, so the directory becomes work for a later scan instead
+        // of being expanded into this one.
+        let should_recurse =
+            metadata.is_dir() && self.config.flags.recursive && scope.descends_into_subdirs();
         let dir_read = if should_recurse {
             match fast_io::pinned_root::read_dir(&path) {
                 Ok(entries) => Some(entries),
@@ -498,7 +559,56 @@ impl GeneratorContext {
             dir: dir_path.to_path_buf(),
             opened: None,
         }];
-        self.drive_walk(base, &mut stack)
+        self.drive_walk(WalkScope::recursive(base), &mut stack)
+    }
+
+    /// Scans exactly one directory: emits an entry per child and descends into
+    /// none of them.
+    ///
+    /// This is the producer step upstream's incremental recursion is built on.
+    /// `send_extra_file_list()` picks one directory off the directory list and
+    /// calls `send_directory()` with `FLAG_DIVERT_DIRS`, which emits that
+    /// directory's children and diverts any subdirectory among them instead of
+    /// expanding it. Each call therefore costs one level, not one subtree, and
+    /// the caller decides when to spend the next.
+    ///
+    /// Filter scope is entered and left around the scan, so per-directory merge
+    /// files apply to the children exactly as they do under the whole-tree walk.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_directory()` - reads one directory and stats each child
+    /// - `flist.c:send1extra()` - one directory, one sub-list
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "consumed by the lazy producer (LF-2c)")
+    )]
+    pub(in crate::generator) fn scan_one_directory(
+        &mut self,
+        base: &Path,
+        dir_path: &Path,
+    ) -> io::Result<()> {
+        // upstream: exclude.c:push_local_filters() - the per-directory scope the
+        // whole-tree walk enters before scanning, entered here for the same
+        // reason: the children are matched against this directory's merge files.
+        let guard = self.filter_chain.enter_directory(dir_path).map_err(|e| {
+            io::Error::other(format!(
+                "filter chain error in \"{}\": {e} {}{}",
+                dir_path.display(),
+                error_location!(),
+                crate::role_trailer::sender()
+            ))
+        })?;
+
+        // LIFO: the scan runs before the scope is released.
+        let mut stack = vec![
+            WalkStep::LeaveDir(guard),
+            WalkStep::ScanChildren {
+                dir: dir_path.to_path_buf(),
+                opened: None,
+            },
+        ];
+        self.drive_walk(WalkScope::one_level(base), &mut stack)
     }
 
     /// Opens `dir_path` when the caller did not, then schedules its children.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -24,6 +24,48 @@ use super::super::io_error_flags;
 use super::super::protocol_io::SenderDiagnostic;
 use super::batch_stat::{StatResult, batch_stat_dir_entries};
 
+/// One pending step of the directory walk.
+///
+/// The walk used to be call-stack recursion: a directory's entry was pushed,
+/// then each child was walked from inside that frame, wrapped in a filter-chain
+/// scope guard. That shape cannot be suspended, and suspending is exactly what
+/// upstream's producer does - `send_directory()` scans ONE directory and
+/// `send_extra_file_list()` (`flist.c`) decides when to scan the next.
+///
+/// Making the stack explicit preserves the traversal order and the guard
+/// nesting exactly while turning every pop into a point the walk can stop at.
+enum WalkStep {
+    /// A path whose metadata is already final: the entry points, which resolve
+    /// metadata before they call in.
+    Visit {
+        path: PathBuf,
+        metadata: std::fs::Metadata,
+        is_top_level: bool,
+    },
+    /// A directory child straight out of the batch stat.
+    ///
+    /// The `--copy-dirlinks` / `--copy-unsafe-links` re-stat is deliberately
+    /// NOT applied when the child is scheduled. It runs when the child is
+    /// reached, because its `copying unsafe symlink` notice must print after
+    /// the previous sibling's subtree, exactly as the recursion printed it.
+    VisitChild(StatResult),
+    /// Read `dir`'s children, batch-stat them, and schedule each one.
+    ///
+    /// `opened` carries a handle the caller already holds. The two arms are not
+    /// interchangeable: the recursive arm opens the directory BEFORE pushing
+    /// that directory's own entry, so an `opendir` failure is reported ahead of
+    /// the entry; the transfer-root arm opens it after entering the filter
+    /// scope. Which side opens is what keeps diagnostic ordering unchanged.
+    ScanChildren {
+        dir: PathBuf,
+        opened: Option<fast_io::pinned_root::ReadDir>,
+    },
+    /// Release one per-directory filter scope.
+    ///
+    /// upstream: `exclude.c:pop_local_filters()`
+    LeaveDir(filters::DirFilterGuard),
+}
+
 impl GeneratorContext {
     /// Pre-checks a top-level source entry and walks it if it exists.
     ///
@@ -190,6 +232,55 @@ impl GeneratorContext {
         metadata: std::fs::Metadata,
         is_top_level: bool,
     ) -> io::Result<()> {
+        let mut stack = vec![WalkStep::Visit {
+            path,
+            metadata,
+            is_top_level,
+        }];
+        self.drive_walk(base, &mut stack)
+    }
+
+    /// Runs the explicit walk stack to exhaustion.
+    ///
+    /// Steps pop LIFO, so a directory that schedules `[LeaveDir, ScanChildren]`
+    /// scans first and releases its filter scope after - the same nesting the
+    /// recursion produced. An error abandons the remaining steps, which is what
+    /// the `?` in the recursive version did by unwinding.
+    fn drive_walk(&mut self, base: &Path, stack: &mut Vec<WalkStep>) -> io::Result<()> {
+        while let Some(step) = stack.pop() {
+            match step {
+                WalkStep::Visit {
+                    path,
+                    metadata,
+                    is_top_level,
+                } => self.visit_walk_entry(base, path, metadata, is_top_level, stack)?,
+                WalkStep::VisitChild(result) => {
+                    if let Some((path, metadata)) = self.resolve_child_metadata(base, result) {
+                        self.visit_walk_entry(base, path, metadata, false, stack)?;
+                    }
+                }
+                WalkStep::ScanChildren { dir, opened } => {
+                    self.scan_children_onto(&dir, opened, stack)?;
+                }
+                WalkStep::LeaveDir(guard) => self.filter_chain.leave_directory(guard),
+            }
+        }
+        Ok(())
+    }
+
+    /// Emits one path's entry and schedules its children when it is a directory
+    /// to descend into.
+    ///
+    /// This is the body the recursion used to run per frame, with the two
+    /// recursive calls replaced by pushes onto `stack`.
+    fn visit_walk_entry(
+        &mut self,
+        base: &Path,
+        path: PathBuf,
+        metadata: std::fs::Metadata,
+        is_top_level: bool,
+        stack: &mut Vec<WalkStep>,
+    ) -> io::Result<()> {
         let relative = path.strip_prefix(base).unwrap_or(&path).to_path_buf();
 
         // upstream: flist.c:2338-2349 - non-relative single-file sources split
@@ -227,10 +318,12 @@ impl GeneratorContext {
                 ))
             })?;
 
-            self.scan_directory_batched(base, &path)?;
-
-            // upstream: exclude.c:pop_local_filters() - restore filter state
-            self.filter_chain.leave_directory(guard);
+            // LIFO: the scan runs before the scope is released.
+            stack.push(WalkStep::LeaveDir(guard));
+            stack.push(WalkStep::ScanChildren {
+                dir: path,
+                opened: None,
+            });
             return Ok(());
         }
 
@@ -343,11 +436,12 @@ impl GeneratorContext {
                 ))
             })?;
 
-            // Collect directory entries, then batch-stat and process
-            self.process_dir_entries_batched(base, &dir_path, entries)?;
-
-            // upstream: exclude.c:pop_local_filters() - restore filter state
-            self.filter_chain.leave_directory(guard);
+            // LIFO: the scan runs before the scope is released.
+            stack.push(WalkStep::LeaveDir(guard));
+            stack.push(WalkStep::ScanChildren {
+                dir: dir_path,
+                opened: Some(entries),
+            });
         }
 
         Ok(())
@@ -400,31 +494,62 @@ impl GeneratorContext {
     ///
     /// - `flist.c:send_directory()` - reads directory and stats each child
     fn scan_directory_batched(&mut self, base: &Path, dir_path: &Path) -> io::Result<()> {
-        match fast_io::pinned_root::read_dir(dir_path) {
-            Ok(entries) => self.process_dir_entries_batched(base, dir_path, entries),
-            Err(e) => {
-                // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
-                let text = format!(
-                    "rsync: [sender] opendir {} failed: {}\n",
-                    full_fname_path(dir_path, self.daemon_paths()),
-                    engine::local_copy::upstream_io_error(&e),
-                );
-                self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
-                self.record_io_error(&e);
-                Ok(())
-            }
-        }
+        let mut stack = vec![WalkStep::ScanChildren {
+            dir: dir_path.to_path_buf(),
+            opened: None,
+        }];
+        self.drive_walk(base, &mut stack)
     }
 
-    /// Collects paths from a `ReadDir` iterator, batch-stats them, and recurses.
+    /// Opens `dir_path` when the caller did not, then schedules its children.
     ///
-    /// For entries where `--copy-unsafe-links` requires re-stat (symlinks escaping
-    /// the transfer tree), the corrected metadata is resolved after the batch.
-    fn process_dir_entries_batched(
+    /// A failed `opendir` is reported and the directory skipped; it does not
+    /// abort the walk.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1878` - `rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)`
+    fn scan_children_onto(
         &mut self,
-        base: &Path,
+        dir_path: &Path,
+        opened: Option<fast_io::pinned_root::ReadDir>,
+        stack: &mut Vec<WalkStep>,
+    ) -> io::Result<()> {
+        let entries = match opened {
+            Some(entries) => entries,
+            None => match fast_io::pinned_root::read_dir(dir_path) {
+                Ok(entries) => entries,
+                Err(e) => {
+                    // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
+                    let text = format!(
+                        "rsync: [sender] opendir {} failed: {}\n",
+                        full_fname_path(dir_path, self.daemon_paths()),
+                        engine::local_copy::upstream_io_error(&e),
+                    );
+                    self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
+                    self.record_io_error(&e);
+                    return Ok(());
+                }
+            },
+        };
+        self.push_dir_entries_onto(dir_path, entries, stack)
+    }
+
+    /// Collects paths from a `ReadDir` iterator, batch-stats them, and schedules
+    /// each child on the walk stack.
+    ///
+    /// Children are pushed in reverse so they pop in readdir order, matching the
+    /// order the recursion visited them.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:send_directory()` - reads directory and stats each child
+    /// - `flist.c:2195` - `rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)`
+    fn push_dir_entries_onto(
+        &mut self,
         dir_path: &Path,
         entries: fast_io::pinned_root::ReadDir,
+        stack: &mut Vec<WalkStep>,
     ) -> io::Result<()> {
         // Phase 1: collect child paths from readdir
         let mut child_paths = Vec::new();
@@ -451,75 +576,89 @@ impl GeneratorContext {
         // Phase 2: determine stat mode and batch-resolve metadata.
         // --copy-links: follow all symlinks (fs::metadata)
         // default: lstat (fs::symlink_metadata)
-        // --copy-unsafe-links needs post-batch fixup for unsafe symlinks
+        // --copy-unsafe-links needs per-child fixup, applied when the child is
+        // reached rather than here - see `WalkStep::VisitChild`.
         let follow = self.config.flags.copy_links;
         let stat_results = batch_stat_dir_entries(child_paths, follow, &self.parallel_thresholds);
 
-        // Phase 3: process each (path, metadata) pair
-        for result in stat_results {
-            let StatResult { path, metadata } = result;
-            match metadata {
-                Ok(mut meta) => {
-                    // upstream: flist.c:1362-1370 link_stat() - with
-                    // --copy-dirlinks (follow_dirlinks), a symlink whose
-                    // target is a directory is transmitted as a real
-                    // directory. Applied before the copy-unsafe-links check
-                    // exactly as upstream applies it inside link_stat() before
-                    // readlink_stat() re-examines S_ISLNK. Only symlinks to
-                    // directories are followed; symlinks to files stay
-                    // symlinks (distinct from --copy-links, which follows all).
-                    if !follow && self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
-                        if let Ok(followed) = fast_io::pinned_root::metadata(&path) {
-                            if followed.file_type().is_dir() {
-                                meta = followed;
-                            }
-                        }
-                    }
+        // Phase 3: schedule each child. Reverse, because the stack pops LIFO.
+        stack.extend(stat_results.into_iter().rev().map(WalkStep::VisitChild));
 
-                    // upstream: flist.c:215 - follow unsafe symlinks when
-                    // --copy-unsafe-links. The batch used lstat, so we need
-                    // to re-stat symlinks whose target escapes the tree.
-                    if !follow
-                        && self.config.flags.copy_unsafe_links
-                        && meta.file_type().is_symlink()
-                    {
-                        if let Ok(target) = self.read_source_link(&path) {
-                            let relative = path.strip_prefix(base).unwrap_or(&path);
-                            if super::super::super::symlink_safety::is_unsafe_symlink(
-                                target.as_os_str(),
-                                relative,
-                            ) {
-                                // upstream: flist.c:229 - INFO_GTE(SYMSAFE, 1)
-                                // fires before the target is dereferenced.
-                                info_log!(
-                                    Symsafe,
-                                    1,
-                                    "copying unsafe symlink \"{}\" -> \"{}\"",
-                                    path.display(),
-                                    target.display()
-                                );
-                                match fast_io::pinned_root::metadata(&path) {
-                                    Ok(followed) => meta = followed,
-                                    Err(e) => {
-                                        self.log_stat_error(&path, &e);
-                                        self.record_io_error(&e);
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                    }
+        Ok(())
+    }
 
-                    self.walk_path_with_metadata(base, path, meta, false)?;
-                }
-                Err(e) => {
-                    self.log_stat_error(&path, &e);
-                    self.record_io_error(&e);
+    /// Applies the per-child stat fixups and reports the failures.
+    ///
+    /// Returns `None` when the child is dropped from the walk: its batch stat
+    /// failed, or the `--copy-unsafe-links` dereference failed. Both are logged
+    /// and counted as I/O errors without aborting the traversal.
+    ///
+    /// This runs when the child is REACHED, not when it is scheduled, so its
+    /// notices stay interleaved with the walk exactly as the recursion had them.
+    fn resolve_child_metadata(
+        &mut self,
+        base: &Path,
+        result: StatResult,
+    ) -> Option<(PathBuf, std::fs::Metadata)> {
+        let StatResult { path, metadata } = result;
+        let mut meta = match metadata {
+            Ok(meta) => meta,
+            Err(e) => {
+                self.log_stat_error(&path, &e);
+                self.record_io_error(&e);
+                return None;
+            }
+        };
+
+        let follow = self.config.flags.copy_links;
+
+        // upstream: flist.c:1362-1370 link_stat() - with --copy-dirlinks
+        // (follow_dirlinks), a symlink whose target is a directory is
+        // transmitted as a real directory. Applied before the copy-unsafe-links
+        // check exactly as upstream applies it inside link_stat() before
+        // readlink_stat() re-examines S_ISLNK. Only symlinks to directories are
+        // followed; symlinks to files stay symlinks (distinct from
+        // --copy-links, which follows all).
+        if !follow && self.config.flags.copy_dirlinks && meta.file_type().is_symlink() {
+            if let Ok(followed) = fast_io::pinned_root::metadata(&path) {
+                if followed.file_type().is_dir() {
+                    meta = followed;
                 }
             }
         }
 
-        Ok(())
+        // upstream: flist.c:215 - follow unsafe symlinks when
+        // --copy-unsafe-links. The batch used lstat, so we need to re-stat
+        // symlinks whose target escapes the tree.
+        if !follow && self.config.flags.copy_unsafe_links && meta.file_type().is_symlink() {
+            if let Ok(target) = self.read_source_link(&path) {
+                let relative = path.strip_prefix(base).unwrap_or(&path);
+                if super::super::super::symlink_safety::is_unsafe_symlink(
+                    target.as_os_str(),
+                    relative,
+                ) {
+                    // upstream: flist.c:229 - INFO_GTE(SYMSAFE, 1) fires before
+                    // the target is dereferenced.
+                    info_log!(
+                        Symsafe,
+                        1,
+                        "copying unsafe symlink \"{}\" -> \"{}\"",
+                        path.display(),
+                        target.display()
+                    );
+                    match fast_io::pinned_root::metadata(&path) {
+                        Ok(followed) => meta = followed,
+                        Err(e) => {
+                            self.log_stat_error(&path, &e);
+                            self.record_io_error(&e);
+                            return None;
+                        }
+                    }
+                }
+            }
+        }
+
+        Some((path, meta))
     }
 
     /// Logs a stat failure with the appropriate upstream error format.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -787,7 +787,7 @@ impl GeneratorContext {
                 format!("file has vanished: {fname}\n"),
             )
         } else {
-            // upstream: flist.c:1846 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
+            // upstream: flist.c:2011 - rsyserr(FERROR_XFER, errno, "link_stat %s failed", ...)
             (
                 SenderDiagnostic::ErrorXfer,
                 format!(
@@ -999,7 +999,7 @@ mod rsyserr_wording_tests {
     /// refactor that re-inserts the source-location or role-version trailer
     /// will fail these asserts.
     const CASES: &[(&str, &str)] = &[
-        // upstream: flist.c:1846 - "link_stat %s failed"
+        // upstream: flist.c:2011 - "link_stat %s failed"
         (
             "rsync: [sender] link_stat \"{path}\" failed: No such file or directory (2)",
             "rsync: [sender] link_stat \"/p\" failed: No such file or directory (2)",

--- a/crates/transfer/src/generator/mod.rs
+++ b/crates/transfer/src/generator/mod.rs
@@ -85,6 +85,7 @@ mod filters;
 pub mod io_error_flags;
 mod item_flags;
 pub mod itemize;
+mod ndx_map;
 mod open_source;
 mod pending_removal;
 mod protocol_io;

--- a/crates/transfer/src/generator/ndx_map.rs
+++ b/crates/transfer/src/generator/ndx_map.rs
@@ -1,0 +1,357 @@
+//! The wire-NDX to flat-index map: oc's analogue of upstream's `flist_for_ndx`.
+//!
+//! # What this replaces
+//!
+//! The same information used to live in three fields of `IncrementalState`,
+//! held in lockstep by hand:
+//!
+//! ```text
+//! ndx_segments:        Vec<(usize, i32)>   // (flat_start, ndx_start)
+//! segment_parent_flat: Vec<i32>            // aligned 1:1 with the above
+//! first_segment_idx:   usize               // reclaim cursor into both
+//! ```
+//!
+//! Two parallel arrays whose alignment was an unwritten invariant, plus three
+//! separate searches over them - `partition_point` in two directions and a
+//! `binary_search_by` for the gap - each spelled out at its own call site. The
+//! `+ 1` gap rule (`flist.c:2966`) was open-coded where sub-lists are pushed,
+//! away from the lookups that depend on it.
+//!
+//! [`NdxSegment`] makes the three values one record, so they cannot drift, and
+//! the searches become methods on [`NdxMap`], so the mapping has one owner.
+//!
+//! # Why this is NOT a `VecDeque`
+//!
+//! Upstream's chain of `struct file_list` is a deque - `flist_free()` drops the
+//! head - and it is tempting to mirror that here. It would be wrong. Upstream
+//! frees a whole sub-list, *including its index range*, because a receiver that
+//! is done with a sub-list never names it again. oc reclaims only the entry
+//! storage (`file_list.reclaim_segment`) and keeps the flat index space, so the
+//! mapping has to stay **total** for the entire transfer: a wire NDX is
+//! absolute, and resolving one from a reclaimed segment must still land on the
+//! right flat slot rather than on a neighbour's.
+//!
+//! So [`NdxMap::first_live`] is a reclaim cursor, not a front pointer, and the
+//! backing store stays a `Vec`. The deque belongs to the *owning* segment chain
+//! that a later change introduces; putting it here would silently corrupt
+//! every NDX below the reclaim point.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
+//! - `rsync.c:424` - `i = ndx - cur_flist->ndx_start`
+//! - `sender.c:267-272` - a gap NDX resolves to the owning directory
+//! - `flist.c:flist_free()` / `sender.c:248` - segment reclaim
+
+/// One sub-list's position in both index spaces.
+///
+/// upstream keeps these on `struct file_list`; oc holds one flat entry list, so
+/// a segment records where it starts in that list rather than owning entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NdxSegment {
+    /// First entry's index in the flat `file_list`.
+    flat_start: usize,
+    /// First entry's wire NDX. upstream `ndx_start`.
+    ndx_start: i32,
+    /// Flat index of the directory this sub-list expands, or `-1` when there is
+    /// none to itemize (an initial list whose first entry is not `.`).
+    ///
+    /// upstream reaches the same entry through
+    /// `dir_flist->files[cur_flist->parent_ndx]` (`sender.c:269-272`). oc has no
+    /// separate `dir_flist`, so the flat index is recorded directly and needs no
+    /// second translation.
+    parent_flat: i32,
+}
+
+impl NdxSegment {
+    /// Wire NDX of this segment's first entry.
+    pub(crate) fn ndx_start(&self) -> i32 {
+        self.ndx_start
+    }
+
+    /// Owning directory's flat index, if this sub-list has one to itemize.
+    fn parent_flat(&self) -> Option<usize> {
+        (self.parent_flat >= 0).then_some(self.parent_flat as usize)
+    }
+}
+
+/// The ordered segment table and the reclaim cursor into it.
+#[derive(Debug)]
+pub(crate) struct NdxMap {
+    /// Ordered by both `flat_start` and `ndx_start`, which increase together.
+    /// Never shrinks: see the module note on totality.
+    segments: Vec<NdxSegment>,
+    /// Index of the oldest segment whose entries have not been reclaimed.
+    ///
+    /// upstream `first_flist` (`flist.c:101`), advanced by `flist_free()`
+    /// (`sender.c:248`). Distinct from index 0 because the *mapping* outlives
+    /// the *storage*.
+    first_live: usize,
+}
+
+impl NdxMap {
+    /// A map holding just the initial list.
+    ///
+    /// `initial_ndx_start` comes from INC_RECURSE negotiation; without
+    /// INC_RECURSE it is 0 and this stays the only segment.
+    pub(crate) fn new(initial_ndx_start: i32) -> Self {
+        Self {
+            segments: vec![NdxSegment {
+                flat_start: 0,
+                ndx_start: initial_ndx_start,
+                parent_flat: -1,
+            }],
+            first_live: 0,
+        }
+    }
+
+    /// Wire NDX of the very first entry.
+    ///
+    /// Read by the flist writer to decide abbreviated vs unabbreviated hardlink
+    /// followers, and by hardlink numbering, which stores `ndx_start + i` as a
+    /// leader's gnum (`hlink.c:match_hard_links()`).
+    pub(crate) fn first_ndx_start(&self) -> i32 {
+        self.segments.first().map_or(0, NdxSegment::ndx_start)
+    }
+
+    /// Records which flat entry the *initial* list itemizes through its own gap
+    /// NDX, or `-1` when it has none.
+    ///
+    /// The initial segment is built before the file list is classified, so its
+    /// owning entry is only known afterwards. upstream keeps the equivalent in
+    /// `flist->parent_ndx` (`flist.c:2572`), which points at `dir_flist[0]`
+    /// (`.`) unless the first sorted entry's basename is not `.`.
+    pub(crate) fn set_initial_parent_flat(&mut self, parent_flat: i32) {
+        self.segments[0].parent_flat = parent_flat;
+    }
+
+    /// Appends a sub-list beginning at `flat_start`, owned by `parent_flat`.
+    ///
+    /// The wire `ndx_start` is derived here rather than by the caller, because
+    /// it is the one place the `+ 1` gap can be stated once:
+    /// `ndx_start = prev->ndx_start + prev->used + 1` (`flist.c:2966`). The
+    /// skipped slot belongs to the parent directory; computing it at a call
+    /// site is how it drifts from the lookups that assume it.
+    ///
+    /// `prev->used` is the previous segment's entry count, which for a flat
+    /// list is the distance between the two `flat_start` values.
+    pub(crate) fn push_sublist(&mut self, flat_start: usize, parent_flat: i32) -> i32 {
+        let prev = self
+            .segments
+            .last()
+            .copied()
+            .expect("the initial segment always exists");
+        let prev_used = (flat_start - prev.flat_start) as i32;
+        let ndx_start = prev.ndx_start + prev_used + 1;
+        self.segments.push(NdxSegment {
+            flat_start,
+            ndx_start,
+            parent_flat,
+        });
+        ndx_start
+    }
+
+    /// Number of segments recorded.
+    pub(crate) fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Resolves a wire NDX to its flat `file_list` index.
+    ///
+    /// upstream: `rsync.c:424` - `i = ndx - cur_flist->ndx_start`, after
+    /// `flist_for_ndx()` has selected the list.
+    pub(crate) fn wire_to_flat(&self, wire_ndx: i32) -> usize {
+        let seg = self.segment_containing_ndx(wire_ndx);
+        seg.flat_start + (wire_ndx - seg.ndx_start) as usize
+    }
+
+    /// Resolves a wire NDX read back from the receiver to the flat index whose
+    /// entry drives itemize formatting and xattr responses.
+    ///
+    /// This is [`Self::wire_to_flat`] for every regular entry. Under
+    /// INC_RECURSE the remote generator itemizes a directory by sending its
+    /// sub-list's *gap* NDX `ndx_start - 1` (`generator.c:2313`) rather than the
+    /// directory's own NDX. Feeding that through the plain mapping lands on the
+    /// trailing file of the previous segment, so the row would print a file type
+    /// char and the wrong path. upstream recovers the directory via
+    /// `dir_flist->files[cur_flist->parent_ndx]` (`sender.c:269-272`); this maps
+    /// the gap to the sub-list's recorded owning directory.
+    ///
+    /// Each sub-list resolves to its own directory - the initial list's gap to
+    /// the `.` root, a subdirectory's gap to that subdirectory - so every
+    /// directory is itemized exactly once, as upstream emits one row per
+    /// directory.
+    pub(crate) fn resolve_itemize(&self, wire_ndx: i32) -> usize {
+        // A gap NDX `g` satisfies `g + 1 == ndx_start` for exactly one
+        // sub-list, and no regular entry's NDX can equal a sub-list start minus
+        // one because that slot is reserved (flist.c:2966). Binary search is
+        // valid because `ndx_start` is strictly increasing.
+        if let Ok(idx) = self
+            .segments
+            .binary_search_by(|seg| seg.ndx_start.cmp(&(wire_ndx + 1)))
+            && let Some(parent) = self.segments[idx].parent_flat()
+        {
+            return parent;
+        }
+        self.wire_to_flat(wire_ndx)
+    }
+
+    /// Converts a flat index back to its wire NDX.
+    ///
+    /// upstream: `generator.c:2338` - `ndx = i + cur_flist->ndx_start`.
+    ///
+    /// Only used by tests since the NDX echo-back fix: the transfer loop
+    /// preserves the original wire NDX rather than round-tripping, which is what
+    /// keeps INC_RECURSE gap NDX values intact.
+    #[cfg(test)]
+    pub(crate) fn flat_to_wire(&self, flat_idx: usize) -> i32 {
+        let idx = self
+            .segments
+            .partition_point(|seg| seg.flat_start <= flat_idx)
+            - 1;
+        let seg = self.segments[idx];
+        seg.ndx_start + (flat_idx - seg.flat_start) as i32
+    }
+
+    /// The flat entry range of the oldest unreclaimed segment, when one can be
+    /// reclaimed.
+    ///
+    /// Returns `None` unless a *later* segment exists: the segment the receiver
+    /// is currently working through must stay live, which is why upstream frees
+    /// `first_flist` only after `cur_flist` has moved past it
+    /// (`sender.c:248`).
+    pub(crate) fn reclaimable_range(&self) -> Option<(usize, usize)> {
+        let first = self.first_live;
+        let next = self.segments.get(first + 1)?;
+        Some((self.segments[first].flat_start, next.flat_start))
+    }
+
+    /// Records that the range from [`Self::reclaimable_range`] has been freed.
+    ///
+    /// The segment stays in the table - only the cursor moves - because the
+    /// index mapping must remain total. upstream can drop the record because it
+    /// frees the index space with the storage; oc cannot.
+    pub(crate) fn advance_reclaimed(&mut self) {
+        self.first_live += 1;
+    }
+
+    /// Index of the oldest unreclaimed segment, for diagnostics.
+    pub(crate) fn first_live(&self) -> usize {
+        self.first_live
+    }
+
+    /// The segment owning `wire_ndx`.
+    ///
+    /// upstream: `flist.c:flist_for_ndx()`. Saturating rather than panicking on
+    /// an NDX below the first segment preserves the previous behaviour exactly;
+    /// such a value is a gap that [`Self::resolve_itemize`] has already handled,
+    /// or a protocol violation the NDX reader rejects before reaching here.
+    fn segment_containing_ndx(&self, wire_ndx: i32) -> NdxSegment {
+        let idx = self
+            .segments
+            .partition_point(|seg| seg.ndx_start <= wire_ndx)
+            .saturating_sub(1);
+        self.segments[idx]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The initial list plus two sub-lists, laid out with upstream's gaps.
+    /// Initial list holds 3 entries at flat 0..3, so the next starts at flat 3
+    /// and its NDX skips one slot.
+    fn three_segments() -> NdxMap {
+        let mut map = NdxMap::new(0);
+        map.push_sublist(3, 1);
+        map.push_sublist(5, 4);
+        map
+    }
+
+    #[test]
+    fn ndx_start_reserves_upstream_s_one_slot_parent_gap() {
+        let map = three_segments();
+        // Initial list occupies wire 0..3; the next sub-list starts at 4, not 3.
+        // flist.c:2966 - the skipped slot is the parent directory's.
+        assert_eq!(map.first_ndx_start(), 0);
+        assert_eq!(map.segments[1].ndx_start(), 4);
+        // Second sub-list: prev started at flat 3, this at flat 5, so prev_used
+        // is 2 -> 4 + 2 + 1.
+        assert_eq!(map.segments[2].ndx_start(), 7);
+    }
+
+    #[test]
+    fn wire_and_flat_round_trip_through_every_segment() {
+        let map = three_segments();
+        for (wire, flat) in [(0, 0), (2, 2), (4, 3), (5, 4), (7, 5), (9, 7)] {
+            assert_eq!(map.wire_to_flat(wire), flat, "wire {wire}");
+            assert_eq!(map.flat_to_wire(flat), wire, "flat {flat}");
+        }
+    }
+
+    #[test]
+    fn a_gap_ndx_itemizes_the_owning_directory_not_the_previous_file() {
+        let map = three_segments();
+        // Gap 3 belongs to the directory recorded at flat 1. Without the
+        // redirect the plain mapping runs one past the initial list's three
+        // entries; upstream's `i = ndx - ndx_start` would index off the end of
+        // that list, and in oc's single flat vector it silently lands on flat 3,
+        // the NEXT segment's first entry.
+        assert_eq!(map.wire_to_flat(3), 3);
+        assert_eq!(map.resolve_itemize(3), 1);
+
+        assert_eq!(map.resolve_itemize(6), 4);
+    }
+
+    #[test]
+    fn a_regular_ndx_is_unaffected_by_the_gap_redirect() {
+        let map = three_segments();
+        for wire in [0, 2, 4, 5, 7, 9] {
+            assert_eq!(map.resolve_itemize(wire), map.wire_to_flat(wire), "{wire}");
+        }
+    }
+
+    #[test]
+    fn an_initial_list_with_no_directory_falls_through_to_the_plain_mapping() {
+        // parent_flat -1 means there is no `.` root to itemize; the gap must not
+        // resolve to entry 0.
+        let map = NdxMap::new(0);
+        assert_eq!(map.resolve_itemize(-1), map.wire_to_flat(-1));
+    }
+
+    #[test]
+    fn reclaim_needs_a_later_segment_to_exist() {
+        let mut map = NdxMap::new(0);
+        // One segment: the receiver is still inside it, so nothing is freeable.
+        assert_eq!(map.reclaimable_range(), None);
+
+        map.push_sublist(3, 1);
+        assert_eq!(map.reclaimable_range(), Some((0, 3)));
+        map.advance_reclaimed();
+        assert_eq!(map.reclaimable_range(), None);
+    }
+
+    #[test]
+    fn reclaiming_does_not_disturb_the_mapping() {
+        let mut map = three_segments();
+        map.advance_reclaimed();
+        // The whole point of keeping the record: an NDX in the reclaimed
+        // segment must still resolve to its own flat slot, not to a neighbour.
+        assert_eq!(map.wire_to_flat(0), 0);
+        assert_eq!(map.wire_to_flat(2), 2);
+        assert_eq!(map.resolve_itemize(3), 1);
+        assert_eq!(map.first_live(), 1);
+        assert_eq!(map.len(), 3);
+    }
+
+    #[test]
+    fn a_negotiated_nonzero_initial_ndx_start_shifts_every_lookup() {
+        let mut map = NdxMap::new(100);
+        map.push_sublist(3, 1);
+        assert_eq!(map.first_ndx_start(), 100);
+        assert_eq!(map.wire_to_flat(100), 0);
+        assert_eq!(map.wire_to_flat(104), 3);
+        assert_eq!(map.resolve_itemize(103), 1);
+    }
+}

--- a/crates/transfer/src/generator/ndx_map.rs
+++ b/crates/transfer/src/generator/ndx_map.rs
@@ -39,7 +39,7 @@
 //! # Upstream Reference
 //!
 //! - `flist.c:2966` - `ndx_start = prev->ndx_start + prev->used + 1`
-//! - `rsync.c:424` - `i = ndx - cur_flist->ndx_start`
+//! - `rsync.c:437` - `i = ndx - cur_flist->ndx_start`
 //! - `sender.c:267-272` - a gap NDX resolves to the owning directory
 //! - `flist.c:flist_free()` / `sender.c:248` - segment reclaim
 
@@ -158,7 +158,7 @@ impl NdxMap {
 
     /// Resolves a wire NDX to its flat `file_list` index.
     ///
-    /// upstream: `rsync.c:424` - `i = ndx - cur_flist->ndx_start`, after
+    /// upstream: `rsync.c:437` - `i = ndx - cur_flist->ndx_start`, after
     /// `flist_for_ndx()` has selected the list.
     pub(crate) fn wire_to_flat(&self, wire_ndx: i32) -> usize {
         let seg = self.segment_containing_ndx(wire_ndx);
@@ -198,7 +198,7 @@ impl NdxMap {
 
     /// Converts a flat index back to its wire NDX.
     ///
-    /// upstream: `generator.c:2338` - `ndx = i + cur_flist->ndx_start`.
+    /// upstream: `generator.c:2812` - `ndx = i + cur_flist->ndx_start`.
     ///
     /// Only used by tests since the NDX echo-back fix: the transfer loop
     /// preserves the original wire NDX rather than round-tripping, which is what

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -735,12 +735,7 @@ impl GeneratorContext {
         // Set first_ndx so the writer can distinguish abbreviated vs
         // unabbreviated hardlink followers (leader in same vs previous segment).
         // upstream: flist.c:send_file_entry() uses first_ndx parameter
-        let initial_ndx_start = self
-            .incremental
-            .ndx_segments
-            .first()
-            .map_or(0, |&(_, ndx_start)| ndx_start);
-        flist_writer.set_first_ndx(initial_ndx_start);
+        flist_writer.set_first_ndx(self.incremental.ndx_map.first_ndx_start());
 
         // Wrap the wire writer in a first-byte latency probe. Cost is one
         // branch per buffered write call - no per-entry sampling.
@@ -838,25 +833,14 @@ impl GeneratorContext {
         flist_writer: &mut protocol::flist::FileListWriter,
         ndx_codec: &mut NdxCodecEnum,
     ) -> io::Result<()> {
-        // Compute ndx_start for this sub-list.
-        // upstream: flist.c:2966 - flist->ndx_start = prev->ndx_start + prev->used + 1
-        let &(prev_flat_start, prev_ndx_start) = self
+        // Append the sub-list to the NDX map. The map owns the `+1` gap rule
+        // (flist.c:2966) and the owning directory's flat index, so the gap NDX
+        // `seg_ndx_start - 1` resolves to that directory rather than to the
+        // trailing file of the previous segment.
+        let seg_ndx_start = self
             .incremental
-            .ndx_segments
-            .last()
-            .expect("initial segment exists");
-        let prev_used = (segment.flist_start - prev_flat_start) as i32;
-        let seg_ndx_start = prev_ndx_start + prev_used + 1;
-        self.incremental
-            .ndx_segments
-            .push((segment.flist_start, seg_ndx_start));
-        // Record the owning directory's flat index so a directory itemize read
-        // back at the gap NDX `seg_ndx_start - 1` resolves to the directory
-        // entry rather than to the trailing file of the previous segment.
-        // upstream: sender.c:269-272 - `dir_flist->files[cur_flist->parent_ndx]`.
-        self.incremental
-            .segment_parent_flat
-            .push(segment.parent_flat_idx as i32);
+            .ndx_map
+            .push_sublist(segment.flist_start, segment.parent_flat_idx as i32);
 
         // Signal new sub-list to receiver.
         // upstream: flist.c:2152 - write_ndx(f, NDX_FLIST_OFFSET - dir_ndx)

--- a/crates/transfer/src/generator/segments.rs
+++ b/crates/transfer/src/generator/segments.rs
@@ -14,6 +14,8 @@
 //! - `io.c:836-857` - `perform_io()` grows the window towards the maximum
 //!   whenever the sender would otherwise idle
 
+use super::ndx_map::NdxMap;
+
 /// Entries the sender keeps queued in sub-lists beyond the one the receiver is
 /// currently working through. Once the backlog reaches this many entries the
 /// sender stops emitting sub-lists and waits for the receiver to catch up, so a
@@ -280,46 +282,13 @@ pub(crate) struct IncrementalState {
     /// When set, `send_file_list()` only sends the first `initial_segment_count`
     /// entries. The remaining entries are sent via the segment scheduler.
     pub(crate) initial_segment_count: Option<usize>,
-    /// Segment boundary table for mapping wire NDX values to flat array indices.
+    /// Wire-NDX to flat-index map, plus the reclaim cursor.
     ///
-    /// With INC_RECURSE, the sender sends segmented file lists with +1 gaps
-    /// between segments (upstream `flist.c:2966`). When the receiver sends
-    /// wire NDX values back, this table maps them to flat array indices.
-    /// Each entry is `(flat_start, ndx_start)`.
-    ///
-    /// Without INC_RECURSE, this contains a single entry `(0, 0)`.
-    pub(crate) ndx_segments: Vec<(usize, i32)>,
-    /// Flat `file_list` index of each sub-list's owning directory, aligned 1:1
-    /// with `ndx_segments`. Stores `-1` when a sub-list has no owning directory
-    /// entry to itemize (the initial list whose first entry is not `.`).
-    ///
-    /// Under INC_RECURSE the remote generator itemizes a directory by sending
-    /// the "gap NDX" `ndx_start - 1` of that directory's sub-list
-    /// (generator.c:2313 `ndx = cur_flist->ndx_start - 1`). The sender must map
-    /// that gap back to the owning directory entry rather than to a regular
-    /// file, mirroring `dir_flist->files[cur_flist->parent_ndx]`
-    /// (sender.c:269-272). oc keeps a single flat entry list rather than a
-    /// separate `dir_flist`, so this table records the flat index of each
-    /// sub-list's owning directory directly, letting `resolve_itemize_ndx`
-    /// return it without a second wire-NDX translation.
-    ///
-    /// The initial list's slot is the flat index of the `.` root when the
-    /// transfer root is `.` (upstream flist.c:2572 keeps `parent_ndx` when the
-    /// first sorted entry is `.`), so the root directory row is itemized rather
-    /// than dropped; otherwise it is `-1`.
-    pub(crate) segment_parent_flat: Vec<i32>,
-    /// Index into `ndx_segments` of the oldest unreclaimed segment.
-    ///
-    /// Advances by one each time a completed segment is reclaimed via
-    /// `reclaim_oldest_segment()`. Mirrors upstream's `first_flist`
-    /// pointer which advances through the circular list as segments
-    /// are freed by `flist_free()`.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `flist.c:101` - `first_flist` pointer
-    /// - `sender.c:248` - `flist_free(first_flist)` advances `first_flist`
-    pub(crate) first_segment_idx: usize,
+    /// With INC_RECURSE the sender emits segmented file lists with `+1` gaps
+    /// between them (`flist.c:2966`); this resolves the NDX values the receiver
+    /// sends back. Without INC_RECURSE it holds a single segment and every
+    /// lookup is the identity.
+    pub(crate) ndx_map: NdxMap,
 }
 
 impl IncrementalState {
@@ -330,9 +299,7 @@ impl IncrementalState {
             flist_eof_sent: false,
             flist_writer_cache: None,
             initial_segment_count: None,
-            ndx_segments: vec![(0, initial_ndx_start)],
-            segment_parent_flat: vec![-1],
-            first_segment_idx: 0,
+            ndx_map: NdxMap::new(initial_ndx_start),
         }
     }
 }

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -7,6 +7,7 @@ use super::delta::{
     write_delta_with_compression,
 };
 use super::file_list::apply_permutation_in_place;
+use super::ndx_map::NdxMap;
 use super::protocol_io::{
     calculate_duration_ms, read_signature_blocks, read_signature_blocks_keepalive,
     signature_read_lull_mod,
@@ -340,13 +341,13 @@ fn ndx_convert_partition_point_depth_grows() {
     use super::{ndx_convert_totals, partition_point_depth};
 
     let (_handshake, mut ctx) = test_generator();
-    // Default ndx_segments has one entry; extend it to four so each query
+    // The map starts with one segment; extend it to four so each query
     // contributes a measurably larger partition_point depth.
-    ctx.incremental.ndx_segments.push((10, 11));
-    ctx.incremental.ndx_segments.push((20, 22));
-    ctx.incremental.ndx_segments.push((30, 33));
+    ctx.incremental.ndx_map.push_sublist(10, -1);
+    ctx.incremental.ndx_map.push_sublist(20, -1);
+    ctx.incremental.ndx_map.push_sublist(30, -1);
 
-    let per_call_depth = partition_point_depth(ctx.incremental.ndx_segments.len());
+    let per_call_depth = partition_point_depth(ctx.incremental.ndx_map.len());
     assert!(
         per_call_depth >= 3,
         "expected partition_point_depth(4) >= 3, got {per_call_depth}"
@@ -391,7 +392,8 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
 
     // Verify INC_RECURSE is active and ndx_start=1
     assert!(ctx.inc_recurse());
-    assert_eq!(ctx.incremental.ndx_segments, vec![(0, 1)]);
+    assert_eq!(ctx.incremental.ndx_map.len(), 1);
+    assert_eq!(ctx.incremental.ndx_map.first_ndx_start(), 1);
 
     // Gap NDX = ndx_start - 1 = 0
     let gap_ndx: i32 = 0;
@@ -400,7 +402,7 @@ fn inc_recurse_gap_ndx_round_trip_preserves_original() {
     // wire_to_flat_ndx + flat_to_wire_ndx is no longer used in production.
     // Verify that the gap NDX value (0) is below ndx_start (1), which is
     // the condition under which upstream echoes the original NDX unchanged.
-    let ndx_start = ctx.incremental.ndx_segments[0].1;
+    let ndx_start = ctx.incremental.ndx_map.first_ndx_start();
     assert!(
         gap_ndx < ndx_start,
         "gap NDX ({gap_ndx}) must be below ndx_start ({ndx_start})"
@@ -520,7 +522,11 @@ fn inc_recurse_gap_ndx_itemizes_parent_directory() {
     // first entry is "."); sub/'s pending sub-list owns `sub` at flat 1. These
     // are flat file_list indices, NOT wire dir_ndx values (`sub` has wire
     // dir_ndx 1 but that alone would misresolve to flat 0 == `.`).
-    assert_eq!(ctx.incremental.segment_parent_flat, vec![0]);
+    assert_eq!(
+        ctx.resolve_itemize_ndx(0),
+        0,
+        "the initial list's gap NDX must resolve to `.` at flat 0"
+    );
     assert_eq!(ctx.incremental.pending_segments.len(), 1);
     assert_eq!(ctx.incremental.pending_segments[0].parent_flat_idx, 1);
     assert_eq!(ctx.incremental.pending_segments[0].flist_start, 2);
@@ -529,8 +535,9 @@ fn inc_recurse_gap_ndx_itemizes_parent_directory() {
     // owning-flat rows, exactly as encode_and_send_segment does in the transfer
     // loop. upstream flist.c:2966: ndx_start = prev(1) + prev_used(2) + 1 = 4,
     // so sub/'s gap NDX is 3. The initial list keeps ndx_start 1, gap NDX 0.
-    ctx.incremental.ndx_segments = vec![(0, 1), (2, 4)];
-    ctx.incremental.segment_parent_flat = vec![0, 1];
+    ctx.incremental.ndx_map.set_initial_parent_flat(0);
+    let sub_ndx_start = ctx.incremental.ndx_map.push_sublist(2, 1);
+    assert_eq!(sub_ndx_start, 4, "flist.c:2966 - 1 + 2 + 1");
 
     // Each gap resolves to its OWN owning directory; the child resolves to
     // itself. The `!= 0` anti-regression: sub/'s gap 3 must be flat 1 (`sub`),
@@ -5107,8 +5114,8 @@ fn empty_segment_sends_wire_bytes() {
     let handshake = test_handshake();
     let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
 
-    // Set up a minimal initial segment in ndx_segments.
-    ctx.incremental.ndx_segments = vec![(0, 0)];
+    // Set up a minimal initial segment.
+    ctx.incremental.ndx_map = NdxMap::new(0);
 
     // Add a dummy file entry so the file_list is non-empty (flist_start=0).
     ctx.push_file_item(
@@ -5150,7 +5157,7 @@ fn nonempty_segment_also_sends_wire_bytes() {
     let handshake = test_handshake();
     let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
 
-    ctx.incremental.ndx_segments = vec![(0, 0)];
+    ctx.incremental.ndx_map = NdxMap::new(0);
     let entry = protocol::flist::FileEntry::new_file("a.txt".into(), 10, 0o644);
     ctx.push_file_item(entry, PathBuf::from("a.txt"));
 
@@ -5208,8 +5215,9 @@ fn reclaim_oldest_segment_frees_first_segment_entries() {
             PathBuf::from(format!("/src/dir/file_{i}.txt")),
         );
     }
-    ctx.incremental.ndx_segments = vec![(0, 1), (3, 5), (5, 8)];
-    ctx.incremental.first_segment_idx = 0;
+    assert_eq!(ctx.incremental.ndx_map.push_sublist(3, -1), 5);
+    assert_eq!(ctx.incremental.ndx_map.push_sublist(5, -1), 8);
+    assert_eq!(ctx.incremental.ndx_map.first_live(), 0);
 
     // Verify initial state.
     assert_eq!(ctx.file_list()[0].name(), "dir/file_0.txt");
@@ -5218,7 +5226,7 @@ fn reclaim_oldest_segment_frees_first_segment_entries() {
 
     // Reclaim first segment [0..3).
     ctx.reclaim_oldest_segment();
-    assert_eq!(ctx.incremental.first_segment_idx, 1);
+    assert_eq!(ctx.incremental.ndx_map.first_live(), 1);
     assert_eq!(ctx.file_list()[0].name(), ""); // reclaimed
     assert_eq!(ctx.file_list()[1].name(), ""); // reclaimed
     assert_eq!(ctx.file_list()[2].name(), ""); // reclaimed
@@ -5227,14 +5235,14 @@ fn reclaim_oldest_segment_frees_first_segment_entries() {
 
     // Reclaim second segment [3..5).
     ctx.reclaim_oldest_segment();
-    assert_eq!(ctx.incremental.first_segment_idx, 2);
+    assert_eq!(ctx.incremental.ndx_map.first_live(), 2);
     assert_eq!(ctx.file_list()[3].name(), ""); // reclaimed
     assert_eq!(ctx.file_list()[4].name(), ""); // reclaimed
     assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt"); // intact
 
     // Third reclaim is a no-op (last segment must not be reclaimed).
     ctx.reclaim_oldest_segment();
-    assert_eq!(ctx.incremental.first_segment_idx, 2); // unchanged
+    assert_eq!(ctx.incremental.ndx_map.first_live(), 2); // unchanged
     assert_eq!(ctx.file_list()[5].name(), "dir/file_5.txt"); // still intact
 }
 
@@ -5253,7 +5261,7 @@ fn reclaim_oldest_segment_noop_without_inc_recurse() {
 
     // Single segment - reclaim is a no-op.
     ctx.reclaim_oldest_segment();
-    assert_eq!(ctx.incremental.first_segment_idx, 0);
+    assert_eq!(ctx.incremental.ndx_map.first_live(), 0);
     assert_eq!(ctx.file_list()[0].name(), "file.txt");
 }
 

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6760,3 +6760,64 @@ fn inc_recurse_partitions_an_already_materialised_file_list() {
          send_directory emits, reached by slicing instead of by scanning"
     );
 }
+
+/// Sorted, wire-side relative names currently in the context's file list.
+fn entry_names(ctx: &GeneratorContext) -> Vec<String> {
+    let mut names: Vec<String> = ctx
+        .file_list()
+        .iter()
+        .map(|e| e.name().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+/// The fixture both scan tests use: one file and one subdirectory at the top,
+/// and two levels of content underneath it. Two levels, because a one-level
+/// scan and a two-level scan would otherwise be indistinguishable.
+fn nested_scan_fixture() -> TempDir {
+    create_test_structure(&["top.txt", "sub/deep.txt", "sub/deeper/x.txt"])
+}
+
+#[test]
+fn scan_one_directory_emits_the_subdirectory_but_not_its_contents() {
+    let temp = nested_scan_fixture();
+
+    let handshake = test_handshake_with_protocol(32);
+    let mut config = test_config();
+    config.flags.recursive = true;
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+    ctx.scan_one_directory(temp.path(), temp.path()).unwrap();
+
+    // `sub` is present as an entry - upstream's FLAG_DIVERT_DIRS records the
+    // directory, it does not drop it. What is absent is everything below it,
+    // which is the work a later scan will do.
+    assert_eq!(entry_names(&ctx), vec!["sub", "top.txt"]);
+}
+
+#[test]
+fn the_recursive_walk_still_expands_the_same_fixture() {
+    let temp = nested_scan_fixture();
+
+    let handshake = test_handshake_with_protocol(32);
+    let mut config = test_config();
+    config.flags.recursive = true;
+    let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+
+    build_file_list_for_contents(&mut ctx, temp.path());
+
+    // Without this the one-level assertion above would also hold for a fixture
+    // that simply has nothing deeper to find.
+    assert_eq!(
+        entry_names(&ctx),
+        vec![
+            ".",
+            "sub",
+            "sub/deep.txt",
+            "sub/deeper",
+            "sub/deeper/x.txt",
+            "top.txt"
+        ]
+    );
+}

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6770,11 +6770,18 @@ fn inc_recurse_partitions_an_already_materialised_file_list() {
 }
 
 /// Sorted, wire-side relative names currently in the context's file list.
+///
+/// The name is derived by `path.strip_prefix(base)`, so it carries the host's
+/// separator - `sub\deep.txt` on Windows. That is correct in memory: the
+/// conversion to the wire's `/` happens at the encode boundary
+/// (`path_bytes_to_wire`, `protocol/src/flist/write/encoding.rs`), not in the
+/// walk. Normalising here is what makes this helper deliver the wire-side
+/// names its name promises, on every platform.
 fn entry_names(ctx: &GeneratorContext) -> Vec<String> {
     let mut names: Vec<String> = ctx
         .file_list()
         .iter()
-        .map(|e| e.name().to_string())
+        .map(|e| e.name().to_string().replace('\\', "/"))
         .collect();
     names.sort();
     names


### PR DESCRIPTION
## Why

`build_file_list` walks the whole source tree by recursing into
`scan_directory_batched`, so there is no point at which the scan can stop and
resume. INC_RECURSE needs that seam: upstream's `send_directory` scans one
directory, emits one sub-list and returns, and `send_extra_file_list(f, at_least)`
resumes it later. Today oc materialises the entire tree and only then partitions
it - the ordering that PR #7611's RED baseline pins.

This change builds the seam without using it yet.

## What

`walk_path_with_metadata` seeds a `Vec<WalkStep>` and hands it to `drive_walk`,
which pops steps until the stack empties. The two former recursion sites push
instead of calling.

Behaviour is preserved deliberately, not incidentally, and each of these is a
place where the obvious rewrite would have changed observable output:

- **Sibling order** - children are pushed with `.rev()` so they pop in readdir
  order.
- **Filter-scope nesting** - `LeaveDir` is pushed *before* `ScanChildren`, so
  the scan runs inside its own scope (`exclude.c` `push_local_filters` /
  `pop_local_filters`).
- **Diagnostic interleaving** - `VisitChild(StatResult)` defers the
  `--copy-dirlinks` / `--copy-unsafe-links` re-stat until the child is
  *reached*, so a `copying unsafe symlink` notice still prints after the
  previous sibling's subtree rather than during the parent's batch stat.
- **Who opens the directory** - `ScanChildren { opened: Option<ReadDir> }`
  because the two arms differ: the recursive arm opens the directory *before*
  pushing that directory's own entry, so an `opendir` failure is reported ahead
  of the entry; the transfer-root arm opens it after entering the filter scope.

No wire bytes, no ordering, no diagnostics change.

## Verification

Measured on this exact change, on this PR's base (`81c158629`):

- `cargo nextest run -p transfer`: **2774 passed**, 3 skipped, 0 failed.
- Full-workspace `cargo nextest run`: exit 0.
- `cargo fmt --all -- --check`: clean.
- Zero new clippy warnings. A/B'd rather than asserted: the `walk.rs` warning
  count is **8 before and 8 after**, all on untouched code. (The workspace-wide
  `collapsible_if` hits are a local-toolchain artefact firing on files this PR
  does not touch.)

Two mutations proving the new traversal logic is exercised and load-bearing,
not merely compiled:

| mutation | result |
|---|---|
| drop `.rev()` on the child push (children pop in reverse readdir order) | **51 failures** |
| swap the `LeaveDir` / `ScanChildren` push order (filter scope released before the scan) | **53 failures** |

---

## Second commit: `feat(transfer): scan one directory level without descending`

The seam above is only useful once something can ask for less than the whole
tree. This adds the policy that does it.

`WalkScope` carries the base and a `Descent` together, so the new decision costs
no extra parameter on the driver. `scan_one_directory()` enters the
per-directory filter scope, drives the stack under `Descent::DivertDirs`, and
leaves it - the children are matched against that directory's merge files exactly
as the whole-tree walk matches them.

upstream: `send_directory()` takes a flags word and `send_extra_file_list()`
passes `FLAG_DIVERT_DIRS`, so a subdirectory found while scanning a sub-list is
recorded and diverted rather than descended into. That one flag is why upstream
never materialises the tree: one call costs one level, not one subtree.

Every existing caller constructs `WalkScope::recursive`, so the tree walk is
unchanged. `scan_one_directory` has no production caller yet - the budgeted
producer loop that consumes it is the next step, and it is `expect(dead_code)`
outside tests until then rather than silently unreferenced.

### Verification (second commit)

- `cargo nextest run -p transfer`: **2776 passed**, 3 skipped, 0 failed.
- `cargo fmt --all -- --check` clean.
- Two tests, and the second exists to stop the first being vacuous:
  `scan_one_directory_emits_the_subdirectory_but_not_its_contents` pins the
  one-level result; `the_recursive_walk_still_expands_the_same_fixture` proves
  the same fixture *does* have deeper content to find, so the first assertion is
  about the policy and not about an empty tree.
- Mutation: forcing `descends_into_subdirs()` to `true` (policy inert) reddens
  exactly the one-level test — `left: ["sub", "sub/deep.txt", "sub/deeper",
  "sub/deeper/x.txt", "top.txt"], right: ["sub", "top.txt"]` — while the
  companion stays green.

⚠ Note on the first suite run of this branch: 51 integration tests failed at
~0.02s each. That is the binary-freshness guard from #7385 firing because
`walk.rs` was edited after the last `cargo build`, not a regression. Rebuilding
the binary returns 2776/2776. The uniform sub-30ms duration is the tell.
