### PR TITLE
docs(crates): promote item prose stranded below its own rustdoc block

### DIFF
--- a/crates/bandwidth/src/limiter/change.rs
+++ b/crates/bandwidth/src/limiter/change.rs
@@ -106,7 +106,7 @@ impl FromIterator<LimiterChange> for LimiterChange {
 /// `true`, throttling is disabled entirely.
 ///
 /// Returns a [`LimiterChange`] describing the transition that occurred.
-// upstream: options.c:2392 - daemon_bwlimit override: strictest rate wins
+/// upstream: options.c:2392 - daemon_bwlimit override: strictest rate wins
 pub fn apply_effective_limit(
     limiter: &mut Option<BandwidthLimiter>,
     limit: Option<NonZeroU64>,

--- a/crates/bandwidth/src/limiter/core/limiter.rs
+++ b/crates/bandwidth/src/limiter/core/limiter.rs
@@ -26,7 +26,7 @@ use super::write_max::calculate_write_max;
 /// linearly with the rate so that pacing sleeps remain short and responsive,
 /// matching the `bwlimit_writemax = bwlimit * 128` formula in upstream rsync.
 ///
-// upstream: io.c:sleep_for_bwlimit()
+/// upstream: io.c:sleep_for_bwlimit()
 #[doc(alias = "--bwlimit")]
 #[derive(Clone, Debug)]
 pub struct BandwidthLimiter {
@@ -39,7 +39,7 @@ pub struct BandwidthLimiter {
 
 impl BandwidthLimiter {
     /// Constructs a new limiter from the supplied byte-per-second rate.
-    // upstream: io.c:sleep_for_bwlimit() - initial setup
+    /// upstream: io.c:sleep_for_bwlimit() - initial setup
     #[must_use]
     pub fn new(limit: NonZeroU64) -> Self {
         let write_max = calculate_write_max(limit);
@@ -60,7 +60,7 @@ impl BandwidthLimiter {
     /// rate applies immediately without carryover from the previous period.
     /// This is also used when a daemon module overrides the client-supplied
     /// `--bwlimit`.
-    // upstream: options.c:2392 - daemon_bwlimit override reconfiguration
+    /// upstream: options.c:2392 - daemon_bwlimit override reconfiguration
     #[doc(alias = "--bwlimit")]
     pub fn update_limit(&mut self, limit: NonZeroU64) {
         let write_max = calculate_write_max(limit);
@@ -95,7 +95,7 @@ impl BandwidthLimiter {
     /// The value scales linearly with the configured rate so that pacing
     /// sleeps remain short and responsive. Callers should split writes
     /// larger than this threshold into chunks.
-    // upstream: options.c:2395 - bwlimit_writemax = bwlimit * 128
+    /// upstream: options.c:2395 - bwlimit_writemax = bwlimit * 128
     #[inline]
     #[must_use]
     pub const fn write_max_bytes(&self) -> usize {
@@ -125,7 +125,7 @@ impl BandwidthLimiter {
     /// and actual sleep durations.
     ///
     /// A zero-byte call is a no-op and returns immediately.
-    // upstream: io.c:sleep_for_bwlimit() - debt accumulation and sleep logic
+    /// upstream: io.c:sleep_for_bwlimit() - debt accumulation and sleep logic
     pub fn register(&mut self, bytes: usize) -> super::super::LimiterSleep {
         if bytes == 0 {
             return super::super::LimiterSleep::default();

--- a/crates/bandwidth/src/limiter/core/write_max.rs
+++ b/crates/bandwidth/src/limiter/core/write_max.rs
@@ -13,7 +13,7 @@ use super::super::MIN_WRITE_MAX;
 ///
 /// The write-max scales linearly with KiB of bandwidth, clamped to at least
 /// `MIN_WRITE_MAX`.
-// upstream: options.c:2395-2397 - bwlimit_writemax = bwlimit * 128, min 512
+/// upstream: options.c:2395-2397 - bwlimit_writemax = bwlimit * 128, min 512
 pub(super) fn calculate_write_max(limit: NonZeroU64) -> usize {
     let kib = if limit.get() < 1024 {
         1

--- a/crates/bandwidth/src/limiter/mod.rs
+++ b/crates/bandwidth/src/limiter/mod.rs
@@ -27,11 +27,11 @@ pub(super) use backend::sleep_with_backend;
 pub(super) use sleep::{duration_from_microseconds, sleep_for};
 
 /// One million microseconds per second.
-// upstream: io.c:sleep_for_bwlimit() ONE_SEC macro
+/// upstream: io.c:sleep_for_bwlimit() ONE_SEC macro
 pub(super) const MICROS_PER_SECOND: u128 = 1_000_000;
 
 /// Minimum accumulated debt before the limiter actually sleeps.
-// upstream: io.c:sleep_for_bwlimit() - `ONE_SEC / 10` threshold
+/// upstream: io.c:sleep_for_bwlimit() - `ONE_SEC / 10` threshold
 pub(super) const MINIMUM_SLEEP_MICROS: u128 = MICROS_PER_SECOND / 10;
 
 /// Largest microsecond value representable as a `Duration`.
@@ -42,7 +42,7 @@ pub(super) const MAX_REPRESENTABLE_MICROSECONDS: u128 =
 pub(super) const MAX_SLEEP_DURATION: Duration = Duration::new(i64::MAX as u64, 999_999_999);
 
 /// Floor for the per-write chunk size.
-// upstream: options.c:2396 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
+/// upstream: options.c:2396 - `if (bwlimit_writemax < 512) bwlimit_writemax = 512`
 pub(super) const MIN_WRITE_MAX: usize = 512;
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/bandwidth/src/limiter/sleep.rs
+++ b/crates/bandwidth/src/limiter/sleep.rs
@@ -67,7 +67,7 @@ pub(crate) const fn duration_from_microseconds(us: u128) -> Duration {
 }
 
 /// Sleeps for the given duration, chunking into `MAX_SLEEP_DURATION` segments.
-// upstream: io.c:sleep_for_bwlimit() - uses select() for the actual sleep
+/// upstream: io.c:sleep_for_bwlimit() - uses select() for the actual sleep
 pub(crate) fn sleep_for(duration: Duration) {
     let mut remaining = duration;
 

--- a/crates/bandwidth/src/parse.rs
+++ b/crates/bandwidth/src/parse.rs
@@ -46,7 +46,7 @@ impl From<SizeArgError> for BandwidthParseError {
 /// whitespace. `Ok(None)` denotes an unlimited transfer rate (users may specify
 /// `0` for this effect). Successful parses return the rounded byte-per-second
 /// limit as [`NonZeroU64`].
-// upstream: options.c:parse_size_arg() - suffix/multiplier/adjust parsing
+/// upstream: options.c:parse_size_arg() - suffix/multiplier/adjust parsing
 #[doc(alias = "--bwlimit")]
 pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, BandwidthParseError> {
     if text.as_bytes().iter().all(u8::is_ascii_whitespace) {
@@ -116,7 +116,7 @@ pub fn parse_bandwidth_argument(text: &str) -> Result<Option<NonZeroU64>, Bandwi
 /// configuration. Surrounding whitespace is rejected to match upstream rsync's
 /// strict parsing. Upstream has no `:BURST` component, so a colon is rejected as
 /// invalid size syntax.
-// upstream: options.c:1714 parse_size_arg(bwlimit_arg, 'K', "bwlimit", 512, -1, True)
+/// upstream: options.c:1714 parse_size_arg(bwlimit_arg, 'K', "bwlimit", 512, -1, True)
 #[doc(alias = "--bwlimit")]
 pub fn parse_bandwidth_limit(text: &str) -> Result<BandwidthLimitComponents, BandwidthParseError> {
     let trimmed = text.trim_matches(|ch: char| ch.is_ascii_whitespace());

--- a/crates/bandwidth/src/parse/components.rs
+++ b/crates/bandwidth/src/parse/components.rs
@@ -129,7 +129,7 @@ impl BandwidthLimitComponents {
     /// the caller previously supplied a rate. This allows higher layers to reason about the
     /// effective limiter without materialising a [`BandwidthLimiter`] instance solely to combine
     /// configuration sources.
-    // upstream: options.c:2392 - min(client, daemon) wins
+    /// upstream: options.c:2392 - min(client, daemon) wins
     #[must_use]
     pub fn constrained_by(&self, override_components: &Self) -> Self {
         let mut rate = self.rate;

--- a/crates/bandwidth/src/size_arg.rs
+++ b/crates/bandwidth/src/size_arg.rs
@@ -35,7 +35,7 @@ pub struct ParsedSize {
 }
 
 /// Checked integer exponentiation used to build the suffix multiplier.
-// upstream: options.c:parse_size_arg() - `while (reps--) size *= mult`
+/// upstream: options.c:parse_size_arg() - `while (reps--) size *= mult`
 pub fn pow_u128(base: u32, exponent: u32) -> Result<u128, SizeArgError> {
     let mut result = 1u128;
     let mut factor = u128::from(base);

--- a/crates/batch/src/script.rs
+++ b/crates/batch/src/script.rs
@@ -418,7 +418,7 @@ fn find_destination(args: &[String]) -> Option<&str> {
 /// - `rsync://host/path` -> `path`
 /// - `/local/path`, `rel/path`, `dest` -> unchanged
 ///
-// upstream: options.c:check_for_hostspec / batch.c:300
+/// upstream: options.c:check_for_hostspec / batch.c:300
 fn strip_hostspec(dest: &str) -> &str {
     const URL_PREFIX: &str = "rsync://";
     // upstream: options.c:3134 - an rsync:// URL is matched case-insensitively.

--- a/crates/cli/src/frontend/execution/compression.rs
+++ b/crates/cli/src/frontend/execution/compression.rs
@@ -186,7 +186,7 @@ fn render_compress_choice_error(err: CompressionAlgorithmParseError, trimmed: &s
 /// The rate accepts a size suffix (`K`/`M`/`G`/...) with a default of KiB.
 /// Returns `Ok(None)` when the value disables the limit. Invalid, too-small,
 /// and too-large values are rejected with a `--bwlimit` error.
-// upstream: options.c:1714 parse_size_arg(bwlimit_arg, 'K', "bwlimit", 512, -1, True)
+/// upstream: options.c:1714 parse_size_arg(bwlimit_arg, 'K', "bwlimit", 512, -1, True)
 pub(crate) fn parse_bandwidth_limit(argument: &OsStr) -> Result<Option<BandwidthLimit>, Message> {
     // upstream: an empty value resolves to 0, and `unlimited_0` makes 0 mean
     // "no limit" for this option (options.c:1821). Measured: `--bwlimit=`

--- a/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
+++ b/crates/cli/src/frontend/execution/drive/workflow/preflight.rs
@@ -149,7 +149,7 @@ where
 ///
 /// `show_version` is a count: 1 = human-readable output (upstream `-V`),
 /// 2+ = machine-readable JSON (upstream `-VV`).
-// upstream: options.c:1940-1942 - version_opt_cnt selects JSON vs human-readable
+/// upstream: options.c:1940-1942 - version_opt_cnt selects JSON vs human-readable
 pub(crate) fn maybe_print_help_or_version<Out>(
     show_help: bool,
     show_version: u8,

--- a/crates/core/src/client/module_list/socket_options/lookup.rs
+++ b/crates/core/src/client/module_list/socket_options/lookup.rs
@@ -12,7 +12,7 @@ use super::types::SocketOptionKind;
 /// Resolves an option name to its `SocketOptionKind`.
 ///
 /// Returns `None` for unrecognized names.
-// upstream: socket.c:set_socket_options()
+/// upstream: socket.c:set_socket_options()
 pub(super) fn lookup_socket_option(name: &str) -> Option<SocketOptionKind> {
     match name {
         "SO_KEEPALIVE" => Some(SocketOptionKind::Bool {

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -255,7 +255,7 @@ impl VersionInfoReport {
     ///
     /// Mirrors upstream rsync's `print_rsync_version(FNONE)` path, which emits
     /// a JSON object with capability flags, algorithm lists, and metadata fields.
-    // upstream: usage.c:252 - print_rsync_version with f == FNONE
+    /// upstream: usage.c:252 - print_rsync_version with f == FNONE
     pub fn write_machine_readable<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
         let metadata = self.metadata;
         let protocol = if metadata.subprotocol_version() != 0 {
@@ -308,7 +308,7 @@ impl VersionInfoReport {
 
     /// Writes JSON capability/optimization sections mirroring upstream's
     /// `print_info_flags(FNONE)`.
-    // upstream: usage.c:37-216 - print_info_flags with as_json=true
+    /// upstream: usage.c:37-216 - print_info_flags with as_json=true
     fn write_json_info_sections<W: FmtWrite>(&self, writer: &mut W) -> fmt::Result {
         let items = self.info_items();
         let mut in_section = false;
@@ -351,7 +351,7 @@ impl VersionInfoReport {
     }
 
     /// Writes a JSON array for an algorithm list.
-    // upstream: usage.c:218-249 - output_nno_list with f == FNONE
+    /// upstream: usage.c:218-249 - output_nno_list with f == FNONE
     fn write_json_list<W: FmtWrite>(
         &self,
         writer: &mut W,
@@ -613,7 +613,7 @@ fn capability_entry(label: &'static str, supported: bool) -> InfoItem {
 /// - `"no crtimes"` -> `"crtimes": false`
 /// - `"crtimes"` -> `"crtimes": true`
 /// - `"optional secluded-args"` -> `"secluded_args": "optional"`
-// upstream: usage.c:172-188 - JSON entry formatting in print_info_flags
+/// upstream: usage.c:172-188 - JSON entry formatting in print_info_flags
 fn write_json_entry<W: FmtWrite>(writer: &mut W, text: &str, needs_comma: bool) -> fmt::Result {
     let comma = if needs_comma { "," } else { "" };
 
@@ -654,7 +654,7 @@ fn write_json_entry<W: FmtWrite>(writer: &mut W, text: &str, needs_comma: bool) 
 
 /// Converts a capability name to a JSON key by replacing hyphens and spaces
 /// with underscores.
-// upstream: usage.c:187-188 - strpbrk loop replacing ' ' and '-' with '_'
+/// upstream: usage.c:187-188 - strpbrk loop replacing ' ' and '-' with '_'
 fn json_key(s: &str) -> String {
     s.chars()
         .map(|c| if c == '-' || c == ' ' { '_' } else { c })

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -613,6 +613,7 @@ fn capability_entry(label: &'static str, supported: bool) -> InfoItem {
 /// - `"no crtimes"` -> `"crtimes": false`
 /// - `"crtimes"` -> `"crtimes": true`
 /// - `"optional secluded-args"` -> `"secluded_args": "optional"`
+///
 /// upstream: usage.c:172-188 - JSON entry formatting in print_info_flags
 fn write_json_entry<W: FmtWrite>(writer: &mut W, text: &str, needs_comma: bool) -> fmt::Result {
     let comma = if needs_comma { "," } else { "" };

--- a/crates/daemon/src/daemon/sections/privilege.rs
+++ b/crates/daemon/src/daemon/sections/privilege.rs
@@ -348,7 +348,7 @@ fn resolve_nobody_uid() -> io::Result<u32> {
 /// faithful mirror: it resolves to exactly what upstream would have baked in on
 /// the host actually running the daemon, and it keeps working if the binary is
 /// moved between distributions.
-// upstream: clientserver.c:873 `add_a_group(f_out, NOBODY_GROUP)`
+/// upstream: clientserver.c:873 `add_a_group(f_out, NOBODY_GROUP)`
 #[cfg(unix)]
 const NOBODY_GROUP_CANDIDATES: [&[u8]; 2] = [b"nobody", b"nogroup"];
 

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -54,8 +54,8 @@ fn batch_sum_head(index: &DeltaSignatureIndex) -> Result<protocol::wire::SumHead
 /// otherwise-matching block is punched into a hole instead of being seeked over
 /// with the rest of the block - that is precisely what `--inplace --sparse`
 /// relies on to keep a hole-y basis file sparse.
-// upstream: fileio.c:252-266 skip_matched() - `if (sparse_files > 0)
-// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, else flush + lseek.
+/// upstream: fileio.c:252-266 skip_matched() - `if (sparse_files > 0)
+/// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, else flush + lseek.
 fn consume_matched_in_place(
     writer: &mut fs::File,
     sparse_state: &mut SparseWriteState,

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -82,9 +82,9 @@ impl<'a> CopyContext<'a> {
     /// arm alone is unreachable in exactly the case upstream prints. `--quiet`
     /// still suppresses it, at `rwrite()`'s FINFO arm, which
     /// `logging::message_stream` owns.
-    // upstream: flist.c:1338 and flist.c:2452 -
-    // `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare relative name
-    // with no surrounding quotes and no trailing "(no recursion)" suffix.
+    /// upstream: flist.c:1338 and flist.c:2452 -
+    /// `rprintf(FINFO, "skipping directory %s\n", ...)`: the bare relative name
+    /// with no surrounding quotes and no trailing "(no recursion)" suffix.
     pub(super) fn record_skipped_directory(&mut self, relative: Option<&Path>) {
         if let Some(path) = relative {
             info_log!(Misc, 0, "skipping directory {}", path.display());
@@ -380,7 +380,7 @@ impl<'a> CopyContext<'a> {
     /// source mtime). It is intentionally retained here to keep this change
     /// scoped to one concern; folding it into the final pass is a deferred DRY
     /// cleanup. Both set the identical value, so the overlap is harmless.
-    // upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
+    /// upstream: generator.c:2419 do_delayed_deletions() runs after generate_files()
     pub(super) fn flush_deferred_deletions(&mut self) -> Result<(), LocalCopyError> {
         // Nothing queued means no delete pass ran, so there is no notice to
         // emit - upstream only prints the skip notice from inside delete_in_dir

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -496,7 +496,7 @@ impl<'a> CopyContext<'a> {
     ///
     /// Also suppresses deletions like any other general I/O error, matching
     /// upstream where `io_error |= IOERR_GENERAL` gates the delete pass.
-    // upstream: flist.c:1631 send_file1() sets io_error |= IOERR_GENERAL.
+    /// upstream: flist.c:1631 send_file1() sets io_error |= IOERR_GENERAL.
     pub(super) fn record_iconv_conversion_error(&mut self) {
         self.iconv_conversion_error = true;
         self.io_errors_occurred = true;
@@ -598,10 +598,10 @@ impl<'a> CopyContext<'a> {
     /// neither the warning nor the skip fires in that case - matching
     /// upstream, where the flag both suppresses the notice and lets the
     /// delete pass run.
-    // upstream: generator.c:304-311 delete_in_dir() prints "IO error
-    // encountered -- skipping file deletion" once (guarded by a static
-    // `already_warned`) and returns without deleting whenever
-    // `io_error & IOERR_GENERAL && !ignore_errors`.
+    /// upstream: generator.c:304-311 delete_in_dir() prints "IO error
+    /// encountered -- skipping file deletion" once (guarded by a static
+    /// `already_warned`) and returns without deleting whenever
+    /// `io_error & IOERR_GENERAL && !ignore_errors`.
     pub(super) fn delete_pass_blocked_by_io_error(&mut self) -> bool {
         if self.deletions_allowed() {
             return false;

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -884,7 +884,7 @@ impl<'a> CopyContext<'a> {
     /// zero runs beyond any preallocated extent become seeks (natural holes),
     /// while zero runs inside a preallocated extent are punched out so the
     /// reserved blocks are actually deallocated.
-    // upstream: fileio.c:write_sparse()
+    /// upstream: fileio.c:write_sparse()
     #[allow(clippy::too_many_arguments)]
     fn copy_file_contents_sparse(
         &mut self,

--- a/crates/engine/src/local_copy/executor/directory/planner.rs
+++ b/crates/engine/src/local_copy/executor/directory/planner.rs
@@ -23,7 +23,7 @@ use super::super::{
 use super::support::{DirectoryEntry, is_device, is_fifo};
 
 /// Action to take for a directory entry during recursive copy.
-// upstream: generator.c:recv_generator() - entry dispatch
+/// upstream: generator.c:recv_generator() - entry dispatch
 #[derive(Clone, Copy)]
 pub(crate) enum EntryAction {
     /// Entry excluded by filter rules.
@@ -184,7 +184,7 @@ fn decide_entry_action(
 /// Iterates over pre-sorted directory entries, applies filter rules,
 /// resolves symlinks when `--copy-links` or `--copy-dirlinks` is active,
 /// and determines the appropriate action for each entry.
-// upstream: flist.c:send_directory() - builds file list from directory
+/// upstream: flist.c:send_directory() - builds file list from directory
 pub(crate) fn plan_directory_entries<'a>(
     context: &mut CopyContext,
     entries: &'a [DirectoryEntry],
@@ -539,7 +539,7 @@ pub(crate) fn reorder_hardlink_group_holders(
 }
 
 /// Applies pre-transfer deletions when `--delete-before` is active.
-// upstream: generator.c:do_delete_pass() - pre-transfer deletion
+/// upstream: generator.c:do_delete_pass() - pre-transfer deletion
 pub(crate) fn apply_pre_transfer_deletions(
     context: &mut CopyContext,
     destination: &Path,

--- a/crates/engine/src/local_copy/executor/directory/support.rs
+++ b/crates/engine/src/local_copy/executor/directory/support.rs
@@ -204,7 +204,7 @@ fn read_directory_entries_sorted_parallel(
 ///
 /// On Unix, uses raw byte comparison for consistency with C `strcmp`.
 /// On Windows, uses wide-character comparison via `encode_wide`.
-// upstream: flist.c:file_compare() - filename ordering
+/// upstream: flist.c:file_compare() - filename ordering
 fn compare_file_names(left: &OsStr, right: &OsStr) -> Ordering {
     #[cfg(unix)]
     {
@@ -239,7 +239,7 @@ fn compare_file_names(left: &OsStr, right: &OsStr) -> Ordering {
 /// dir/sub/`, ...). The directory type is taken from the lstat'd metadata, so
 /// an unfollowed symlink-to-directory is a non-directory here, matching
 /// upstream's `S_ISDIR` test on the flist entry.
-// upstream: flist.c:3299 f_name_cmp() - type-then-name ordering
+/// upstream: flist.c:3299 f_name_cmp() - type-then-name ordering
 fn compare_directory_entries(a: &DirectoryEntry, b: &DirectoryEntry) -> Ordering {
     // `false < true`, so non-directories (is_dir == false) sort first.
     a.metadata

--- a/crates/engine/src/local_copy/executor/file/append.rs
+++ b/crates/engine/src/local_copy/executor/file/append.rs
@@ -40,7 +40,7 @@ pub(crate) enum AppendMode {
 /// appended bytes on disk (receiver.c:1029, reached because `--append` implies
 /// `--inplace` - options.c:2400-2411) and redoes the file in phase 2 against
 /// that retained partial.
-// upstream: receiver.c:recv_files() - append mode size comparison
+/// upstream: receiver.c:recv_files() - append mode size comparison
 pub(crate) fn determine_append_mode(
     append_allowed: bool,
     append_verify: bool,

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -300,9 +300,9 @@ fn apply_backup_dir_attrs(
 /// `backup.c:306-317`, where `make_backup` returns 3 and leaves no backup:
 /// a device without `am_root && --devices`, or a special without
 /// `--specials`).
-// upstream: backup.c:make_backup() - copy-tree fallback (COPY / SYMLINK /
-// DEVICE branches). Device and special nodes are recreated via do_mknod_at
-// (backup.c:278-285), gated on am_root+preserve_devices / preserve_specials.
+/// upstream: backup.c:make_backup() - copy-tree fallback (COPY / SYMLINK /
+/// DEVICE branches). Device and special nodes are recreated via do_mknod_at
+/// (backup.c:278-285), gated on am_root+preserve_devices / preserve_specials.
 pub(crate) fn copy_entry_to_backup(
     source: &Path,
     backup_path: &Path,
@@ -358,9 +358,9 @@ pub(crate) fn copy_entry_to_backup(
 /// placing a backup). Under `--fake-super` the node is virtualised as a `0600`
 /// placeholder carrying the `%stat` xattr, matching `syscall.c:do_mknod()`'s
 /// `am_root < 0` branch.
-// upstream: backup.c:278 - `(am_root && preserve_devices && IS_DEVICE(mode))
-// || (preserve_specials && IS_SPECIAL(mode))` gates `do_mknod_at`. am_root is
-// non-zero for real root, --super, and --fake-super (options.c:90).
+/// upstream: backup.c:278 - `(am_root && preserve_devices && IS_DEVICE(mode))
+/// || (preserve_specials && IS_SPECIAL(mode))` gates `do_mknod_at`. am_root is
+/// non-zero for real root, --super, and --fake-super (options.c:90).
 #[cfg(unix)]
 fn copy_special_to_backup(
     source: &Path,

--- a/crates/engine/src/local_copy/executor/file/paths.rs
+++ b/crates/engine/src/local_copy/executor/file/paths.rs
@@ -63,7 +63,7 @@ const TMPNAME_SUFFIX_LEN: usize = 7;
 ///
 /// `suffix` is the six-character unique component (upstream fills it via
 /// `mkstemp`; the caller supplies a candidate and retries on collision).
-// upstream: receiver.c:145 get_tmpname()
+/// upstream: receiver.c:145 get_tmpname()
 pub(crate) fn temp_name_with_suffix(
     destination: &Path,
     temp_dir: Option<&Path>,

--- a/crates/engine/src/local_copy/executor/file/preallocate.rs
+++ b/crates/engine/src/local_copy/executor/file/preallocate.rs
@@ -26,8 +26,8 @@ use crate::local_copy::LocalCopyError;
 /// size - with `KEEP_SIZE` the reserved blocks sit beyond EOF and the punch
 /// silently does nothing, leaving the file fully allocated. So when holes will
 /// also be punched (`--sparse`), upstream reserves at full size instead.
-// upstream: syscall.c:2597 do_fallocate() - `int opts = (inplace ||
-// preallocate_files) && sparse_files <= 0 ? DO_FALLOC_OPTIONS : 0;`
+/// upstream: syscall.c:2597 do_fallocate() - `int opts = (inplace ||
+/// preallocate_files) && sparse_files <= 0 ? DO_FALLOC_OPTIONS : 0;`
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Reservation {
     /// `opts == FALLOC_FL_KEEP_SIZE`: no holes will be punched.
@@ -39,7 +39,7 @@ pub(crate) enum Reservation {
 
 impl Reservation {
     /// Selects the reservation upstream would make for this sparse setting.
-    // upstream: syscall.c:2597 - `sparse_files <= 0` is what selects KEEP_SIZE.
+    /// upstream: syscall.c:2597 - `sparse_files <= 0` is what selects KEEP_SIZE.
     pub(crate) const fn for_sparse(sparse: bool) -> Self {
         if sparse {
             Self::FullSize
@@ -78,8 +78,8 @@ const fn available(reservation: Reservation) -> Reservation {
 /// run's start against it to choose `do_punch_hole()` over a plain `lseek()`, so
 /// a stray `0` here silently leaves `--preallocate --sparse` files fully
 /// allocated - the exact regression upstream records at syscall.c:2622.
-// upstream: syscall.c:2589 do_fallocate(); receiver.c:479
-// `preallocated_len = do_fallocate(fd, 0, total_size)`
+/// upstream: syscall.c:2589 do_fallocate(); receiver.c:479
+/// `preallocated_len = do_fallocate(fd, 0, total_size)`
 pub(crate) fn maybe_preallocate_destination(
     file: &mut fs::File,
     path: &Path,

--- a/crates/engine/src/local_copy/executor/file/sparse/state.rs
+++ b/crates/engine/src/local_copy/executor/file/sparse/state.rs
@@ -41,7 +41,7 @@ impl SparseWriteState {
     /// Records the preallocated length so zero runs inside the reserved extent
     /// are punched out rather than merely seeked over (which would leave the
     /// preallocated blocks allocated).
-    // upstream: fileio.c:84 - if (sparse_past_write >= preallocated_len)
+    /// upstream: fileio.c:84 - if (sparse_past_write >= preallocated_len)
     pub(crate) const fn set_preallocated_len(&mut self, len: u64) {
         self.preallocated_len = len;
     }
@@ -57,7 +57,7 @@ impl SparseWriteState {
     /// forward when that position is at or beyond the preallocated extent (the
     /// natural-hole case for a fresh file), otherwise punches a hole to
     /// deallocate the blocks that preallocation reserved.
-    // upstream: fileio.c:80-95 flush_sparse_hole()
+    /// upstream: fileio.c:80-95 flush_sparse_hole()
     fn flush(&mut self, writer: &mut fs::File, destination: &Path) -> Result<(), LocalCopyError> {
         if self.pending_zero_run == 0 {
             return Ok(());
@@ -110,7 +110,7 @@ impl SparseWriteState {
     ///
     /// Returns the final logical file position (including any trailing hole)
     /// for the caller's `set_len`.
-    // upstream: fileio.c:43 sparse_end()
+    /// upstream: fileio.c:43 sparse_end()
     pub(crate) fn finish(
         &mut self,
         writer: &mut fs::File,
@@ -149,7 +149,7 @@ pub(crate) enum SpanWrite {
 /// as seeks (natural holes) or hole-punches (inside a preallocated extent) when
 /// non-zero data follows. This produces sparse files when the filesystem
 /// supports it.
-// upstream: fileio.c:write_sparse()
+/// upstream: fileio.c:write_sparse()
 pub(crate) fn write_sparse_chunk(
     writer: &mut fs::File,
     state: &mut SparseWriteState,
@@ -165,9 +165,9 @@ pub(crate) fn write_sparse_chunk(
 /// spans are seeked over rather than rewritten - but its interior zero runs are
 /// still scanned and punched. Skipping that scan is what leaves a hole-y basis
 /// file fully allocated under `--inplace --sparse`.
-// upstream: fileio.c:256-259 skip_matched() - `if (sparse_files > 0)
-// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, only the non-sparse arm
-// lseeks straight past the block.
+/// upstream: fileio.c:256-259 skip_matched() - `if (sparse_files > 0)
+/// write_file(fd, 1 /*use_seek*/, offset, buf, len)`, only the non-sparse arm
+/// lseeks straight past the block.
 pub(crate) fn skip_matched_sparse(
     writer: &mut fs::File,
     state: &mut SparseWriteState,

--- a/crates/engine/src/local_copy/executor/reference.rs
+++ b/crates/engine/src/local_copy/executor/reference.rs
@@ -163,7 +163,7 @@ fn reference_mtime_matches(
 /// permission bits (`perms_differ`), owner/group (`ownership_differs`), mtime
 /// (`any_time_differs`), and, when `-X` is active, the transferable extended
 /// attributes (`xattrs_differ`), each gated on the corresponding preserve option.
-// upstream: generator.c:475-509 unchanged_attrs - perms/ownership/time/xattr.
+/// upstream: generator.c:475-509 unchanged_attrs - perms/ownership/time/xattr.
 pub(crate) fn reference_attrs_unchanged(
     basis: &Path,
     source: &Path,

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -29,7 +29,7 @@ use ::metadata::{MetadataOptions, apply_file_metadata_with_options};
 ///
 /// Handles hard-link deduplication, `--existing`, directory replacement via
 /// `--force`, backup, and dry-run mode.
-// upstream: receiver.c - device node handling
+/// upstream: receiver.c - device node handling
 pub(crate) fn copy_device(
     context: &mut CopyContext,
     source: &Path,
@@ -476,7 +476,7 @@ pub(crate) fn copy_device(
 /// Builds the WIND-2 skip-with-warn message for a device entry the Windows
 /// receiver cannot materialise. Exposed for regression tests so they can
 /// assert the wording without capturing stderr.
-// WIND-2: docs/design/windows-device-file-strategy.md
+/// WIND-2: docs/design/windows-device-file-strategy.md
 #[cfg(not(unix))]
 pub(crate) fn format_skip_device_message(destination: &Path) -> String {
     format!(
@@ -489,7 +489,7 @@ pub(crate) fn format_skip_device_message(destination: &Path) -> String {
 ///
 /// Encodes mode (with `S_IFMT` bits), uid, gid, and rdev so a later
 /// fake-super read can faithfully reconstruct the original node.
-// upstream: xattrs.c:set_stat_xattr()
+/// upstream: xattrs.c:set_stat_xattr()
 #[cfg(all(unix, feature = "xattr"))]
 fn store_fake_super_for_local_metadata(
     destination: &Path,

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -31,7 +31,7 @@ use ::metadata::{
 ///
 /// Handles hard-link deduplication, `--existing`, directory replacement via
 /// `--force`, backup, and dry-run mode.
-// upstream: receiver.c - FIFO handling
+/// upstream: receiver.c - FIFO handling
 pub(crate) fn copy_fifo(
     context: &mut CopyContext,
     source: &Path,
@@ -482,7 +482,7 @@ pub(crate) fn copy_fifo(
 ///
 /// Encodes mode (with `S_IFMT` bits), uid, and gid so a later fake-super
 /// read can faithfully reconstruct the original node.
-// upstream: xattrs.c:set_stat_xattr()
+/// upstream: xattrs.c:set_stat_xattr()
 #[cfg(all(unix, feature = "xattr"))]
 fn store_fake_super_for_local_metadata(
     destination: &Path,

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -33,7 +33,7 @@ use super::{device::copy_device, fifo::copy_fifo, try_hard_link_basis};
 ///
 /// Rejects absolute paths, empty targets, and targets whose `..` components
 /// would escape above the directory depth implied by `link_relative`.
-// upstream: clientserver.c - safe symlink checking
+/// upstream: clientserver.c - safe symlink checking
 pub(crate) fn symlink_target_is_safe(target: &Path, link_relative: &Path) -> bool {
     if target.as_os_str().is_empty() || target.has_root() {
         return false;
@@ -105,7 +105,7 @@ pub(crate) fn symlink_target_is_safe(target: &Path, link_relative: &Path) -> boo
 /// Handles `--safe-links`, `--copy-unsafe-links`, `--munge-links`, hard-link
 /// deduplication, and dry-run mode. When `--copy-unsafe-links` is active and
 /// the target is unsafe, the link target is copied as a regular entry instead.
-// upstream: receiver.c:recv_files() - symlink handling
+/// upstream: receiver.c:recv_files() - symlink handling
 pub(crate) fn copy_symlink(
     context: &mut CopyContext,
     source: &Path,

--- a/crates/engine/src/local_copy/metadata_sync.rs
+++ b/crates/engine/src/local_copy/metadata_sync.rs
@@ -251,7 +251,7 @@ pub(crate) fn sync_nfsv4_acls_if_requested(
 ///
 /// No-op unless `--fake-super` is active together with ownership preservation,
 /// matching `metadata::apply::ownership::set_owner_like`'s fake-super gate.
-// upstream: xattrs.c:set_stat_xattr() driven by x_lstat()/get_stat_xattr()
+/// upstream: xattrs.c:set_stat_xattr() driven by x_lstat()/get_stat_xattr()
 #[cfg(all(unix, feature = "xattr"))]
 pub(crate) fn store_effective_fake_super_if_requested(
     options: &::metadata::MetadataOptions,

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -233,7 +233,7 @@ const CROSS_DEVICE_ERROR_CODE: i32 = 18;
 ///
 /// Delegates to `filters::collapse_dot_dot_dirs`, the single implementation of
 /// upstream's `clean_fname(name, CFN_COLLAPSE_DOT_DOT_DIRS)` rule.
-// upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS
+/// upstream: util1.c clean_fname() CFN_COLLAPSE_DOT_DOT_DIRS
 pub(crate) fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf {
     filters::collapse_dot_dot_dirs(path)
 }

--- a/crates/engine/src/local_copy/options/metadata/accessors.rs
+++ b/crates/engine/src/local_copy/options/metadata/accessors.rs
@@ -140,10 +140,10 @@ impl LocalCopyOptions {
     /// result is forced to `false` so callers route privileged operations
     /// (chown, mknod, mkfifo) through the fake-super xattr placeholder
     /// path, mirroring upstream's `am_root < 0` sentinel.
-    // upstream: options.c:89 - am_root tri-state: 0 normal, 1 root, 2 --super,
-    //                          -1 --fake-super (negative is "fake")
-    // upstream: clientserver.c:1116-1119 - daemon `fake super = yes` forces am_root=-1
-    // upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
+    /// upstream: options.c:89 - am_root tri-state: 0 normal, 1 root, 2 --super,
+    ///                          -1 --fake-super (negative is "fake")
+    /// upstream: clientserver.c:1116-1119 - daemon `fake super = yes` forces am_root=-1
+    /// upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
     #[must_use]
     pub fn am_root(&self) -> bool {
         effective_am_root(self.super_mode, self.fake_super)
@@ -163,8 +163,8 @@ impl LocalCopyOptions {
 /// `am_root = -1` sentinel that demotes privileged paths to the
 /// fake-super xattr placeholder branch). Otherwise the explicit `--super`
 /// flag wins, falling back to the effective UID check.
-// upstream: options.c:89 - am_root tri-state, -1 is "fake-super"
-// upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
+/// upstream: options.c:89 - am_root tri-state, -1 is "fake-super"
+/// upstream: syscall.c do_mknod() - am_root<0 sentinel substitutes 0600 placeholder
 #[must_use]
 pub(super) fn effective_am_root(super_mode: Option<bool>, fake_super: bool) -> bool {
     if fake_super {

--- a/crates/fast_io/src/preallocate.rs
+++ b/crates/fast_io/src/preallocate.rs
@@ -28,7 +28,7 @@ use rustix::fs::{FallocateFlags, fallocate};
 /// `rsyserr(FWARNING, ...)` and continue: preallocation is an optimization, and
 /// its failure (an unsupported filesystem, `ENOSPC`, ...) must never abort the
 /// transfer.
-// upstream: syscall.c:1528 do_fallocate() / receiver.c:323
+/// upstream: syscall.c:1528 do_fallocate() / receiver.c:323
 #[cfg(target_os = "linux")]
 pub fn preallocate(file: &File, length: u64) -> io::Result<u64> {
     // fallocate's offset/length args are signed; skip when length would
@@ -55,7 +55,7 @@ pub fn preallocate(file: &File, length: u64) -> io::Result<u64> {
 /// Non-Linux platforms lack `fallocate`; upstream compiles the preallocation
 /// path out entirely (`SUPPORT_PREALLOCATION` undefined), so this is a no-op
 /// that reports no reserved extent.
-// upstream: syscall.c - SUPPORT_PREALLOCATION guards the whole feature.
+/// upstream: syscall.c - SUPPORT_PREALLOCATION guards the whole feature.
 #[cfg(not(target_os = "linux"))]
 pub fn preallocate(_file: &File, _length: u64) -> io::Result<u64> {
     Ok(0)

--- a/crates/flist/src/parallel.rs
+++ b/crates/flist/src/parallel.rs
@@ -37,10 +37,10 @@ use crate::file_list_walker::FileListWalker;
 /// let entries = collect_entries(walker)?;
 /// println!("Found {} entries", entries.len());
 /// ```
-// Enumeration is silent: upstream announces a completed file list only via the
-// `sending incremental file list` FCLIENT banner (flist.c:2252) or the
-// `building file list ... done` progress pair (flist.c:2250/2524), never as an
-// entry count, so a count emitted here would have no upstream analog on stdout.
+/// Enumeration is silent: upstream announces a completed file list only via the
+/// `sending incremental file list` FCLIENT banner (flist.c:2252) or the
+/// `building file list ... done` progress pair (flist.c:2250/2524), never as an
+/// entry count, so a count emitted here would have no upstream analog on stdout.
 pub fn collect_entries(walker: FileListWalker) -> Result<Vec<FileListEntry>, FileListError> {
     walker.collect()
 }

--- a/crates/logging/src/config.rs
+++ b/crates/logging/src/config.rs
@@ -21,7 +21,7 @@ use super::levels::{DebugFlag, DebugLevels, InfoFlag, InfoLevels};
 /// [`apply_info_flag`](Self::apply_info_flag) /
 /// [`apply_debug_flag`](Self::apply_debug_flag) for `--info=`/`--debug=`
 /// overrides.
-// upstream: options.c struct that backs info_levels[] + debug_levels[]
+/// upstream: options.c struct that backs info_levels[] + debug_levels[]
 #[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VerbosityConfig {
@@ -37,8 +37,8 @@ impl VerbosityConfig {
     /// Applies cumulative upstream rsync verbosity mapping. Each level adds flags
     /// from all lower levels, matching `set_output_verbosity()` which iterates
     /// `j = 0..=level` over the `info_verbosity[]` and `debug_verbosity[]` tables.
-    // upstream: options.c:513 set_output_verbosity()
-    // upstream: options.c:228-243 debug_verbosity[] / info_verbosity[]
+    /// upstream: options.c:513 set_output_verbosity()
+    /// upstream: options.c:228-243 debug_verbosity[] / info_verbosity[]
     #[must_use]
     pub fn from_verbose_level(level: u8) -> Self {
         let mut config = Self::default();
@@ -198,7 +198,7 @@ impl VerbosityConfig {
     /// Parses the token into a flag name and optional numeric level suffix
     /// (defaulting to 1), then sets that flag. This implements the per-flag
     /// override syntax used by `--info=FLAGS`.
-    // upstream: options.c:parse_output_words()
+    /// upstream: options.c:parse_output_words()
     pub fn apply_info_flag(&mut self, token: &str) -> Result<(), String> {
         let (name, level) = parse_flag_token(token)?;
 
@@ -232,7 +232,7 @@ impl VerbosityConfig {
     /// Parses the token into a flag name and optional numeric level suffix
     /// (defaulting to 1), then sets that flag. This implements the per-flag
     /// override syntax used by `--debug=FLAGS`.
-    // upstream: options.c:parse_output_words()
+    /// upstream: options.c:parse_output_words()
     pub fn apply_debug_flag(&mut self, token: &str) -> Result<(), String> {
         let (name, level) = parse_flag_token(token)?;
 

--- a/crates/logging/src/levels/debug.rs
+++ b/crates/logging/src/levels/debug.rs
@@ -11,7 +11,7 @@
 /// (verbose level 2) and increase through `-vvvvv` (level 5). Upstream
 /// defines these in `rsync.h` as `DEBUG_*` constants and indexes into
 /// the `debug_levels[]` array.
-// upstream: rsync.h DEBUG_ACL..DEBUG_TIME, options.c:237 debug_verbosity[]
+/// upstream: rsync.h DEBUG_ACL..DEBUG_TIME, options.c:237 debug_verbosity[]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DebugFlag {
@@ -78,7 +78,7 @@ pub enum DebugFlag {
 /// Each field holds the current verbosity level for its corresponding
 /// [`DebugFlag`]. A value of 0 means the flag is disabled. Upstream rsync
 /// stores these in the global `debug_levels[]` array (upstream: rsync.h).
-// upstream: rsync.h debug_levels[]
+/// upstream: rsync.h debug_levels[]
 #[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DebugLevels {

--- a/crates/logging/src/levels/info.rs
+++ b/crates/logging/src/levels/info.rs
@@ -10,7 +10,7 @@
 /// skip/delete notifications. They are set by `-v` (level 1) and `-vv`
 /// (level 2). Upstream defines these in `rsync.h` as `INFO_*` constants
 /// and indexes into the `info_levels[]` array.
-// upstream: rsync.h INFO_BACKUP..INFO_SYMSAFE, options.c:228 info_verbosity[]
+/// upstream: rsync.h INFO_BACKUP..INFO_SYMSAFE, options.c:228 info_verbosity[]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InfoFlag {
@@ -47,7 +47,7 @@ pub enum InfoFlag {
 /// Each field holds the current verbosity level for its corresponding
 /// [`InfoFlag`]. A value of 0 means the flag is disabled. Upstream rsync
 /// stores these in the global `info_levels[]` array (upstream: rsync.h).
-// upstream: rsync.h info_levels[]
+/// upstream: rsync.h info_levels[]
 #[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoLevels {

--- a/crates/logging/src/stream.rs
+++ b/crates/logging/src/stream.rs
@@ -74,7 +74,7 @@ pub struct BadLogCode(pub LogCode);
 /// Returns [`BadLogCode`] for a code `rwrite` rejects. Callers that cannot
 /// abort should surface it; they must not silently pick a stream, which is the
 /// defect this function exists to prevent.
-// upstream: log.c:251-328 rwrite()
+/// upstream: log.c:251-328 rwrite()
 pub const fn message_stream(
     code: LogCode,
     ctx: StreamContext,

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -104,7 +104,7 @@ pub fn set_quiet(quiet: bool) {
 ///
 /// The single question a producer or renderer should ask before emitting an
 /// upstream `rprintf(FINFO, ...)` that carries no `INFO_GTE` gate of its own.
-// upstream: log.c:345 rwrite() `if (quiet)` - the FINFO arm's early return.
+/// upstream: log.c:345 rwrite() `if (quiet)` - the FINFO arm's early return.
 #[must_use]
 pub fn finfo_suppressed() -> bool {
     QUIET.with(Cell::get)
@@ -133,7 +133,7 @@ pub fn debug_gte(flag: DebugFlag, level: u8) -> bool {
 /// (client stdout, subject to verbosity) matches how the renderer treats
 /// every drained event today. Producers that mirror a different upstream
 /// `rprintf()` code use [`emit_info_coded`].
-// upstream: log.c:rwrite() dispatches FINFO messages
+/// upstream: log.c:rwrite() dispatches FINFO messages
 pub fn emit_info(flag: InfoFlag, level: u8, message: String) {
     emit_info_coded(flag, level, LogCode::Info, message);
 }
@@ -168,7 +168,7 @@ pub fn emit_info_coded(flag: InfoFlag, level: u8, code: LogCode, message: String
 /// `rsync warning: … (code N) at file(line)` trailer upstream renders at
 /// `log.c:956` is deliberately not applied here; that formatting belongs to
 /// the single logcode-to-stream funnel, not to the emitter.
-// upstream: log.c:341 rwrite() `case FWARNING:`
+/// upstream: log.c:341 rwrite() `case FWARNING:`
 pub fn emit_warning(message: String) {
     emit_info_coded(InfoFlag::Misc, 0, LogCode::Warning, message);
 }
@@ -181,7 +181,7 @@ pub fn emit_warning(message: String) {
 /// The event is tagged [`LogCode::Info`]: upstream debug traces are emitted
 /// through `rprintf(FINFO, ...)` and share FINFO routing. Producers that
 /// mirror a different upstream code use [`emit_debug_coded`].
-// upstream: log.c:rwrite() dispatches FINFO debug messages
+/// upstream: log.c:rwrite() dispatches FINFO debug messages
 pub fn emit_debug(flag: DebugFlag, level: u8, message: String) {
     emit_debug_coded(flag, level, LogCode::Info, message);
 }
@@ -306,7 +306,7 @@ pub fn drain_events_coded(code: LogCode) -> Vec<DiagnosticEvent> {
 /// server's whole `--debug` output on the wire as a side effect of fixing a
 /// warning. `FLOG` is excluded because upstream returns before the switch
 /// (upstream: log.c:331-333); it belongs to [`drain_events_coded`].
-// upstream: log.c:357-366 rwrite() `if (am_server ...) send_msg(msg, ...)`
+/// upstream: log.c:357-366 rwrite() `if (am_server ...) send_msg(msg, ...)`
 pub fn drain_events_for_peer() -> Vec<DiagnosticEvent> {
     drain_events_where(|code| {
         matches!(

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 /// Preserves permission bits (best-effort on non-Unix targets) and
 /// nanosecond timestamps. Delegates to [`apply_directory_metadata_with_options`]
 /// with default options (all preservation flags enabled).
-// upstream: rsync.c:set_file_attrs() - directory metadata application
+/// upstream: rsync.c:set_file_attrs() - directory metadata application
 pub fn apply_directory_metadata(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -42,7 +42,7 @@ pub fn apply_directory_metadata(
 ///
 /// Applies ownership, permissions, and timestamps in the same order as
 /// upstream rsync's `set_file_attrs()`: chown, chmod, then utimensat.
-// upstream: rsync.c:set_file_attrs() - order: chown → chmod → utimensat
+/// upstream: rsync.c:set_file_attrs() - order: chown → chmod → utimensat
 pub fn apply_directory_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -63,7 +63,7 @@ pub fn apply_directory_metadata_with_options(
 /// Preserves permission bits (best-effort on non-Unix targets) and
 /// nanosecond timestamps. Delegates to [`apply_file_metadata_with_options`]
 /// with default options (all preservation flags enabled).
-// upstream: rsync.c:set_file_attrs() - file metadata application
+/// upstream: rsync.c:set_file_attrs() - file metadata application
 pub fn apply_file_metadata(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -75,7 +75,7 @@ pub fn apply_file_metadata(
 ///
 /// Applies ownership, permissions, timestamps, and creation time in the
 /// same order as upstream rsync's `set_file_attrs()`.
-// upstream: rsync.c:set_file_attrs() - order: chown → chmod → utimensat → crtime
+/// upstream: rsync.c:set_file_attrs() - order: chown → chmod → utimensat → crtime
 pub fn apply_file_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -128,7 +128,7 @@ pub fn apply_dest_mode_pre_transfer(
 /// `am_root` is sampled through the same libc `geteuid` the chmod apply path
 /// uses, so the self-lock decision and the on-disk fixup agree under
 /// `fakeroot`. See [`crate::transfer_root_self_locks`] for the mechanism.
-// upstream: rsync.c:set_file_attrs() new_mode + generator.c:1512 fixup.
+/// upstream: rsync.c:set_file_attrs() new_mode + generator.c:1512 fixup.
 #[cfg(unix)]
 pub fn transfer_root_chmod_self_lock(
     destination: &Path,
@@ -287,8 +287,8 @@ pub fn apply_file_metadata_with_fd_if_changed(
 /// (generator.c:418) to a single read-only-bit compare, mirroring the Unix
 /// arm's permission leg. Kept as a pure, platform-independent helper so it is
 /// unit-testable on Linux even though it only gates the `cfg(not(unix))` path.
-// upstream: generator.c:418 perms_differ() - the mode compare behind
-// unchanged_attrs()'s `if perms_differ(...)` leg.
+/// upstream: generator.c:418 perms_differ() - the mode compare behind
+/// unchanged_attrs()'s `if perms_differ(...)` leg.
 #[cfg(any(not(unix), test))]
 pub(crate) fn windows_readonly_differs(entry_permissions: u32, current_readonly: bool) -> bool {
     let required_readonly = entry_permissions & 0o200 == 0;
@@ -473,7 +473,7 @@ pub fn metadata_unchanged(
 /// Applies metadata from `metadata` to the destination symbolic link without
 /// following the link target. Delegates to [`apply_symlink_metadata_with_options`]
 /// with default options.
-// upstream: rsync.c:set_file_attrs() - symlink path uses AT_SYMLINK_NOFOLLOW
+/// upstream: rsync.c:set_file_attrs() - symlink path uses AT_SYMLINK_NOFOLLOW
 pub fn apply_symlink_metadata(
     destination: &Path,
     metadata: &fs::Metadata,

--- a/crates/metadata/src/apply/ownership.rs
+++ b/crates/metadata/src/apply/ownership.rs
@@ -52,8 +52,8 @@ use std::os::unix::fs::MetadataExt;
 /// returns `EPERM`, dropping every file to `0:0`. Only the parent-directory
 /// walk uses `openat2`, which fakeroot ignores because it tracks ownership per
 /// inode on the chown call, not on directory opens.
-// upstream: syscall.c:do_lchown()/do_chown() call the lchown(2)/chown(2) libc
-// symbols; rsync 3.4.3+ resolves them under the module dirfd (CVE-2026-29518).
+/// upstream: syscall.c:do_lchown()/do_chown() call the lchown(2)/chown(2) libc
+/// symbols; rsync 3.4.3+ resolves them under the module dirfd (CVE-2026-29518).
 #[cfg(unix)]
 fn chown_path(
     path: &Path,
@@ -89,7 +89,7 @@ fn chown_path(
 /// fd-based counterpart to [`chown_path`] using the libc `fchown(2)` symbol via
 /// `nix`. See [`chown_path`] for why the call must go through libc rather than a
 /// raw syscall (fakeroot `LD_PRELOAD` interposition).
-// upstream: syscall.c:do_fchown() calls the fchown(2) libc symbol.
+/// upstream: syscall.c:do_fchown() calls the fchown(2) libc symbol.
 #[cfg(unix)]
 fn chown_fd(
     fd: BorrowedFd<'_>,
@@ -145,7 +145,7 @@ const IMPOSSIBLE_ID: u32 = u32::MAX;
 ///
 /// Kept pure so the exact wording can be pinned in a unit test. The path is
 /// quoted like upstream `full_fname`, and `kind` is `"uid"` or `"gid"`.
-// upstream: rsync.c:691-694 - "uid 4294967295 (-1) is impossible to set on %s".
+/// upstream: rsync.c:691-694 - "uid 4294967295 (-1) is impossible to set on %s".
 #[cfg(unix)]
 fn impossible_id_message(kind: &str, destination: &Path) -> String {
     format!(
@@ -164,7 +164,7 @@ fn warn_impossible_id(kind: &str, destination: &Path) {
 
 /// Returns `true` when a resolved id of `(uid_t)-1` cannot be applied because
 /// the destination is not already owned by `-1`.
-// upstream: rsync.c:690-692 - `uid == (uid_t)-1 && sxp->st.st_uid != (uid_t)-1`.
+/// upstream: rsync.c:690-692 - `uid == (uid_t)-1 && sxp->st.st_uid != (uid_t)-1`.
 #[cfg(unix)]
 fn id_is_impossible(resolved: Option<u32>, pre_chown_id: Option<u32>) -> bool {
     matches!(resolved, Some(IMPOSSIBLE_ID)) && pre_chown_id.unwrap_or(0) != IMPOSSIBLE_ID
@@ -173,7 +173,7 @@ fn id_is_impossible(resolved: Option<u32>, pre_chown_id: Option<u32>) -> bool {
 /// Returns `true` when the pre-chown mode carried setuid/setgid, so the caller
 /// must re-stat: `chown` clears those bits on many systems and the later mode
 /// compare must observe the post-chown state to restore them.
-// upstream: rsync.c:564-567 - `if (sxp->st.st_mode & (S_ISUID | S_ISGID)) link_stat(...)`.
+/// upstream: rsync.c:564-567 - `if (sxp->st.st_mode & (S_ISUID | S_ISGID)) link_stat(...)`.
 #[cfg(unix)]
 fn suid_sgid_needs_restat(pre_chown_mode: Option<u32>) -> bool {
     pre_chown_mode
@@ -189,7 +189,7 @@ fn suid_sgid_needs_restat(pre_chown_mode: Option<u32>) -> bool {
 /// before the chown. Returns `true` when the caller should refresh its cached
 /// destination stat before the permission comparison so the dropped
 /// setuid/setgid bits get re-applied.
-// upstream: rsync.c:558-568 set_file_attrs() - impossible-id warning + suid/sgid re-stat.
+/// upstream: rsync.c:558-568 set_file_attrs() - impossible-id warning + suid/sgid re-stat.
 #[cfg(unix)]
 fn post_chown_bookkeeping(
     destination: &Path,
@@ -316,7 +316,7 @@ pub fn group_is_settable(gid: u32) -> bool {
 /// `getpwuid(raw)` - which is wrong when the raw sender id is absent or bound to
 /// a different name locally. Without an inline name (local copy) the raw id is
 /// round-tripped through the receiver's database exactly as before.
-// upstream: flist.c:914 recv_user_name / uidlist.c:307 match_uid
+/// upstream: flist.c:914 recv_user_name / uidlist.c:307 match_uid
 #[cfg(unix)]
 fn resolve_owner_uid(
     entry: &protocol::flist::FileEntry,
@@ -360,7 +360,7 @@ fn resolve_owner_uid(
 /// The group counterpart of [`resolve_owner_uid`]: `--groupmap` first, then the
 /// sender-transmitted group name (INC_RECURSE `XMIT_GROUP_NAME_FOLLOWS`) resolved
 /// against the receiver's group database.
-// upstream: flist.c:926 recv_group_name / uidlist.c:317 match_gid
+/// upstream: flist.c:926 recv_group_name / uidlist.c:317 match_gid
 #[cfg(unix)]
 fn resolve_group_gid(
     entry: &protocol::flist::FileEntry,
@@ -399,7 +399,7 @@ fn resolve_group_gid(
 ///
 /// Resolution priority: override > mapping > source metadata, matching
 /// upstream's chown logic.
-// upstream: rsync.c:set_file_attrs() - UID/GID resolution before chown
+/// upstream: rsync.c:set_file_attrs() - UID/GID resolution before chown
 #[cfg(unix)]
 pub(super) fn resolve_ownership(
     metadata: &fs::Metadata,
@@ -452,7 +452,7 @@ pub(super) fn resolve_ownership(
 ///
 /// Compares only the fields that are being changed - `None` values are
 /// treated as "no change requested" and always match.
-// upstream: rsync.c:set_file_attrs() - skips chown when uid/gid already match
+/// upstream: rsync.c:set_file_attrs() - skips chown when uid/gid already match
 #[cfg(unix)]
 pub(super) fn ownership_matches(
     owner: &Option<unix_fs::Uid>,
@@ -484,7 +484,7 @@ pub(super) fn ownership_matches(
 /// Returns `true` when the destination carried setuid/setgid bits that the
 /// chown may have cleared, so the caller must re-stat before the permission
 /// comparison (upstream rsync.c:564-567). Returns `false` when no chown ran.
-// upstream: rsync.c:set_file_attrs() - chownat with conditional AT_SYMLINK_NOFOLLOW
+/// upstream: rsync.c:set_file_attrs() - chownat with conditional AT_SYMLINK_NOFOLLOW
 pub(super) fn set_owner_like(
     metadata: &fs::Metadata,
     destination: &Path,
@@ -606,7 +606,7 @@ pub(super) fn set_owner_like_with_fd(
 /// Returns `true` when the destination carried setuid/setgid bits that the
 /// chown may have cleared, so the caller must re-stat before applying
 /// permissions (upstream rsync.c:564-567). Returns `false` when no chown ran.
-// upstream: rsync.c:set_file_attrs() - chown path for receiver-side file entries
+/// upstream: rsync.c:set_file_attrs() - chown path for receiver-side file entries
 #[cfg(unix)]
 pub(super) fn apply_ownership_from_entry(
     destination: &Path,
@@ -708,7 +708,7 @@ pub(super) fn apply_ownership_from_entry(
 /// `do_lchown(fname, uid, gid)` path in `set_file_attrs()`. Fake-super xattr
 /// storage is skipped because `lsetxattr` on symlinks is not portable; upstream
 /// rsync also takes the skip path for symlinks under `am_root < 0`.
-// upstream: rsync.c:set_file_attrs() - do_lchown for symlinks
+/// upstream: rsync.c:set_file_attrs() - do_lchown for symlinks
 #[cfg(unix)]
 pub(super) fn apply_symlink_ownership_from_entry(
     destination: &Path,
@@ -786,7 +786,7 @@ pub(super) fn apply_symlink_ownership_from_entry(
 /// Used when `--fake-super` is enabled, allowing non-root users to
 /// preserve ownership information in extended attributes. Encodes
 /// mode, uid, gid, and rdev into a `user.rsync.%stat` xattr.
-// upstream: rsync.c:set_file_attrs() with am_root==0 and fake_super active
+/// upstream: rsync.c:set_file_attrs() with am_root==0 and fake_super active
 #[cfg(unix)]
 fn apply_ownership_via_fake_super(
     destination: &Path,
@@ -842,7 +842,7 @@ fn apply_ownership_via_fake_super(
 /// Mirrors `apply_ownership_via_fake_super`'s "no-op when the existing xattr
 /// already matches" fast path. On platforms or builds without xattr support
 /// this is a graceful no-op.
-// upstream: xattrs.c:set_stat_xattr() / rsync.c:set_file_attrs() with am_root<0
+/// upstream: xattrs.c:set_stat_xattr() / rsync.c:set_file_attrs() with am_root<0
 #[cfg(unix)]
 fn store_fake_super_from_local_metadata(
     destination: &Path,

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -23,7 +23,7 @@ use std::os::fd::BorrowedFd;
 /// daemon chmod paths all compute one identical result (DRY). `am_root` is
 /// sampled through the same libc `geteuid` the ownership gate uses so
 /// `fakeroot`'s faked identity is honoured.
-// upstream: generator.c:1512-1520 fixup + generator.c:2107-2145 touch_up_dirs.
+/// upstream: generator.c:1512-1520 fixup + generator.c:2107-2145 touch_up_dirs.
 #[cfg(unix)]
 fn tweak_directory_transfer_mode(mode: u32, file_type: fs::FileType) -> u32 {
     if !file_type.is_dir() {
@@ -41,7 +41,7 @@ fn tweak_directory_transfer_mode(mode: u32, file_type: fs::FileType) -> u32 {
 /// its stat wrapper reports a stale mode and silently drops preserved
 /// permission bits. Routing chmod through libc keeps it consistent with chown,
 /// matching upstream (which drives every attribute through libc symbols).
-// upstream: syscall.c:do_fchmod() calls the fchmod(2) libc symbol.
+/// upstream: syscall.c:do_fchmod() calls the fchmod(2) libc symbol.
 #[cfg(unix)]
 fn fchmod_libc(
     fd: BorrowedFd<'_>,
@@ -334,7 +334,7 @@ fn dest_mode_for_existing_or_new(
 /// Windows, only the read-only flag is mirrored. The `options` carrier lets
 /// the Unix path honor `--keep-dirlinks` via [`chmod_path_honoring_keep_dirlinks`]
 /// instead of the dirfd sandbox that rejects symlinked parents.
-// upstream: rsync.c:set_file_attrs() - chmod path for direct permission copy
+/// upstream: rsync.c:set_file_attrs() - chmod path for direct permission copy
 pub(super) fn set_permissions_like(
     metadata: &fs::Metadata,
     destination: &Path,
@@ -376,7 +376,7 @@ pub(super) fn set_permissions_like(
 
 /// Returns `true` when `target_mode` already matches the permission bits on
 /// `existing`, comparing only the lower 12 bits (suid/sgid/sticky + rwx).
-// upstream: rsync.c:set_file_attrs() - skips chmod when mode already matches
+/// upstream: rsync.c:set_file_attrs() - skips chmod when mode already matches
 #[cfg(unix)]
 pub(super) fn permissions_match(target_mode: u32, existing: &fs::Metadata) -> bool {
     use std::os::unix::fs::PermissionsExt;
@@ -400,8 +400,8 @@ pub(super) fn permissions_match(target_mode: u32, existing: &fs::Metadata) -> bo
 /// real attributes already match, upstream writes no shim and removes any stale
 /// `%stat` (`xattrs.c:1225-1237`), so an unprivileged same-owner copy of a
 /// plain 0755 dir / 0644 file leaves no `%stat` behind.
-// upstream: xattrs.c:1188-1237 set_stat_xattr() - mode = (fmode & ACCESSPERMS)
-//           | (S_ISDIR ? 0700 : 0600); write-or-remove based on faithfulness.
+/// upstream: xattrs.c:1188-1237 set_stat_xattr() - mode = (fmode & ACCESSPERMS)
+///           | (S_ISDIR ? 0700 : 0600); write-or-remove based on faithfulness.
 #[cfg(unix)]
 fn apply_fake_super_mode(
     destination: &Path,
@@ -491,7 +491,7 @@ fn apply_fake_super_mode(
 /// When chmod modifiers are configured, applies them on top of the base mode.
 /// Otherwise delegates to [`apply_permissions_without_chmod`] for direct
 /// permission copy or executability-only preservation.
-// upstream: rsync.c:set_file_attrs() - chmod with optional modifier chain
+/// upstream: rsync.c:set_file_attrs() - chmod with optional modifier chain
 pub(super) fn apply_permissions_with_chmod(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -820,7 +820,7 @@ pub(super) fn apply_symlink_permissions_like(
 /// [`compute_dest_mode`]) supplies the baseline. Chmod modifiers, when present,
 /// are layered last so the recorded xattr reflects the same mode a privileged
 /// transfer would have applied on disk.
-// upstream: rsync.c:495-519 set_file_attrs() new_mode / dest_mode + tweak_mode
+/// upstream: rsync.c:495-519 set_file_attrs() new_mode / dest_mode + tweak_mode
 #[cfg(unix)]
 fn intended_fake_super_mode(
     destination: &Path,
@@ -857,7 +857,7 @@ fn intended_fake_super_mode(
 /// executor uses this to detect a transfer-root directory whose tweaked mode
 /// strips owner execute and therefore self-locks (see
 /// [`crate::transfer_root_self_locks`]).
-// upstream: rsync.c:set_file_attrs() new_mode, pre generator.c:1512 fixup.
+/// upstream: rsync.c:set_file_attrs() new_mode, pre generator.c:1512 fixup.
 #[cfg(unix)]
 pub(super) fn chmod_directory_target_mode(
     destination: &Path,
@@ -1012,7 +1012,7 @@ fn apply_permissions_without_chmod(
 /// pre-transfer at this mode"; `None` means "no pre-transfer destination
 /// state available" - either the file is new or the caller cannot supply
 /// it.
-// upstream: rsync.c:set_file_attrs() - receiver-side permission application
+/// upstream: rsync.c:set_file_attrs() - receiver-side permission application
 pub(super) fn apply_permissions_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,

--- a/crates/metadata/src/apply/timestamps.rs
+++ b/crates/metadata/src/apply/timestamps.rs
@@ -33,9 +33,9 @@ use std::os::fd::BorrowedFd;
 /// through the ambient namespace like upstream `generator.c:1344`'s
 /// `link_stat`. The syscall never opens the node, so a peerless FIFO cannot
 /// block it.
-// upstream: rsync.c:set_file_attrs()/util1.c:set_times() apply times through
-// utimensat on the path (never opening the node); rsync 3.4.3+ resolves under
-// the module dirfd (CVE-2026-29518).
+/// upstream: rsync.c:set_file_attrs()/util1.c:set_times() apply times through
+/// utimensat on the path (never opening the node); rsync 3.4.3+ resolves under
+/// the module dirfd (CVE-2026-29518).
 #[cfg(unix)]
 fn set_times_via(
     destination: &Path,
@@ -109,7 +109,7 @@ fn set_times_via(
 /// comparison is included in the skip check so that atime-only changes
 /// still trigger a `utimensat` call. Without `options` (or when atimes is
 /// disabled), only the mtime is compared.
-// upstream: rsync.c:set_file_attrs() - utimensat / lutimensat based on follow flag
+/// upstream: rsync.c:set_file_attrs() - utimensat / lutimensat based on follow flag
 pub(super) fn set_timestamp_like(
     metadata: &fs::Metadata,
     destination: &Path,
@@ -212,7 +212,7 @@ fn is_tolerable_special_time_error(error: &io::Error) -> bool {
 ///
 /// When `options` is provided and `options.atimes()` is true, the atime
 /// comparison is included in the skip check.
-// upstream: rsync.c:set_file_attrs() - futimens path when fd is available
+/// upstream: rsync.c:set_file_attrs() - futimens path when fd is available
 #[cfg(unix)]
 pub(super) fn set_timestamp_with_fd(
     metadata: &fs::Metadata,
@@ -275,7 +275,7 @@ pub(super) fn set_timestamp_with_fd(
 /// Used in the local copy path when `--atimes` is active but `--times` is not,
 /// mirroring upstream's `set_file_attrs()` behavior where atime and mtime are
 /// governed independently by `ATTRS_SKIP_ATIME` / `ATTRS_SKIP_MTIME`.
-// upstream: rsync.c:604-612 - atime applied independently of mtime
+/// upstream: rsync.c:604-612 - atime applied independently of mtime
 pub(super) fn apply_atime_only_from_metadata(
     metadata: &fs::Metadata,
     destination: &Path,
@@ -319,7 +319,7 @@ pub(super) fn apply_atime_only_from_metadata(
 ///
 /// Uses `futimens` on the open fd to set only the atime while preserving the
 /// destination's existing mtime.
-// upstream: rsync.c:604-612 - atime applied independently of mtime
+/// upstream: rsync.c:604-612 - atime applied independently of mtime
 #[cfg(unix)]
 pub(super) fn apply_atime_only_from_metadata_with_fd(
     metadata: &fs::Metadata,
@@ -371,7 +371,7 @@ pub(super) fn apply_atime_only_from_metadata_with_fd(
 /// When `--atimes` is not active, both atime and mtime are set to the entry's
 /// mtime value. Skips the syscall when both timestamps already match
 /// `cached_meta`.
-// upstream: rsync.c:597 - `if (!(flags & ATTRS_SKIP_MTIME) && !same_mtime(...))`
+/// upstream: rsync.c:597 - `if (!(flags & ATTRS_SKIP_MTIME) && !same_mtime(...))`
 pub(super) fn apply_timestamps_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
@@ -429,7 +429,7 @@ pub(super) fn apply_timestamps_from_entry(
 /// symlinks, so they take the `AT_SYMLINK_NOFOLLOW` leaf. Tolerable
 /// special-file errnos are swallowed as best-effort, mirroring
 /// [`set_timestamp_like`].
-// upstream: rsync.c:set_file_attrs() - utimensat on the path, never opens the node
+/// upstream: rsync.c:set_file_attrs() - utimensat on the path, never opens the node
 fn set_entry_times(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
@@ -468,7 +468,7 @@ fn set_entry_times(
 /// the symlink's own mtime is updated instead of the link target's. The
 /// receiver invokes this after `do_symlink` so the on-disk link mtime
 /// matches the source-side value.
-// upstream: rsync.c:set_file_attrs() + set_times() - symlink path uses lutimes
+/// upstream: rsync.c:set_file_attrs() + set_times() - symlink path uses lutimes
 pub(super) fn apply_symlink_timestamps_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
@@ -573,7 +573,7 @@ pub(super) fn apply_atime_only_from_entry(
 ///
 /// Reads the birth time via `metadata.created()` and applies it using
 /// `set_crtime`. On platforms where `created()` is unavailable, this is a no-op.
-// upstream: rsync.c:615 - crtime application after file transfer
+/// upstream: rsync.c:615 - crtime application after file transfer
 pub(super) fn apply_crtime_from_source_metadata(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -593,7 +593,7 @@ pub(super) fn apply_crtime_from_source_metadata(
 ///
 /// On macOS this uses `setattrlist(2)` with `ATTR_CMN_CRTIME`. On other
 /// platforms this is a no-op since creation time is not universally settable.
-// upstream: rsync.c:751 - `if (crtimes_ndx && !(flags & ATTRS_SKIP_CRTIME))`
+/// upstream: rsync.c:751 - `if (crtimes_ndx && !(flags & ATTRS_SKIP_CRTIME))`
 pub(super) fn apply_crtime_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
@@ -654,7 +654,7 @@ fn crtime_needs_update(
 }
 
 /// Sets the creation time (birth time) of a file on macOS via `setattrlist(2)`.
-// upstream: rsync.c uses utimensat for mtime/atime; crtime uses setattrlist on macOS
+/// upstream: rsync.c uses utimensat for mtime/atime; crtime uses setattrlist on macOS
 #[cfg(target_os = "macos")]
 #[allow(unsafe_code)]
 fn set_crtime(path: &Path, secs: i64) -> Result<(), MetadataError> {
@@ -744,7 +744,7 @@ fn set_crtime(path: &Path, secs: i64) -> Result<(), MetadataError> {
 /// is converted to a `FILETIME` (100-ns ticks since 1601-01-01). Pre-1601 or
 /// overflowing inputs leave the destination crtime untouched rather than write
 /// a bogus value.
-// upstream: rsync.c uses utimensat for mtime/atime; crtime uses SetFileTime on Windows
+/// upstream: rsync.c uses utimensat for mtime/atime; crtime uses SetFileTime on Windows
 #[cfg(windows)]
 #[allow(unsafe_code)]
 fn set_crtime(path: &Path, secs: i64) -> Result<(), MetadataError> {

--- a/crates/metadata/src/fake_super.rs
+++ b/crates/metadata/src/fake_super.rs
@@ -222,7 +222,7 @@ impl FakeSuperStat {
     /// `%stat`-encoded mode. Mirrors upstream, where `x_lstat()` layers
     /// `get_stat_xattr()` over `lstat()` so hlink/generator see the recorded
     /// type rather than the placeholder's regular mode.
-    // upstream: xattrs.c:get_stat_xattr() consumed via x_lstat()
+    /// upstream: xattrs.c:get_stat_xattr() consumed via x_lstat()
     pub const fn is_regular_file(&self) -> bool {
         const S_IFMT: u32 = 0o170000;
         const S_IFREG: u32 = 0o100000;
@@ -396,7 +396,7 @@ pub fn remove_fake_super_default_acl(path: &Path) -> io::Result<()> {
 /// This mirrors upstream rsync's `x_lstat()`, which layers `get_stat_xattr()`
 /// over the raw `lstat()` so the placeholder appears to have the recorded
 /// ownership/type on every subsequent read.
-// upstream: xattrs.c:get_stat_xattr() consumed via x_lstat()
+/// upstream: xattrs.c:get_stat_xattr() consumed via x_lstat()
 #[cfg(all(unix, feature = "xattr"))]
 pub fn effective_source_stat(source: &Path, metadata: &Metadata) -> FakeSuperStat {
     match load_fake_super(source) {

--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -97,7 +97,7 @@ impl NameMapping {
     /// is. A name target is looked up on the receiver via the kind-appropriate
     /// NSS call; on success the target is rewritten to the resolved id, on
     /// failure the upstream warning is printed and the caller drops the rule.
-    // upstream: uidlist.c:547-561 - user_to_uid/group_to_gid, drop on failure.
+    /// upstream: uidlist.c:547-561 - user_to_uid/group_to_gid, drop on failure.
     fn resolve_target(kind: MappingKind, target: &mut MappingTarget) -> bool {
         let MappingTarget::Name(name) = target else {
             return true;

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -42,7 +42,7 @@ pub fn create_device_node(
 ///
 /// Returns [`MetadataError`] if the placeholder cannot be created or if the
 /// underlying mknod call fails.
-// upstream: syscall.c:do_mknod() - placeholder substitution when am_root < 0
+/// upstream: syscall.c:do_mknod() - placeholder substitution when am_root < 0
 pub fn create_fifo_with_fake_super(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -69,7 +69,7 @@ pub fn create_fifo_with_fake_super(
 ///
 /// Returns [`MetadataError`] if the placeholder cannot be created or if the
 /// underlying mknod call fails.
-// upstream: syscall.c:do_mknod() - placeholder substitution when am_root < 0
+/// upstream: syscall.c:do_mknod() - placeholder substitution when am_root < 0
 pub fn create_device_node_with_fake_super(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -98,7 +98,7 @@ pub fn create_device_node_with_fake_super(
 /// # Errors
 ///
 /// Returns [`MetadataError`] if the node cannot be created.
-// upstream: generator.c recv_generator FT_SPECIAL -> syscall.c:do_mknod()
+/// upstream: generator.c recv_generator FT_SPECIAL -> syscall.c:do_mknod()
 pub fn create_fifo_node_from_parts(
     destination: &Path,
     mode_bits: u32,
@@ -131,7 +131,7 @@ pub fn create_fifo_node_from_parts(
 /// # Errors
 ///
 /// Returns [`MetadataError`] if the node cannot be created.
-// upstream: generator.c recv_generator FT_DEVICE -> syscall.c:do_mknod()
+/// upstream: generator.c recv_generator FT_DEVICE -> syscall.c:do_mknod()
 pub fn create_device_node_from_parts(
     destination: &Path,
     mode_bits: u32,
@@ -154,7 +154,7 @@ pub fn create_device_node_from_parts(
 /// pre-existing entry at `destination` is removed first to mirror the
 /// `unlink + create` semantics used by upstream when overwriting an existing
 /// special-file destination.
-// upstream: syscall.c:90-174 - do_mknod() routes to do_open when am_root < 0
+/// upstream: syscall.c:90-174 - do_mknod() routes to do_open when am_root < 0
 fn create_fake_super_placeholder(
     destination: &Path,
     context: &'static str,
@@ -616,8 +616,8 @@ fn mknod_device_raw(
 ///
 /// Mirrors the `xattr_stub::warn_xattr_unsupported` stderr convention used
 /// elsewhere in this crate for unsupported metadata operations.
-// WIND-2: skip-with-warn strategy for Windows device files.
-// docs/design/windows-device-file-strategy.md
+/// WIND-2: skip-with-warn strategy for Windows device files.
+/// docs/design/windows-device-file-strategy.md
 #[cfg(not(unix))]
 fn warn_skip_special(destination: &Path, kind_label: &'static str) {
     eprintln!("{}", format_skip_special_message(destination, kind_label));

--- a/crates/metadata/src/stat_cache.rs
+++ b/crates/metadata/src/stat_cache.rs
@@ -174,7 +174,7 @@ fn fetch_metadata_optimized(path: &Path) -> io::Result<CachedMetadata> {
 /// that fakeroot would have faked. `nix::sys::stat::lstat` calls the libc
 /// `lstat` symbol, which fakeroot interposes, so the faked owner/mode is seen.
 /// `lstat` keeps the `AT_SYMLINK_NOFOLLOW` semantics the old statx path used.
-// upstream: syscall.c:do_lstat() calls the lstat(2) libc symbol.
+/// upstream: syscall.c:do_lstat() calls the lstat(2) libc symbol.
 #[cfg(all(unix, target_os = "linux"))]
 fn fetch_metadata_lstat(path: &Path) -> io::Result<CachedMetadata> {
     let stat = nix::sys::stat::lstat(path).map_err(io::Error::from)?;

--- a/crates/metadata/src/xattr.rs
+++ b/crates/metadata/src/xattr.rs
@@ -313,7 +313,7 @@ pub fn strip_source_xattrs(
 /// cannot access are excluded (`list_attributes` already applies the namespace
 /// filter). Used by the `--link-dest` match-level check to decide whether a
 /// basis file's xattrs already equal the source's.
-// upstream: xattrs.c xattrs_differ() via generator.c:468 unchanged_attrs()
+/// upstream: xattrs.c xattrs_differ() via generator.c:468 unchanged_attrs()
 pub fn xattrs_match(a: &Path, b: &Path, follow_symlinks: bool) -> Result<bool, MetadataError> {
     let mut a_map: std::collections::BTreeMap<Vec<u8>, Vec<u8>> = std::collections::BTreeMap::new();
     for name in list_attributes(a, follow_symlinks, receiver_screen())? {
@@ -350,7 +350,7 @@ pub fn xattrs_match(a: &Path, b: &Path, follow_symlinks: bool) -> Result<bool, M
 /// case, which never transfers them as -X data. Excluding them from the delete
 /// pass also protects the `%stat` that the fake-super metadata step writes on
 /// the destination independently of the xattr transfer.
-// upstream: xattrs.c:259-267 rsync_xal_get() - rsync.%FOO skipped for the sender.
+/// upstream: xattrs.c:259-267 rsync_xal_get() - rsync.%FOO skipped for the sender.
 pub fn sync_xattrs(
     source: &Path,
     destination: &Path,

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -947,7 +947,7 @@ fn open_output_file(
 /// length. A `do_fallocate()` failure warns and continues (`receiver.c:324`), so
 /// this never propagates an error - preallocation is a best-effort optimization
 /// and its failure must not abort the receive.
-// upstream: receiver.c:320 - preallocated_len = do_fallocate(fd, 0, total_size)
+/// upstream: receiver.c:320 - preallocated_len = do_fallocate(fd, 0, total_size)
 fn maybe_preallocate(
     file: &fs::File,
     config: &DiskCommitConfig,
@@ -1003,8 +1003,8 @@ fn maybe_preallocate(
 /// which upstream forbids together with `--whole-file` (`options.c:2400`). The
 /// truncate is best-effort: on failure the caller keeps the basis length and
 /// falls back to punching, which is equally correct.
-// upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
-// fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
+/// upstream: receiver.c:receive_data - `if (sparse_files > 0 && whole_file &&
+/// fd >= 0 && do_ftruncate(fd, 0) == 0) preallocated_len = 0;`
 pub(super) fn truncate_for_whole_file_sparse(
     file: &fs::File,
     begin: &BeginMessage,

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -167,7 +167,7 @@ fn sparse_enabled_for_pass(sparse: bool, append: bool, is_redo_pass: bool) -> bo
 /// `MSG_ERROR_XFER`, `MSG_WARNING` -> `MSG_INFO`, log.c:359-363) are not
 /// repeated here - they already live in the emitters, which gate on
 /// `supports_generator_messages()`.
-// upstream: log.c:358 rwrite() `enum msgcode msg = (enum msgcode)code;`
+/// upstream: log.c:358 rwrite() `enum msgcode msg = (enum msgcode)code;`
 const fn peer_message_code(code: logging::LogCode) -> Option<protocol::MessageCode> {
     match code {
         logging::LogCode::ErrorXfer => Some(protocol::MessageCode::ErrorXfer),


### PR DESCRIPTION
## What

An item already carries a `///` block, and prose about that same item sits **between** the block and the item as `//`:

```rust
/// Which `--info=FLAG` names an info level, and indexes into `info_levels[]`.
// upstream: rsync.h INFO_BACKUP..INFO_SYMSAFE, options.c:228 info_verbosity[]
#[derive(Copy, Clone, Debug, PartialEq, Eq)]
pub enum InfoFlag {
```

rustdoc stops at the first non-doc line, so that citation is **invisible in the generated docs** while reading, in source, as though it were part of the doc block. `crates/bandwidth/src/limiter/core/limiter.rs` even ends its doc block with a bare `///` before the stranded `// upstream: io.c:sleep_for_bwlimit()`.

This promotes those runs to `///`. Pure in-place `//` -> `///`; nothing moves, no text changes after the marker.

## Scope, measured not estimated

A census of all **224,455** comment lines in `crates/` classified them, then split the "`//` run directly above an item" population by shape:

| shape | count | action |
|---|---|---|
| item **has** rustdoc, run carries an upstream citation | 183 | **promoted** |
| item **has** rustdoc, run is plain prose | 6 | **promoted** |
| item has **no** rustdoc, run carries a citation | 505 | untouched |
| item has **no** rustdoc, run is plain prose | 279 | untouched |

The bottom two rows are deliberately left alone: there the `//` is a legitimate non-doc implementation note, and promoting it would *newly document* the item. That is a per-site judgement call, not a mechanical move.

Restricting the top two rows to the published surface (rustdoc emits nothing for test/bench targets or `#[cfg(test)]` items, so promoting there is churn with no reader) gives the **164 lines across 50 files** in this diff. `git diff --shortstat` is `164 insertions(+), 164 deletions(-)` — confirming the pure in-place rewrite with no line movement.

## The check that matters here

154 of the 164 lines carry an upstream citation, so the binding question is whether the citation gate still sees them.

`tools/ci/citation_drift_audit.py --ratchet` -> **`ratchet OK`**, no crate above its baseline. The gate filters on the word `upstream` plus a `\b([a-z_0-9]+)\.c:(\d+)` regex and is syntax-agnostic about the comment marker, so `//` -> `///` preserves every one of the 23,500+ citations. That is measured, not assumed.

## Other verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --all-features` — clean
- `cargo doc --workspace --no-deps` — every diagnostic location is in a file **absent from this diff** (`core/src/lib.rs`, `rsync_io/src/lib.rs`, `core/.../module_list/types.rs`, `transfer/src/pipeline/receiver.rs`), so all are inherited by construction
- `cargo clippy --workspace --all-targets --all-features` — **zero doc lints**; `doc_markdown` does not fire on the promoted `options.c:89`-style citations, which was the real risk of turning these into rustdoc

## Not in scope

Three defect classes I expected to find measured as ~zero, each refuted by sampling before acting:

- **commented-out code** (300 raw hits) — all wrapped prose continuation lines beginning `for`/`if`/`while`/`match`. Zero real.
- **stale TODO/FIXME markers** (8) — all `XSTATE_TODO` xattr protocol state, the upstream-mirrored enum variant.
- **stale symbol references in docs** (9,966 raw hits) — Win32 API names (`ReadFile`, `WriteFile`), `CAP_SYS_NICE`, criterion benchmark cell names, std types (`FileExt`).

The tree is already in good shape on documentation: 22 of 25 crates carry both `#![deny(missing_docs)]` and `#![deny(rustdoc::broken_intra_doc_links)]`, and there are 146k rustdoc lines against 52k plain comment lines. The three crates lacking the doc lints (`matching`, `test-support`, `windows-gnu-eh`) are a real completeness gap but a separate change.
