### PR TITLE
docs(crates): deny missing_docs on the three crates that lacked it

### DIFF
--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
 //! Shared test utilities for the oc-rsync workspace.

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::undocumented_unsafe_blocks)]
 


### PR DESCRIPTION
## What

22 of 25 crates carry both `#![deny(missing_docs)]` and `#![deny(rustdoc::broken_intra_doc_links)]`. `matching`, `test-support` and `windows-gnu-eh` carried only the broken-link lint, so their public surface had no completeness gate.

This adds the missing lint. Three lines.

## This adds no documentation

Measured before changing anything — compiling all three with `warn(missing_docs)`:

| crate | undocumented public items |
|---|---|
| matching | 0 |
| test-support | 0 |
| windows-gnu-eh | 0 |

They were already fully documented. The change converts *"currently documented"* into *"cannot regress"*, which is the durable form.

## Why the zero is a measurement and not an inert probe

A zero from an instrument nobody has falsified is worth nothing. Positive control: plant one undocumented `pub fn` per crate and re-run —

```
matching            1
test-support        1
windows-gnu-eh      1
TOTAL               3        INSTRUMENT LIVE
```

3 for 3. The instrument fires, so the zero is real.

## The platform blind spot, closed by compiling rather than reasoning

`windows-gnu-eh` gates most of its surface behind `cfg(all(target_os = "windows", target_env = "gnu"))`. A macOS or Linux host build never compiles that module, so a host-only measurement is structurally incapable of seeing those items — the exact shape that has bitten this repo before (a CI cell whose package list silently excluded the one crate that mattered).

Verified two independent ways:

1. **Read the source.** The two `pub unsafe extern "C" fn` items (`___register_frame_info`, `___deregister_frame_info`) carry `///` docs, as does `force_link` in both `cfg` arms.
2. **Compiled the target.** `cargo check -p windows-gnu-eh --target x86_64-pc-windows-gnu` passes with the lint active — and a planted undocumented item on *that same target* produces `error: missing documentation for a function`, confirming the lint is live there rather than quietly absent.

## Gates

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace --all-features --all-targets` — clean
- `cargo check -p windows-gnu-eh --target x86_64-pc-windows-gnu` — clean, non-vacuity proven above
