### PR TITLE
test(daemon): provoke the session error with a non-UTF-8 request line

### DIFF
--- a/tests/daemon_session_error_keeps_listener.rs
+++ b/tests/daemon_session_error_keeps_listener.rs
@@ -9,9 +9,18 @@
 //! failure and `fork` failure each `continue`. Only listener setup can end the
 //! daemon (`exit_cleanup(RERR_SOCKETIO)` at socket.c:699 and socket.c:715).
 //!
-//! This test pins that contract for the threaded model: client one drives an
-//! invalid `@RSYNCD:` state transition, and client two must still complete a
-//! real transfer against the same listener afterwards.
+//! This test pins that contract for the threaded model: client one drives a
+//! genuine session error, and client two must still complete a real transfer
+//! against the same listener afterwards.
+//!
+//! The provoked error is a non-UTF-8 request line. It has to be an error the
+//! daemon still raises: a repeated `@RSYNCD:` banner does NOT, because
+//! `start_daemon()` reads the version line exactly once and treats the next
+//! line as the request whatever it contains (clientserver.c:1534-1538), so a
+//! second banner is answered as an unknown module rather than refused as an
+//! out-of-order transition. Driving the FSM edge again would be fatal to the
+//! whole listener, which is precisely the shape a peer must not be able to
+//! reach.
 
 #![cfg(unix)]
 
@@ -36,10 +45,11 @@ fn allocate_test_port() -> Option<(u16, TcpListener)> {
     Some((port, listener))
 }
 
-/// Connects, reads the greeting, then sends the `@RSYNCD:` version banner
-/// twice. The second banner re-drives `Greeting -> ModuleSelect` from
-/// `ModuleSelect`, which the connection FSM rejects, producing a session error
-/// that is neither a broken pipe nor a reset.
+/// Connects, reads the greeting, echoes the version banner, then sends a
+/// request line that is not valid UTF-8. The daemon reads that line with
+/// `BufRead::read_line` into a `String`, which fails with `InvalidData` -
+/// a session error that is neither a broken pipe nor a reset, so
+/// `report_session_failure` logs it instead of treating it as a normal close.
 fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
     let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let mut stream = loop {
@@ -70,8 +80,8 @@ fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
     }
 
     stream
-        .write_all(b"@RSYNCD: 32.0 md5 md4\n@RSYNCD: 32.0 md5 md4\n")
-        .map_err(|err| format!("send repeated banner: {err}"))?;
+        .write_all(b"@RSYNCD: 32.0 md5 md4\n\xff\xfe\n")
+        .map_err(|err| format!("send non-utf8 request line: {err}"))?;
     stream.flush().map_err(|err| format!("flush: {err}"))?;
 
     let mut rest = String::new();
@@ -180,8 +190,8 @@ fn session_error_does_not_stop_the_accept_loop() {
         "expected exactly one logged session failure for the first client; log:\n{log_contents}"
     );
     assert!(
-        failure_lines[0].contains("invalid daemon connection transition"),
-        "the provoked failure must be the rejected state transition: {}",
+        failure_lines[0].contains("UTF-8"),
+        "the provoked failure must be the non-UTF-8 request line, not some\n         unrelated session error that would make this fixture prove nothing: {}",
         failure_lines[0]
     );
 }


### PR DESCRIPTION
`session_error_does_not_stop_the_accept_loop` fails on **master**, and on every open PR whose base carries both of the commits below. It is not caused by any one PR.

## Mechanism

`run_provoker` sends the version banner twice in one write:

```
@RSYNCD: 32.0 md5 md4\n@RSYNCD: 32.0 md5 md4\n
```

Line 2 was meant to re-drive `Greeting -> ModuleSelect` from `ModuleSelect` and be refused by the FSM, producing the session error the test needs.

The daemon no longer refuses it. `session_runtime.rs` deliberately treats a second banner as a module name:

```rust
// upstream: clientserver.c:1534-1538 start_daemon() - the version line is read
// exactly once, by exchange_protocols(); the very next read_line_old() is the
// request line whatever it contains. A second `@RSYNCD:` banner is therefore a
// module name, not a re-greeting, and falls through to the unknown-module
// refusal. Taking the Greeting -> ModuleSelect edge again instead would fail the
// FSM's ordering check, and a session error is fatal to the whole listener
// (workers.rs join_worker), so a peer could end the daemon with two greeting lines.
Ok(LegacyDaemonMessage::Version(_)) => {}
```

So the daemon answers `@ERROR: Unknown module '@RSYNCD: 32.0 md5 md4'` — exactly the string the failing assertion reports.

## Why it landed green

| commit | PR | merged |
|---|---|---|
| `34b49e9cd` the fallthrough arm | #7579 | 2026-09-01 **14:09** |
| `7e2d9391a` the test | #7590 | 2026-09-01 **16:39** |

The arm merged first, but #7590's tested head (`53d155c07`) does **not** contain it — verified with `git merge-base --is-ancestor`. Up-to-date-branch enforcement is off, so the test was validated against a master that still refused the repeated banner. Two individually-correct commits, never run together until both were on master.

## What this changes

The arm is upstream-faithful and security-motivated — restoring the FSM rejection would revert #7579 and re-open the DoS its comment names. It stays.

Instead the provoker is re-pointed at an error the daemon still raises: a **non-UTF-8 request line**. The daemon reads it with `BufRead::read_line` into a `String`, which fails with `InvalidData`. That is not a connection-closed kind, so `report_session_failure` (`workers.rs:82`) logs it rather than treating it as a normal close — and the accept loop must still serve the second client, which is the property under test.

The module and helper docs now say why a repeated banner cannot be the provoker, so this does not get re-introduced.

## The guard did its job

The assertion that fires is the fixture's own non-vacuity check, whose comment predicted this exactly:

> *"If the daemon ever starts answering a repeated banner cleanly this fixture stops provoking anything, and the property above would pass while proving nothing - so fail loudly here instead."*

Without it the transfer assertions would still have passed and the test would have gone quietly inert. It is kept unchanged; only the log assertion is re-pointed at the new cause.

## Verification

- **RED on pristine master** (macOS, local): `first client must be dropped mid-session, not answered; got ["@ERROR: Unknown module '@RSYNCD: 32.0 md5 md4'"]` — the CI failure reproduced locally, independent of CI.
- **GREEN after**: `1 test run: 1 passed`.
- **Mutation-lethal**: replacing the non-UTF-8 bytes with a valid-UTF-8 module name reddens it again (`got ["@ERROR: Unknown module 'nosuchmodule'"]`), so the fixture genuinely depends on the non-UTF-8 byte rather than passing for free.
- `cargo fmt --all -- --check` clean. Test-only change, 1 file, +21/-11.

## Blast radius

Measured across the open set, these carry both commits and are affected: #7614, #7613, #7612, #7611, #7607, #7598, #7588. Only #7588's feature-flag cells had finished at diagnosis time; #7611 and #7598 had them still in flight. No PR anywhere shows SUCCESS on those cells while carrying both commits.

⚠ nextest fail-fast truncated the CI runs, so one failing test there is a lower bound, not the failure set.
