### PR TITLE
test(daemon): pin the listener against a refusal, not a silent drop

### DIFF
--- a/tests/daemon_session_error_keeps_listener.rs
+++ b/tests/daemon_session_error_keeps_listener.rs
@@ -9,9 +9,9 @@
 //! failure and `fork` failure each `continue`. Only listener setup can end the
 //! daemon (`exit_cleanup(RERR_SOCKETIO)` at socket.c:699 and socket.c:715).
 //!
-//! This test pins that contract for the threaded model: client one drives an
-//! invalid `@RSYNCD:` state transition, and client two must still complete a
-//! real transfer against the same listener afterwards.
+//! This test pins that contract for the threaded model: client one is refused
+//! mid-handshake, and client two must still complete a real transfer against
+//! the same listener afterwards.
 
 #![cfg(unix)]
 
@@ -28,6 +28,10 @@ use tempfile::tempdir;
 
 const MODULE_NAME: &str = "uploads";
 
+/// The version banner the provoker repeats. Sent twice, the second copy lands
+/// where the daemon expects a module name.
+const REPEATED_BANNER: &str = "@RSYNCD: 32.0 md5 md4";
+
 /// Allocates a free TCP port and hands the bound listener to the daemon so
 /// there is no TOCTOU window between allocation and the daemon's own bind.
 fn allocate_test_port() -> Option<(u16, TcpListener)> {
@@ -37,9 +41,10 @@ fn allocate_test_port() -> Option<(u16, TcpListener)> {
 }
 
 /// Connects, reads the greeting, then sends the `@RSYNCD:` version banner
-/// twice. The second banner re-drives `Greeting -> ModuleSelect` from
-/// `ModuleSelect`, which the connection FSM rejects, producing a session error
-/// that is neither a broken pipe nor a reset.
+/// twice. Upstream reads exactly one line after the version exchange and takes
+/// it as the module name (clientserver.c:1538-1570), so the second banner is
+/// refused as an unknown module rather than served. That refusal is what this
+/// fixture provokes.
 fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
     let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let mut stream = loop {
@@ -70,7 +75,7 @@ fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
     }
 
     stream
-        .write_all(b"@RSYNCD: 32.0 md5 md4\n@RSYNCD: 32.0 md5 md4\n")
+        .write_all(format!("{REPEATED_BANNER}\n{REPEATED_BANNER}\n").as_bytes())
         .map_err(|err| format!("send repeated banner: {err}"))?;
     stream.flush().map_err(|err| format!("flush: {err}"))?;
 
@@ -161,27 +166,26 @@ fn session_error_does_not_stop_the_accept_loop() {
         "one client's session error must not fail the daemon: {daemon_result:?}"
     );
 
-    // Non-vacuity: the first client has to have genuinely broken its session.
-    // If the daemon ever starts answering a repeated banner cleanly this
-    // fixture stops provoking anything, and the property above would pass
-    // while proving nothing - so fail loudly here instead.
+    // Non-vacuity: the first client has to have been REFUSED, not served. The
+    // daemon protocol refuses by answering `@ERROR:` and closing, so a silent
+    // drop is the wrong expectation - upstream answers this exact input with
+    // `@ERROR: Unknown module '%s'` (clientserver.c:1570). Pinning the refusal
+    // itself is what keeps the property above from passing vacuously: if the
+    // daemon ever started serving this client, both assertions fire.
     let provoker_trailing = provoker.expect("provoker client failed before it could provoke");
-    assert!(
-        provoker_trailing.is_empty(),
-        "first client must be dropped mid-session, not answered; got {provoker_trailing:?}"
+    assert_eq!(
+        provoker_trailing,
+        vec![format!("@ERROR: Unknown module '{REPEATED_BANNER}'")],
+        "first client must be refused, not served; log:\n{log_contents}"
     );
-    let failure_lines: Vec<&str> = log_contents
+    let refusal_needle = format!("unknown module '{REPEATED_BANNER}' tried from");
+    let refusal_lines: Vec<&str> = log_contents
         .lines()
-        .filter(|line| line.contains("failed to serve legacy handshake"))
+        .filter(|line| line.contains(&refusal_needle))
         .collect();
     assert_eq!(
-        failure_lines.len(),
+        refusal_lines.len(),
         1,
-        "expected exactly one logged session failure for the first client; log:\n{log_contents}"
-    );
-    assert!(
-        failure_lines[0].contains("invalid daemon connection transition"),
-        "the provoked failure must be the rejected state transition: {}",
-        failure_lines[0]
+        "expected exactly one logged module refusal for the first client; log:\n{log_contents}"
     );
 }


### PR DESCRIPTION
test(daemon): pin the listener against a refusal, not a silent drop

`session_error_does_not_stop_the_accept_loop` fails on pristine master. Its
property - one bad client must not take the accept loop down - is correct and
still holds. Both of its supporting assertions describe a daemon neither oc
nor upstream has.

The fixture connects, completes the version exchange, then sends the
`@RSYNCD:` banner a second time. The test called that "an invalid state
transition the connection FSM rejects", and asserted the client is dropped
mid-session with an empty reply plus a `failed to serve legacy handshake`
log line naming an `invalid daemon connection transition`.

Upstream reads exactly ONE line after the version exchange and takes it as
the module name (clientserver.c:1538). A line that names no module is
refused, not dropped - clientserver.c:1568-1570 logs

    unknown module '%s' tried from %s (%s)

and answers

    @ERROR: Unknown module '%s'

before closing. Measured against the 3.5.0 oracle and against oc: both
produce that pair, byte-shape identical, for this exact input. So the daemon
is right and the test is wrong on both counts - the reply is not empty, and
no handshake-failure line is logged because an orderly refusal is not a
session failure. A probe confirmed the second assertion would also have
failed had the first not fired first.

Both assertions now pin the refusal itself:

- the provoker must receive exactly `@ERROR: Unknown module '<banner>'`
- the log must carry exactly one `unknown module '<banner>' tried from` line

That is strictly stronger than the old pair, because it is what the daemon
actually does. The banner is named once as `REPEATED_BANNER` so the fixture
and both assertions cannot drift apart. The module doc comment loses the
false FSM claim and cites clientserver.c:1538-1570.

NON-VACUITY: mutating the fixture so the second line names a real module -
the daemon then SERVES the first client - reddens assertion one
(`left: ["@RSYNCD: OK"]`). The guard discriminates on daemon behaviour, not
on fixture shape.

Verified: 3/3 green at 0.64s each on the corrected file, fmt clean.
