### PR TITLE
test(daemon): report the whole exchange when the accept-loop pin fails

### DIFF
--- a/tests/daemon_session_error_keeps_listener.rs
+++ b/tests/daemon_session_error_keeps_listener.rs
@@ -50,7 +50,20 @@ fn allocate_test_port() -> Option<(u16, TcpListener)> {
 /// `BufRead::read_line` into a `String`, which fails with `InvalidData` -
 /// a session error that is neither a broken pipe nor a reset, so
 /// `report_session_failure` logs it instead of treating it as a normal close.
-fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
+/// What the provoking client observed on its own socket.
+///
+/// The greeting is kept alongside the trailing lines because the assertion that
+/// fails is about which line the daemon treated as the module request - and that
+/// is unanswerable from the trailing lines alone.
+struct ProvokerOutcome {
+    /// The daemon's greeting line, as received.
+    greeting: String,
+    /// Everything the daemon sent after the request line. Must be empty: the
+    /// session error drops the connection rather than answering it.
+    trailing: Vec<String>,
+}
+
+fn run_provoker(port: u16, deadline: Instant) -> Result<ProvokerOutcome, String> {
     let target = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
     let mut stream = loop {
         match TcpStream::connect_timeout(&target, Duration::from_millis(500)) {
@@ -75,6 +88,7 @@ fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
     reader
         .read_line(&mut greeting)
         .map_err(|err| format!("read greeting: {err}"))?;
+    let greeting = greeting.trim_end_matches(['\r', '\n']).to_owned();
     if !greeting.starts_with("@RSYNCD:") {
         return Err(format!("unexpected greeting: {greeting:?}"));
     }
@@ -86,7 +100,10 @@ fn run_provoker(port: u16, deadline: Instant) -> Result<Vec<String>, String> {
 
     let mut rest = String::new();
     let _ = reader.read_to_string(&mut rest);
-    Ok(rest.lines().map(str::to_owned).collect())
+    Ok(ProvokerOutcome {
+        greeting,
+        trailing: rest.lines().map(str::to_owned).collect(),
+    })
 }
 
 #[test]
@@ -175,10 +192,17 @@ fn session_error_does_not_stop_the_accept_loop() {
     // If the daemon ever starts answering a repeated banner cleanly this
     // fixture stops provoking anything, and the property above would pass
     // while proving nothing - so fail loudly here instead.
-    let provoker_trailing = provoker.expect("provoker client failed before it could provoke");
+    let provoker_outcome = provoker.expect("provoker client failed before it could provoke");
     assert!(
-        provoker_trailing.is_empty(),
-        "first client must be dropped mid-session, not answered; got {provoker_trailing:?}"
+        provoker_outcome.trailing.is_empty(),
+        "first client must be dropped mid-session, not answered.\n\
+         got trailing lines: {:?}\n\
+         greeting the provoker received: {:?}\n\
+         client_result: {client_result:?}\n\
+         daemon_result: {daemon_result:?}\n\
+         daemon log:\n{log_contents}",
+        provoker_outcome.trailing,
+        provoker_outcome.greeting,
     );
     let failure_lines: Vec<&str> = log_contents
         .lines()


### PR DESCRIPTION
test(daemon): report the whole exchange when the accept-loop pin fails

`session_error_does_not_stop_the_accept_loop` fails on every Linux cell of
every open PR, and its assertion discards the evidence needed to diagnose it:

    first client must be dropped mid-session, not answered;
    got ["@ERROR: Unknown module '@RSYNCD: 32.0 md5 md4'"]

That names the symptom - the daemon answered the client's VERSION line as if
it were the module request - and then throws away everything that identifies
which line the daemon read first: the greeting the provoker actually received,
the daemon's own log, and both peers' results. The assertion two blocks above
it already carries `log_contents`; this one, the one that actually fires, does
not.

It is not deterministic. #7615's own `nextest (stable)` was SUCCESS on this
exact merge commit, and it fails on other PRs' merge commits with the same
base - so it is a flake that reproduces only in CI. 65 local runs across five
regimes on an aarch64 Linux host all pass: 3x alone (default features), 6x
alone (--all-features), the parallel package run, 24-way concurrent, and
32-way pinned to a single CPU. No x86_64 Linux host is reachable to run the
real cell (`--workspace --all-features`, 33482 tests), so the next CI failure
is the only instrument available - and it has to carry more than it does now.

Two changes, both test-only:

1. `run_provoker` returns a named `ProvokerOutcome { greeting, trailing }`
   instead of a bare `Vec<String>`. The greeting was read and dropped; it is
   the control for "did the daemon speak first at all", which is precisely the
   question the failure raises.

2. The non-vacuity assertion reports the greeting, the trailing lines, both
   results and the daemon log.

Nothing about the property under test moves: the same condition is asserted on
the same value.

Verified: the diagnostic is non-vacuous - mutating the predicate to `false`
makes it fire and print the greeting (`@RSYNCD: 32.0 sha512 sha256 sha1 md5
md4`), both results, and the full daemon log including the
`failed to serve legacy handshake ... stream did not contain valid UTF-8`
line. Restored, re-run, green. `rustfmt --edition 2024 --check` clean.
