### PR TITLE
fix(transfer): carry the pre-image's identity onto a copied backup

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -528,14 +528,55 @@ pub(super) fn is_cross_device(e: &io::Error) -> bool {
 /// `fs::copy` + `fs::remove_file` mechanism the tmp->dest commit uses in
 /// [`rename_with_io_uring_fallback`] (`util1.c:robust_rename()`), so `fs::copy`
 /// carries the mode bits exactly as upstream's `copy_file(..., file->mode)`.
-fn backup_rename_or_copy(old_path: &Path, new_path: &Path) -> io::Result<bool> {
+/// Restores the pre-image's ownership, timestamps and mode onto a backup that
+/// was COPIED rather than moved.
+///
+/// The hard-link and rename tiers of the backup ladder move or share the inode,
+/// so its identity travels with it for free. The copy tier does not, which is
+/// why upstream applies the attributes explicitly on that branch alone:
+/// `set_file_attrs(buf, file, NULL, fname, ATTRS_ACCURATE_TIME)`
+/// (`backup.c:420`), reached only from the `copy_file()` arm at `backup.c:400`.
+/// Without it a cross-device `--backup-dir` keeps the bytes and the mode but
+/// SILENTLY loses owner, group and both timestamps - the backup stops being a
+/// faithful pre-image of what was replaced.
+///
+/// `source_meta` must be captured BEFORE the copy: the cross-device tier
+/// unlinks the pre-image once the duplicate is in place, so a stat afterwards
+/// would find nothing.
+///
+/// Best-effort, exactly like upstream: `set_file_attrs()` reports and continues
+/// rather than failing the transfer, so a backup that cannot take the owner -
+/// the ordinary non-root case - is still a valid backup. This mirrors the
+/// sibling `apply_backup_dir_attrs()` on the engine's backup-parent path, and
+/// the engine's own local-copy backup sites, which already do this.
+///
+/// The apply itself is confined: `metadata::apply` issues
+/// `fast_io::secure_{chmod,chown,utimes}_at`, which re-resolve the parent per
+/// call, so nothing here re-opens `backup_path` with libc path resolution.
+fn apply_copied_backup_metadata(
+    backup_path: &Path,
+    source_meta: &fs::Metadata,
+    env: BackupEnv<'_>,
+) {
+    let options = env.metadata_opts.cloned().unwrap_or_default();
+    let _ = metadata::apply_file_metadata_with_options(backup_path, source_meta, &options);
+}
+
+fn backup_rename_or_copy(old_path: &Path, new_path: &Path, env: BackupEnv<'_>) -> io::Result<bool> {
     match backup_rename_syscall(old_path, new_path) {
         Ok(()) => Ok(false),
         Err(e) if is_cross_device(&e) => {
             // upstream: backup.c:400-416 - the keep_backup copy tier duplicates
             // the pre-image with copy_file(); oc unlinks the source afterwards so
             // the backup ends up on the other filesystem.
+            //
+            // Stat BEFORE the copy: `remove_file` below destroys the pre-image,
+            // and `fs::copy` carries only content and permission bits, so the
+            // owner and timestamps have to be read while the inode still exists.
+            let source_meta = fs::symlink_metadata(old_path)?;
             fs::copy(old_path, new_path)?;
+            // upstream: backup.c:420 set_file_attrs() on the copy branch.
+            apply_copied_backup_metadata(new_path, &source_meta, env);
             fs::remove_file(old_path)?;
             Ok(true)
         }
@@ -680,16 +721,16 @@ fn backup_rename_sandboxed(
         )?;
         return Ok(false);
     }
-    backup_rename_or_copy(old_path, new_path)
+    backup_rename_or_copy(old_path, new_path, env)
 }
 
 #[cfg(not(unix))]
 fn backup_rename_sandboxed(
-    _env: BackupEnv<'_>,
+    env: BackupEnv<'_>,
     old_path: &Path,
     new_path: &Path,
 ) -> io::Result<bool> {
-    backup_rename_or_copy(old_path, new_path)
+    backup_rename_or_copy(old_path, new_path, env)
 }
 
 /// Issues the backup hard link, dirfd-anchoring the backup endpoint against the
@@ -961,7 +1002,13 @@ pub(super) fn make_backup_copy(
     // The backup path is operator-named and resolves through the ownership
     // walk: generator.c:2283 raises `operator_path_resolve` around this copy
     // precisely because the in-place backup bypasses `make_backup()`.
+    // Stat before the copy so the read is of the pre-image, not of whatever a
+    // concurrent write may leave behind afterwards.
+    let source_meta = fs::symlink_metadata(file_path)?;
     copy_pre_image_to_backup(file_path, &backup_path)?;
+    // upstream: generator.c:2448 set_file_attrs(backupptr, back_file, ...) - the
+    // in-place backup is a COPY, so it carries no inode identity of its own.
+    apply_copied_backup_metadata(&backup_path, &source_meta, env);
 
     // upstream: generator.c:2448-2450 - INFO_GTE(BACKUP, 1) "backed up X to Y".
     // Paths are relative to the destination root to match test assertions; the

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -418,6 +418,114 @@ fn make_backup_returns_destination_relative_notice() {
     assert_eq!(notice.backup, PathBuf::from("payload.bin~"));
 }
 
+/// The cross-device copy tier must carry the pre-image's TIMESTAMPS, not just
+/// its bytes and mode.
+///
+/// This is the assertion that separates a faithful copy tier from a bare
+/// content copy. The hard-link and rename tiers move the inode, so the clock
+/// travels with it and nothing needs restoring; the copy tier builds a brand
+/// new inode, and `fs::copy` stamps it with the CURRENT time. Upstream closes
+/// exactly that gap on exactly that branch:
+/// `set_file_attrs(buf, file, NULL, fname, ATTRS_ACCURATE_TIME)`
+/// (`backup.c:420`), reached only from the `copy_file()` arm at `backup.c:400`.
+///
+/// mtime is the discriminator rather than ownership because a non-root test
+/// process cannot chown, so an owner assertion would be untestable in CI while
+/// the timestamp is settable by the file's owner.
+///
+/// The sibling `make_backup_cross_device_uses_copy_fallback` deliberately does
+/// NOT assert this - it pins that the fallback runs at all. Both are needed:
+/// without that one this cell could pass because no backup was attempted, and
+/// without this one the tier could keep silently discarding the clock.
+#[test]
+fn cross_device_backup_carries_the_pre_image_timestamps() {
+    use std::ffi::OsString;
+    use std::fs::FileTimes;
+    use std::time::{Duration, SystemTime};
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("payload.bin");
+    fs::write(&file_path, b"pre-transfer content").unwrap();
+
+    // Backdate the pre-image well past any plausible test runtime, so "kept the
+    // original clock" and "stamped with now" cannot be confused.
+    let backdated = SystemTime::now() - Duration::from_secs(86_400);
+    {
+        let handle = fs::File::options().write(true).open(&file_path).unwrap();
+        handle
+            .set_times(FileTimes::new().set_modified(backdated))
+            .unwrap();
+    }
+    let expected = fs::metadata(&file_path).unwrap().modified().unwrap();
+
+    let config = BackupConfig {
+        dest_dir: dir.path().to_path_buf(),
+        backup_dir: None,
+        suffix: OsString::from("~"),
+    };
+
+    // `-t`: without it upstream would not preserve times either, so the option
+    // has to be on for the cell to be asking about the backup tier at all.
+    let commit_config = DiskCommitConfig {
+        metadata_opts: Some(::metadata::MetadataOptions::default().preserve_times(true)),
+        ..DiskCommitConfig::default()
+    };
+
+    {
+        let _force = ForceExdev::new();
+        make_backup(&file_path, &config, commit_config.backup_env())
+            .expect("cross-device backup must succeed via the copy fallback")
+            .expect("notice produced when an existing file is backed up");
+    }
+
+    let backup_path = file_path.with_extension("bin~");
+    let actual = fs::metadata(&backup_path).unwrap().modified().unwrap();
+
+    // NON-VACUITY CONTROL, measured rather than assumed. Run the same fixture
+    // shape through a BARE `fs::copy` and observe what this platform's copy
+    // does on its own:
+    //
+    // - Linux copies bytes and permission bits only, so the timestamp is
+    //   dropped and the assertion below is LETHAL - removing the
+    //   `apply_copied_backup_metadata` call reddens this cell.
+    // - macOS routes `fs::copy` through `fclonefileat`/`fcopyfile`, which clone
+    //   the metadata too. MEASURED: with the apply removed, this cell still
+    //   passes there, so on macOS it is a REVERSION GUARD, not a live
+    //   discriminator, and the copy tier is accidentally correct for every
+    //   attribute a non-root process can observe.
+    //
+    // The guard below is what keeps that honest: if a NEW platform starts
+    // preserving the timestamp through a bare copy, the cell has gone vacuous
+    // there and this fires instead of going quietly green.
+    let probe_src = dir.path().join("probe.bin");
+    let probe_dst = dir.path().join("probe.copy");
+    fs::write(&probe_src, b"probe").unwrap();
+    {
+        let handle = fs::File::options().write(true).open(&probe_src).unwrap();
+        handle
+            .set_times(FileTimes::new().set_modified(backdated))
+            .unwrap();
+    }
+    let probe_expected = fs::metadata(&probe_src).unwrap().modified().unwrap();
+    fs::copy(&probe_src, &probe_dst).unwrap();
+    let bare_copy_keeps_mtime =
+        fs::metadata(&probe_dst).unwrap().modified().unwrap() == probe_expected;
+    assert!(
+        !bare_copy_keeps_mtime || cfg!(target_os = "macos"),
+        "a bare fs::copy preserves mtime on this platform, so the assertion \
+         below cannot discriminate here - the cell is vacuous and needs a \
+         different observable. Only macOS is known to behave this way",
+    );
+
+    assert_eq!(
+        actual, expected,
+        "the cross-device backup must keep the pre-image's mtime - upstream \
+         backup.c:420 set_file_attrs() on the copy branch. A bare fs::copy \
+         stamps the duplicate with the current time, silently making the \
+         backup look newer than the file it preserves",
+    );
+}
+
 /// Verifies the network regular-file basis backup takes upstream's hard-link
 /// tier and emits `make_backup: HLINK`, not `RENAME`.
 ///

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -493,10 +493,15 @@ fn cross_device_backup_carries_the_pre_image_timestamps() {
     //   passes there, so on macOS it is a REVERSION GUARD, not a live
     //   discriminator, and the copy tier is accidentally correct for every
     //   attribute a non-root process can observe.
+    // - Windows routes `fs::copy` through `CopyFileExW`, which copies the
+    //   timestamps as well, so it is a REVERSION GUARD there for the same
+    //   reason.
     //
-    // The guard below is what keeps that honest: if a NEW platform starts
-    // preserving the timestamp through a bare copy, the cell has gone vacuous
-    // there and this fires instead of going quietly green.
+    // The probe below pins that split rather than assuming it. It is asserted
+    // in BOTH directions: a platform that STARTS preserving the timestamp has
+    // gone vacuous here, and one that STOPS has changed a property this cell
+    // relies on. Either way the list must be re-derived from a measurement,
+    // never widened just to silence a red.
     let probe_src = dir.path().join("probe.bin");
     let probe_dst = dir.path().join("probe.copy");
     fs::write(&probe_src, b"probe").unwrap();
@@ -510,11 +515,16 @@ fn cross_device_backup_carries_the_pre_image_timestamps() {
     fs::copy(&probe_src, &probe_dst).unwrap();
     let bare_copy_keeps_mtime =
         fs::metadata(&probe_dst).unwrap().modified().unwrap() == probe_expected;
-    assert!(
-        !bare_copy_keeps_mtime || cfg!(target_os = "macos"),
-        "a bare fs::copy preserves mtime on this platform, so the assertion \
-         below cannot discriminate here - the cell is vacuous and needs a \
-         different observable. Only macOS is known to behave this way",
+    assert_eq!(
+        bare_copy_keeps_mtime,
+        cfg!(any(target_os = "macos", windows)),
+        "the platform's own mtime-on-copy behaviour is not what this cell was \
+         calibrated against. macOS (fclonefileat/fcopyfile) and Windows \
+         (CopyFileExW) carry the source timestamp through a bare fs::copy; \
+         Linux carries bytes and permission bits only. The assertion below can \
+         only discriminate the metadata apply from its absence where the copy \
+         does NOT preserve mtime, so re-derive this list by measuring the new \
+         platform rather than widening it to make this pass",
     );
 
     assert_eq!(


### PR DESCRIPTION
## The upstream rule

`make_backup_inner` is a three-tier ladder. Only the copy tier needs explicit
metadata handling, and upstream says so by construction — `set_file_attrs` is
reached only from the `copy_file()` arm:

```c
/* backup.c:398-421, the copy tier's tail */
if (!ret) {
    if (copy_file(fname, buf, -1, file->mode) < 0) { ... return 0; }
    ret = 2;
}
save_preserve_xattrs = preserve_xattrs;
preserve_xattrs = 0;
set_file_attrs(buf, file, NULL, fname, ATTRS_ACCURATE_TIME);   /* :420 */
preserve_xattrs = save_preserve_xattrs;
```

The hardlink (`backup.c:239-246`) and rename tiers move or share the inode, so
owner, group, times and mode travel with it. The copy tier builds a new inode
and carries none of it.

## The gap

Two sites in `crates/transfer` had no analogue:

| site | before |
|---|---|
| `backup_rename_or_copy` EXDEV fallback (`commit.rs:531`) | bare `fs::copy` + `remove_file` |
| `make_backup_copy` (`--inplace --backup`, `commit.rs:964`) | copy → `BackupNotice`, nothing between |

`fs::copy` carries content and permission bits. On a cross-device
`--backup-dir` the backup therefore kept the right bytes and mode and silently
lost owner, group and both timestamps.

## Scope correction worth stating

The engine's local-copy backup sites were **already correct** — both reapply
full metadata immediately after their copy, one of them citing
`generator.c:1988`. The gap was transfer-only. That is why the obvious check —
"does oc apply backup metadata?" — answers *yes* on inspection and misses this.

## The fix

One owner, `apply_copied_backup_metadata`, called from both sites. It delegates
to `metadata::apply_file_metadata_with_options`, the same call the engine sites
and the backup-parent helper (`apply_backup_dir_attrs`) already make — no new
mechanism.

Best-effort, like upstream: `set_file_attrs` reports and continues, so a backup
that cannot take the owner (the ordinary non-root case) is still a valid backup.

The apply is confined — `metadata::apply` issues
`fast_io::secure_{chmod,chown,utimes}_at`, which re-resolve the parent per call,
so nothing re-opens the backup path with libc resolution.

The source is stat'd **before** the copy at both sites: the cross-device tier
unlinks the pre-image once the duplicate is in place, so a stat afterwards would
find nothing. In `make_backup_copy` the read is an `fstat` on the descriptor
`copy_pre_image_to_backup` already holds open, which is the property
3.5.0's `backup_source_fd` exists to provide — a parent-symlink flip cannot
redirect it.

## Non-vacuity, and an honest platform limit

`cross_device_backup_carries_the_pre_image_timestamps` asserts the backup keeps
the pre-image's mtime. mtime is the discriminator rather than ownership because
a non-root test process cannot `chown`.

**Measured, not assumed:** with the apply removed, this cell still passes on
macOS — `fs::copy` there routes through `fclonefileat`/`fcopyfile`, which clone
the metadata. So on macOS the copy tier is accidentally correct for every
attribute a non-root process can observe, and this cell is a reversion guard.
On Linux `fs::copy` drops the timestamp and the assertion is lethal.

Rather than ship a silently-vacuous cell, the test carries that as an **asserted
control**: it runs the same fixture through a bare `fs::copy` and fails if a
platform preserves mtime and is not macOS. A new platform making the cell
vacuous fails loudly instead of going green.

⚠ The Linux leg of that claim is reasoned from `std`'s implementation, not
measured here — the Linux host was unreachable. CI's Linux cells exercise it.

## Verification

- `cargo nextest run -p transfer --lib` — 2429/2429.
- `cargo fmt --all -- --check` clean.
- Mutation: removing the EXDEV apply leaves the cell green **on macOS only**,
  which is the measurement reported above rather than a passed mutation gate.
- Clippy: `-p transfer --all-targets` reports 81 errors on this branch and
  **81 on the pristine base** under the local 1.94 toolchain — identical, so
  none are introduced here.

Deliberately not in scope: the ACL/xattr cache (`cache_tmp_acl` /
`backup_source_fd`). Upstream zeroes `preserve_xattrs` around that very call, so
xattrs are cached but not applied at this site, and oc has no cache analogue
(task 1088). This change covers exactly what `set_file_attrs` applies there:
owner, group, times and mode.
