### PR TITLE
ci(citations): scan the 42% of citations the drift gate could not see, non-blocking

### DIFF
--- a/.github/workflows/citation-drift.yml
+++ b/.github/workflows/citation-drift.yml
@@ -19,6 +19,18 @@
 # standing false positives cost nothing. A gate at zero would be switched off
 # the first time a legitimate citation tripped it.
 #
+# TWO POPULATIONS. The audit's line filter used to require the word `upstream`
+# on the citation line itself, so citations written as bullets under a
+# `/// # Upstream Reference` heading - where that word sits on the heading only
+# - were never scanned. That is 42% of the tree's citations. The filter now
+# reaches them, but the newly reached half is REPORTED, not gated: it lands in
+# the step summary as its own table plus a `::warning` carrying the count, and
+# the ratchet still sees only the population it always saw. No baseline is
+# written for the new half - several hundred unreviewed findings frozen into a
+# suppression file would read as accepted and would swallow the next real drift
+# whole. The step summary keeps the two tables apart and states the size of both
+# populations, so an empty report cannot be mistaken for a clean one.
+#
 # No cargo, no build lock: fetch a 1.2 MB tarball and scan text.
 
 name: Citation drift

--- a/crates/protocol/src/xattr/wire/encode.rs
+++ b/crates/protocol/src/xattr/wire/encode.rs
@@ -205,7 +205,7 @@ pub fn send_sender_xattr_response<W: Write>(
 /// Upstream abbreviates values larger than `MAX_FULL_DATUM` with
 /// `sum_init(xattr_sum_nni, checksum_seed)` + `sum_update(value)` +
 /// `sum_end()`. For protocol versions 30-32 the negotiated `xattr_sum_nni`
-/// is always MD5 (`compat.c:824` hardcodes `parse_csum_name(NULL, 0)`, which
+/// is always MD5 (`compat.c:835` hardcodes `parse_csum_name(NULL, 0)`, which
 /// returns md5 for protocol >= 30), and the streaming `sum_init()` path for
 /// `CSUM_MD5` does `md5_begin()` only - it does NOT fold `checksum_seed` into
 /// the digest. Only the MD4-family cases feed the seed via
@@ -221,9 +221,9 @@ pub fn send_sender_xattr_response<W: Write>(
 ///
 /// # Upstream Reference
 ///
-/// - `xattrs.c:275-281` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum.
-/// - `checksum.c:588-597` - `sum_init()` `CSUM_MD5` case: `md5_begin()`, no seed.
-/// - `compat.c:824-825` - `xattr_sum_nni` / `xattr_sum_len` fixed to md5 (16 bytes).
+/// - `xattrs.c:287-293` - `sum_init(xattr_sum_nni, checksum_seed)` over the datum.
+/// - `checksum.c:615-617` - `sum_init()` `CSUM_MD5` case: `md5_begin()`, no seed.
+/// - `compat.c:835-836` - `xattr_sum_nni` / `xattr_sum_len` fixed to md5 (16 bytes).
 pub fn compute_xattr_checksum(data: &[u8], checksum_seed: i32) -> [u8; MAX_XATTR_DIGEST_LEN] {
     // upstream: the CSUM_MD5 branch of sum_init() ignores the seed; only the
     // MD4-family branches fold it in. Keep the parameter for signature parity.

--- a/tools/ci/citation_drift_audit.py
+++ b/tools/ci/citation_drift_audit.py
@@ -32,6 +32,24 @@ dropped in silence. An unresolved count is not a failure - a paraphrased quote l
 there too - but it is the population a version bump must be read against, because
 that is where "the code this cites no longer exists" hides.
 
+TWO POPULATIONS, ONE OF THEM GATING. The line filter used to be "does this line
+contain the word `upstream`", which sees `// upstream: flist.c:123 "..."` and
+misses every citation written as a bullet under a `/// # Upstream Reference`
+heading - the word is on the heading, never on the bullets. That is 5,240 of the
+tree's 12,596 `file.c:NNN` citations, 42%, across 748 files: an entire
+documentation style the tool had never once opened. The filter is now `.c:`,
+the substring both `CITE` and `RANGE` already require, and the old predicate
+survives as the SPLIT between two tallies rather than as a skip:
+
+  * BLOCKING - line carries `upstream`. Ratcheted against
+    tools/ci/citation_drift_baseline.json; a backwards range fails outright.
+    Byte-for-byte the behaviour this tool had before the widening.
+  * NON-BLOCKING - everything the widened filter newly reaches. Counted and
+    reported (step summary table plus a `::warning` carrying the number), never
+    gating, and deliberately NOT baselined: a suppression file holding several
+    hundred unreviewed findings reads as "accepted" without anyone having
+    accepted them, and the one new drift that matters would vanish inside it.
+
 Usage:
     python3 tools/ci/citation_drift_audit.py [crate ...]   # default: all crates
 """
@@ -58,24 +76,72 @@ def anchors(comment):
             out.append(q.replace('\\n', '').split('%')[0].strip())
     return [x for x in out if len(x) >= 8]
 
+class Tally:
+    """Counters for ONE population of citations.
+
+    The tool scans two populations and must never let a reader confuse them:
+
+      * BLOCKING - the citation's line carries the word "upstream" somewhere on
+        it (`// upstream: flist.c:123 "..."`). This is the population the tool
+        has always seen, and the only one `--ratchet` and the backwards-range
+        hard failure act on.
+      * EXTENDED - the line carries a `file.c:NNN` citation but NOT the word
+        "upstream". Overwhelmingly these are bullets under a
+        `/// # Upstream Reference` heading, where the word sits on the heading
+        line and never on the citation lines. 42% of the tree's citations are
+        written that way and were invisible to this tool until now. They are
+        REPORTED and never gate.
+    """
+
+    __slots__ = ("cites", "checked", "miss", "unresolved", "ex", "unres", "backwards")
+
+    def __init__(self):
+        self.cites = self.checked = self.miss = self.unresolved = 0
+        self.ex = []
+        self.unres = []
+        self.backwards = []
+
+
+def _summarise(tally):
+    return (f"string-anchored={tally.checked} suspected-drift={tally.miss} "
+            f"({tally.miss / max(1, tally.checked):.0%}) unresolved={tally.unresolved}")
+
+
 def audit(crate):
-    checked = miss = read = unresolved = 0; ex = []; unres = []; backwards = []
+    """Scan one crate and return (blocking, extended, files_read).
+
+    The line filter used to be `if "upstream" not in ln.lower(): continue`,
+    which silently dropped every citation written as a bullet under a
+    `/// # Upstream Reference` heading - the word is on the heading, never on
+    the bullet. The filter is now `.c:`, which is exactly the substring both
+    `CITE` and `RANGE` require, so it cannot skip a line either regex could
+    have matched. The old predicate survives verbatim, but as the SPLIT between
+    the two tallies rather than as a skip: every line that used to be scanned
+    still lands in `blocking`, and only lines that used to be dropped land in
+    `extended`.
+    """
+    blocking, extended = Tally(), Tally()
+    read = 0
     for rs in glob.glob(f"crates/{crate}/src/**/*.rs", recursive=True):
         read += 1
         for lineno, ln in enumerate(open(rs, errors="replace"), 1):
-            if "upstream" not in ln.lower():
+            if ".c:" not in ln:
                 continue
+            t = blocking if "upstream" in ln.lower() else extended
+            t.cites += len(CITE.findall(ln))
             # Structural invariant, checked first and independent of the anchor
             # machinery: END >= START. `CITE` matches only `file.c:START`, so nothing
             # else in this tool ever looks at END - a retarget that moves START leaves
             # END behind and yields `exclude.c:1381-1237`, which every other check
             # here audits perfectly clean. A gate that accepts a backwards range has
-            # demonstrably not checked the range, so this one is hard-failing and is
-            # deliberately NOT ratcheted: there is no such thing as an accepted
-            # inverted range.
+            # demonstrably not checked the range, so this one is hard-failing for the
+            # BLOCKING population and is deliberately NOT ratcheted: there is no such
+            # thing as an accepted inverted range. An inverted range found only by the
+            # widened scan is reported, not failed, because widening the filter must
+            # not redden a tree that was green a commit ago.
             for rm in RANGE.finditer(ln):
                 if int(rm.group(3)) < int(rm.group(2)):
-                    backwards.append(f"{rs}:{lineno}: {rm.group(0)} runs backwards")
+                    t.backwards.append(f"{rs}:{lineno}: {rm.group(0)} runs backwards")
             anc = anchors(ln)
             if not anc:
                 continue
@@ -90,12 +156,12 @@ def audit(crate):
                     locs = [i + 1 for i, l in enumerate(s) if a in l]
                     if not locs:
                         continue
-                    checked += 1
+                    t.checked += 1
                     if min(abs(p - a1) for p in locs) > 4:
-                        miss += 1
+                        t.miss += 1
                         # Print every hit, not the first 12. A sweep driven by a
                         # truncated list is the sweep that leaves the rest behind.
-                        ex.append(f"{rs}: {f}.c:{a1} '{a[:24]}' -> {VER}@{locs[:3]}")
+                        t.ex.append(f"{rs}: {f}.c:{a1} '{a[:24]}' -> {VER}@{locs[:3]}")
                     break
                 else:
                     # No anchor on this line resolves anywhere in the pinned source,
@@ -104,18 +170,28 @@ def audit(crate):
                     # version bump hides "the code this cites no longer exists", so
                     # report it. It is not a failure on its own - a paraphrased quote
                     # lands here too - and it does not feed the ratchet.
-                    unresolved += 1
-                    unres.append(f"{rs}: {f}.c:{a1} '{anc[0][:32]}' resolves nowhere")
-    print(f"{crate}: string-anchored={checked} suspected-drift={miss} "
-          f"({miss/max(1,checked):.0%}) unresolved={unresolved}"
-          + (f" BACKWARDS-RANGES={len(backwards)}" if backwards else ""))
-    for e in ex:
+                    t.unresolved += 1
+                    t.unres.append(f"{rs}: {f}.c:{a1} '{anc[0][:32]}' resolves nowhere")
+    print(f"{crate}: {_summarise(blocking)}"
+          + (f" BACKWARDS-RANGES={len(blocking.backwards)}" if blocking.backwards else ""))
+    for e in blocking.ex:
         print("  ", e)
-    for u in unres:
+    for u in blocking.unres:
         print("  ?", u)
-    for b in backwards:
+    for b in blocking.backwards:
         print("  !", b)
-    return checked, miss, read, backwards
+    if extended.cites:
+        print(f"{crate}: [non-blocking] extended-scan citations={extended.cites} "
+              f"{_summarise(extended)}"
+              + (f" backwards-ranges={len(extended.backwards)}" if extended.backwards else ""))
+        # Drift leads are printed in full; the extended `unresolved` list runs to
+        # thousands of paraphrase-anchored bullets and would bury them.
+        for e in extended.ex:
+            print("  +", e)
+        for b in extended.backwards:
+            print("  +!", b)
+    return blocking, extended, read
+
 
 BASELINE = "tools/ci/citation_drift_baseline.json"
 
@@ -149,6 +225,109 @@ def ratchet(counts, path):
           "baseline in the same commit with a note saying why.")
     return 1
 
+def _load_baseline_quiet():
+    import json
+    try:
+        with open(BASELINE) as fh:
+            return {k: v for k, v in json.load(fh).items() if not k.startswith("_")}
+    except OSError:
+        return {}
+
+
+def extended_report(blocking, extended, files_read, crates):
+    """Emit the widened scan's findings as a counted, NON-BLOCKING report.
+
+    Deliberately not a baseline. A suppression file holding several hundred
+    accepted findings would freeze them in as "reviewed" - nobody reviewed them -
+    and the one new drift that matters would land inside a number that large and
+    never be seen again. A counted warning keeps the population visible and keeps
+    the reader's eye on the delta instead of on a ratchet nobody can audit.
+
+    The report always states the size of BOTH populations, so it can never read
+    as clean by having scanned nothing: a run that opened no files, or one a
+    filter regression emptied, prints zeros next to zeros and is refused by the
+    caller rather than passing quietly.
+    """
+    def tot(d, field):
+        return sum(getattr(t, field) for t in d.values())
+
+    b_cites = tot(blocking, "cites")
+    b_checked = tot(blocking, "checked")
+    b_miss = tot(blocking, "miss")
+    e_cites = tot(extended, "cites")
+    e_checked = tot(extended, "checked")
+    e_miss = tot(extended, "miss")
+    e_unres = tot(extended, "unresolved")
+    e_back = sum(len(t.backwards) for t in extended.values())
+    base = _load_baseline_quiet()
+
+    md = []
+    md.append("## Citation drift audit")
+    md.append("")
+    md.append(f"Scanned {files_read} Rust file(s) across {len(crates)} crate(s) against the "
+              f"pinned upstream rsync {VER} source. Two populations, reported separately: "
+              "they are not interchangeable and only one of them gates.")
+    md.append("")
+    md.append("### 1. BLOCKING - citations whose line carries the word `upstream`")
+    md.append("")
+    md.append(f"{b_cites} citation(s); {b_checked} string-anchored; {b_miss} suspected drift. "
+              "Ratcheted per crate against `tools/ci/citation_drift_baseline.json`; a rise "
+              "fails this job, and a backwards range fails it outright.")
+    md.append("")
+    md.append("| crate | citations | string-anchored | suspected-drift | baseline |")
+    md.append("| --- | ---: | ---: | ---: | ---: |")
+    for c in sorted(blocking):
+        t = blocking[c]
+        if not t.cites:
+            continue
+        md.append(f"| `{c}` | {t.cites} | {t.checked} | {t.miss} | {base.get(c, '-')} |")
+    md.append("")
+    md.append("### 2. NON-BLOCKING - citations the blocking gate cannot see")
+    md.append("")
+    md.append("These lines carry a `file.c:NNN` citation but not the word `upstream`. Almost "
+              "all are bullets under a `/// # Upstream Reference` heading, where the word "
+              "sits on the heading line only, so the whole documentation style was invisible "
+              "to this tool until the line filter was widened.")
+    md.append("")
+    md.append(f"{e_cites} citation(s); {e_checked} string-anchored; **{e_miss} suspected drift**; "
+              f"{e_unres} unresolved; {e_back} backwards range(s).")
+    md.append("")
+    md.append("No baseline is written for these and none should be. A frozen list that size "
+              "reads as accepted without anyone having accepted it, and hides the next real "
+              "drift inside itself. This section is a count to work down, not a ratchet to "
+              "satisfy.")
+    md.append("")
+    md.append("| crate | citations | string-anchored | suspected-drift | unresolved |")
+    md.append("| --- | ---: | ---: | ---: | ---: |")
+    for c in sorted(extended):
+        t = extended[c]
+        if not t.cites:
+            continue
+        md.append(f"| `{c}` | {t.cites} | {t.checked} | {t.miss} | {t.unresolved} |")
+    md.append("")
+    text = "\n".join(md) + "\n"
+
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a") as fh:
+            fh.write(text)
+    else:
+        print()
+        print(text, end="")
+
+    # The annotation carries the NUMBER, so a reader who never opens the step
+    # summary still sees the size of the population, and names which population
+    # it belongs to so it can never be read as the gating one. No `%` anywhere in
+    # it: GitHub reads `%` as the start of an escape in a workflow command.
+    print(f"::warning title=Citation drift (non-blocking)::{e_miss} suspected-drift finding(s) "
+          f"among {e_checked} string-anchored citations that the blocking gate cannot see, "
+          f"out of {e_cites} such citations in {files_read} file(s). "
+          f"The blocking population is separate and unaffected: {b_miss} of {b_checked} "
+          "anchored, ratcheted. Not baselined and not gating - work the number down, do not "
+          "freeze it.")
+    return text
+
+
 if __name__ == "__main__":
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
     flags = {a for a in sys.argv[1:] if a.startswith("--")}
@@ -163,15 +342,22 @@ if __name__ == "__main__":
             "clean 0/0 for months without opening a file; examining nothing is "
             "a failure, not a pass."
         )
+    blocking = {}
+    extended = {}
     counts = {}
     files_read = 0
     backwards = []
     for c in crates:
-        checked, miss, read, bad = audit(c)
+        b, e, read = audit(c)
+        blocking[c] = b
+        extended[c] = e
         files_read += read
-        backwards += bad
-        if checked:
-            counts[c] = miss
+        # Only the BLOCKING tally reaches `counts`, and only `counts` reaches the
+        # ratchet and the baseline. Widening the line filter must not move a single
+        # citation into the gating population, and this is the one place that could.
+        backwards += b.backwards
+        if b.checked:
+            counts[c] = b.miss
     if files_read == 0:
         sys.exit(
             f"refusing to report: opened ZERO Rust files across {len(crates)} "
@@ -185,6 +371,23 @@ if __name__ == "__main__":
             "ZERO citations. The anchor extractor or the upstream source lookup "
             "is broken; a clean result here would be meaningless."
         )
+    if not args and not sum(t.cites for t in extended.values()):
+        # A whole-tree run that finds no citation outside the `upstream`-bearing
+        # lines means the widened filter stopped widening - the exact regression
+        # this change exists to prevent. Thousands of such citations are in the
+        # tree today, so this cannot fire on a healthy run; if it ever does, the
+        # non-blocking section would otherwise print an empty table and read as
+        # clean when in fact it examined nothing.
+        sys.exit(
+            "refusing to report: the widened scan saw ZERO citations outside the "
+            "lines carrying the word 'upstream'. The line filter has regressed to "
+            "the narrow one, and an empty non-blocking report is indistinguishable "
+            "from a clean one."
+        )
+    # Emitted before any exit path decides the status, so a run that hard-fails on
+    # the blocking population still publishes the non-blocking report rather than
+    # dying with it unwritten.
+    extended_report(blocking, extended, files_read, crates)
     if backwards:
         # Fails in every mode, including --write-baseline: a backwards range is
         # never correct, so there is nothing here to accept as debt. Fix the range,

--- a/tools/tests/test_citation_drift_audit.py
+++ b/tools/tests/test_citation_drift_audit.py
@@ -1,0 +1,257 @@
+"""Unit tests for the citation drift audit's two-population scan.
+
+The audit's line filter used to be `if "upstream" not in ln.lower(): continue`.
+Citations written as bullets under a `/// # Upstream Reference` heading carry
+that word on the heading line and never on the bullets, so 42% of the tree's
+`file.c:NNN` citations - 5,240 of 12,596, across 748 files - were never once
+opened by the tool. Widening the filter has to satisfy two claims at the same
+time, and each test below pins one of them:
+
+  * the widened scan SEES a bullet-style citation, and
+  * the population that already gated is untouched by the widening.
+
+Nine of the ten tests fail against the pre-widening script, which is the point:
+a test that passes both ways proves nothing about the change. The tenth,
+`test_the_bullet_is_not_counted_in_the_gating_population`, passes both ways BY
+DESIGN and is labelled as such - it is the regression pin on the half that must
+not move, and a pin that only starts holding after the change is not a pin.
+
+The tests build their own throwaway workspace and their own throwaway upstream
+C source, so they do not need the pinned tarball the CI job fetches.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "tools" / "ci" / "citation_drift_audit.py"
+
+sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci import citation_drift_audit as audit_mod  # noqa: E402
+
+# Anchors long enough for `anchors()` (>= 8 chars, containing a space) and
+# distinctive enough to resolve to exactly one line of the fake source below.
+BLOCKING_ANCHOR = "if (protocol_version < 30)"
+BULLET_ANCHOR = "while (S_ISLNK(file->mode))"
+
+# `flist` is in the tool's HIGH set, so citations naming it are audited.
+BLOCKING_ANCHOR_LINE = 12
+BULLET_ANCHOR_LINE = 99
+BULLET_CITED_LINE = 40  # 59 lines away from where the anchor really lives
+
+
+def fake_upstream() -> list[str]:
+    lines = ["static int pad;"] * 200
+    lines[BLOCKING_ANCHOR_LINE - 1] = f"\t{BLOCKING_ANCHOR}"
+    lines[BULLET_ANCHOR_LINE - 1] = f"\t{BULLET_ANCHOR}"
+    return lines
+
+
+@contextlib.contextmanager
+def workspace(sources: dict[str, str]):
+    """A temporary tree of `crates/<crate>/src/lib.rs`, cwd'd into."""
+    prev = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmp:
+        for crate, text in sources.items():
+            src = Path(tmp) / "crates" / crate / "src"
+            src.mkdir(parents=True)
+            (src / "lib.rs").write_text(text)
+        os.chdir(tmp)
+        try:
+            yield Path(tmp)
+        finally:
+            os.chdir(prev)
+
+
+def run_audit(crate: str):
+    """Call `audit(crate)` against the fake upstream source, capturing stdout.
+
+    Returns `(stdout, result)`. The result is whatever `audit` returns, which
+    differs between the pre- and post-widening scripts; assertions that must run
+    against BOTH read the stdout instead, because its blocking half is
+    byte-identical across the change.
+    """
+    audit_mod._cache.clear()
+    audit_mod._cache["flist"] = fake_upstream()
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        result = audit_mod.audit(crate)
+    return buf.getvalue(), result
+
+
+class WidenedScanTests(unittest.TestCase):
+    """The whole point: a bullet-style citation is no longer invisible."""
+
+    BULLET_ONLY = f"""
+/// # Upstream Reference
+/// - `{BULLET_ANCHOR}` at flist.c:{BULLET_CITED_LINE}
+pub fn f() {{}}
+"""
+
+    def test_a_bullet_under_an_upstream_reference_heading_is_scanned(self) -> None:
+        with workspace({"demo": self.BULLET_ONLY}):
+            out, _ = run_audit("demo")
+        self.assertIn("[non-blocking]", out)
+        self.assertIn("extended-scan citations=1", out)
+        self.assertIn("string-anchored=1 suspected-drift=1", out)
+
+    def test_the_bullet_is_not_counted_in_the_gating_population(self) -> None:
+        # PASSES BOTH BEFORE AND AFTER THE WIDENING, deliberately. This is the
+        # regression pin on the population that must not move; a pin that only
+        # begins to hold after the change would not have detected the change
+        # doing damage. The claims that discriminate live in the tests around it.
+        with workspace({"demo": self.BULLET_ONLY}):
+            out, _ = run_audit("demo")
+        # The crate's own line - the one the ratchet reads - must still report a
+        # zero it can carry, not the finding from the widened half.
+        self.assertIn("demo: string-anchored=0 suspected-drift=0 (0%) unresolved=0", out)
+
+
+class PopulationSplitTests(unittest.TestCase):
+    """Widening must move nothing INTO the gating population."""
+
+    BOTH_STYLES = f"""
+// upstream: flist.c:{BLOCKING_ANCHOR_LINE} "{BLOCKING_ANCHOR}"
+pub fn g() {{}}
+
+/// # Upstream Reference
+/// - `{BULLET_ANCHOR}` at flist.c:{BULLET_CITED_LINE}
+pub fn h() {{}}
+"""
+
+    def test_each_style_lands_in_exactly_one_population(self) -> None:
+        with workspace({"demo": self.BOTH_STYLES}):
+            out, result = run_audit("demo")
+        # Blocking: the one `// upstream:` citation, anchored and on target.
+        self.assertIn("demo: string-anchored=1 suspected-drift=0 (0%) unresolved=0", out)
+        # Non-blocking: the one bullet, anchored and drifted.
+        self.assertIn("[non-blocking] extended-scan citations=1", out)
+        self.assertIn("string-anchored=1 suspected-drift=1", out)
+
+        blocking, extended, read = result
+        self.assertEqual((blocking.cites, blocking.checked, blocking.miss), (1, 1, 0))
+        self.assertEqual((extended.cites, extended.checked, extended.miss), (1, 1, 1))
+        self.assertEqual(read, 1)
+
+    def test_a_backwards_range_found_only_by_the_widened_scan_does_not_hard_fail(self) -> None:
+        # A backwards range in the gating population is a hard failure and stays
+        # one. Widening the filter must not turn a tree that was green into a red
+        # one, so an inverted range the tool could not previously see is reported
+        # in the non-blocking half instead.
+        source = """
+// upstream: flist.c:12-20 in-order range
+/// # Upstream Reference
+/// - flist.c:80-40
+pub fn f() {}
+"""
+        with workspace({"demo": source}):
+            _, result = run_audit("demo")
+        blocking, extended, _ = result
+        self.assertEqual(blocking.backwards, [])
+        self.assertEqual(len(extended.backwards), 1)
+        self.assertIn("flist.c:80-40 runs backwards", extended.backwards[0])
+
+
+class ReportTests(unittest.TestCase):
+    """The non-blocking half is a counted, reason-carrying report."""
+
+    def build(self) -> tuple[dict, dict, str]:
+        with workspace({"demo": PopulationSplitTests.BOTH_STYLES}):
+            _, (blocking, extended, read) = run_audit("demo")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            text = audit_mod.extended_report(
+                {"demo": blocking}, {"demo": extended}, read, ["demo"]
+            )
+        return text, buf.getvalue()
+
+    def test_a_warning_annotation_carries_the_count(self) -> None:
+        _, stdout = self.build()
+        warning = [l for l in stdout.splitlines() if l.startswith("::warning")]
+        self.assertEqual(len(warning), 1, stdout)
+        self.assertIn("non-blocking", warning[0])
+        self.assertIn("1 suspected-drift finding(s)", warning[0])
+        # `%` opens an escape in a workflow command, so the annotation must not
+        # carry the percentage the human-readable lines print.
+        self.assertNotIn("%", warning[0])
+
+    def test_the_summary_separates_the_two_populations_by_name(self) -> None:
+        text, _ = self.build()
+        self.assertIn("### 1. BLOCKING", text)
+        self.assertIn("### 2. NON-BLOCKING", text)
+        self.assertLess(text.index("### 1. BLOCKING"), text.index("### 2. NON-BLOCKING"))
+        self.assertIn("Ratcheted per crate", text)
+        self.assertIn("No baseline is written for these", text)
+
+    def test_the_summary_states_the_size_of_both_populations(self) -> None:
+        # A report that only ever prints findings reads as clean when it scanned
+        # nothing at all. Stating both population sizes is what separates "no
+        # drift found" from "nothing examined".
+        text, _ = self.build()
+        self.assertIn("Scanned 1 Rust file(s) across 1 crate(s)", text)
+        self.assertIn("1 citation(s); 1 string-anchored; 0 suspected drift", text)
+        self.assertIn("1 citation(s); 1 string-anchored; **1 suspected drift**", text)
+
+    def test_the_summary_goes_to_the_step_summary_file_when_one_is_set(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "summary.md")
+            prev = os.environ.get("GITHUB_STEP_SUMMARY")
+            os.environ["GITHUB_STEP_SUMMARY"] = path
+            try:
+                text, _ = self.build()
+            finally:
+                if prev is None:
+                    os.environ.pop("GITHUB_STEP_SUMMARY", None)
+                else:
+                    os.environ["GITHUB_STEP_SUMMARY"] = prev
+            self.assertEqual(Path(path).read_text(), text)
+
+
+class EndToEndTests(unittest.TestCase):
+    """Drive the script the way CI does, in a self-contained workspace."""
+
+    def run_script(self, sources: dict[str, str], env_extra: dict | None = None):
+        with workspace(sources) as tmp:
+            pinned = tmp / "target" / "interop" / "upstream-src" / f"rsync-{audit_mod.VER}"
+            pinned.mkdir(parents=True)
+            (pinned / "flist.c").write_text("\n".join(fake_upstream()) + "\n")
+            env = dict(os.environ)
+            env.pop("GITHUB_STEP_SUMMARY", None)
+            env.update(env_extra or {})
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                capture_output=True, text=True, cwd=tmp, env=env,
+            )
+        return proc
+
+    def test_a_run_emits_the_non_blocking_count(self) -> None:
+        proc = self.run_script({"demo": PopulationSplitTests.BOTH_STYLES})
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("::warning title=Citation drift (non-blocking)::", proc.stdout)
+        self.assertIn("1 suspected-drift finding(s)", proc.stdout)
+
+    def test_a_whole_tree_run_that_reaches_nothing_new_refuses(self) -> None:
+        # If the line filter ever narrows back, the non-blocking section would
+        # print an empty table - indistinguishable from a clean one. The tool
+        # refuses instead of reporting. Thousands of bullet-style citations exist
+        # in the real tree, so this cannot fire on a healthy run.
+        only_blocking = f"""
+// upstream: flist.c:{BLOCKING_ANCHOR_LINE} "{BLOCKING_ANCHOR}"
+pub fn g() {{}}
+"""
+        proc = self.run_script({"demo": only_blocking})
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("widened scan saw ZERO citations", proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The hole

`tools/ci/citation_drift_audit.py` filtered candidate lines with:

```python
if "upstream" not in ln.lower():
    continue
```

Citations written as bullets under a `/// # Upstream Reference` heading carry
that word on the **heading** line and never on the citation lines. The entire
documentation style was therefore invisible to the gate.

### Measured counts (this branch's base, `dcb8d6f0`, over `crates/*/src/**/*.rs`)

| | citations | files |
| --- | ---: | ---: |
| total `file.c:NNN` | 12,596 | 2,570 scanned |
| visible to the gate | 7,356 | |
| **invisible** | **5,240 (42%)** | 748 |

Running the gate's own anchor machinery over each half:

| population | string-anchored | suspected-drift | unresolved |
| --- | ---: | ---: | ---: |
| blocking (word `upstream` on the line) | 587 | 11 (2%) | 330 |
| non-blocking (newly reached) | 482 | **373 (77%)** | 392 |

**Discrepancy to flag.** The scoping figures I was handed for the invisible half
were 535 anchored / 386 drift. I measure **482 / 373**. The 12,596 / 7,356 /
5,240 / 748 figures reproduce exactly, so the divergence is in the anchor pass,
not the census. I reproduced my number two independent ways - the widened script,
and the *unmodified* pre-change script with its filter predicate inverted
(`if "upstream" in ln.lower(): continue`) - and both give 482 / 373 on this base.
I have not adopted the 535 / 386 figures; they most likely predate some commit on
current master.

## What this changes

The filter is now `.c:`, which is exactly the substring both `CITE` and `RANGE`
already require, so it provably cannot skip a line either regex could have
matched. The old predicate survives verbatim as the **split** between two tallies
rather than as a skip.

**Stays blocking, unchanged:** the `upstream`-bearing population. Only that
tally reaches `counts`, and only `counts` reaches `--ratchet` and
`--write-baseline`. A backwards range is still a hard failure there and still
not ratcheted.

Proof the widening perturbed nothing: the per-crate blocking output is
byte-for-byte identical before and after on this tree (587 anchored, 11 drift,
`ratchet OK`). `diff` of the two runs reports exactly one line moved - the
`ratchet OK` verdict now prints after the new report instead of before it.

**Newly reported, non-blocking:** the 5,240 citations the gate could not see,
as a `$GITHUB_STEP_SUMMARY` table plus a `::warning` carrying the number:

```
::warning title=Citation drift (non-blocking)::373 suspected-drift finding(s)
among 482 string-anchored citations that the blocking gate cannot see, out of
5240 such citations in 2570 file(s). The blocking population is separate and
unaffected: 11 of 587 anchored, ratcheted. Not baselined and not gating.
```

The step summary renders the two populations as two separately headed tables
(`### 1. BLOCKING`, `### 2. NON-BLOCKING`), each stating its own citation count,
anchored count, and drift count, so one can never be read as the other. An
inverted range reached only by the widened scan is reported rather than failed,
because widening a filter must not redden a tree that was green a commit ago.

## Why no baseline

Deliberate, and the point of the design. A suppression file holding ~373
findings nobody has reviewed reads as "accepted" without anyone having accepted
them, and the one new drift that matters would land inside a number that large
and never be seen again. A ratchet is only honest when its contents have been
adjudicated; these have not. A counted warning keeps the population visible and
keeps the reader's eye on the delta.

## Not readable as clean when it did not run

Two guards, because a `success` conclusion conflates PASSED with DID-NOT-RUN:

- the report always prints the **size of both populations** and the file count,
  so "no drift found" is distinguishable from "nothing examined";
- a whole-tree run whose widened scan reaches zero citations now **refuses
  outright**. Thousands exist today, so it cannot fire on a healthy tree; if the
  filter ever narrows back, the section would otherwise print an empty table.

The report is emitted before any exit path decides the status, so a run that
hard-fails on the blocking population still publishes it.

## Non-vacuity proof

`tools/tests/test_citation_drift_audit.py` (10 tests, runs in the blocking
`tools unit tests` job) builds its own workspace and its own upstream C source,
so it needs no pinned tarball.

Each assertion was run against the **pre-change** script (restored from `HEAD`)
and then against the post-change script:

| | pre-change | post-change |
| --- | --- | --- |
| all 10 | **4 FAIL, 5 ERROR, 1 pass** | 10 pass |

The nine that fail pre-change include the load-bearing one: a fixture whose only
citation is a `/// # Upstream Reference` bullet reports `string-anchored=0` under
the old filter and `string-anchored=1 suspected-drift=1` under the new one. The
end-to-end subprocess tests fail pre-change too - no `::warning` is emitted, and
the narrow-filter refusal does not exist.

The tenth, `test_the_bullet_is_not_counted_in_the_gating_population`, passes both
ways **by design** and says so in a comment: it is the regression pin on the half
that must not move, and a pin that only begins to hold after the change would not
have caught the change doing damage.

YAML was validated by `yaml.safe_load`-ing the committed
`.github/workflows/citation-drift.yml`, extracting the audit step's `run` block
back out of the parsed document, and executing that exact string - not a
retyped copy. It exits 0 and emits the warning. Confirmed the job and the step
carry no `if:` guard.

## Second commit

`fix(protocol):` retargets four stale citations in
`crates/protocol/src/xattr/wire/encode.rs`, each re-read against
`target/interop/upstream-src/rsync-3.5.0/`. Three are 3.4.4->3.5.0 shifts
(`compat.c:824`->835, `compat.c:824-825`->835-836, `xattrs.c:275-281`->287-293).
`checksum.c:588-597` is not a shift: in 3.4.4 that range starts inside the
`CSUM_XXH3_64` case and ends on the `case CSUM_MD5:` label, so an ordinal
retarget would have carried a wrong start forward; the bullet describes the
`CSUM_MD5` arm of `sum_init()`, which is checksum.c:615-617. All four were in
the newly visible population - the gate had never looked at them. `protocol`
audits 65 anchored / 0 blocking drift before and after; its non-blocking drift
falls 56 -> 54.
