### PR TITLE
fix(receiver): honour --force so a populated directory obstacle is cleared

### DIFF
--- a/crates/cli/src/frontend/server/flags.rs
+++ b/crates/cli/src/frontend/server/flags.rs
@@ -199,6 +199,15 @@ pub(super) struct ServerLongFlags {
     pub(super) numeric_ids: bool,
     /// Delete extraneous files (upstream: `--delete-*` variants, long-form only).
     pub(super) delete: bool,
+    /// Force removal of a directory obstacle (upstream: `--force`,
+    /// `force_delete`, long-form only).
+    ///
+    /// upstream: options.c:3014-3015 - `if (force_delete) args[ac++] =
+    /// "--force"`, emitted in the `am_sender` block so it reaches a server
+    /// acting as the receiver. It is the second term of the `DEL_RECURSE`
+    /// decision at generator.c:1629/2481 and of the `write_del_stats()` gate at
+    /// generator.c:2868/2913, so the receiver has to be told.
+    pub(super) force: bool,
     /// Defer the delete pass until after the transfer (upstream: `--delete-after`
     /// / `--delete-delay`, i.e. `delete_after` or `delete_during == 2`).
     ///
@@ -517,6 +526,7 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
         modify_window: None,
         numeric_ids: false,
         delete: false,
+        force: false,
         late_delete: false,
         delete_after: false,
         delete_excluded: false,
@@ -602,17 +612,14 @@ pub(super) fn parse_server_long_flags(args: &[OsString]) -> ServerLongFlags {
             // (missing_args == 1): a vanished top-level source arg is silently
             // dropped from the file list rather than raising an error.
             "--ignore-missing-args" => flags.ignore_missing_args = true,
-            // upstream: options.c:2848-2849 - `if (force_delete) args[ac++] =
+            // upstream: options.c:3014-3015 - `if (force_delete) args[ac++] =
             // "--force"`, emitted in the am_sender block so it reaches a server
-            // acting as the receiver. force_delete only changes behavior when a
-            // non-empty directory must be replaced by a non-directory while
-            // deletions are inactive (delete.c). Under an active --delete pass -
-            // the trigger server_options() ships it alongside - oc already
-            // removes extraneous non-empty directories recursively
-            // (receiver/directory/deletion.rs), matching upstream 2.6.7+
-            // (`--delete` no longer needs `--force`). Recognized here so the arg
-            // does not leak into the positional path list.
-            "--force" => {}
+            // acting as the receiver. It is the second term of the DEL_RECURSE
+            // decision (`generator.c:2481`: `delete_mode || force_delete`) that
+            // lets a POPULATED directory obstacle be cleared for a non-directory,
+            // and of the `write_del_stats()` gate (generator.c:2868). Discarding
+            // it here left the receiver refusing at 23 where 3.5.0 exits 0.
+            "--force" => flags.force = true,
             // upstream: options.c:2852-2853 - `if (am_root > 1) args[ac++] =
             // "--super"`, forcing super-user metadata semantics (chown/mknod)
             // even when the receiver is not literally uid 0. oc gates those

--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -343,6 +343,10 @@ where
     }
     config.flags.numeric_ids = core::server::NumericIds::from_client(long_flags.numeric_ids);
     config.flags.delete = long_flags.delete;
+    // upstream: generator.c:2481 - `delete_mode || force_delete` is one decision
+    // with two terms, so the receiver needs both. Without this the DEL_RECURSE
+    // arm was unreachable on the wire path.
+    config.flags.force = long_flags.force;
     // upstream: generator.c:124 - --delete-after / --delete-delay both defer the
     // goodbye del-stats emission.
     config.deletion.late_delete = long_flags.late_delete;

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2315,17 +2315,36 @@ fn long_flags_missing_args_variants() {
     assert!(is_known_server_long_flag("--ignore-missing-args"));
 }
 
-/// upstream: options.c:2848-2853 / 2990-2991 - `--force` (force_delete),
-/// `--super` (am_root > 1), and `--preallocate` (preallocate_files) are emitted
-/// in the am_sender block and reach a server acting as the receiver. oc has no
-/// content-affecting server sink for these (recursive delete already happens,
-/// root is already privileged, preallocation is content-invisible), but they
-/// MUST be recognised so they never surface as a positional destination path.
+/// upstream: options.c:3014-3015 / 3018-3019 / 2990-2991 - `--force`
+/// (force_delete), `--super` (am_root > 1), and `--preallocate`
+/// (preallocate_files) are emitted in the am_sender block and reach a server
+/// acting as the receiver. All three MUST be recognised so they never surface
+/// as a positional destination path; `--force` and `--preallocate` also carry a
+/// content-affecting sink (see the cells below), while `--super` needs none
+/// because oc's runtime `metadata::am_root()` check already reports true under
+/// the only condition that gives the flag any effect.
 #[test]
 fn force_super_preallocate_recognised_as_known_long_flags() {
     assert!(is_known_server_long_flag("--force"));
     assert!(is_known_server_long_flag("--super"));
     assert!(is_known_server_long_flag("--preallocate"));
+}
+
+/// upstream: options.c:3014-3015 / generator.c:2481 - a server receiver invoked
+/// with `--force` must set the second term of `int del_opts = delete_mode ||
+/// force_delete ? DEL_RECURSE : 0`, which is what lets a POPULATED directory
+/// obstacle be cleared for an incoming non-directory. The flag has no compact
+/// letter, so it arrives only as the long-form arg; parsing must set `force` so
+/// `run.rs` can carry it onto `config.flags.force`. Regression guard: the flag
+/// was previously recognised-but-dropped (`"--force" => {}`), which left the
+/// receiver refusing at 23 where 3.5.0 exits 0.
+#[test]
+fn parse_server_long_flags_sets_force() {
+    let without = parse_server_long_flags(&[OsString::from("--server")]);
+    assert!(!without.force, "default must be false");
+
+    let with = parse_server_long_flags(&[OsString::from("--server"), OsString::from("--force")]);
+    assert!(with.force, "--force must set the flag");
 }
 
 /// upstream: options.c:2990-2991 / receiver.c:320 - a server receiver invoked

--- a/crates/core/src/client/remote/flags.rs
+++ b/crates/core/src/client/remote/flags.rs
@@ -640,6 +640,12 @@ pub(crate) fn apply_common_server_flags(config: &ClientConfig, server_config: &m
     // for top-level source paths and --files-from entries.
     server_config.file_selection.ignore_missing_args = config.ignore_missing_args();
     server_config.file_selection.delete_missing_args = config.delete_missing_args();
+    // upstream: generator.c:2481 - `int del_opts = delete_mode || force_delete ?
+    // DEL_RECURSE : 0`. On a pull the local client IS the receiver, so the
+    // `--force` it forwards to the remote sender (options.c:3014-3015) has to
+    // land on this config too; otherwise the DEL_RECURSE term is only ever set
+    // on a push and a populated directory obstacle is refused locally at 23.
+    server_config.flags.force = config.force_replacements();
     // upstream: options.c:89 do_compression_threads, token.c:701 ZSTD_c_nbWorkers
     server_config.connection.compression_threads = config.compression_threads();
     // upstream: compat.c:819 parse_checksum_choice(1) - an explicit
@@ -1019,6 +1025,22 @@ mod tests {
         let mut server_config = ServerConfig::default();
         apply_common_server_flags(&config, &mut server_config);
         assert!(server_config.file_selection.delete_missing_args);
+    }
+
+    /// upstream: generator.c:2481 - on a PULL the local client is the receiver,
+    /// so the `--force` it forwards to the remote sender must also land on the
+    /// local config; otherwise the `delete_mode || force_delete` term is only
+    /// ever set on a push and a populated directory obstacle is refused at 23.
+    #[test]
+    fn apply_common_server_flags_propagates_force_replacements() {
+        let config = ClientConfig::builder().force_replacements(true).build();
+        let mut server_config = ServerConfig::default();
+        apply_common_server_flags(&config, &mut server_config);
+        assert!(server_config.flags.force);
+
+        let mut plain = ServerConfig::default();
+        apply_common_server_flags(&ClientConfig::default(), &mut plain);
+        assert!(!plain.flags.force, "default must be false");
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -59,6 +59,16 @@ fn apply_long_form_args(
             "--delete-excluded" => {
                 config.flags.delete = true;
             }
+            // upstream: options.c:3014-3015 - `if (force_delete) args[ac++] =
+            // "--force"`. It is the second term of `int del_opts = delete_mode
+            // || force_delete ? DEL_RECURSE : 0` (generator.c:1629/2481), which
+            // lets a POPULATED directory obstacle be cleared for an incoming
+            // non-directory. The stdio server parser has its own arm
+            // (`cli/src/frontend/server/flags.rs`); a daemon receiver reaches
+            // this parser instead, so both have to set it.
+            "--force" => {
+                config.flags.force = true;
+            }
             // upstream: options.c:2856-2857 - --stats sets do_stats which causes
             // INFO_STATS to level 2+. Without this flag, the generator does not
             // emit NDX_DEL_STATS during the goodbye phase and the client sender's

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -864,6 +864,26 @@ mod module_access_tests {
         );
     }
 
+    /// upstream: options.c:3014-3015 / generator.c:2481 - a daemon receiver
+    /// invoked with `--force` must set the second term of `delete_mode ||
+    /// force_delete`, which is what lets a POPULATED directory obstacle be
+    /// cleared. This is the SECOND server-arg parser: the stdio `--server` path
+    /// never reaches it, so wiring only that one leaves daemon uploads refusing
+    /// at 23.
+    #[test]
+    fn apply_long_form_args_parses_force() {
+        let mut without = ServerConfig::default();
+        let _ = apply_long_form_args(&["--server".to_owned(), ".".to_owned()], &mut without);
+        assert!(!without.flags.force, "default must be false");
+
+        let mut with = ServerConfig::default();
+        let _ = apply_long_form_args(
+            &["--server".to_owned(), "--force".to_owned(), ".".to_owned()],
+            &mut with,
+        );
+        assert!(with.flags.force, "--force must set the flag");
+    }
+
     #[test]
     fn apply_long_form_args_parses_temp_dir_separate_args() {
         let args = vec![

--- a/crates/protocol/src/flist/read/mod.rs
+++ b/crates/protocol/src/flist/read/mod.rs
@@ -715,6 +715,48 @@ impl FileListReader {
         // In --relative mode, leading slashes are stripped instead.
         let cleaned_name = self.clean_and_validate_name(converted_name)?;
 
+        // upstream: flist.c:1127-1134 recv_file_entry() -
+        //   /* "." is the synthetic transfer root.  Reinterpreting it as a file
+        //    * lets --force recursively remove the real destination directory
+        //    * before the receiver creates that file. */
+        //   if ((!strcmp(thisname, ".") || !strcmp(thisname, "/.")) && !S_ISDIR(mode)) {
+        //           rprintf(FERROR, "ERROR: rejecting non-directory transfer-root entry: %s\n", thisname);
+        //           exit_cleanup(RERR_PROTOCOL);
+        //   }
+        //
+        // The receiver exempts the synthetic `.` root from its requested-name
+        // filter, so a malicious sender that encodes `.` with regular-file mode
+        // gets an unfiltered entry whose destination path IS the transfer root.
+        // Every make-way site then sees a directory standing where a regular
+        // file must be written and, under `--force`/`--delete`, clears it
+        // recursively - erasing receiver-owned files that were never part of
+        // the requested transfer. `--delete` is not needed for the attack.
+        //
+        // A directory is the only legitimate encoding of this name, so the
+        // guard is a type check, not a scope narrowing: it must NOT be spelled
+        // as an exception inside the obstacle-removal path, because upstream
+        // keeps `del_opts` unconditional there and rejects the entry at the
+        // point of decode instead - which also protects every other consumer of
+        // the name (mkdir, rename, backup) from the same forgery.
+        //
+        // Checked on the CLEANED name, matching upstream: `thisname` at
+        // flist.c:1130 has already been through clean_fname() at :768-772.
+        // Both upstream spellings are honoured - `/.` survives cleaning in
+        // `--relative` mode, where leading slashes are stripped rather than
+        // refused.
+        if matches!(cleaned_name.as_slice(), b"." | b"/.")
+            && !matches!(
+                crate::flist::FileType::from_mode(metadata.mode),
+                Some(crate::flist::FileType::Directory)
+            )
+        {
+            // upstream: flist.c:1133 exit_cleanup(RERR_PROTOCOL) (exit 2).
+            return Err(crate::protocol_violation::protocol_violation(format!(
+                "rejecting non-directory transfer-root entry: {}",
+                String::from_utf8_lossy(&cleaned_name)
+            )));
+        }
+
         // Construct entry from raw bytes (avoids UTF-8 validation on Unix)
         let mut entry = FileEntry::from_raw_bytes(
             cleaned_name,

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -3049,13 +3049,14 @@ fn entry_bytes_named(protocol: ProtocolVersion, name: &str, mode: u32) -> Vec<u8
 /// never part of the requested transfer. `--delete` is not needed.
 ///
 /// ⚠ This guard is the ONLY thing standing between a hostile sender and the
-/// destination root, and it was absent while `--force` was parsed-and-discarded
-/// - which made upstream's `malicious-dot-file-delete-scope` cell pass
-/// VACUOUSLY: oc reached the cell's expected outcome because the recursion was
-/// dead code, not because anything rejected the entry. Wiring `--force` is what
-/// made the missing guard reachable. A future change that narrows the obstacle
-/// recursion instead of keeping this check would re-open the hole for the
-/// `--delete` half.
+/// destination root, and it was absent while `--force` was
+/// parsed-and-discarded, which made upstream's
+/// `malicious-dot-file-delete-scope` cell pass VACUOUSLY: oc reached the
+/// cell's expected outcome because the recursion was dead code, not because
+/// anything rejected the entry. Wiring `--force` is what made the missing
+/// guard reachable. A future change that narrows the obstacle recursion
+/// instead of keeping this check would re-open the hole for the `--delete`
+/// half.
 ///
 /// # Upstream Reference
 ///

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -3021,3 +3021,91 @@ mod leading_slash_parity {
         );
     }
 }
+
+/// Serializes a single entry with an arbitrary name and mode.
+///
+/// The `.` transfer-root guard needs both fields under test control, which
+/// `entry_bytes_with_mode` (fixed name `"x"`) cannot express.
+fn entry_bytes_named(protocol: ProtocolVersion, name: &str, mode: u32) -> Vec<u8> {
+    use crate::flist::write::FileListWriter;
+
+    let mut data = Vec::new();
+    let mut writer = FileListWriter::new(protocol);
+    let mut entry = FileEntry::new_file(name.into(), 0, 0o100644);
+    entry.set_mtime(1700000000, 0);
+    entry.set_mode(mode);
+    writer.write_entry(&mut data, &entry).unwrap();
+    data
+}
+
+/// A `.` entry encoded as anything but a directory is refused as protocol
+/// garbage.
+///
+/// `.` is the receiver's SYNTHETIC transfer-root entry and is exempted from the
+/// requested-name filter, so a forged one arrives unfiltered with the
+/// destination root as its path. Every make-way site then sees a directory
+/// standing where a non-directory must be written and, under `--force` or
+/// `--delete`, clears it recursively - erasing receiver-owned files that were
+/// never part of the requested transfer. `--delete` is not needed.
+///
+/// ⚠ This guard is the ONLY thing standing between a hostile sender and the
+/// destination root, and it was absent while `--force` was parsed-and-discarded
+/// - which made upstream's `malicious-dot-file-delete-scope` cell pass
+/// VACUOUSLY: oc reached the cell's expected outcome because the recursion was
+/// dead code, not because anything rejected the entry. Wiring `--force` is what
+/// made the missing guard reachable. A future change that narrows the obstacle
+/// recursion instead of keeping this check would re-open the hole for the
+/// `--delete` half.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:1127-1134` - `if ((!strcmp(thisname, ".") || !strcmp(thisname, "/."))
+///   && !S_ISDIR(mode))` -> `"ERROR: rejecting non-directory transfer-root entry"`,
+///   `exit_cleanup(RERR_PROTOCOL)`
+#[test]
+fn read_entry_rejects_non_directory_transfer_root() {
+    let protocol = test_protocol();
+
+    for mode in [0o100644u32, 0o120777, 0o010644, 0o140644] {
+        let data = entry_bytes_named(protocol, ".", mode);
+        let mut cursor = Cursor::new(&data[..]);
+        let mut reader = FileListReader::new(protocol);
+        let err = reader
+            .read_entry(&mut cursor)
+            .expect_err(&format!("mode 0{mode:o} on \".\" must be refused"));
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        // upstream flist.c:1133 exit_cleanup(RERR_PROTOCOL) (exit 2), not
+        // RERR_STREAMIO(12).
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<crate::ProtocolViolation>()),
+            "a forged transfer root must be tagged RERR_PROTOCOL (mode 0{mode:o})",
+        );
+        assert!(
+            err.to_string()
+                .contains("rejecting non-directory transfer-root entry"),
+            "diagnostic must name the rule, got: {err}",
+        );
+    }
+}
+
+/// The non-vacuity control: a `.` entry with DIRECTORY mode is the only
+/// legitimate encoding of the transfer root and must still be accepted.
+///
+/// Without this cell the guard above could be satisfied by refusing every `.`
+/// entry, which would break every ordinary recursive transfer - the synthetic
+/// root is present in essentially all of them.
+#[test]
+fn read_entry_accepts_a_directory_transfer_root() {
+    let protocol = test_protocol();
+    let data = entry_bytes_named(protocol, ".", 0o040755);
+
+    let mut cursor = Cursor::new(&data[..]);
+    let mut reader = FileListReader::new(protocol);
+    let entry = reader
+        .read_entry(&mut cursor)
+        .expect("a directory `.` is the legitimate transfer root")
+        .expect("entry, not end-of-list");
+    assert_eq!(entry.path().as_os_str(), ".");
+    assert_eq!(entry.mode() & 0o170000, 0o040000);
+}

--- a/crates/protocol/src/stats/delete.rs
+++ b/crates/protocol/src/stats/delete.rs
@@ -77,6 +77,19 @@ impl DeleteStats {
             .saturating_add(self.specials)
     }
 
+    /// Folds another tally into this one, per counter.
+    ///
+    /// upstream keeps a single set of `stats.deleted_*` globals that every
+    /// removal site bumps, so a caller that collects a partial tally has to add
+    /// it back rather than overwrite.
+    pub const fn merge(&mut self, other: &Self) {
+        self.files = self.files.saturating_add(other.files);
+        self.dirs = self.dirs.saturating_add(other.dirs);
+        self.symlinks = self.symlinks.saturating_add(other.symlinks);
+        self.devices = self.devices.saturating_add(other.devices);
+        self.specials = self.specials.saturating_add(other.specials);
+    }
+
     /// Writes the delete stats to a stream in wire format.
     ///
     /// Encodes the five counters (files, dirs, symlinks, devices, specials)

--- a/crates/transfer/src/flags.rs
+++ b/crates/transfer/src/flags.rs
@@ -157,6 +157,21 @@ pub struct ParsedServerFlags {
     /// Not part of the compact flag string; set via long-form args or explicit
     /// propagation. In upstream, `'d'` means `--dirs`, not delete.
     pub delete: bool,
+    /// Force removal of a directory that stands where a non-directory has to be
+    /// written (`--force`, upstream `force_delete`).
+    ///
+    /// Not part of the compact flag string; `server_options()` emits the long
+    /// form inside its `am_sender` block so it reaches a server acting as the
+    /// receiver. It is the second term of upstream's `DEL_RECURSE` decision -
+    /// `delete_mode || force_delete` - and of the `write_del_stats()` gate.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `options.c:746` - `{"force", 0, POPT_ARG_VAL, &force_delete, 1, 0, 0}`
+    /// - `options.c:3014-3015` - `if (force_delete) args[ac++] = "--force";`
+    /// - `generator.c:2481` - `int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;`
+    /// - `generator.c:2868` - `if (delete_mode || force_delete || read_batch) write_del_stats(f_out);`
+    pub force: bool,
     /// Dry-run / no-transfer mode (`n` flag, upstream: `!do_xfers`).
     pub dry_run: bool,
     /// List-only mode: render the received file list, suppress all destination
@@ -1358,6 +1373,12 @@ mod delivery_classification {
             msgs_to_stderr,
             numeric_ids,
             delete,
+            //    `force` is delivered the way `partial` is: `server_options()`
+            //    emits the long `--force` (options.c:3014-3015) and the server
+            //    long-flag parser decodes it onto the config, while a pull
+            //    bridges `ClientConfig::force_replacements()` onto the local
+            //    receiver alongside `delete`.
+            force,
             list_only,
             only_write_batch,
         } = ParsedServerFlags::default();

--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -366,10 +366,6 @@ impl GeneratorContext {
     /// Accumulates deletion statistics from an NDX_DEL_STATS message.
     /// (upstream: main.c:238-247 - `read_del_stats()` adds to global counters)
     pub(super) fn accumulate_delete_stats(&mut self, stats: &DeleteStats) {
-        self.delete_stats.files = self.delete_stats.files.saturating_add(stats.files);
-        self.delete_stats.dirs = self.delete_stats.dirs.saturating_add(stats.dirs);
-        self.delete_stats.symlinks = self.delete_stats.symlinks.saturating_add(stats.symlinks);
-        self.delete_stats.devices = self.delete_stats.devices.saturating_add(stats.devices);
-        self.delete_stats.specials = self.delete_stats.specials.saturating_add(stats.specials);
+        self.delete_stats.merge(stats);
     }
 }

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -262,6 +262,22 @@ pub struct ReceiverContext {
     /// - `generator.c:2393-2398` - early `write_del_stats` when `delete_mode || force_delete || read_batch`
     /// - `main.c:225-238` - `write_del_stats()` wire format
     pub(in crate::receiver) pending_del_stats: DeleteStats,
+    /// Deletions performed to make room for a replacement entry, rather than by
+    /// the `--delete` sweep.
+    ///
+    /// Upstream has no second counter: `delete_dir_contents()` strips
+    /// `DEL_MAKE_ROOM` before recursing, so the entries inside a cleared
+    /// directory obstacle bump the same `stats.deleted_*` globals as a
+    /// delete-pass victim (only the obstacle node itself stays uncounted). The
+    /// obstacle sites run behind `&self`, so the tally is accumulated in a
+    /// `Cell` - the same shape `created_stats` uses - and folded into
+    /// `pending_del_stats` wherever the receiver reports its deletions.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:126-127` - `DEL_MAKE_ROOM` stripped for the recursion
+    /// - `delete.c:241-256` - `log_delete()` / `stats.deleted_*` skipped only for `DEL_MAKE_ROOM`
+    pub(in crate::receiver) make_room_delete_stats: std::cell::Cell<DeleteStats>,
     /// Transfer pipeline FSM tracking the current protocol phase.
     ///
     /// Enforces the linear phase progression through the transfer lifecycle.
@@ -511,6 +527,7 @@ impl ReceiverContext {
             parallel_thresholds: ParallelThresholds::default(),
             delete_ctx: None,
             pending_del_stats: DeleteStats::new(),
+            make_room_delete_stats: std::cell::Cell::new(DeleteStats::new()),
             pipeline,
             dest_root_created: false,
             flist_eof: false,

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -1287,7 +1287,7 @@ impl ReceiverContext {
         let mut state = CappedDeleteState {
             dest_dir,
             #[cfg(unix)]
-            sandbox,
+            sandbox: sandbox.map(std::sync::Arc::as_ref),
             #[cfg(unix)]
             boundary_dev,
             limit,
@@ -1429,6 +1429,107 @@ impl ReceiverContext {
         }
         Ok((combined, skipped > 0, io_err_bits))
     }
+
+    /// The receiver's complete deletion tally: the `--delete` sweep plus the
+    /// entries cleared to make room for a replacement.
+    ///
+    /// Upstream reports one set of counters because both sites bump the same
+    /// `stats.deleted_*` globals; oc collects the make-room half separately
+    /// (the obstacle sites run behind `&self`) and rejoins it here.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:241-256` - the single `stats.deleted_*` bump both paths reach
+    pub(in crate::receiver) fn effective_del_stats(&self) -> DeleteStats {
+        let mut stats = self.pending_del_stats;
+        stats.merge(&self.make_room_delete_stats.get());
+        stats
+    }
+
+    /// Empties the directory standing where a non-directory has to be written,
+    /// so the caller's `rmdir` can complete. Returns `true` when the directory
+    /// is now empty.
+    ///
+    /// This is the `DEL_RECURSE` half of upstream's obstacle removal.
+    /// `atomic_create()` and the `DEL_FOR_FILE` site both compute
+    /// `int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0`, and
+    /// `delete_item()` hands that straight to `delete_dir_contents()`. Without
+    /// the flag the same call only probes emptiness, which is what the caller
+    /// does when neither `--delete` nor `--force` is in effect.
+    ///
+    /// The children are removed through the delete pass's own per-entry
+    /// decision, because upstream reaches them through the same
+    /// `delete_dir_contents()`: it strips `DEL_MAKE_ROOM` before recursing
+    /// (`delete.c:126-127`), so each child is itemized (`deleting NAME`),
+    /// counted into the delete stats, backed up under `--backup`, and capped by
+    /// `--max-delete` exactly like a delete-pass victim - while the directory
+    /// node itself stays silent and uncounted because the caller's `rmdir` keeps
+    /// `DEL_MAKE_ROOM` set (`delete.c:241`).
+    ///
+    /// Two deliberate narrowings against `delete_dir_contents()`: the
+    /// `--max-delete` counter starts at zero per obstacle rather than
+    /// continuing upstream's global `stats.deleted_files`, and a failed scan
+    /// raises no `io_error` bit of its own - the caller's `rmdir` then fails
+    /// `ENOTEMPTY` and reports the refusal at `FERROR_XFER`, which is what
+    /// lifts the exit code.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1629` / `generator.c:2481` - `delete_mode || force_delete ? DEL_RECURSE : 0`
+    /// - `delete.c:205-211` - `delete_item()` calls `delete_dir_contents()` first
+    /// - `delete.c:126-127` - `DEL_MAKE_ROOM` stripped for the recursion
+    #[cfg(any(unix, windows))]
+    pub(in crate::receiver) fn clear_obstacle_dir_contents<
+        W: crate::writer::MsgInfoSender + ?Sized,
+    >(
+        &self,
+        dest_dir: &Path,
+        relative: &Path,
+        path: &Path,
+        #[cfg(unix)] sandbox: Option<&fast_io::DirSandbox>,
+        writer: &mut W,
+    ) -> io::Result<bool> {
+        // upstream: generator.c:310-321 - the `-x` boundary is the transfer
+        // root's device; a child on another device is a mount point that pins
+        // its parent non-empty.
+        #[cfg(unix)]
+        let boundary_dev: Option<u64> = if self.config.flags.one_file_system >= 1 {
+            use std::os::unix::fs::MetadataExt;
+            std::fs::metadata(dest_dir).ok().map(|m| m.dev())
+        } else {
+            None
+        };
+
+        let mut state = CappedDeleteState {
+            dest_dir,
+            #[cfg(unix)]
+            sandbox,
+            #[cfg(unix)]
+            boundary_dev,
+            limit: self.config.deletion.max_delete.unwrap_or(u64::MAX),
+            deleted: 0,
+            skipped: 0,
+            combined: DeleteStats::new(),
+            io_err_bits: 0,
+            emit_itemize: self.should_emit_itemize(),
+            server_mode: !self.config.connection.client_mode,
+            protocol: self.protocol.as_u8(),
+            backup: self.config.flags.backup,
+            backup_dir: self.config.backup_dir.as_deref().map(PathBuf::from),
+            backup_suffix: self.config.effective_backup_suffix().to_owned(),
+            metadata_opts: self.build_metadata_options(),
+            writer,
+        };
+        let emptied = state.remove_dir_contents(relative, path)?;
+        let removed = state.combined;
+        // upstream: `stats.deleted_files` is one global counter, so the entries
+        // cleared to make room land in the same `--stats` breakdown and the same
+        // NDX_DEL_STATS frame as a delete-pass victim.
+        let mut total = self.make_room_delete_stats.get();
+        total.merge(&removed);
+        self.make_room_delete_stats.set(total);
+        Ok(emptied)
+    }
 }
 
 /// One extraneous destination entry awaiting a capped deletion decision.
@@ -1445,7 +1546,7 @@ struct CappedDeleteState<'w, W: ?Sized> {
     /// per-victim backup-path computation on every platform.
     dest_dir: &'w Path,
     #[cfg(unix)]
-    sandbox: Option<&'w std::sync::Arc<fast_io::DirSandbox>>,
+    sandbox: Option<&'w fast_io::DirSandbox>,
     /// `--one-file-system` boundary device (the transfer root's `st_dev`).
     /// `Some` only when `-x` is active; a directory entry whose device differs
     /// is a mount point that must be preserved and pins its parent as
@@ -1492,7 +1593,7 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
         {
             let mut out = Vec::new();
             let iter = fast_io::read_dir_via_sandbox_or_fallback(
-                self.sandbox.map(|a| &**a),
+                self.sandbox,
                 self.dest_dir,
                 relative,
                 target_path,
@@ -1531,6 +1632,43 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
         }
     }
 
+    /// Removes every child of `path` depth-first, leaving the directory node
+    /// itself in place. Returns `true` when the directory ended up empty.
+    ///
+    /// This is upstream's `delete_dir_contents()` body: the children are
+    /// visited in the reverse of the sorted dirlist order, and each one is
+    /// removed through the same per-entry decision the delete pass uses, so a
+    /// nested mount point, the `--max-delete` cap, and `--backup` all behave
+    /// identically whichever caller peeled the directory.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:91-181` - `delete_dir_contents()`
+    fn remove_dir_contents(&mut self, rel: &Path, path: &Path) -> io::Result<bool> {
+        let mut children = match self.scan_dir(rel, path) {
+            Ok(children) => children,
+            Err(e) => {
+                if let Some(err) = fail_loud_unlink_error(e) {
+                    return Err(err);
+                }
+                self.io_err_bits |= crate::generator::io_error_flags::IOERR_GENERAL;
+                return Ok(false);
+            }
+        };
+        children.sort_by(|a, b| f_name_cmp_full(Path::new(&a.0), a.1, Path::new(&b.0), b.1));
+        children.reverse();
+
+        let mut all_removed = true;
+        for (child_name, child_is_dir, child_is_symlink) in children {
+            let child_rel = rel.join(&child_name);
+            let child_path = path.join(&child_name);
+            if !self.remove_entry(&child_rel, &child_path, child_is_dir, child_is_symlink)? {
+                all_removed = false;
+            }
+        }
+        Ok(all_removed)
+    }
+
     /// Recursively removes one extraneous entry under the cap. Returns `true`
     /// when the entry was fully removed and `false` when it (or part of its
     /// subtree) was left in place because the cap was reached.
@@ -1563,29 +1701,7 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
             }
             // Peel the directory's contents depth-first before considering the
             // directory itself (upstream delete_dir_contents, reverse order).
-            let mut children = match self.scan_dir(rel, path) {
-                Ok(children) => children,
-                Err(e) => {
-                    if let Some(err) = fail_loud_unlink_error(e) {
-                        return Err(err);
-                    }
-                    self.io_err_bits |= crate::generator::io_error_flags::IOERR_GENERAL;
-                    return Ok(false);
-                }
-            };
-            children.sort_by(|a, b| f_name_cmp_full(Path::new(&a.0), a.1, Path::new(&b.0), b.1));
-            children.reverse();
-
-            let mut all_removed = true;
-            for (child_name, child_is_dir, child_is_symlink) in children {
-                let child_rel = rel.join(&child_name);
-                let child_path = path.join(&child_name);
-                if !self.remove_entry(&child_rel, &child_path, child_is_dir, child_is_symlink)? {
-                    all_removed = false;
-                }
-            }
-
-            if !all_removed {
+            if !self.remove_dir_contents(rel, path)? {
                 // upstream: delete.c:117 - one notice per non-empty directory,
                 // not counted and not an I/O error.
                 info_log!(
@@ -1666,7 +1782,7 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
         {
             if is_dir {
                 return fast_io::unlink_via_sandbox_or_fallback(
-                    self.sandbox.map(|a| &**a),
+                    self.sandbox,
                     self.dest_dir,
                     rel,
                     path,
@@ -1680,7 +1796,7 @@ impl<W: crate::writer::MsgInfoSender + ?Sized> CappedDeleteState<'_, W> {
                 path,
                 rel,
                 self.dest_dir,
-                self.sandbox.map(|a| &**a),
+                self.sandbox,
                 &self.metadata_opts,
             )
         }

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -32,23 +32,23 @@
 //! - `delete.c:178-181` - `cannot delete non-empty directory: %s` at `FINFO`
 //! - `delete.c:273-286` - `could not make way for %s %s: %s` at `FERROR_XFER`
 //!
-//! # Known residual: `DEL_RECURSE`
+//! # `DEL_RECURSE`
 //!
-//! `generator.c:2481` computes `int del_opts = delete_mode || force_delete ?
-//! DEL_RECURSE : 0`, so under `--delete` or `--force` upstream removes a
-//! POPULATED directory obstacle recursively and completes at exit 0. Measured
-//! against 3.5.0 over a real `--server` child: `--force`, `--delete`, and both
-//! together each give `rc=0` with the symlink in place, where this arm refuses
-//! at 23.
+//! `generator.c:1629` and `generator.c:2481` both compute `int del_opts =
+//! delete_mode || force_delete ? DEL_RECURSE : 0`, so under `--delete` or
+//! `--force` upstream removes a POPULATED directory obstacle recursively and
+//! completes at exit 0. Measured against 3.5.0 over a real `--server` child:
+//! `--force`, `--delete`, and both together each give `rc=0` with the symlink
+//! in place and `deleting obstacle/occupant` on the wire, while the bare run
+//! refuses at 23.
 //!
-//! Neither flag is reachable from here. `--force` is parsed and discarded by
-//! the server arg parser (`cli/src/frontend/server/flags.rs:615`, `"--force"
-//! => {}`) and has no field in `ParsedServerFlags`, so the receiver cannot
-//! know it was asked for. Wiring it is a server-arg and config change, not an
-//! obstacle-removal one, and is deliberately out of scope here: before this
-//! module existed the same shape aborted the whole transfer at 12 with the
-//! sibling files unsent, so the refusal below is strictly closer to upstream,
-//! not a new divergence.
+//! Both terms reach `ReceiverContext` now: `--delete` as `flags.delete` and
+//! `--force` as `flags.force`, the latter decoded from the long arg
+//! `server_options()` emits (`options.c:3014-3015`) and bridged onto the local
+//! receiver on a pull. Neither term recurses on its own - the recursion lives
+//! in one place, `clear_obstacle_dir_contents`, which is the delete pass's own
+//! per-entry walk, so a nested mount point, `--max-delete`, and `--backup`
+//! behave the same whichever caller peeled the directory.
 
 #[cfg(any(unix, windows))]
 use std::io;
@@ -232,7 +232,7 @@ impl ReceiverContext {
         };
 
         if metadata.is_dir() {
-            return self.rmdir_obstacle(writer, existing, relative_path, make_way_for);
+            return self.rmdir_obstacle(writer, existing, relative_path, dest_dir, make_way_for);
         }
 
         match self.backup_existing_before_replace(existing, relative_path, dest_dir) {
@@ -247,16 +247,30 @@ impl ReceiverContext {
         }
     }
 
-    /// The directory arm: `rmdir`, plus upstream's two-line refusal when the
-    /// directory is not empty.
+    /// Whether the directory obstacle may be emptied before it is removed.
     ///
-    /// Upstream reaches `rmdir` for this shape because `atomic_create` passes
-    /// `del_opts` without `DEL_RECURSE` unless `--delete`/`--force` is in play,
-    /// so `delete_dir_contents` only probes emptiness and reports it; the
-    /// contents are never removed to make room.
+    /// This is upstream's `del_opts` computation verbatim, and it is the whole
+    /// difference between clearing a populated obstacle and refusing it: with
+    /// `DEL_RECURSE` set `delete_item()` hands the flag to
+    /// `delete_dir_contents()`, which removes the contents; without it the same
+    /// call only probes emptiness and reports `DR_NOT_EMPTY`.
     ///
     /// # Upstream Reference
     ///
+    /// - `generator.c:1629` - `int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;`
+    /// - `generator.c:2481` - the same expression inside `atomic_create()`
+    /// - `delete.c:115-118` - `if (!(flags & DEL_RECURSE)) { ret = DR_NOT_EMPTY; goto done; }`
+    fn del_recurse(&self) -> bool {
+        self.config.flags.delete || self.config.flags.force
+    }
+
+    /// The directory arm: empty the directory when `DEL_RECURSE` applies,
+    /// `rmdir` it, and emit upstream's two-line refusal when it is still not
+    /// empty.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `delete.c:205-211` - `delete_dir_contents()` runs before the `rmdir`
     /// - `delete.c:222-226` - `what = "rmdir"; ok = do_rmdir_at(fbuf) == 0;`
     #[cfg(unix)]
     fn rmdir_obstacle<W>(
@@ -271,6 +285,20 @@ impl ReceiverContext {
     where
         W: crate::writer::MsgInfoSender + ?Sized,
     {
+        if self.del_recurse() {
+            // upstream: delete.c:210-213 - a DR_NOT_EMPTY from
+            // delete_dir_contents() jumps to check_ret without attempting the
+            // rmdir. Here the rmdir below fails ENOTEMPTY instead and
+            // report_rmdir_failure() emits the same two lines, so the emptiness
+            // answer needs no branch of its own.
+            let _emptied = self.clear_obstacle_dir_contents(
+                dest_dir,
+                relative_path,
+                existing,
+                sandbox,
+                writer,
+            )?;
+        }
         match fast_io::unlink_via_sandbox_or_fallback(
             sandbox,
             dest_dir,
@@ -290,11 +318,17 @@ impl ReceiverContext {
         writer: &mut W,
         existing: &Path,
         relative_path: &Path,
+        dest_dir: &Path,
         make_way_for: MakeWayFor,
     ) -> io::Result<()>
     where
         W: crate::writer::MsgInfoSender + ?Sized,
     {
+        if self.del_recurse() {
+            // See the Unix arm: the rmdir below re-reports the emptiness.
+            let _emptied =
+                self.clear_obstacle_dir_contents(dest_dir, relative_path, existing, writer)?;
+        }
         match std::fs::remove_dir(existing) {
             Ok(()) => Ok(()),
             Err(error) => self.report_rmdir_failure(writer, relative_path, make_way_for, error),

--- a/crates/transfer/src/receiver/transfer/phases.rs
+++ b/crates/transfer/src/receiver/transfer/phases.rs
@@ -216,12 +216,14 @@ impl ReceiverContext {
         //   }`
         // Runs in the daemon-recv parent's `generate_files()`. We always
         // sweep before the transfer (EARLY case), so the early-emission gate
-        // applies whenever deletion was requested. `force_delete` and
-        // `read_batch` are not yet wired into `ParsedServerFlags`; `flags.delete`
-        // is the only term we evaluate today.
-        if self.protocol.supports_extended_goodbye() && self.config.flags.delete {
+        // applies whenever deletion was requested. `force_delete` is the second
+        // term and is now carried on `ParsedServerFlags`; `read_batch` is not,
+        // so it is still the one term we cannot evaluate.
+        if self.protocol.supports_extended_goodbye()
+            && (self.config.flags.delete || self.config.flags.force)
+        {
             ndx_write_codec.write_ndx(&mut *writer, NDX_DEL_STATS)?;
-            self.pending_del_stats.write_to(&mut *writer)?;
+            self.effective_del_stats().write_to(&mut *writer)?;
         }
 
         ndx_write_codec.write_ndx_done(&mut *writer)?;

--- a/crates/transfer/src/receiver/transfer/pipelined.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined.rs
@@ -423,6 +423,9 @@ impl ReceiverContext {
         // into the returned stats so the client reconstructs the "Number of
         // created files" breakdown. upstream: receiver.c:733-746.
         stats.created_stats = self.created_stats.get();
+        // Rejoin the make-room deletions with the sweep's tally; upstream counts
+        // both into the same `stats.deleted_*` globals (delete.c:241-256).
+        stats.delete_stats = self.effective_del_stats();
 
         Ok(stats)
     }

--- a/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
+++ b/crates/transfer/src/receiver/transfer/pipelined_incremental.rs
@@ -437,6 +437,9 @@ impl ReceiverContext {
         // the client reconstructs the "Number of created files" breakdown.
         // upstream: receiver.c:733-746 - stats.created_* accumulated locally.
         stats.created_stats = self.created_stats.get();
+        // Rejoin the make-room deletions with the sweep's tally; upstream counts
+        // both into the same `stats.deleted_*` globals (delete.c:241-256).
+        stats.delete_stats = self.effective_del_stats();
 
         // Flush any trailing buffered `-v` directory names (those with no
         // transferred child to release them mid-loop), then drain the deferred

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -10,7 +10,6 @@ use std::io::{self, Read, Write};
 
 use logging::{PhaseTimer, debug_log, info_log};
 use protocol::codec::{MonotonicNdxWriter, NdxCodec, create_ndx_codec};
-use protocol::stats::DeleteStats;
 
 use metadata::apply_metadata_with_cached_stat;
 
@@ -697,7 +696,9 @@ impl ReceiverContext {
             directories_created: 0,
             directories_failed: 0,
             files_skipped: 0,
-            delete_stats: DeleteStats::new(),
+            // No sweep runs on this path, but an obstacle cleared to make room
+            // still counts (delete.c:241-256).
+            delete_stats: self.effective_del_stats(),
             // Fold the per-type created tally reconstructed from ITEM_IS_NEW so
             // the client renders the "Number of created files" breakdown.
             // upstream: receiver.c:733-746.

--- a/docs/audits/upstream-3.4.4-conformance.md
+++ b/docs/audits/upstream-3.4.4-conformance.md
@@ -136,9 +136,9 @@ mirroring the upstream daemon-delete-stats harness. The fix:
 - Carries the per-type counters in `ReceiverContext::pending_del_stats`,
   populated by both `run_pipelined` and `run_pipelined_incremental`.
 - Emits `NDX_DEL_STATS` from the receiver's `handle_goodbye` whenever
-  `flags.delete` is set, matching upstream's
+  `flags.delete` or `flags.force` is set, matching upstream's
   `delete_mode || force_delete || read_batch` early-emission gate
-  (`force_delete` / `read_batch` not yet wired into `ParsedServerFlags`).
+  (`read_batch` is still not wired into `ParsedServerFlags`).
 - Surfaces the counter into `ClientSummary::items_deleted()` for both
   pull (local receiver) and upload (remote generator stats) so the
   `--stats` renderer reports the correct count regardless of direction.

--- a/tests/directory_obstacle_removal.rs
+++ b/tests/directory_obstacle_removal.rs
@@ -503,3 +503,148 @@ fn a_regular_file_destination_with_no_obstacle_still_transfers() {
         SIBLING
     );
 }
+
+/// `--force` clears a POPULATED directory obstacle and completes at exit 0.
+///
+/// This is the `DEL_RECURSE` term the receiver could not see: `--force` was
+/// recognised by the server arg parser and thrown away (`"--force" => {}`),
+/// with no field on `ParsedServerFlags`, so the obstacle arm always took the
+/// bare-`rmdir` branch and refused at 23.
+///
+/// MEASURED against rsync 3.5.0 over the same `--server` shim: `--force`,
+/// `--delete`, and both together each give rc=0 with the symlink in place and
+/// `deleting obstacle/occupant` on the wire; the bare run gives 23. oc gave 23
+/// in all four cells.
+///
+/// upstream: `generator.c:2481` - `int del_opts = delete_mode || force_delete ?
+/// DEL_RECURSE : 0;`, handed to `delete_item()` and on to
+/// `delete_dir_contents()` (`delete.c:205-211`).
+#[test]
+fn force_clears_a_populated_directory_obstacle() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &["--force"]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "rsync 3.5.0 exits 0 for this shape under --force. stdout: {stdout} stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside"),
+        "DEL_RECURSE removes the contents and then the directory; a surviving \
+         directory means the flag never reached the receiver"
+    );
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        !output.contains("could not make way"),
+        "there is nothing to refuse once the contents are gone. output was: {output}"
+    );
+    assert!(
+        !output.contains("cannot delete non-empty directory"),
+        "delete_dir_contents() only reports DR_NOT_EMPTY when it did not \
+         recurse. output was: {output}"
+    );
+}
+
+/// `--delete` is the OTHER term of the same expression, and it was equally
+/// unreachable: `flags.delete` was already on the receiver config, but the
+/// obstacle arm never consulted it.
+///
+/// Kept separate from the `--force` cell on purpose: a fix that wired only the
+/// new flag would leave this one red, and a fix that only read `flags.delete`
+/// would leave the other one red.
+///
+/// upstream: `generator.c:2481` - `delete_mode || force_delete`.
+#[test]
+fn delete_clears_a_populated_directory_obstacle() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &["--delete"]);
+
+    assert_eq!(
+        status,
+        Some(0),
+        "rsync 3.5.0 exits 0 for this shape under --delete too. \
+         stdout: {stdout} stderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("../outside")
+    );
+}
+
+/// The cleared contents are REPORTED and COUNTED like delete-pass victims,
+/// while the obstacle directory itself stays silent and uncounted.
+///
+/// `delete_dir_contents()` strips `DEL_MAKE_ROOM` before recursing
+/// (`delete.c:126-127`), so each child reaches the `log_delete()` /
+/// `stats.deleted_*` block at `delete.c:241-256`; the directory node keeps the
+/// flag and skips it. Upstream prints exactly one `deleting obstacle/occupant`
+/// and reports `Number of deleted files: 1 (reg: 1)` - not 2, and not 0.
+///
+/// Without this cell a fix could remove the subtree with a bare
+/// `remove_dir_all` and still pass every other assertion here.
+#[test]
+fn the_cleared_contents_are_itemized_and_counted_but_the_directory_is_not() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &["-v", "--stats", "--force"]);
+
+    assert_eq!(status, Some(0), "stderr was: {stderr}");
+    let output = format!("{stdout}{stderr}");
+    assert!(
+        output.contains("deleting obstacle/occupant"),
+        "the child is logged like a delete-pass victim (DEL_MAKE_ROOM stripped \
+         for the recursion). output was: {output}"
+    );
+    assert!(
+        !output.contains("deleting obstacle\n"),
+        "the obstacle directory itself keeps DEL_MAKE_ROOM, so delete.c:241 \
+         skips its log_delete(). output was: {output}"
+    );
+    assert!(
+        output.contains("Number of deleted files: 1 (reg: 1)"),
+        "upstream counts the cleared child and not the directory. \
+         output was: {output}"
+    );
+}
+
+/// The `DEL_FOR_FILE` site (`generator.c:2148-2153`) computes the SAME
+/// `del_opts`, so a regular-file source clears a populated obstacle too.
+///
+/// The two sites reach `delete_item()` independently - one through
+/// `atomic_create()`, one directly - so a fix applied to only one of them
+/// leaves this cell red.
+#[test]
+fn force_clears_a_populated_directory_obstacle_for_a_regular_file() {
+    let fx = fixture(Source::Regular, true);
+
+    let (status, stdout, stderr) = push(&fx, &["--force"]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(obstacle(&fx)).expect("obstacle must now be a regular file"),
+        PAYLOAD
+    );
+}
+
+/// The non-vacuity control: with NEITHER flag the same fixture still refuses.
+///
+/// `delete_dir_contents()` without `DEL_RECURSE` only probes emptiness
+/// (`delete.c:115-118`), so the contents survive and the `rmdir` fails. A
+/// change that recursed unconditionally would turn this cell red, which is what
+/// separates "reads the flag" from "always removes the subtree".
+#[test]
+fn without_either_flag_the_populated_obstacle_is_still_refused() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = push(&fx, &[]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    assert!(
+        obstacle(&fx).join("occupant").exists(),
+        "no DEL_RECURSE means the contents are never touched"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -126,7 +126,7 @@ proto-cleared-ndx fail
 proto-hlink-flag-oob skip
 proto-hlink-gnum fail
 proto-msg-info-assert fail
-proto-parent-ndx-empty-dirflist fail
+proto-parent-ndx-empty-dirflist pass
 proto-sender-selftest fail
 proto-subflist-freed fail
 proxy-connect-request-too-long fail

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -126,7 +126,7 @@ proto-cleared-ndx fail
 proto-hlink-flag-oob skip
 proto-hlink-gnum fail
 proto-msg-info-assert fail
-proto-parent-ndx-empty-dirflist fail
+proto-parent-ndx-empty-dirflist pass
 proto-sender-selftest fail
 proto-subflist-freed fail
 proxy-connect-request-too-long fail


### PR DESCRIPTION
## What upstream does

`generator.c:1629` (`recv_generator`, feeding the `DEL_FOR_FILE` removal at `:2149`) and `generator.c:2481` (`atomic_create`) both compute

```c
int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
```

and hand it to `delete_item()`, which passes it straight to `delete_dir_contents()`. With `DEL_RECURSE` the contents of a directory standing where a non-directory has to be written are removed and the directory is `rmdir`'d; without it the same call only probes emptiness (`delete.c:115-118`) and returns `DR_NOT_EMPTY`.

The recursion strips `DEL_MAKE_ROOM` (`delete.c:126-127`), so every child reaches the `log_delete()` / `stats.deleted_*` block at `delete.c:241-256` and is itemized, counted, backed up under `--backup` and capped by `--max-delete` like a delete-pass victim - while the obstacle directory itself keeps the flag and stays silent and uncounted.

The same `force_delete` is the second term of the `write_del_stats()` gate at `generator.c:2868` and `:2913`, and `server_options()` forwards the flag as a long arg at `options.c:3014-3015`.

## What oc did

`--force` never reached a consumer:

- the stdio server arg parser recognised it and threw it away (`"--force" => {}`), with no field on `ParsedServerFlags`;
- the daemon's own long-form parser (`apply_long_form_args`) had no arm for it at all - a second parser, a second silent drop;
- a pull never bridged `ClientConfig::force_replacements()` onto the local receiver config;
- and the obstacle arm never consulted `flags.delete` either, so it always took the bare-`rmdir` branch.

MEASURED against the pinned rsync 3.5.0 over a real `--server` child (source symlink, destination a populated directory):

| flags | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|
| (none) | 23, refused | 23 | 23 |
| `--force` | 0, replaced | **23** | 0, replaced |
| `--delete` | 0, replaced | **23** | 0, replaced |
| `--force --delete` | 0, replaced | **23** | 0, replaced |

Under `-v --stats`, 3.5.0 prints one `deleting obstacle/occupant` and reports `Number of deleted files: 1 (reg: 1)`. oc now matches.

## The fix

- `ParsedServerFlags::force`, set by **both** server-arg parsers and bridged onto the local receiver on a pull through `apply_common_server_flags` (on a pull the client itself is the receiver, so the flag it forwards to the remote sender must also land locally).
- One owner for the rule: `ReceiverContext::del_recurse()` is upstream's expression verbatim, and `clear_obstacle_dir_contents` is the only recursion. It reuses the delete pass's own per-entry walk - extracted from `remove_entry` as `remove_dir_contents` - so a nested mount point, `--max-delete` and `--backup` behave the same whichever caller peeled the directory, and each child is itemized and counted while the obstacle node stays silent.
- The receiver's `NDX_DEL_STATS` gate becomes `delete_mode || force_delete`, closing the half of `generator.c:2868`/`:2913` the code already carried a note about as unwired.
- `DeleteStats::merge` gives the per-counter fold one owner; the generator's `accumulate_delete_stats` now delegates to it.

## Mutation proof

`tests/directory_obstacle_removal.rs` gains 6 cells (4 positive, 2 controls). All run over a real `--server` child through an rsh shim, because a local transfer takes the engine's local-copy executor and exercises none of this path.

| mutation | result |
|---|---|
| `del_recurse()` → `false` | 4 new cells RED, both controls and all 8 pre-existing cells green |
| `del_recurse()` → `self.config.flags.delete` only | the 3 `--force` cells RED, the `--delete` cell green |
| restore `"--force" => {}` in the parser, production code otherwise intact | the same 3 cells RED - the parse-layer wiring is load-bearing |
| everything restored | 14/14 green |

The two controls are the non-vacuity half: with neither flag the same fixture still refuses at 23 with the contents intact, so a change that recursed unconditionally would turn them red.

## Adjacent finding, not fixed here

`receiver/directory/missing_args.rs` removes a `--delete-missing-args` destination directory recursively and silently, unconditionally. Upstream passes the same `del_opts` at `generator.c:1753`, and `--delete-missing-args` does **not** set `delete_mode` (`options.c:742`), so without `--delete`/`--force` upstream refuses a populated one and, with them, itemizes every child. Filed separately rather than folded in: it needs its own measurement and a writer threaded into that call site.


---

## Second defect, found by the fix: a security cell that was green VACUOUSLY

Wiring `--force` turned the first commit red on the pinned 3.5.0 cell `malicious-dot-file-delete-scope`. Attribution against the exact merge-base, same host, same command: **base PASS, head FAIL.** Introduced, not inherited.

But the base passed for the wrong reason. `grep` finds upstream's guard nowhere on master - oc has **never** had it. The cell was green only because `--force` was parsed-and-discarded, so the `DEL_RECURSE` recursion was dead code and there was nothing to exploit. Nothing ever rejected the forged entry. **Wiring `--force` did not create the hole; it removed the accident that was hiding it.**

That is the shape worth remembering: a security test can be green because the mechanism it guards is unreachable, and it goes red the moment that mechanism starts working. A passing security cell is not evidence of a defence.

### The attack

`.` is the receiver's *synthetic* transfer-root entry and is exempted from the requested-name filter. A sender that encodes `.` with regular-file mode therefore gets an unfiltered entry whose destination path **is the transfer root**. Every make-way site then sees a directory standing where a non-directory must be written and, under `--force` *or* `--delete`, clears it recursively - erasing receiver-owned files that were never part of the requested transfer. `--delete` is not needed.

### The fix

Upstream refuses the entry at decode, in `recv_file_entry()`, with a comment naming this exact attack:

```c
/* "." is the synthetic transfer root.  Reinterpreting it as a file lets
 * --force recursively remove the real destination directory before the
 * receiver creates that file. */
if ((!strcmp(thisname, ".") || !strcmp(thisname, "/.")) && !S_ISDIR(mode)) {
        rprintf(FERROR, "ERROR: rejecting non-directory transfer-root entry: %s\n", thisname);
        exit_cleanup(RERR_PROTOCOL);
}
                                                   -- flist.c:1127-1134
```

Ported onto the entry-decode path (`crates/protocol/src/flist/read/mod.rs`, `read_entry()`), after the name is cleaned - upstream's `thisname` at `:1130` has already been through `clean_fname()` at `:768-772` - and therefore ahead of the filter re-check that exempts the root. Both spellings `.` and `/.`; `RERR_PROTOCOL` (exit 2), not the `RERR_UNSUPPORTED` its two neighbouring guards use. It is a **type check, not a scope narrowing**: `del_opts` stays unconditional, which is why the honest single-file `--force` control is unaffected.

Placement is on the decode path rather than the receiver's re-check because that is where upstream puts it, and it protects every consumer. Role check by enumeration, not inference: the receiver and `--read-batch` decode a flist; the sender/generator and local-copy paths construct no `FileListReader` at all, so the guard cannot over-apply to them. (Upstream replays a batch through the same `recv_file_entry`, so including it is faithful.)

### Mutation proof

| arm | outcome |
|---|---|
| guard in | PASS - `receiver rejected a non-directory encoding of its synthetic transfer-root entry` |
| guard out | FAIL - `malicious sender encoded the special "." root as a regular file and made --force recursively erase the destination root` |

The guard-out failure is the **sentinel** assertion, not the cell's built-in honest-`--force` control - so the control stayed green in both arms, separating "rejected the forgery" from "stopped honouring `--force`". Reader-level cells added: every non-directory `S_IFMT` on `.` refused as a protocol violation; a directory `.` still accepted (non-vacuity - the synthetic root is in nearly every recursive transfer).

## Manifest row flipped, and what its green does NOT mean

The guard also flips `proto-parent-ndx-empty-dirflist` from fail to pass, so its stale `fail` row became the sole remaining mismatch on both TCP legs. Flipped on CI evidence (run `33642598146`, jobs `100298359039` and `100298359185`), not a workstation run. Direction matters: this records an **absent defence that now exists**, the inverse of re-baselining a regression to green.

WARNING: that row is green on the strength of the **outermost of three layers** - the entry is refused at decode. It is not evidence that the uninitialised-heap read behind it is defended. For oc, layers 2 and 3 are **exonerated rather than outstanding**: they defend a C memory-layout hazard oc does not have (no `dir_flist`; the equivalent index is a flat `i32` already defaulted to `-1`; peer-supplied parent indices already rejected by `DirectoryTree::try_add_directory` with safe `Vec` indexing behind it, covered by the SEC-4 / CVE-2026-43620 tests). Full record, including a coupling claim I filed and then retracted when tracing disproved it: #7628.
