### PR TITLE
fix(daemon): keep a dead name converter apart from an unknown name

### DIFF
--- a/crates/batch/src/reader/flist.rs
+++ b/crates/batch/src/reader/flist.rs
@@ -202,13 +202,13 @@ impl BatchReader {
             // upstream: uidlist.c:465 - (preserve_uid || preserve_acls) && numeric_ids <= 0
             if (flags.preserve_uid || flags.preserve_acls) && !numeric_ids {
                 let mut uid_list = IdList::new();
-                uid_list.read(reader, id0_names, proto_ver, |_| None)?;
+                uid_list.read(reader, id0_names, proto_ver, |_| Ok(None))?;
             }
 
             // upstream: uidlist.c:473 - (preserve_gid || preserve_acls) && numeric_ids <= 0
             if (flags.preserve_gid || flags.preserve_acls) && !numeric_ids {
                 let mut gid_list = IdList::new();
-                gid_list.read(reader, id0_names, proto_ver, |_| None)?;
+                gid_list.read(reader, id0_names, proto_ver, |_| Ok(None))?;
             }
         }
 

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -53,6 +53,7 @@ use core::{
     },
 };
 use logging_sink::MessageSink;
+use metadata::id_lookup::ConverterOutcome;
 use protocol::{
     AdvertisedDigests, EARLY_INPUT_CMD, EARLY_INPUT_MAX_SIZE, LEGACY_DAEMON_PREFIX_LEN,
     LegacyDaemonMessage, MessageCode, MessageFrame, ProtocolVersion, filters::FilterRuleWireFormat,

--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -10,8 +10,94 @@
 #[cfg(unix)]
 struct NameConverter {
     child: std::process::Child,
+    /// The request/answer pipes, or the reason they can no longer be used.
+    ///
+    /// A converter that has died stays dead: the state lives in the type, so a
+    /// later lookup cannot find a usable stream where there is none and read
+    /// that absence as "this name has no id". Upstream reaches the same place
+    /// by dying itself - a write to a converter that has gone away hits
+    /// clientserver.c:1329-1334 and `exit_cleanup(RERR_SOCKETIO)`.
+    stream: Result<ConverterStream, ConverterDeath>,
+}
+
+/// The two halves of the converter's line protocol.
+#[cfg(unix)]
+struct ConverterStream {
     stdin: io::BufWriter<std::process::ChildStdin>,
     stdout: io::BufReader<std::process::ChildStdout>,
+}
+
+/// Why the converter can no longer be spoken to.
+///
+/// Kept as the parts of an `io::Error` rather than the error itself, because
+/// every later lookup has to be told the same thing and `io::Error` is not
+/// `Clone`.
+#[cfg(unix)]
+struct ConverterDeath {
+    kind: io::ErrorKind,
+    detail: String,
+}
+
+#[cfg(unix)]
+impl ConverterDeath {
+    /// Records a failed pipe operation.
+    fn from_io(context: &str, err: &io::Error) -> Self {
+        Self {
+            kind: err.kind(),
+            detail: format!("name converter: {context}: {err}"),
+        }
+    }
+
+    /// Records the converter having closed its answer pipe.
+    ///
+    /// upstream: clientserver.c:1336-1337 - `read_line_old()` fails for this
+    /// call, and the next request's write then exits the process at :1333. The
+    /// session ends either way; taking it here is what keeps the *first* such
+    /// lookup from reading as "no such name".
+    fn exited() -> Self {
+        Self {
+            kind: io::ErrorKind::UnexpectedEof,
+            detail: "name converter: closed its answer pipe".to_owned(),
+        }
+    }
+
+    /// Reproduces the error to hand to this lookup's caller.
+    fn error(&self) -> io::Error {
+        io::Error::new(self.kind, self.detail.clone())
+    }
+}
+
+#[cfg(unix)]
+impl ConverterStream {
+    /// Writes one request line and reads one answer line.
+    ///
+    /// `Ok(None)` is an answer that names nothing (upstream's empty line);
+    /// `Err` means the stream is broken and the converter is finished.
+    fn exchange(&mut self, request: &str) -> Result<Option<String>, ConverterDeath> {
+        // upstream: clientserver.c:1329-1334 - a write that does not complete
+        // is `exit_cleanup(RERR_SOCKETIO)`, never a lookup that "found
+        // nothing".
+        self.stdin
+            .write_all(request.as_bytes())
+            .map_err(|err| ConverterDeath::from_io("writing the request", &err))?;
+        self.stdin
+            .flush()
+            .map_err(|err| ConverterDeath::from_io("writing the request", &err))?;
+
+        let mut line = String::new();
+        match self.stdout.read_line(&mut line) {
+            // upstream: clientserver.c:1336-1337 - `read_line_old()` failed.
+            Ok(0) => Err(ConverterDeath::exited()),
+            Err(err) => Err(ConverterDeath::from_io("reading the answer", &err)),
+            Ok(_) => {
+                let trimmed = line.trim_end().to_owned();
+                // upstream: clientserver.c:1345-1346 - `if (!*buf) return
+                // False`. An empty answer is "unknown"; reading it as the id
+                // `atol("") == 0` is CVE-2026-53798.
+                Ok((!trimmed.is_empty()).then_some(trimmed))
+            }
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -30,79 +116,91 @@ impl NameConverter {
 
         Ok(Self {
             child,
-            stdin,
-            stdout,
+            stream: Ok(ConverterStream { stdin, stdout }),
         })
     }
 
     /// Sends a query to the converter and reads one line of response.
     ///
-    /// `arg` is rejected outright when it carries a control byte: the request
-    /// framing is one line per query, so an embedded newline would make the
-    /// converter answer twice while this reads once, leaving the surplus answer
-    /// buffered for the *next* lookup to consume.
-    fn query(&mut self, cmd: &str, arg: &str) -> Option<String> {
+    /// The four outcomes are upstream's, un-merged:
+    ///
+    /// | outcome    | cause                                | upstream                  |
+    /// |------------|--------------------------------------|---------------------------|
+    /// | `Resolved` | a usable answer line                 | clientserver.c:1355 True  |
+    /// | `Unknown`  | an empty answer line                 | clientserver.c:1345 False |
+    /// | `Refused`  | a control byte in `arg`; nothing sent| clientserver.c:1317 False |
+    /// | `Failed`   | over-long request, or broken stream  | clientserver.c:1326, 1333 |
+    fn query(&mut self, cmd: &str, arg: &str) -> ConverterOutcome<String> {
+        // `arg` is rejected outright when it carries a control byte: the
+        // request framing is one line per query, so an embedded newline would
+        // make the converter answer twice while this reads once, leaving the
+        // surplus answer buffered for the *next* lookup to consume.
         if !is_safe_token(arg) {
-            return None;
+            return ConverterOutcome::Refused;
         }
         let request = format!("{cmd} {arg}\n");
-        // upstream: clientserver.c:1322 - `len >= (int)sizeof buf` on a 1024-byte
+        // upstream: clientserver.c:1324 - `len >= (int)sizeof buf` on a 1024-byte
         // buffer, so 1024 itself is already too long (snprintf truncated it).
+        // Upstream answers a truncated request with
+        // `exit_cleanup(RERR_UNSUPPORTED)`, so it is a failure and not a name
+        // that "has no id". The stream stays usable: nothing was written.
         if request.len() >= NAMECVT_REQUEST_LIMIT {
-            return None;
+            return ConverterOutcome::Failed(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "name converter: request too large to frame",
+            ));
         }
-        if self.stdin.write_all(request.as_bytes()).is_err() {
-            return None;
-        }
-        if self.stdin.flush().is_err() {
-            return None;
-        }
-        let mut line = String::new();
-        match self.stdout.read_line(&mut line) {
-            Ok(0) | Err(_) => None,
-            Ok(_) => {
-                let trimmed = line.trim_end().to_owned();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(trimmed)
-                }
+
+        let stream = match &mut self.stream {
+            Ok(stream) => stream,
+            Err(death) => return ConverterOutcome::Failed(death.error()),
+        };
+
+        match stream.exchange(&request) {
+            Ok(Some(answer)) => ConverterOutcome::Resolved(answer),
+            Ok(None) => ConverterOutcome::Unknown,
+            Err(death) => {
+                let err = death.error();
+                self.stream = Err(death);
+                ConverterOutcome::Failed(err)
             }
         }
     }
 
     /// Converts a numeric UID to a username.
-    fn uid_to_name(&mut self, uid: u32) -> Option<String> {
+    fn uid_to_name(&mut self, uid: u32) -> ConverterOutcome<String> {
         self.query("uid", &uid.to_string())
     }
 
     /// Converts a numeric GID to a group name.
-    fn gid_to_name(&mut self, gid: u32) -> Option<String> {
+    fn gid_to_name(&mut self, gid: u32) -> ConverterOutcome<String> {
         self.query("gid", &gid.to_string())
     }
 
     /// Converts a username to a numeric UID.
-    fn name_to_uid(&mut self, name: &str) -> Option<u32> {
-        parse_converter_id(&self.query("usr", name)?)
+    fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        self.query("usr", name)
+            .map_answer(|answer| parse_converter_id(&answer))
     }
 
     /// Converts a group name to a numeric GID.
-    fn name_to_gid(&mut self, name: &str) -> Option<u32> {
-        parse_converter_id(&self.query("grp", name)?)
+    fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        self.query("grp", name)
+            .map_answer(|answer| parse_converter_id(&answer))
     }
 }
 
 /// Upper bound on a converter request, matching upstream's `char buf[1024]`.
 ///
-/// upstream: clientserver.c:1313 - `char buf[1024]`, refused at `:1322` once the
+/// upstream: clientserver.c:1313 - `char buf[1024]`, refused at `:1324` once the
 /// formatted request reaches that length.
 #[cfg(unix)]
 const NAMECVT_REQUEST_LIMIT: usize = 1024;
 
 /// Rejects a name that cannot be framed as a single request line.
 ///
-/// upstream: clientserver.c:1362 `namecvt_safe_token()` - refuses any byte below
-/// `' '` or equal to `0x7f`, checked at `:1317` *before* the request is
+/// upstream: clientserver.c:1362-1370 `namecvt_safe_token()` - refuses any byte
+/// below `' '` or equal to `0x7f`, checked at `:1317` *before* the request is
 /// formatted. Newline is the byte that matters (it desynchronises the
 /// request/answer stream); the rest of the control range comes along because
 /// upstream refuses the whole class rather than one byte.
@@ -113,7 +211,7 @@ fn is_safe_token(name: &str) -> bool {
 
 /// Parses a converter's id answer under upstream's strict digit rule.
 ///
-/// upstream: clientserver.c:1341-1355 - an empty line, any non-digit byte, or a
+/// upstream: clientserver.c:1345-1354 - an empty line, any non-digit byte, or a
 /// value that does not fit `id_t` yields `False` and leaves the id untouched.
 /// The explicit digit loop is why a leading `+` is refused, which Rust's
 /// `str::parse::<u32>` would otherwise accept.
@@ -137,16 +235,16 @@ impl Drop for NameConverter {
 
 #[cfg(unix)]
 impl metadata::id_lookup::NameConverterCallbacks for NameConverter {
-    fn uid_to_name(&mut self, uid: u32) -> Option<String> {
+    fn uid_to_name(&mut self, uid: u32) -> ConverterOutcome<String> {
         self.uid_to_name(uid)
     }
-    fn gid_to_name(&mut self, gid: u32) -> Option<String> {
+    fn gid_to_name(&mut self, gid: u32) -> ConverterOutcome<String> {
         self.gid_to_name(gid)
     }
-    fn name_to_uid(&mut self, name: &str) -> Option<u32> {
+    fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32> {
         self.name_to_uid(name)
     }
-    fn name_to_gid(&mut self, name: &str) -> Option<u32> {
+    fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32> {
         self.name_to_gid(name)
     }
 }
@@ -172,20 +270,22 @@ impl WindowsNameConverter {
 
 #[cfg(windows)]
 impl metadata::id_lookup::NameConverterCallbacks for WindowsNameConverter {
-    fn uid_to_name(&mut self, uid: u32) -> Option<String> {
-        platform::name_resolution::rid_to_account_name(uid)
+    fn uid_to_name(&mut self, uid: u32) -> ConverterOutcome<String> {
+        platform::name_resolution::rid_to_account_name(uid).into()
     }
-    fn gid_to_name(&mut self, gid: u32) -> Option<String> {
+    fn gid_to_name(&mut self, gid: u32) -> ConverterOutcome<String> {
         // On Windows, GIDs map to group RIDs. Resolve them through the same
         // rid_to_account_name path used for user RIDs, which matches accounts
         // by RID regardless of whether they name a user or a local group.
-        platform::name_resolution::rid_to_account_name(gid)
+        platform::name_resolution::rid_to_account_name(gid).into()
     }
-    fn name_to_uid(&mut self, name: &str) -> Option<u32> {
-        platform::name_resolution::name_to_rid(name)
+    fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        platform::name_resolution::name_to_rid(name).into()
     }
-    fn name_to_gid(&mut self, name: &str) -> Option<u32> {
-        platform::name_resolution::lookup_account_info(name).map(|(rid, _)| rid)
+    fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        platform::name_resolution::lookup_account_info(name)
+            .map(|(rid, _)| rid)
+            .into()
     }
 }
 
@@ -223,14 +323,34 @@ fn install_windows_name_converter() -> NameConverterGuard {
 mod name_converter_tests {
     use super::*;
 
+    /// The answered value, with the three non-answers kept apart.
+    ///
+    /// A `Failed` outcome panics instead of reading as `None`: collapsing it
+    /// into "this name has no id" is the defect the outcome type exists to
+    /// prevent, and a helper that quietly did so would hide it from every
+    /// test below.
+    #[cfg(unix)]
+    fn answered<T: std::fmt::Debug>(outcome: ConverterOutcome<T>) -> Option<T> {
+        match outcome {
+            ConverterOutcome::Resolved(value) => Some(value),
+            ConverterOutcome::Unknown | ConverterOutcome::Refused => None,
+            ConverterOutcome::Failed(err) => panic!("the converter failed: {err}"),
+        }
+    }
+
+    #[cfg(unix)]
+    fn is_failure<T>(outcome: &ConverterOutcome<T>) -> bool {
+        matches!(outcome, ConverterOutcome::Failed(_))
+    }
+
     #[cfg(unix)]
     #[test]
     fn spawn_and_query_uid_to_name() {
         // Simple script that echoes a fixed name for any uid query
         let mut nc = NameConverter::spawn("while read cmd arg; do echo testuser; done")
             .expect("spawn should succeed");
-        assert_eq!(nc.uid_to_name(1000), Some("testuser".to_owned()));
-        assert_eq!(nc.uid_to_name(0), Some("testuser".to_owned()));
+        assert_eq!(answered(nc.uid_to_name(1000)), Some("testuser".to_owned()));
+        assert_eq!(answered(nc.uid_to_name(0)), Some("testuser".to_owned()));
     }
 
     #[cfg(unix)]
@@ -238,7 +358,7 @@ mod name_converter_tests {
     fn spawn_and_query_gid_to_name() {
         let mut nc = NameConverter::spawn("while read cmd arg; do echo testgroup; done")
             .expect("spawn should succeed");
-        assert_eq!(nc.gid_to_name(1000), Some("testgroup".to_owned()));
+        assert_eq!(answered(nc.gid_to_name(1000)), Some("testgroup".to_owned()));
     }
 
     #[cfg(unix)]
@@ -246,7 +366,7 @@ mod name_converter_tests {
     fn spawn_and_query_name_to_uid() {
         let mut nc = NameConverter::spawn("while read cmd arg; do echo 1001; done")
             .expect("spawn should succeed");
-        assert_eq!(nc.name_to_uid("alice"), Some(1001));
+        assert_eq!(answered(nc.name_to_uid("alice")), Some(1001));
     }
 
     #[cfg(unix)]
@@ -254,24 +374,105 @@ mod name_converter_tests {
     fn spawn_and_query_name_to_gid() {
         let mut nc = NameConverter::spawn("while read cmd arg; do echo 2002; done")
             .expect("spawn should succeed");
-        assert_eq!(nc.name_to_gid("staff"), Some(2002));
+        assert_eq!(answered(nc.name_to_gid("staff")), Some(2002));
     }
 
+    /// upstream: clientserver.c:1345-1346 - `if (!*buf) return False`. An empty
+    /// answer is the converter saying "I do not know", which is NOT a failure:
+    /// the converter must still be usable afterwards.
     #[cfg(unix)]
     #[test]
-    fn empty_response_returns_none() {
-        let mut nc = NameConverter::spawn("while read cmd arg; do echo ''; done")
-            .expect("spawn should succeed");
-        assert_eq!(nc.uid_to_name(1000), None);
+    fn an_empty_answer_is_unknown_and_leaves_the_converter_usable() {
+        let mut nc = NameConverter::spawn(
+            r#"while read cmd arg; do
+                case "$arg" in
+                    alice) echo 1001 ;;
+                    *)     echo '' ;;
+                esac
+            done"#,
+        )
+        .expect("spawn should succeed");
+
+        let outcome = nc.name_to_uid("nobody");
+        assert!(
+            matches!(outcome, ConverterOutcome::Unknown),
+            "an empty answer is `unknown`, not a failure: {outcome:?}"
+        );
+        assert_eq!(
+            answered(nc.name_to_uid("alice")),
+            Some(1001),
+            "an `unknown` answer must not end the converter's usefulness"
+        );
     }
 
+    /// THE FAIL-OPEN CASE. A converter that has died must not read as "this
+    /// name has no id" - that answer would hand the caller the sender's own
+    /// numeric id for every name for the rest of the session.
+    ///
+    /// upstream: clientserver.c:1336-1337 returns False for the EOF itself and
+    /// :1329-1334 then exits the process on the NEXT request's write, so the
+    /// session never continues past a dead converter either.
     #[cfg(unix)]
     #[test]
-    fn broken_pipe_returns_none() {
-        // Child exits immediately, causing broken pipe on write or EOF on read.
-        // The query call blocks on read_line which returns EOF once the child exits.
+    fn a_dead_converter_fails_instead_of_answering_unknown() {
+        // The child exits immediately: the answer pipe is at EOF.
         let mut nc = NameConverter::spawn("exit 0").expect("spawn should succeed");
-        assert_eq!(nc.uid_to_name(1000), None);
+
+        let first = nc.uid_to_name(1000);
+        assert!(
+            is_failure(&first),
+            "EOF from the converter must be a failure, not `unknown`: {first:?}"
+        );
+
+        // Sticky: the death is recorded in the type, so every later lookup
+        // reports it too. Without that, one dead converter degrades into a
+        // silent "no such name" for every subsequent id in the transfer.
+        for later in [
+            is_failure(&nc.uid_to_name(1001)),
+            is_failure(&nc.gid_to_name(1001)),
+            is_failure(&nc.name_to_uid("alice")),
+            is_failure(&nc.name_to_gid("staff")),
+        ] {
+            assert!(later, "a dead converter must stay dead");
+        }
+
+        // ... and it stays dead of the SAME cause. A converter whose death was
+        // not recorded would be spoken to again and report whatever the pipe
+        // said this time (an EPIPE from writing to a reader that is gone),
+        // which is the tell that the stream was retried rather than known to
+        // be finished.
+        match nc.uid_to_name(1002) {
+            ConverterOutcome::Failed(err) => assert_eq!(
+                err.kind(),
+                io::ErrorKind::UnexpectedEof,
+                "the recorded cause must be reported, not a fresh one: {err}"
+            ),
+            other => panic!("a dead converter must keep failing: {other:?}"),
+        }
+    }
+
+    /// The fail-closed rule as the lookup API sees it: a dead converter is an
+    /// error, and the error survives the tolerance that a host-database
+    /// failure is granted.
+    #[cfg(unix)]
+    #[test]
+    fn a_dead_converter_is_an_error_at_the_lookup_api() {
+        let nc = NameConverter::spawn("exit 0").expect("spawn should succeed");
+        let _guard = install_name_converter(nc);
+
+        let err = metadata::id_lookup::lookup_user_by_name(b"alice")
+            .expect_err("a dead converter must not resolve to `no such user`");
+        assert!(err.is_converter_failure());
+
+        // Non-vacuity for the tolerance helper: `no_id_unless_converter_failed`
+        // turns a database failure into `None`, and must NOT do that here.
+        assert!(
+            metadata::id_lookup::no_id_unless_converter_failed(
+                metadata::id_lookup::lookup_user_by_name(b"alice")
+            )
+            .is_err(),
+            "the fail-closed rule must survive the database-failure tolerance"
+        );
     }
 
     /// Spawns a converter that answers per-name AND records one byte per request
@@ -317,7 +518,11 @@ mod name_converter_tests {
         let (mut nc, log) = spawn_counting_converter(&dir.path().join("seen"));
 
         // Injection attempt: the tail `usr root` would be a SECOND request line.
-        assert_eq!(nc.name_to_uid("zz\nusr root"), None);
+        let outcome = nc.name_to_uid("zz\nusr root");
+        assert!(
+            matches!(outcome, ConverterOutcome::Refused),
+            "a control byte is refused before the write: {outcome:?}"
+        );
         assert_eq!(requests_seen(&log), 0, "the request must never be written");
 
         // THE ASSERTION THAT MATTERS. Unpatched, the converter answered twice
@@ -325,7 +530,7 @@ mod name_converter_tests {
         // lookup consumes the stale `0` and alice resolves to root. Every later
         // lookup in the session stays shifted by one.
         assert_eq!(
-            nc.name_to_uid("alice"),
+            answered(nc.name_to_uid("alice")),
             Some(1001),
             "a refused name must not leave a surplus answer buffered for the next lookup"
         );
@@ -339,16 +544,19 @@ mod name_converter_tests {
 
         // upstream refuses the class (`< ' '` or 0x7f), not just the byte that
         // happens to be exploitable. Only `\n` desynchronises the stream, so
-        // the returned None is NOT discriminating for these - the request count
-        // is. Each must be refused before any write.
+        // the returned outcome is NOT discriminating for these - the request
+        // count is. Each must be refused before any write.
         for name in ["a\rb", "a\tb", "a\u{7f}b", "a\u{1}b"] {
-            assert_eq!(nc.name_to_uid(name), None, "{name:?} must be refused");
+            assert!(
+                matches!(nc.name_to_uid(name), ConverterOutcome::Refused),
+                "{name:?} must be refused"
+            );
             assert_eq!(requests_seen(&log), 0, "{name:?} must not be written");
         }
 
         // Non-vacuity control: an ordinary name IS sent, so the counter above
         // is actually capable of moving.
-        assert_eq!(nc.name_to_uid("alice"), Some(1001));
+        assert_eq!(answered(nc.name_to_uid("alice")), Some(1001));
         assert_eq!(requests_seen(&log), 1, "a safe name reaches the converter");
     }
 
@@ -361,10 +569,19 @@ mod name_converter_tests {
         // Exercised through name_to_uid, not the helper directly: a test that
         // calls parse_converter_id() alone still passes when the production
         // path is wired straight to str::parse, which is the mistake to catch.
-        // upstream clientserver.c:1345-1348 walks the bytes explicitly, so the
+        // upstream clientserver.c:1347-1350 walks the bytes explicitly, so the
         // leading `+` that Rust's parse::<u32> accepts must be refused here.
-        assert_eq!(nc.name_to_uid("plus"), None, "`+5` is not a valid id");
-        assert_eq!(nc.name_to_uid("alice"), Some(1001), "stream still in sync");
+        let outcome = nc.name_to_uid("plus");
+        assert!(
+            matches!(outcome, ConverterOutcome::Unknown),
+            "`+5` is a malformed answer, which upstream reports as False (not a \
+             transport failure): {outcome:?}"
+        );
+        assert_eq!(
+            answered(nc.name_to_uid("alice")),
+            Some(1001),
+            "stream still in sync"
+        );
     }
 
     #[cfg(unix)]
@@ -388,15 +605,20 @@ mod name_converter_tests {
         let (mut nc, log) = spawn_counting_converter(&dir.path().join("seen"));
 
         // "usr " + name + "\n" == NAMECVT_REQUEST_LIMIT exactly, which upstream
-        // already treats as truncated (`len >= sizeof buf`). Both sizes return
-        // None (neither name is known), so only the request count separates
-        // "refused" from "sent and unknown".
+        // already treats as truncated (`len >= sizeof buf`) and answers with
+        // `exit_cleanup(RERR_UNSUPPORTED)` - a failure, not a name with no id.
         let exact = "n".repeat(NAMECVT_REQUEST_LIMIT - "usr ".len() - 1);
-        assert_eq!(nc.name_to_uid(&exact), None);
-        assert_eq!(requests_seen(&log), 0, "a full buffer is truncation");
+        let outcome = nc.name_to_uid(&exact);
+        assert!(is_failure(&outcome), "a full buffer is truncation");
+        assert_eq!(requests_seen(&log), 0, "and nothing is written");
 
+        // One byte shorter fits, so it IS sent - and the converter is still
+        // usable, because an over-long request never touched the stream.
         let under = "n".repeat(NAMECVT_REQUEST_LIMIT - "usr ".len() - 2);
-        assert_eq!(nc.name_to_uid(&under), None, "unknown, but it WAS sent");
+        assert!(
+            matches!(nc.name_to_uid(&under), ConverterOutcome::Unknown),
+            "unknown, but it WAS sent"
+        );
         assert_eq!(requests_seen(&log), 1, "one byte shorter still fits");
     }
 
@@ -453,7 +675,7 @@ mod name_converter_tests {
     fn non_numeric_response_for_name_to_uid_returns_none() {
         let mut nc = NameConverter::spawn("while read cmd arg; do echo 'not_a_number'; done")
             .expect("spawn should succeed");
-        assert_eq!(nc.name_to_uid("alice"), None);
+        assert_eq!(answered(nc.name_to_uid("alice")), None);
     }
 
     #[cfg(unix)]
@@ -473,13 +695,13 @@ mod name_converter_tests {
         )
         .expect("spawn should succeed");
 
-        assert_eq!(nc.uid_to_name(1000), Some("alice".to_owned()));
-        assert_eq!(nc.uid_to_name(9999), None);
-        assert_eq!(nc.gid_to_name(100), Some("users".to_owned()));
-        assert_eq!(nc.gid_to_name(9999), None);
-        assert_eq!(nc.name_to_uid("alice"), Some(1000));
-        assert_eq!(nc.name_to_uid("nobody"), None);
-        assert_eq!(nc.name_to_gid("users"), Some(100));
-        assert_eq!(nc.name_to_gid("nobody"), None);
+        assert_eq!(answered(nc.uid_to_name(1000)), Some("alice".to_owned()));
+        assert_eq!(answered(nc.uid_to_name(9999)), None);
+        assert_eq!(answered(nc.gid_to_name(100)), Some("users".to_owned()));
+        assert_eq!(answered(nc.gid_to_name(9999)), None);
+        assert_eq!(answered(nc.name_to_uid("alice")), Some(1000));
+        assert_eq!(answered(nc.name_to_uid("nobody")), None);
+        assert_eq!(answered(nc.name_to_gid("users")), Some(100));
+        assert_eq!(answered(nc.name_to_gid("nobody")), None);
     }
 }

--- a/crates/metadata/src/id_lookup/converter.rs
+++ b/crates/metadata/src/id_lookup/converter.rs
@@ -8,7 +8,90 @@
 //! upstream: uidlist.c:110-193 - the name converter subprocess replaces
 //! getpwuid/getpwnam/getgrgid/getgrnam calls.
 
+use super::error::LookupError;
 use std::cell::RefCell;
+use std::io;
+
+/// What one name-converter query produced.
+///
+/// Upstream's `namecvt_call()` returns a bare `BOOL` (clientserver.c:1311) only
+/// because two of its outcomes never return at all: an over-long request
+/// (:1324-1327) and a failed write (:1329-1334) each call `exit_cleanup()`. The
+/// two that do return - a refused token (:1317-1319) and an answer the callers
+/// cannot use (:1345-1354) - are the only ones `False` ever means. Reproducing
+/// that as a single `Option` in Rust would merge a converter that has *died*
+/// with a name it simply does not know, and "does not know" is the arm callers
+/// are entitled to shrug off.
+#[derive(Debug)]
+pub enum ConverterOutcome<T> {
+    /// The converter answered, and the answer is usable.
+    ///
+    /// upstream: clientserver.c:1355-1359 - `*id_p`/`*name_p` is set and the
+    /// call returns `True`.
+    Resolved(T),
+
+    /// The converter answered, and its answer names nothing: an empty line, or
+    /// (name to id) a line that is not a plain decimal id that fits.
+    ///
+    /// upstream: clientserver.c:1345-1354 - `False` with the caller's id left
+    /// untouched. CVE-2026-53798 is precisely this arm being read as `atol("")
+    /// == 0` and mapping an unknown name onto root.
+    Unknown,
+
+    /// The request was never written, because the name cannot be framed as one
+    /// request line. The converter itself is untouched and still usable.
+    ///
+    /// upstream: clientserver.c:1317-1319 `namecvt_safe_token()` - the token is
+    /// reported and the call returns `False` without writing anything
+    /// (CVE-2026-53788).
+    Refused,
+
+    /// The query could not be completed. The session must not continue as
+    /// though the name were merely unknown.
+    ///
+    /// upstream: clientserver.c:1324-1327 (`RERR_UNSUPPORTED`) and :1329-1334
+    /// (`RERR_SOCKETIO`) exit the process; a converter that has closed its
+    /// answer pipe (:1336-1337) exits on the next request's write.
+    Failed(io::Error),
+}
+
+impl<T> ConverterOutcome<T> {
+    /// Rewrites the answered value, turning one the caller cannot use into
+    /// [`ConverterOutcome::Unknown`].
+    ///
+    /// upstream: clientserver.c:1347-1354 - a malformed id answer is `False`,
+    /// the same result an empty answer produces; it is not a transport failure.
+    pub fn map_answer<U>(self, map: impl FnOnce(T) -> Option<U>) -> ConverterOutcome<U> {
+        match self {
+            Self::Resolved(value) => {
+                map(value).map_or(ConverterOutcome::Unknown, ConverterOutcome::Resolved)
+            }
+            Self::Unknown => ConverterOutcome::Unknown,
+            Self::Refused => ConverterOutcome::Refused,
+            Self::Failed(err) => ConverterOutcome::Failed(err),
+        }
+    }
+
+    /// Collapses the outcome into the lookup API's result.
+    ///
+    /// The two arms upstream returns `False` for become `Ok(None)` ("no such
+    /// name"); the arm upstream exits on becomes an error, never `Ok(None)`.
+    pub(super) fn into_lookup(self) -> Result<Option<T>, LookupError> {
+        match self {
+            Self::Resolved(value) => Ok(Some(value)),
+            Self::Unknown | Self::Refused => Ok(None),
+            Self::Failed(err) => Err(LookupError::Converter(err)),
+        }
+    }
+}
+
+impl<T> From<Option<T>> for ConverterOutcome<T> {
+    /// Lifts an answer from a back end that has no failure mode of its own -
+    /// one that can only say "here it is" or "no such account".
+    fn from(answer: Option<T>) -> Self {
+        answer.map_or(Self::Unknown, Self::Resolved)
+    }
+}
 
 /// External name-to-ID and ID-to-name conversion.
 ///
@@ -18,21 +101,21 @@ use std::cell::RefCell;
 /// upstream: uidlist.c:110-193
 pub trait NameConverterCallbacks: Send {
     /// Converts a numeric UID to a username.
-    fn uid_to_name(&mut self, uid: u32) -> Option<String>;
+    fn uid_to_name(&mut self, uid: u32) -> ConverterOutcome<String>;
     /// Converts a numeric GID to a group name.
-    fn gid_to_name(&mut self, gid: u32) -> Option<String>;
+    fn gid_to_name(&mut self, gid: u32) -> ConverterOutcome<String>;
     /// Converts a username to a numeric UID.
-    fn name_to_uid(&mut self, name: &str) -> Option<u32>;
+    fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32>;
     /// Converts a group name to a numeric GID.
-    fn name_to_gid(&mut self, name: &str) -> Option<u32>;
+    fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32>;
 }
 
 /// Runs `query` against the installed name converter, if there is one.
 ///
-/// `Some(answer)` means a converter is installed and `answer` is its verdict -
-/// including `Some(None)` for "the converter does not recognise this id or
-/// name". `None` means no converter is installed, and only then may the caller
-/// consult the host user database.
+/// `Some(outcome)` means a converter is installed and `outcome` is its verdict -
+/// including the arms that say "I do not know this name" and "I could not
+/// answer at all". `None` means no converter is installed, and only then may
+/// the caller consult the host user database.
 ///
 /// upstream: uidlist.c:114-121, :131-138, :154-163, :180-189 - every lookup is
 /// `if (namecvt_pid) { namecvt_call(...) } else { getpw*()/getgr*() }`. The
@@ -42,8 +125,8 @@ pub trait NameConverterCallbacks: Send {
 /// the directive is configured, so the two arms are mutually exclusive and this
 /// helper is the single place that says so.
 pub(super) fn with_name_converter<T>(
-    query: impl FnOnce(&mut dyn NameConverterCallbacks) -> Option<T>,
-) -> Option<Option<T>> {
+    query: impl FnOnce(&mut dyn NameConverterCallbacks) -> ConverterOutcome<T>,
+) -> Option<ConverterOutcome<T>> {
     NAME_CONVERTER_SLOT.with(|slot| slot.borrow_mut().as_mut().map(|nc| query(&mut **nc)))
 }
 

--- a/crates/metadata/src/id_lookup/error.rs
+++ b/crates/metadata/src/id_lookup/error.rs
@@ -1,0 +1,127 @@
+//! The error half of a uid/gid lookup.
+//!
+//! A lookup has two back ends - the host user database and, when a daemon
+//! module configures `name converter`, an operator-supplied subprocess - and
+//! upstream treats their failures differently. `getpwnam()` returning nothing
+//! (for any reason) leaves the sender's numeric id in place (uidlist.c:160-163),
+//! whereas a name-converter transport failure ends the session outright
+//! (clientserver.c:1326, :1333 `exit_cleanup()`). Collapsing both into
+//! `Ok(None)` is what lets a dead converter read as "this name has no id",
+//! which is the fail-open shape [`LookupError`] exists to prevent.
+
+use std::error::Error;
+use std::fmt;
+use std::io;
+
+/// A uid/gid lookup that yields `Ok(None)` when the back end answered "no such
+/// name/id" and [`LookupError`] when it could not answer at all.
+pub type LookupResult<T> = Result<Option<T>, LookupError>;
+
+/// Why a uid/gid lookup could not be answered.
+///
+/// The variant is the discriminator a caller needs to decide between upstream's
+/// two failure policies, so it must survive any conversion; [`From<LookupError>
+/// for io::Error`](#impl-From<LookupError>-for-Error) keeps the value itself as
+/// the error's payload rather than flattening it to a message.
+#[derive(Debug)]
+pub enum LookupError {
+    /// The host user database call failed.
+    ///
+    /// upstream: uidlist.c:160-163 `user_to_uid()` - a `getpwnam()` that yields
+    /// no entry is "no id"; the caller keeps the sender's numeric id. Upstream
+    /// cannot distinguish "absent" from "the NSS backend errored" and neither
+    /// arm ends the transfer, so this variant is tolerated the same way.
+    Database(io::Error),
+
+    /// The daemon name converter could not answer.
+    ///
+    /// upstream: clientserver.c:1324-1327 (request too large,
+    /// `RERR_UNSUPPORTED`) and :1329-1334 (write to the converter failed,
+    /// `RERR_SOCKETIO`) both call `exit_cleanup()`, and a converter that has
+    /// closed its answer pipe (:1336-1337) dies on the next request's write. The
+    /// session ends; the lookup never degrades into "no such name".
+    Converter(io::Error),
+}
+
+impl LookupError {
+    /// Reports whether the name converter, rather than the host database, is
+    /// the back end that failed.
+    #[must_use]
+    pub fn is_converter_failure(&self) -> bool {
+        matches!(self, Self::Converter(_))
+    }
+}
+
+impl fmt::Display for LookupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Database(err) => write!(f, "user database lookup failed: {err}"),
+            Self::Converter(err) => write!(f, "name converter failed: {err}"),
+        }
+    }
+}
+
+impl Error for LookupError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Database(err) | Self::Converter(err) => Some(err),
+        }
+    }
+}
+
+impl From<LookupError> for io::Error {
+    fn from(err: LookupError) -> Self {
+        let kind = match &err {
+            LookupError::Database(inner) | LookupError::Converter(inner) => inner.kind(),
+        };
+        io::Error::new(kind, err)
+    }
+}
+
+/// Applies upstream's asymmetry between the two lookup back ends: a host
+/// database failure is "no id", a converter failure is fatal.
+///
+/// This is the conversion every id-list and file-list call site needs, and
+/// having one of it is what keeps the fail-closed rule from being re-decided
+/// (and re-lost) per call site.
+///
+/// upstream: uidlist.c:160-163 vs clientserver.c:1326/:1333.
+pub fn no_id_unless_converter_failed<T>(result: LookupResult<T>) -> io::Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(LookupError::Database(_)) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_database_failure_reads_as_no_id() {
+        let err = LookupError::Database(io::Error::from(io::ErrorKind::PermissionDenied));
+        assert!(!err.is_converter_failure());
+        assert_eq!(
+            no_id_unless_converter_failed::<u32>(Err(err)).expect("tolerated"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_converter_failure_is_fatal_and_stays_recognisable() {
+        let err = LookupError::Converter(io::Error::from(io::ErrorKind::BrokenPipe));
+        assert!(err.is_converter_failure());
+        let fatal = no_id_unless_converter_failed::<u32>(Err(err))
+            .expect_err("a dead converter must not read as `no such name`");
+        assert_eq!(fatal.kind(), io::ErrorKind::BrokenPipe);
+        // The discriminator has to survive the trip through io::Error, or a
+        // caller downstream of the conversion is back to one undifferentiated
+        // failure.
+        let payload = fatal
+            .get_ref()
+            .and_then(|inner| inner.downcast_ref::<LookupError>())
+            .expect("the LookupError itself is the payload");
+        assert!(payload.is_converter_failure());
+    }
+}

--- a/crates/metadata/src/id_lookup/mod.rs
+++ b/crates/metadata/src/id_lookup/mod.rs
@@ -24,6 +24,7 @@
 #[cfg(unix)]
 mod cache;
 mod converter;
+mod error;
 mod name_cache;
 #[cfg(unix)]
 mod nss;
@@ -34,7 +35,10 @@ mod nss_win;
 
 #[cfg(unix)]
 pub use cache::{map_gid, map_uid};
-pub use converter::{NameConverterCallbacks, clear_name_converter, set_name_converter};
+pub use converter::{
+    ConverterOutcome, NameConverterCallbacks, clear_name_converter, set_name_converter,
+};
+pub use error::{LookupError, LookupResult, no_id_unless_converter_failed};
 pub use name_cache::{lookup_group_name_cached, lookup_user_name_cached};
 #[cfg(unix)]
 pub use nss::{

--- a/crates/metadata/src/id_lookup/name_cache.rs
+++ b/crates/metadata/src/id_lookup/name_cache.rs
@@ -15,9 +15,9 @@
 //! upstream: uidlist.c:456-480 - add_uid()/add_gid() cache each id once.
 
 use super::converter::has_name_converter;
+use super::error::LookupResult;
 use super::{lookup_group_name, lookup_user_name};
 use std::collections::HashMap;
-use std::io;
 use std::sync::{LazyLock, RwLock};
 
 /// Id to resolved-name memo. The `None` value caches a "no such name" outcome.
@@ -52,7 +52,7 @@ fn record_nss_lookup() {}
 /// `None` result for unknown ids, but performs at most one NSS query per
 /// distinct uid for the lifetime of the process. Bypasses the cache when a
 /// thread-local name converter is installed.
-pub fn lookup_user_name_cached(uid: u32) -> Result<Option<Vec<u8>>, io::Error> {
+pub fn lookup_user_name_cached(uid: u32) -> LookupResult<Vec<u8>> {
     if has_name_converter() {
         return lookup_user_name(uid);
     }
@@ -79,7 +79,7 @@ pub fn lookup_user_name_cached(uid: u32) -> Result<Option<Vec<u8>>, io::Error> {
 /// `None` result for unknown ids, but performs at most one NSS query per
 /// distinct gid for the lifetime of the process. Bypasses the cache when a
 /// thread-local name converter is installed.
-pub fn lookup_group_name_cached(gid: u32) -> Result<Option<Vec<u8>>, io::Error> {
+pub fn lookup_group_name_cached(gid: u32) -> LookupResult<Vec<u8>> {
     if has_name_converter() {
         return lookup_group_name(gid);
     }

--- a/crates/metadata/src/id_lookup/nss.rs
+++ b/crates/metadata/src/id_lookup/nss.rs
@@ -10,6 +10,7 @@
 #![allow(unsafe_code)]
 
 use super::converter::with_name_converter;
+use super::error::{LookupError, LookupResult};
 use rustix::process::{RawGid, RawUid};
 use std::ffi::{CStr, CString};
 use std::io;
@@ -21,10 +22,12 @@ use std::ptr;
 /// Returns `Ok(Some(name))` if the user exists, `Ok(None)` if not found.
 /// Uses `getpwuid_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
-pub fn lookup_user_name(uid: RawUid) -> Result<Option<Vec<u8>>, io::Error> {
+pub fn lookup_user_name(uid: RawUid) -> LookupResult<Vec<u8>> {
     // upstream: uidlist.c:114-121 - the converter replaces getpwuid outright.
-    if let Some(answer) = with_name_converter(|nc| nc.uid_to_name(uid)) {
-        return Ok(answer.map(String::into_bytes));
+    if let Some(outcome) = with_name_converter(|nc| nc.uid_to_name(uid)) {
+        return outcome
+            .into_lookup()
+            .map(|name| name.map(String::into_bytes));
     }
 
     let mut buffer = vec![0_u8; 1024];
@@ -61,7 +64,7 @@ pub fn lookup_user_name(uid: RawUid) -> Result<Option<Vec<u8>>, io::Error> {
             continue;
         }
 
-        return Err(io::Error::from_raw_os_error(errno));
+        return Err(LookupError::Database(io::Error::from_raw_os_error(errno)));
     }
 }
 
@@ -70,7 +73,7 @@ pub fn lookup_user_name(uid: RawUid) -> Result<Option<Vec<u8>>, io::Error> {
 /// Returns `Ok(Some(uid))` if the user exists, `Ok(None)` if not found.
 /// Uses `getpwnam_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
-pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
+pub fn lookup_user_by_name(name: &[u8]) -> LookupResult<RawUid> {
     // upstream: uidlist.c:146 `user_to_uid()` - an empty name is "no id",
     // decided before the converter or the host database is consulted.
     if name.is_empty() {
@@ -79,9 +82,11 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
 
     // upstream: uidlist.c:131-138 - the converter replaces getpwnam outright.
     if let Ok(name_str) = std::str::from_utf8(name)
-        && let Some(answer) = with_name_converter(|nc| nc.name_to_uid(name_str))
+        && let Some(outcome) = with_name_converter(|nc| nc.name_to_uid(name_str))
     {
-        return Ok(answer.map(|uid| uid as RawUid));
+        return outcome
+            .into_lookup()
+            .map(|uid| uid.map(|uid| uid as RawUid));
     }
 
     let Ok(c_name) = CString::new(name) else {
@@ -121,7 +126,7 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
             continue;
         }
 
-        return Err(io::Error::from_raw_os_error(errno));
+        return Err(LookupError::Database(io::Error::from_raw_os_error(errno)));
     }
 }
 
@@ -130,10 +135,12 @@ pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<RawUid>, io::Error> {
 /// Returns `Ok(Some(name))` if the group exists, `Ok(None)` if not found.
 /// Uses `getgrgid_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
-pub fn lookup_group_name(gid: RawGid) -> Result<Option<Vec<u8>>, io::Error> {
+pub fn lookup_group_name(gid: RawGid) -> LookupResult<Vec<u8>> {
     // upstream: uidlist.c:154-163 - the converter replaces getgrgid outright.
-    if let Some(answer) = with_name_converter(|nc| nc.gid_to_name(gid)) {
-        return Ok(answer.map(String::into_bytes));
+    if let Some(outcome) = with_name_converter(|nc| nc.gid_to_name(gid)) {
+        return outcome
+            .into_lookup()
+            .map(|name| name.map(String::into_bytes));
     }
 
     let mut buffer = vec![0_u8; 1024];
@@ -170,7 +177,7 @@ pub fn lookup_group_name(gid: RawGid) -> Result<Option<Vec<u8>>, io::Error> {
             continue;
         }
 
-        return Err(io::Error::from_raw_os_error(errno));
+        return Err(LookupError::Database(io::Error::from_raw_os_error(errno)));
     }
 }
 
@@ -179,7 +186,7 @@ pub fn lookup_group_name(gid: RawGid) -> Result<Option<Vec<u8>>, io::Error> {
 /// Returns `Ok(Some(gid))` if the group exists, `Ok(None)` if not found.
 /// Uses `getgrnam_r` for thread-safe lookup. When a name converter is
 /// installed via [`super::set_name_converter`], delegates to it instead.
-pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<RawGid>, io::Error> {
+pub fn lookup_group_by_name(name: &[u8]) -> LookupResult<RawGid> {
     // upstream: uidlist.c:172 `group_to_gid()` - an empty name is "no id",
     // decided before the converter or the host database is consulted.
     if name.is_empty() {
@@ -188,9 +195,11 @@ pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<RawGid>, io::Error> {
 
     // upstream: uidlist.c:180-189 - the converter replaces getgrnam outright.
     if let Ok(name_str) = std::str::from_utf8(name)
-        && let Some(answer) = with_name_converter(|nc| nc.name_to_gid(name_str))
+        && let Some(outcome) = with_name_converter(|nc| nc.name_to_gid(name_str))
     {
-        return Ok(answer.map(|gid| gid as RawGid));
+        return outcome
+            .into_lookup()
+            .map(|gid| gid.map(|gid| gid as RawGid));
     }
 
     let Ok(c_name) = CString::new(name) else {
@@ -230,7 +239,7 @@ pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<RawGid>, io::Error> {
             continue;
         }
 
-        return Err(io::Error::from_raw_os_error(errno));
+        return Err(LookupError::Database(io::Error::from_raw_os_error(errno)));
     }
 }
 

--- a/crates/metadata/src/id_lookup/nss_stub.rs
+++ b/crates/metadata/src/id_lookup/nss_stub.rs
@@ -9,82 +9,138 @@
 //! POSIX path. There is no host database to fall back to here, so the
 //! helper's "converter installed" and "converter answered" arms collapse to
 //! the same `Ok(None)` - but going through it keeps one description of how a
-//! converter is consulted instead of four copies of the slot dance.
+//! converter is consulted instead of four copies of the slot dance. A
+//! converter that could not answer at all is *not* part of that collapse: it
+//! is an error on this path exactly as it is on the POSIX one.
 
 use super::converter::with_name_converter;
-use std::io;
+use super::error::LookupResult;
 
 /// Looks up the username for a given UID.
 ///
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
-pub fn lookup_user_name(uid: u32) -> Result<Option<Vec<u8>>, io::Error> {
-    Ok(with_name_converter(|nc| nc.uid_to_name(uid))
-        .flatten()
-        .map(String::into_bytes))
+pub fn lookup_user_name(uid: u32) -> LookupResult<Vec<u8>> {
+    match with_name_converter(|nc| nc.uid_to_name(uid)) {
+        Some(outcome) => outcome
+            .into_lookup()
+            .map(|name| name.map(String::into_bytes)),
+        None => Ok(None),
+    }
 }
 
 /// Looks up the UID for a given username.
 ///
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
-pub fn lookup_user_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
+pub fn lookup_user_by_name(name: &[u8]) -> LookupResult<u32> {
+    // upstream: uidlist.c:146-147 `user_to_uid()` - `if (!name || !*name)
+    // return 0;`. The guard is in the caller, not in the converter protocol
+    // (`namecvt_safe_token("")` is happily True), so it has to be repeated on
+    // every platform's lookup or an empty name reaches the converter as the
+    // bare request line `usr \n`.
+    if name.is_empty() {
+        return Ok(None);
+    }
+
     let Ok(name_str) = std::str::from_utf8(name) else {
         return Ok(None);
     };
-    Ok(with_name_converter(|nc| nc.name_to_uid(name_str)).flatten())
+    match with_name_converter(|nc| nc.name_to_uid(name_str)) {
+        Some(outcome) => outcome.into_lookup(),
+        None => Ok(None),
+    }
 }
 
 /// Looks up the group name for a given GID.
 ///
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
-pub fn lookup_group_name(gid: u32) -> Result<Option<Vec<u8>>, io::Error> {
-    Ok(with_name_converter(|nc| nc.gid_to_name(gid))
-        .flatten()
-        .map(String::into_bytes))
+pub fn lookup_group_name(gid: u32) -> LookupResult<Vec<u8>> {
+    match with_name_converter(|nc| nc.gid_to_name(gid)) {
+        Some(outcome) => outcome
+            .into_lookup()
+            .map(|name| name.map(String::into_bytes)),
+        None => Ok(None),
+    }
 }
 
 /// Looks up the GID for a given group name.
 ///
 /// Delegates to the thread-local name converter if installed, otherwise
 /// returns `Ok(None)`.
-pub fn lookup_group_by_name(name: &[u8]) -> Result<Option<u32>, io::Error> {
+pub fn lookup_group_by_name(name: &[u8]) -> LookupResult<u32> {
+    // upstream: uidlist.c:172-173 `group_to_gid()` - the same empty-name rule
+    // as `user_to_uid()`, decided before any back end is consulted.
+    if name.is_empty() {
+        return Ok(None);
+    }
+
     let Ok(name_str) = std::str::from_utf8(name) else {
         return Ok(None);
     };
-    Ok(with_name_converter(|nc| nc.name_to_gid(name_str)).flatten())
+    match with_name_converter(|nc| nc.name_to_gid(name_str)) {
+        Some(outcome) => outcome.into_lookup(),
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::id_lookup::converter::{
-        NameConverterCallbacks, clear_name_converter, set_name_converter,
+        ConverterOutcome, NameConverterCallbacks, clear_name_converter, set_name_converter,
     };
+    use std::io;
 
     struct TestConverter;
 
     impl NameConverterCallbacks for TestConverter {
-        fn uid_to_name(&mut self, uid: u32) -> Option<String> {
+        fn uid_to_name(&mut self, uid: u32) -> ConverterOutcome<String> {
             if uid == 0 {
-                Some("root".to_string())
+                ConverterOutcome::Resolved("root".to_string())
             } else {
-                None
+                ConverterOutcome::Unknown
             }
         }
-        fn gid_to_name(&mut self, gid: u32) -> Option<String> {
+        fn gid_to_name(&mut self, gid: u32) -> ConverterOutcome<String> {
             if gid == 0 {
-                Some("wheel".to_string())
+                ConverterOutcome::Resolved("wheel".to_string())
             } else {
-                None
+                ConverterOutcome::Unknown
             }
         }
-        fn name_to_uid(&mut self, name: &str) -> Option<u32> {
-            if name == "root" { Some(0) } else { None }
+        fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32> {
+            if name == "root" {
+                ConverterOutcome::Resolved(0)
+            } else {
+                ConverterOutcome::Unknown
+            }
         }
-        fn name_to_gid(&mut self, name: &str) -> Option<u32> {
-            if name == "wheel" { Some(0) } else { None }
+        fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32> {
+            if name == "wheel" {
+                ConverterOutcome::Resolved(0)
+            } else {
+                ConverterOutcome::Unknown
+            }
+        }
+    }
+
+    /// A converter whose request/answer stream has broken.
+    struct DeadConverter;
+
+    impl NameConverterCallbacks for DeadConverter {
+        fn uid_to_name(&mut self, _uid: u32) -> ConverterOutcome<String> {
+            ConverterOutcome::Failed(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+        fn gid_to_name(&mut self, _gid: u32) -> ConverterOutcome<String> {
+            ConverterOutcome::Failed(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+        fn name_to_uid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+            ConverterOutcome::Failed(io::Error::from(io::ErrorKind::BrokenPipe))
+        }
+        fn name_to_gid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+            ConverterOutcome::Failed(io::Error::from(io::ErrorKind::BrokenPipe))
         }
     }
 
@@ -114,6 +170,45 @@ mod tests {
         clear_name_converter();
         let result = lookup_group_by_name(b"wheel").unwrap();
         assert!(result.is_none());
+    }
+
+    /// upstream: uidlist.c:146-147 / :172-173 - an empty name is decided
+    /// before any back end is consulted, so no request is framed for it.
+    #[test]
+    fn an_empty_name_never_reaches_the_converter() {
+        set_name_converter(Box::new(DeadConverter));
+
+        // A converter that fails every query it is asked makes the guard
+        // observable: without it, these would be errors, not `None`.
+        assert!(
+            lookup_user_by_name(b"")
+                .expect("empty name is not a query")
+                .is_none()
+        );
+        assert!(
+            lookup_group_by_name(b"")
+                .expect("empty name is not a query")
+                .is_none()
+        );
+
+        // Non-vacuity: the same converter IS installed and IS reached by a
+        // non-empty name.
+        assert!(lookup_user_by_name(b"root").is_err());
+
+        clear_name_converter();
+    }
+
+    /// A converter that cannot answer must not read as "no such name".
+    #[test]
+    fn a_failed_converter_is_an_error_not_a_missing_name() {
+        set_name_converter(Box::new(DeadConverter));
+
+        assert!(lookup_user_name(0).is_err());
+        assert!(lookup_group_name(0).is_err());
+        assert!(lookup_user_by_name(b"root").is_err());
+        assert!(lookup_group_by_name(b"wheel").is_err());
+
+        clear_name_converter();
     }
 
     #[test]

--- a/crates/metadata/src/id_lookup/tests.rs
+++ b/crates/metadata/src/id_lookup/tests.rs
@@ -456,17 +456,17 @@ fn cached_lookup_distinct_ids_each_look_up() {
 struct FixedConverter;
 
 impl NameConverterCallbacks for FixedConverter {
-    fn uid_to_name(&mut self, _uid: u32) -> Option<String> {
-        Some("converted-user".to_string())
+    fn uid_to_name(&mut self, _uid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Resolved("converted-user".to_string())
     }
-    fn gid_to_name(&mut self, _gid: u32) -> Option<String> {
-        Some("converted-group".to_string())
+    fn gid_to_name(&mut self, _gid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Resolved("converted-group".to_string())
     }
-    fn name_to_uid(&mut self, _name: &str) -> Option<u32> {
-        None
+    fn name_to_uid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+        ConverterOutcome::Unknown
     }
-    fn name_to_gid(&mut self, _name: &str) -> Option<u32> {
-        None
+    fn name_to_gid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+        ConverterOutcome::Unknown
     }
 }
 
@@ -507,21 +507,100 @@ struct DisclaimingConverter;
 
 #[cfg(unix)]
 impl NameConverterCallbacks for DisclaimingConverter {
-    fn uid_to_name(&mut self, _uid: u32) -> Option<String> {
-        None
+    fn uid_to_name(&mut self, _uid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Unknown
     }
 
-    fn gid_to_name(&mut self, _gid: u32) -> Option<String> {
-        None
+    fn gid_to_name(&mut self, _gid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Unknown
     }
 
-    fn name_to_uid(&mut self, name: &str) -> Option<u32> {
-        (name == "mapped-only").then_some(4242)
+    fn name_to_uid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        (name == "mapped-only").then_some(4242).into()
     }
 
-    fn name_to_gid(&mut self, name: &str) -> Option<u32> {
-        (name == "mapped-only").then_some(4243)
+    fn name_to_gid(&mut self, name: &str) -> ConverterOutcome<u32> {
+        (name == "mapped-only").then_some(4243).into()
     }
+}
+
+/// A converter whose request/answer stream has broken.
+///
+/// upstream: clientserver.c:1329-1334 - a converter that cannot be written to
+/// ends the session; it never reports a name as merely absent.
+#[cfg(unix)]
+struct DeadConverter;
+
+#[cfg(unix)]
+impl NameConverterCallbacks for DeadConverter {
+    fn uid_to_name(&mut self, _uid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Failed(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+    }
+
+    fn gid_to_name(&mut self, _gid: u32) -> ConverterOutcome<String> {
+        ConverterOutcome::Failed(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+    }
+
+    fn name_to_uid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+        ConverterOutcome::Failed(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+    }
+
+    fn name_to_gid(&mut self, _name: &str) -> ConverterOutcome<u32> {
+        ConverterOutcome::Failed(std::io::Error::from(std::io::ErrorKind::BrokenPipe))
+    }
+}
+
+/// A dead converter must be distinguishable from a name it does not know.
+///
+/// The contrast with [`DisclaimingConverter`] is the whole point: that one
+/// answers "no such name" and this one cannot answer at all, and before the
+/// outcome type existed both arrived at the call site as the same `None`. The
+/// host database is left in place as the second discriminator - a fall-through
+/// would resolve `root`, and the failure must not become that either.
+#[cfg(unix)]
+#[test]
+fn a_converter_that_cannot_answer_is_not_a_name_that_does_not_resolve() {
+    clear_name_converter();
+    assert!(
+        lookup_user_by_name(b"root").expect("host lookup").is_some(),
+        "this host cannot resolve `root`, so this test cannot discriminate"
+    );
+
+    set_name_converter(Box::new(DisclaimingConverter));
+    assert_eq!(
+        lookup_user_by_name(b"root").expect("a disclaimed name is not an error"),
+        None,
+        "a converter that answers `unknown` yields `None`"
+    );
+
+    set_name_converter(Box::new(DeadConverter));
+    for outcome in [
+        lookup_user_by_name(b"root").map(|id| id.is_some()),
+        lookup_group_by_name(b"root").map(|id| id.is_some()),
+    ] {
+        let err = outcome.expect_err("a dead converter must not read as `no such name`");
+        assert!(err.is_converter_failure(), "{err}");
+    }
+    assert!(
+        lookup_user_name(0)
+            .expect_err("a dead converter must not read as `this uid has no name`")
+            .is_converter_failure()
+    );
+    assert!(
+        lookup_group_name(0)
+            .expect_err("a dead converter must not read as `this gid has no name`")
+            .is_converter_failure()
+    );
+
+    // A host-database failure keeps its tolerance; only the converter's is
+    // fatal. Without this contrast the helper could simply propagate
+    // everything and still pass the assertions above.
+    assert!(
+        no_id_unless_converter_failed(lookup_user_by_name(b"root")).is_err(),
+        "a converter failure survives the database-failure tolerance"
+    );
+
+    clear_name_converter();
 }
 
 /// An installed converter REPLACES the host user database; it is not merely
@@ -573,20 +652,33 @@ fn installed_converter_replaces_the_host_database() {
     clear_name_converter();
 }
 
-/// upstream: uidlist.c:146 `user_to_uid()` / :172 `group_to_gid()` -
+/// upstream: uidlist.c:146-147 `user_to_uid()` / :172-173 `group_to_gid()` -
 /// `if (!name || !*name) return 0;`. An empty name is decided before either the
 /// converter or the host database is consulted, so no request is framed for it.
+///
+/// The converter is one that FAILS every query it is given. A converter that
+/// merely answered "unknown" would return `None` for the empty name whether or
+/// not the guard exists, which is how a missing guard passes a test: the
+/// discriminator is that reaching the converter at all must be observable.
 #[cfg(unix)]
 #[test]
 fn an_empty_name_resolves_to_nothing_without_consulting_the_converter() {
-    set_name_converter(Box::new(DisclaimingConverter));
-    assert_eq!(lookup_user_by_name(b"").expect("lookup"), None);
-    assert_eq!(lookup_group_by_name(b"").expect("lookup"), None);
-    // Non-vacuity: the same converter still answers a real name, so the two
-    // `None`s above are the empty-name rule and not a broken fixture.
+    set_name_converter(Box::new(DeadConverter));
+
     assert_eq!(
-        lookup_user_by_name(b"mapped-only").expect("lookup"),
-        Some(4242)
+        lookup_user_by_name(b"").expect("an empty name is decided before the converter"),
+        None
     );
+    assert_eq!(
+        lookup_group_by_name(b"").expect("an empty name is decided before the converter"),
+        None
+    );
+
+    // Non-vacuity: this converter IS installed and IS reached by a non-empty
+    // name, so the two `Ok(None)`s above are the empty-name rule and not an
+    // inert fixture.
+    assert!(lookup_user_by_name(b"anything").is_err());
+    assert!(lookup_group_by_name(b"anything").is_err());
+
     clear_name_converter();
 }

--- a/crates/metadata/src/mapping/name_mapping.rs
+++ b/crates/metadata/src/mapping/name_mapping.rs
@@ -250,21 +250,19 @@ impl NameMapping {
     }
 
     /// Resolves an identifier to a name using the appropriate system lookup.
+    ///
+    /// A back end that could not answer stays an error here: a name-converter
+    /// failure must not present itself as an id with no name, which would
+    /// silently skip every name and wildcard rule.
     fn lookup_name(&self, identifier: u32) -> io::Result<Option<String>> {
-        match self.kind {
-            MappingKind::User => lookup_user_name(identifier as RawUid).map(|opt| {
-                opt.map(|bytes| match String::from_utf8(bytes) {
-                    Ok(s) => s,
-                    Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
-                })
-            }),
-            MappingKind::Group => lookup_group_name(identifier as RawGid).map(|opt| {
-                opt.map(|bytes| match String::from_utf8(bytes) {
-                    Ok(s) => s,
-                    Err(e) => String::from_utf8_lossy(e.as_bytes()).into_owned(),
-                })
-            }),
-        }
+        let bytes = match self.kind {
+            MappingKind::User => lookup_user_name(identifier as RawUid)?,
+            MappingKind::Group => lookup_group_name(identifier as RawGid)?,
+        };
+        Ok(bytes.map(|bytes| match String::from_utf8(bytes) {
+            Ok(name) => name,
+            Err(err) => String::from_utf8_lossy(err.as_bytes()).into_owned(),
+        }))
     }
 
     /// Returns the number of mapping rules.

--- a/crates/protocol/src/idlist/mod.rs
+++ b/crates/protocol/src/idlist/mod.rs
@@ -73,7 +73,7 @@ struct IdEntry {
 /// ```ignore
 /// let mut id_list = IdList::new();
 /// // Read the list from sender
-/// id_list.read(&mut reader, false, |name| lookup_user_by_name(name).ok().flatten())?;
+/// id_list.read(&mut reader, false, |name| Ok(lookup_user_by_name(name).ok().flatten()))?;
 /// // Later, when applying ownership:
 /// let local_uid = id_list.match_id(remote_uid);
 /// ```
@@ -262,7 +262,10 @@ impl IdList {
     /// * `reader` - The source of encoded data
     /// * `id0_names` - Whether to read id=0's name (ID0_NAMES compat flag)
     /// * `protocol_version` - The negotiated protocol version (affects decoding)
-    /// * `name_to_id` - Function to resolve a name to a local ID
+    /// * `name_to_id` - Function to resolve a name to a local ID. Returning
+    ///   `Ok(None)` is upstream's "no such name" (the sender's numeric id is
+    ///   kept); returning `Err` ends the transfer, which is what a name
+    ///   converter that could not answer must do.
     ///
     /// # Upstream Reference
     ///
@@ -276,7 +279,7 @@ impl IdList {
         name_to_id: F,
     ) -> io::Result<()>
     where
-        F: Fn(&[u8]) -> Option<u32>,
+        F: Fn(&[u8]) -> io::Result<Option<u32>>,
     {
         self.read_with_kind(reader, id0_names, protocol_version, None, name_to_id)
     }
@@ -301,7 +304,7 @@ impl IdList {
         name_to_id: F,
     ) -> io::Result<()>
     where
-        F: Fn(&[u8]) -> Option<u32>,
+        F: Fn(&[u8]) -> io::Result<Option<u32>>,
     {
         // Read (id, name) pairs until id=0
         let mut count = 0usize;
@@ -357,7 +360,7 @@ impl IdList {
         name_to_id: &F,
     ) -> io::Result<(Option<Vec<u8>>, u32)>
     where
-        F: Fn(&[u8]) -> Option<u32>,
+        F: Fn(&[u8]) -> io::Result<Option<u32>>,
     {
         let mut len_buf = [0u8; 1];
         reader.read_exact(&mut len_buf)?;
@@ -370,8 +373,10 @@ impl IdList {
         let mut name = vec![0u8; len];
         reader.read_exact(&mut name)?;
 
-        // Try to resolve the name to a local ID
-        let local_id = name_to_id(&name).unwrap_or(remote_id);
+        // Try to resolve the name to a local ID. A resolver that cannot answer
+        // (upstream: a name converter that has died, clientserver.c:1333)
+        // propagates instead of degrading into "keep the sender's id".
+        let local_id = name_to_id(&name)?.unwrap_or(remote_id);
 
         Ok((Some(name), local_id))
     }
@@ -476,7 +481,7 @@ mod tests {
     fn read_empty_list_proto30() {
         let data = vec![0u8]; // Just terminator (varint)
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), false, 30, |_| None)
+        list.read(&mut data.as_slice(), false, 30, |_| Ok(None))
             .unwrap();
         assert!(list.is_empty());
     }
@@ -485,7 +490,7 @@ mod tests {
     fn read_empty_list_proto29() {
         let data = vec![0u8, 0, 0, 0]; // Just terminator (4-byte int)
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), false, 29, |_| None)
+        list.read(&mut data.as_slice(), false, 29, |_| Ok(None))
             .unwrap();
         assert!(list.is_empty());
     }
@@ -495,7 +500,7 @@ mod tests {
         // varint(1), len(4), "root", varint(0)
         let data = vec![1, 4, b'r', b'o', b'o', b't', 0];
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), false, 30, |_| Some(0))
+        list.read(&mut data.as_slice(), false, 30, |_| Ok(Some(0)))
             .unwrap();
         assert_eq!(list.len(), 1);
         // Name resolved to 0
@@ -507,7 +512,7 @@ mod tests {
         // int32(1), len(4), "root", int32(0)
         let data = vec![1, 0, 0, 0, 4, b'r', b'o', b'o', b't', 0, 0, 0, 0];
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), false, 29, |_| Some(0))
+        list.read(&mut data.as_slice(), false, 29, |_| Ok(Some(0)))
             .unwrap();
         assert_eq!(list.len(), 1);
         // Name resolved to 0
@@ -519,7 +524,7 @@ mod tests {
         // varint(0) terminator, len(4), "root"
         let data = vec![0, 4, b'r', b'o', b'o', b't'];
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), true, 30, |_| Some(0))
+        list.read(&mut data.as_slice(), true, 30, |_| Ok(Some(0)))
             .unwrap();
         assert_eq!(list.len(), 1);
         assert_eq!(list.match_id(0), 0);
@@ -535,7 +540,7 @@ mod tests {
         crate::write_varint(&mut data, 0).unwrap(); // terminator
 
         let mut list = IdList::new();
-        list.read(&mut data.as_slice(), false, 30, |_| None)
+        list.read(&mut data.as_slice(), false, 30, |_| Ok(None))
             .unwrap();
         // Name not resolved, falls back to remote ID
         assert_eq!(list.match_id(50), 50);
@@ -553,9 +558,9 @@ mod tests {
         let mut receiver = IdList::new();
         receiver
             .read(&mut buf.as_slice(), false, 30, |name| match name {
-                b"root" => Some(0),
-                b"user" => Some(500),
-                _ => None,
+                b"root" => Ok(Some(0)),
+                b"user" => Ok(Some(500)),
+                _ => Ok(None),
             })
             .unwrap();
 
@@ -575,9 +580,9 @@ mod tests {
         let mut receiver = IdList::new();
         receiver
             .read(&mut buf.as_slice(), false, 29, |name| match name {
-                b"root" => Some(0),
-                b"user" => Some(500),
-                _ => None,
+                b"root" => Ok(Some(0)),
+                b"user" => Ok(Some(500)),
+                _ => Ok(None),
             })
             .unwrap();
 
@@ -622,7 +627,11 @@ mod tests {
         let data = vec![1, 4, b'r', b'o', b'o', b't', 0, 4, b'r', b'o', b'o', b't'];
         let mut list = IdList::new();
         list.read_with_kind(&mut data.as_slice(), true, 30, Some(IdKind::Uid), |name| {
-            if name == b"root" { Some(0) } else { None }
+            if name == b"root" {
+                Ok(Some(0))
+            } else {
+                Ok(None)
+            }
         })
         .unwrap();
 
@@ -660,7 +669,7 @@ mod tests {
 
         let data = vec![1, 4, b'r', b'o', b'o', b't', 0];
         let mut list = IdList::new();
-        list.read_with_kind(&mut data.as_slice(), false, 30, None, |_| Some(0))
+        list.read_with_kind(&mut data.as_slice(), false, 30, None, |_| Ok(Some(0)))
             .unwrap();
 
         let messages: Vec<String> = drain_events()
@@ -696,7 +705,7 @@ mod tests {
         crate::write_varint(&mut data, 0).unwrap();
 
         let mut list = IdList::new();
-        let result = list.read(&mut data.as_slice(), false, 30, |_| None);
+        let result = list.read(&mut data.as_slice(), false, 30, |_| Ok(None));
         assert!(result.is_err(), "oversized ID list should be rejected");
         let err = result.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
@@ -718,7 +727,7 @@ mod tests {
         crate::write_varint(&mut data, 0).unwrap();
 
         let mut list = IdList::new();
-        let result = list.read(&mut data.as_slice(), false, 30, |_| None);
+        let result = list.read(&mut data.as_slice(), false, 30, |_| Ok(None));
         assert!(
             result.is_ok(),
             "ID list at cap should be accepted, got: {result:?}"

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -307,10 +307,13 @@ impl GeneratorContext {
             // sending via XMIT_USER_NAME_FOLLOWS when INC_RECURSE is active.
             // Without names, the receiver can't map uid->name on the remote.
             if self.config.flags.numeric_ids.is_off() {
-                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_user_name_cached(uid) {
-                    if let Ok(name) = String::from_utf8(name_bytes) {
-                        entry.set_user_name(name);
-                    }
+                // A name converter that could not answer stops the file list
+                // here; only a host-database miss is "this uid has no name".
+                if let Some(name_bytes) = metadata::id_lookup::no_id_unless_converter_failed(
+                    metadata::id_lookup::lookup_user_name_cached(uid),
+                )? && let Ok(name) = String::from_utf8(name_bytes)
+                {
+                    entry.set_user_name(name);
                 }
             }
         }
@@ -323,10 +326,12 @@ impl GeneratorContext {
             // upstream: flist.c:488-492 - add_gid() looks up name for inline
             // sending via XMIT_GROUP_NAME_FOLLOWS when INC_RECURSE is active.
             if self.config.flags.numeric_ids.is_off() {
-                if let Ok(Some(name_bytes)) = metadata::id_lookup::lookup_group_name_cached(gid) {
-                    if let Ok(name) = String::from_utf8(name_bytes) {
-                        entry.set_group_name(name);
-                    }
+                // As above: only a host-database miss means "no name".
+                if let Some(name_bytes) = metadata::id_lookup::no_id_unless_converter_failed(
+                    metadata::id_lookup::lookup_group_name_cached(gid),
+                )? && let Ok(name) = String::from_utf8(name_bytes)
+                {
+                    entry.set_group_name(name);
                 }
             }
         }

--- a/crates/transfer/src/generator/file_list/hardlinks.rs
+++ b/crates/transfer/src/generator/file_list/hardlinks.rs
@@ -78,14 +78,16 @@ impl GeneratorContext {
     ///
     /// - `uidlist.c:add_uid()` / `add_gid()` - called during file list building
     #[cfg(unix)]
-    pub fn collect_id_mappings(&mut self) {
-        use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
+    pub fn collect_id_mappings(&mut self) -> std::io::Result<()> {
+        use metadata::id_lookup::{
+            lookup_group_name_cached, lookup_user_name_cached, no_id_unless_converter_failed,
+        };
 
         // upstream: flist.c:490 gates add_uid()/add_gid() on `!numeric_ids`, so
         // the id-list is populated only when names are active (`numeric_ids ==
         // 0`). Both daemon-forced and explicit numeric-ids leave it empty.
         if self.config.flags.numeric_ids.maps_numeric() {
-            return;
+            return Ok(());
         }
 
         self.uid_list.clear();
@@ -97,7 +99,11 @@ impl GeneratorContext {
                 if let Some(uid) = entry.uid() {
                     // Skip expensive lookup if we already have this UID
                     if !self.uid_list.contains(uid) {
-                        let name = lookup_user_name_cached(uid).ok().flatten();
+                        // A converter that could not answer is not "this uid
+                        // has no name": upstream exits rather than send a file
+                        // list whose ownership the operator's converter never
+                        // vouched for (clientserver.c:1326, :1333).
+                        let name = no_id_unless_converter_failed(lookup_user_name_cached(uid))?;
                         self.uid_list.add_id(uid, name);
                     }
                 }
@@ -108,15 +114,19 @@ impl GeneratorContext {
                 if let Some(gid) = entry.gid() {
                     // Skip expensive lookup if we already have this GID
                     if !self.gid_list.contains(gid) {
-                        let name = lookup_group_name_cached(gid).ok().flatten();
+                        let name = no_id_unless_converter_failed(lookup_group_name_cached(gid))?;
                         self.gid_list.add_id(gid, name);
                     }
                 }
             }
         }
+
+        Ok(())
     }
 
     /// No-op on non-Unix platforms - ownership is not preserved.
     #[cfg(not(unix))]
-    pub fn collect_id_mappings(&mut self) {}
+    pub fn collect_id_mappings(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -195,7 +195,7 @@ impl GeneratorContext {
         }
 
         self.timing.flist_build_end = Some(Instant::now());
-        self.collect_id_mappings();
+        self.collect_id_mappings()?;
 
         let count = self.file_list.len();
         debug_log!(Flist, 2, "file list entries: {:?}", {
@@ -466,7 +466,7 @@ impl GeneratorContext {
         }
 
         self.timing.flist_build_end = Some(Instant::now());
-        self.collect_id_mappings();
+        self.collect_id_mappings()?;
 
         let count = self.file_list.len();
         debug_log!(Flist, 2, "file list entries: {:?}", {

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -125,19 +125,21 @@ impl GeneratorContext {
     /// when `--acls` is disabled, or when the sender-side ACL cache is
     /// unavailable.
     #[cfg(unix)]
-    pub(crate) fn collect_acl_id_mappings(&mut self) {
-        use metadata::id_lookup::{lookup_group_name_cached, lookup_user_name_cached};
+    pub(crate) fn collect_acl_id_mappings(&mut self) -> io::Result<()> {
+        use metadata::id_lookup::{
+            lookup_group_name_cached, lookup_user_name_cached, no_id_unless_converter_failed,
+        };
 
         // upstream: acls.c:593,595 - `name = numeric_ids ? NULL : add_uid(...)`;
         // the named-entry id is added (and later mapped) only when names are in
         // play, i.e. `numeric_ids == 0`. Both daemon-forced and explicit
         // numeric-ids suppress it (`numeric_ids != 0`).
         if self.config.flags.numeric_ids.maps_numeric() || !self.config.flags.acls {
-            return;
+            return Ok(());
         }
 
         let Some(writer) = self.incremental.flist_writer_cache.as_ref() else {
-            return;
+            return Ok(());
         };
 
         // Snapshot the (id, is_user) pairs so the borrow of the cache ends
@@ -152,19 +154,26 @@ impl GeneratorContext {
         for (id, is_user) in named {
             if is_user {
                 if !self.uid_list.contains(id) {
-                    let name = lookup_user_name_cached(id).ok().flatten();
+                    // As in `collect_id_mappings`: a converter that could not
+                    // answer ends the session rather than producing a nameless
+                    // entry the receiver would map by raw id.
+                    let name = no_id_unless_converter_failed(lookup_user_name_cached(id))?;
                     self.uid_list.add_id(id, name);
                 }
             } else if !self.gid_list.contains(id) {
-                let name = lookup_group_name_cached(id).ok().flatten();
+                let name = no_id_unless_converter_failed(lookup_group_name_cached(id))?;
                 self.gid_list.add_id(id, name);
             }
         }
+
+        Ok(())
     }
 
     /// No-op on non-Unix platforms - ACL ids are not remapped by numeric id.
     #[cfg(not(unix))]
-    pub(crate) fn collect_acl_id_mappings(&mut self) {}
+    pub(crate) fn collect_acl_id_mappings(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 
     /// Sends io_error flag for protocol < 30.
     ///

--- a/crates/transfer/src/generator/transfer/orchestrator.rs
+++ b/crates/transfer/src/generator/transfer/orchestrator.rs
@@ -238,7 +238,7 @@ impl GeneratorContext {
         // upstream: acls.c:592-595 - named ACL-entry ids join the shared id-list
         // so the receiver remaps them like file owners. Runs after the file list
         // is sent (ACL cache complete) and before the id-list is transmitted.
-        self.collect_acl_id_mappings();
+        self.collect_acl_id_mappings()?;
         self.send_id_lists(writer)?;
         self.send_io_error_flag(writer)?;
 

--- a/crates/transfer/src/receiver/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/file_list/id_lists.rs
@@ -10,7 +10,9 @@ use std::io::{self, Read};
 use protocol::CompatibilityFlags;
 
 #[cfg(unix)]
-use metadata::id_lookup::{lookup_group_by_name, lookup_user_by_name};
+use metadata::id_lookup::{
+    lookup_group_by_name, lookup_user_by_name, no_id_unless_converter_failed,
+};
 
 use super::super::ReceiverContext;
 
@@ -57,7 +59,14 @@ impl ReceiverContext {
                 id0_names,
                 protocol_version,
                 Some(protocol::idlist::IdKind::Uid),
-                |name| lookup_user_by_name(name).ok().flatten(),
+                // upstream: uidlist.c:273-282 `recv_add_id()` - an unresolved
+                // name keeps the sender's numeric id, but only because
+                // `user_to_uid()` got an answer. A name converter that could
+                // not answer ends the session instead (clientserver.c:1333):
+                // mapping a name the operator's converter never approved onto
+                // the sender's own id is the failure `name converter` exists
+                // to prevent.
+                |name| no_id_unless_converter_failed(lookup_user_by_name(name)),
             )?;
         }
 
@@ -68,7 +77,8 @@ impl ReceiverContext {
                 id0_names,
                 protocol_version,
                 Some(protocol::idlist::IdKind::Gid),
-                |name| lookup_group_by_name(name).ok().flatten(),
+                // upstream: uidlist.c:273-282 - as for uids above.
+                |name| no_id_unless_converter_failed(lookup_group_by_name(name)),
             )?;
         }
 
@@ -113,7 +123,7 @@ impl ReceiverContext {
                 id0_names,
                 protocol_version,
                 Some(protocol::idlist::IdKind::Uid),
-                |_| None,
+                |_| Ok(None),
             )?;
         }
 
@@ -123,7 +133,7 @@ impl ReceiverContext {
                 id0_names,
                 protocol_version,
                 Some(protocol::idlist::IdKind::Gid),
-                |_| None,
+                |_| Ok(None),
             )?;
         }
 

--- a/crates/transfer/src/receiver/tests/file_list/id_lists.rs
+++ b/crates/transfer/src/receiver/tests/file_list/id_lists.rs
@@ -277,3 +277,111 @@ fn remap_falls_back_to_local_name_resolution_when_no_rule_matches() {
         "with no matching rule, ownership follows the local getpwnam(name)"
     );
 }
+
+/// A converter that answers exactly one name and disclaims the rest.
+#[cfg(unix)]
+struct DisclaimingConverter;
+
+#[cfg(unix)]
+impl metadata::id_lookup::NameConverterCallbacks for DisclaimingConverter {
+    fn uid_to_name(&mut self, _uid: u32) -> metadata::id_lookup::ConverterOutcome<String> {
+        metadata::id_lookup::ConverterOutcome::Unknown
+    }
+    fn gid_to_name(&mut self, _gid: u32) -> metadata::id_lookup::ConverterOutcome<String> {
+        metadata::id_lookup::ConverterOutcome::Unknown
+    }
+    fn name_to_uid(&mut self, _name: &str) -> metadata::id_lookup::ConverterOutcome<u32> {
+        metadata::id_lookup::ConverterOutcome::Unknown
+    }
+    fn name_to_gid(&mut self, _name: &str) -> metadata::id_lookup::ConverterOutcome<u32> {
+        metadata::id_lookup::ConverterOutcome::Unknown
+    }
+}
+
+/// A converter whose request/answer stream has broken.
+#[cfg(unix)]
+struct DeadConverter;
+
+#[cfg(unix)]
+impl metadata::id_lookup::NameConverterCallbacks for DeadConverter {
+    fn uid_to_name(&mut self, _uid: u32) -> metadata::id_lookup::ConverterOutcome<String> {
+        metadata::id_lookup::ConverterOutcome::Failed(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe,
+        ))
+    }
+    fn gid_to_name(&mut self, _gid: u32) -> metadata::id_lookup::ConverterOutcome<String> {
+        metadata::id_lookup::ConverterOutcome::Failed(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe,
+        ))
+    }
+    fn name_to_uid(&mut self, _name: &str) -> metadata::id_lookup::ConverterOutcome<u32> {
+        metadata::id_lookup::ConverterOutcome::Failed(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe,
+        ))
+    }
+    fn name_to_gid(&mut self, _name: &str) -> metadata::id_lookup::ConverterOutcome<u32> {
+        metadata::id_lookup::ConverterOutcome::Failed(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe,
+        ))
+    }
+}
+
+/// One uid list carrying `1000 -> "alice"`, as the sender writes it.
+#[cfg(unix)]
+fn uid_list_wire() -> Vec<u8> {
+    let mut list = protocol::idlist::IdList::new();
+    list.add_id(1000, Some(b"alice".to_vec()));
+    let mut wire = Vec::new();
+    list.write(&mut wire, false, 32).expect("write id list");
+    wire
+}
+
+/// A name the converter does not know keeps the sender's numeric id - the
+/// tolerated outcome, and the control that makes the next test discriminating.
+///
+/// upstream: uidlist.c:273-282 `recv_add_id()` - an unresolved name leaves the
+/// sender's id in place.
+#[cfg(unix)]
+#[test]
+fn an_unknown_name_keeps_the_senders_id() {
+    let handshake = test_handshake();
+    let config = config_with_flags(true, false, NumericIds::Off);
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    metadata::id_lookup::set_name_converter(Box::new(DisclaimingConverter));
+    let wire = uid_list_wire();
+    let result = ctx.receive_id_lists(&mut Cursor::new(wire.as_slice()));
+    metadata::id_lookup::clear_name_converter();
+
+    assert!(result.is_ok(), "an unknown name is not a transfer error");
+    assert_eq!(
+        ctx.uid_list.match_id(1000),
+        1000,
+        "the sender's id is kept when the converter does not know the name"
+    );
+}
+
+/// THE FAIL-CLOSED CASE. A name converter that could not answer must not be
+/// read as "this name has no local id": that verdict silently installs the
+/// SENDER's numeric id for every named owner in the transfer, which is the
+/// ownership decision the operator configured a converter to take away from
+/// the sender.
+///
+/// upstream: clientserver.c:1329-1334 - a converter that cannot be spoken to
+/// is `exit_cleanup(RERR_SOCKETIO)`; the session never proceeds to map names
+/// without it.
+#[cfg(unix)]
+#[test]
+fn a_dead_converter_aborts_instead_of_keeping_the_senders_id() {
+    let handshake = test_handshake();
+    let config = config_with_flags(true, false, NumericIds::Off);
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+
+    metadata::id_lookup::set_name_converter(Box::new(DeadConverter));
+    let wire = uid_list_wire();
+    let result = ctx.receive_id_lists(&mut Cursor::new(wire.as_slice()));
+    metadata::id_lookup::clear_name_converter();
+
+    let err = result.expect_err("a dead converter must end the transfer");
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe, "{err}");
+}


### PR DESCRIPTION
Residuals from the daemon name-converter work (task 751), following the request-side newline-injection fix in #7346.

## What was wrong

`NameConverter::query()` returned `Option<String>`. Five situations arrived at the caller as one `None`:

| situation | upstream (`namecvt_call`, clientserver.c:1311) | oc before |
|---|---|---|
| a usable answer | `True` (:1355-1359) | `Some(line)` |
| an empty answer | `False` (:1345-1346) | `None` |
| a malformed id answer | `False` (:1347-1354) | `None` |
| a control byte in the name | FERROR + `False` (:1317-1319), nothing written | `None` |
| a request too long to frame | `exit_cleanup(RERR_UNSUPPORTED)` (:1324-1327) | `None` |
| a failed write to the converter | `exit_cleanup(RERR_SOCKETIO)` (:1329-1334) | `None` |
| the converter closed its answer pipe | `False` (:1336-1337), then the next request's write exits at :1333 | `None` |

Upstream gets away with a bare `BOOL` because the two fatal rows never return. `False` therefore only ever means "the converter answered, and the answer is no id". Merging the fatal rows into it fails open: a daemon module configures `name converter` to take ownership decisions away from the peer, and a converter that has died then reports every name as unresolved - at which point `recv_add_id()` (uidlist.c:273-282) keeps the **sender's** numeric id for each one.

## What changed

**The four outcomes are a type.** `ConverterOutcome<T>` = `Resolved` / `Unknown` / `Refused` / `Failed(io::Error)`, returned by `NameConverterCallbacks`, with each arm carrying its upstream citation. The converter's own liveness is in its type too: the pipes are a `Result<ConverterStream, ConverterDeath>`, so a stream that has broken cannot be spoken to again and reported as "no such name".

**Fail closed at the lookup API.** `LookupError` splits `Database` from `Converter`, because upstream treats them differently - a `getpwnam()` that yields nothing is "no id" (uidlist.c:160-163), a converter failure ends the session. `no_id_unless_converter_failed()` is that asymmetry written once; the call sites that used `.ok().flatten()` now go through it, and `IdList::read()`'s resolver became fallible so the receiver's name-to-id pass propagates a converter failure instead of keeping the sender's ids.

**Empty-name guard on the non-Unix lookups** (uidlist.c:146-147, :172-173), where upstream decides an empty name before consulting any back end.

## Refuted / corrected

- The empty-name guard was **already present** on the Unix path (`nss.rs`) and is not new here. What was missing is the non-Unix half - and, more usefully, its Unix test could not see the guard: it installed a converter that answered "unknown", so `lookup_user_by_name(b"")` returned `None` whether or not the guard existed. Removing the guard did not redden it. The test now installs a converter that *fails* every query, which makes reaching the converter observable; both halves are now mutation-killed.
- An empty answer to an id-to-name query stays "unknown" here, where upstream `strdup("")`s it (clientserver.c:1357). The two are wire-equivalent (an empty name is written with length 0 and read back as no name), and "unknown" is the arm the CVE-2026-53798 fix asks for.

## Mutation results

Each production change was reverted individually; `passed + failed == run` on every row, so no kill list was truncated.

| mutation | result |
|---|---|
| `Failed` maps to `Ok(None)` in `into_lookup` | 4 tests RED |
| converter EOF reads as an empty answer | 2 RED |
| the recorded death is not stored (stream retried) | 1 RED |
| an over-long request reads as `Unknown` | 1 RED |
| an empty answer reads as a transport failure | 3 RED |
| the control-byte guard is removed | 2 RED |
| `IdList::read` swallows the resolver's error | 1 RED |
| the receiver call site tolerates every failure | 1 RED |
| `no_id_unless_converter_failed` tolerates the converter too | 4 RED |
| the Unix empty-name guard is removed (user half) | 1 RED |
| the Unix empty-name guard is removed (group half) | 1 RED |
| the non-Unix empty-name guard is removed | not killable on macOS - `nss_stub` is `cfg(not(unix))`; its test runs in the Windows job |

Baseline after every revert: 39/39 green.

## Verification

Rebased onto master `023b695fa`; head `22921f56b`. Every number below was measured on that head, not on the original base.

- `cargo fmt --all -- --check`: exit 0.
- `cargo nextest run -p metadata -p protocol -p daemon -p transfer -p batch`: 11395 passed, 0 failed.
- `cargo nextest run --workspace`: 32597 run, 32595 passed, 2 failed - neither in a crate this branch touches:
  - `xtask ... backdated_tree_populates_and_backdates_the_root` shells out to `touch -d @epoch`, a GNU-ism BSD `touch` rejects, so it fails on macOS regardless of this branch.
  - `bandwidth limiter::tests::convergence::debt_decreases_toward_zero_over_steady_state` is a timing convergence assertion; it passes 3/3 in isolation, and this branch changes zero files in `crates/bandwidth`.
  - Across the three full runs on successive rebases the failing set rotated (`engine execute_sparse_with_multiple_hole_patterns`, `core run_client_sparse_copy_creates_holes`, then this one), each passing on isolated re-run and each in a crate outside this diff - host noise, not a footprint.
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps`: exit 0, 0 errors. The `collapsible_if` warnings in touched files (`idlist/mod.rs:222`, `name_cache.rs:60/87`, `nss.rs:301`) all sit outside this diff's hunks.
- `python3 tools/ci/citation_drift_audit.py --ratchet` (the gate strengthened by #7627): **ratchet OK**. This branch adds 9 citations to the scanned population (5263 vs master's 5254) and 0 new suspected-drift findings (374 on both). The advisory `transfer improved 6 -> 4; lower the baseline` note reproduces on pristine master, so it is pre-existing baseline slack, not this branch's doing.
- `cargo check --target x86_64-pc-windows-gnu -p metadata -p daemon -p transfer -p batch` (incl. `--all-targets` for metadata) clean, since the non-Unix lookups and the Windows converter both changed shape.
- Mutation kills re-verified on the rebased heads: `into_lookup` 4 RED, `eof_unknown` 2, `not_sticky` 1, `idlist_swallow` 1, `receiver_tolerates` 1, `nss_empty_name` 1; baseline 39/39 after every revert, and `passed + failed == run` on every row.

### Rebase collision check

`86a549bbf` (#7612) restructured the resumable walk and collapsed the parallel NDX fields into `NdxMap`, touching two files this branch also touches. The rebase replayed with no conflict and the overlap is genuinely disjoint: master's edits are in `assign_hardlink_indices` / `send_file_list`'s sub-list push, this branch's in `collect_id_mappings` / `collect_acl_id_mappings`. Both survive in the rebased tree (`ndx_map.first_ndx_start()` still at `hardlinks.rs:40` and `protocol_io.rs:747`); the restructure added no new callers of the two functions whose signature changed, and no new `IdList::read` call sites. Master carries none of this work (`git grep` for `ConverterOutcome|LookupError|no_id_unless_converter_failed|ConverterDeath` on `origin/master` is empty, and master's `query()` still returns `Option<String>`), so nothing here regresses it.

## Known residuals (not addressed here)

- Upstream prints `invalid name-converter token: %s` to FERROR (clientserver.c:1318); the `Refused` arm here is silent, because the converter holds no log sink. Routing one in is a separate change.
- `id_lookup::cache::map_uid_uncached()` and the `--usermap`/`--groupmap` ACL mappers still fold a lookup error into "keep the id". They run after the id-list pass that now aborts, so a dead converter no longer reaches them, but they are not themselves fail-closed.
- `engine/src/local_copy/executor/directory/recursive/batch.rs:98,103` still uses `.ok().flatten()`. That is the local-copy executor, where no name converter is ever installed (only the daemon session thread installs one), so it stays tolerant by construction rather than by oversight.
