### PR TITLE
fix(protocol): reject a modern NDX that overflows a signed file index

### DIFF
--- a/crates/protocol/src/codec/ndx/codec.rs
+++ b/crates/protocol/src/codec/ndx/codec.rs
@@ -35,31 +35,62 @@ fn classify_ndx_lead(lead: u8) -> NdxLead {
     }
 }
 
+/// Narrows a decoded modern NDX to `i32`, rejecting a peer-supplied index that
+/// does not fit.
+///
+/// This is the single owner of upstream's bound. `read_ndx` accumulates every
+/// arm into a `uint32` and refuses anything above `MAX_INT32` before narrowing
+/// (`io.c:2582-2586`), because the result is used unchecked as a file-list
+/// index; upstream states that reason in its own comment at `io.c:2579-2581`.
+///
+/// The UNSIGNED accumulation is as load-bearing as the bound. Upstream's
+/// operands are `uint32` (`io.c:2574-2578`), where overflow is defined and
+/// wraps into the range this guard then rejects. Performing the same addition
+/// in `i32` panics under Rust's debug overflow checks on bytes a peer fully
+/// controls, so the arithmetic must be unsigned even though the result is not.
+///
+/// Tagged as a protocol violation so the exit-code mapper yields
+/// `RERR_PROTOCOL` (2), matching `exit_cleanup(RERR_PROTOCOL)` at `io.c:2585`.
+#[inline]
+fn ndx_from_unsigned(unum: u32) -> io::Result<i32> {
+    if unum > i32::MAX as u32 {
+        return Err(crate::protocol_violation(format!(
+            "Invalid file index: {unum}"
+        )));
+    }
+    Ok(unum as i32)
+}
+
 /// Reconstructs the full 4-byte modern NDX value from the `0xFE`/high-bit form.
 ///
 /// `tag` is the byte whose high bit was set; `b0`, `b1`, `b2` are the three
-/// following bytes. Upstream `io.c:2307-2311`.
+/// following bytes. Upstream `io.c:2570-2574`.
+///
+/// The masked tag caps this arm at `i32::MAX`, so the bound can never fire
+/// here; it is routed through [`ndx_from_unsigned`] anyway because upstream
+/// applies one check to `unum` after all three arms, and splitting that would
+/// leave the next arm added here unguarded.
 #[inline]
-fn decode_ndx_extended_full(tag: u8, b0: u8, b1: u8, b2: u8) -> i32 {
-    let high = (tag & !0x80) as i32;
-    (high << 24) | (b0 as i32) | ((b1 as i32) << 8) | ((b2 as i32) << 16)
+fn decode_ndx_extended_full(tag: u8, b0: u8, b1: u8, b2: u8) -> io::Result<i32> {
+    let high = (tag & !0x80) as u32;
+    ndx_from_unsigned((high << 24) | (b0 as u32) | ((b1 as u32) << 8) | ((b2 as u32) << 16))
 }
 
 /// Reconstructs a modern NDX value from the `0xFE` 2-byte diff form.
 ///
-/// Upstream `io.c:2312-2314`.
+/// Upstream `io.c:2576`.
 #[inline]
-fn decode_ndx_extended_diff(hi: u8, lo: u8, prev_val: i32) -> i32 {
-    let diff = ((hi as i32) << 8) | (lo as i32);
-    prev_val + diff
+fn decode_ndx_extended_diff(hi: u8, lo: u8, prev_val: i32) -> io::Result<i32> {
+    let diff = ((hi as u32) << 8) | (lo as u32);
+    ndx_from_unsigned(diff.wrapping_add(prev_val as u32))
 }
 
 /// Reconstructs a modern NDX value from the single-byte short-diff form.
 ///
-/// Upstream `io.c:2316`.
+/// Upstream `io.c:2578`.
 #[inline]
-fn decode_ndx_short(diff_byte: u8, prev_val: i32) -> i32 {
-    prev_val + diff_byte as i32
+fn decode_ndx_short(diff_byte: u8, prev_val: i32) -> io::Result<i32> {
+    ndx_from_unsigned((diff_byte as u32).wrapping_add(prev_val as u32))
 }
 
 /// Strategy trait for NDX encoding/decoding.
@@ -287,7 +318,7 @@ impl ModernNdxCodec {
             }
         } else {
             decode_ndx_short(b[0], prev_val)
-        };
+        }?;
 
         Ok(self.commit_ndx(is_negative, num))
     }
@@ -385,7 +416,7 @@ impl NdxCodec for ModernNdxCodec {
             }
         } else {
             decode_ndx_short(b[0], prev_val)
-        };
+        }?;
 
         Ok(self.commit_ndx(is_negative, num))
     }

--- a/crates/protocol/src/codec/ndx/tests.rs
+++ b/crates/protocol/src/codec/ndx/tests.rs
@@ -1174,3 +1174,51 @@ fn test_write_goodbye_roundtrip_all_versions() {
         read_goodbye(&mut cursor, version).unwrap();
     }
 }
+
+/// A peer-supplied diff that carries the running index past `i32::MAX` is
+/// refused, not wrapped and not panicked on.
+///
+/// The byte string is the minimal case `proptest` reduced
+/// `modern_ndx_sequential_never_panics` to. It first drives `prev_positive` to
+/// near `i32::MAX` through the `0xFE`/high-bit full form, then adds a `0xFE`
+/// 2-byte diff on top. Upstream accumulates that in `uint32` and rejects the
+/// result at `io.c:2582-2586`; oc summed it in `i32`, which is an overflow
+/// panic under debug assertions on bytes the peer chooses.
+#[test]
+fn modern_ndx_rejects_a_diff_that_overflows_the_index() {
+    let mut codec = ModernNdxCodec::new(32);
+    let mut cursor = Cursor::new(vec![254, 255, 0, 193, 255, 254, 63, 0]);
+
+    let first = codec
+        .read_ndx(&mut cursor)
+        .expect("the full form seeds prev_positive without overflowing");
+    assert!(
+        first > i32::MAX - 0xFFFF,
+        "the fixture must leave the running index within one 16-bit diff of \
+         the ceiling, else the second read cannot overflow and this test is \
+         vacuous; got {first}"
+    );
+
+    let err = codec
+        .read_ndx(&mut cursor)
+        .expect_err("the overflowing diff must be refused");
+    assert!(
+        err.to_string().contains("Invalid file index"),
+        "expected upstream's wording, got {err}"
+    );
+}
+
+/// Non-vacuity companion: an ordinary short diff on the same codec still
+/// decodes. Without this, narrowing the guard to reject everything would leave
+/// the test above passing.
+#[test]
+fn modern_ndx_still_accepts_an_ordinary_short_diff() {
+    let mut codec = ModernNdxCodec::new(32);
+    let mut cursor = Cursor::new(vec![1u8]);
+
+    assert_eq!(
+        codec.read_ndx(&mut cursor).expect("a 1-byte diff decodes"),
+        0,
+        "prev_positive starts at -1, so a diff of 1 yields index 0"
+    );
+}


### PR DESCRIPTION
## The defect

`read_ndx` accumulated the peer-supplied diff forms in `i32`:

```rust
fn decode_ndx_extended_diff(hi: u8, lo: u8, prev_val: i32) -> i32 {
    let diff = ((hi as i32) << 8) | (lo as i32);
    prev_val + diff          // <- unchecked i32 add on peer bytes
}
```

A stream that drives the running index near `i32::MAX` and then adds a diff
**panics** under debug overflow checks and **wraps silently** in release.
Both the `0xFE` 2-byte form and the 1-byte short form are reachable from
bytes the peer fully controls.

## Upstream does neither

`io.c:2574-2578` accumulates every arm into a `uint32`, where the overflow is
defined; `io.c:2582-2586` then refuses anything above `MAX_INT32` *before*
narrowing:

```c
        unum = (UVAL(b,0)<<8) + UVAL(b,1) + (uint32)*prev_ptr;
...
/* A peer-supplied index that overflows a signed int32 (used unchecked as a
 * file-list index) is a protocol violation -- reject it here rather than
 * relying on every downstream consumer to bounds-check. */
if (unum > (uint32)MAX_INT32) {
        rprintf(FERROR, "Invalid file index: %lu [%s]\n", ...);
        exit_cleanup(RERR_PROTOCOL);
}
```

oc had ported the **sibling** guard — `rsync.c`'s `Invalid file index: %d
(%d - %d)`, a range check applied later against the materialised list — but
not this one. They are different guards on different quantities, and this one
runs first.

## The fix

Both halves land together, because the bound alone would still leave the
`i32` add in place:

- accumulate in `u32` (`wrapping_add`), matching upstream's operand types;
- funnel all three decode arms through a single `ndx_from_unsigned` that
  applies the `> i32::MAX` bound.

One owner rather than the bound repeated at four call sites: two sync and two
async `read_ndx` bodies share these helpers, and a future fourth arm would
otherwise be added unguarded. `protocol_violation` yields `RERR_PROTOCOL` (2),
matching `exit_cleanup(RERR_PROTOCOL)`.

The `extended_full` arm is capped at `i32::MAX` by its own masked tag, so the
bound can never fire there; it is routed through the same owner anyway
because upstream applies one check after all three arms.

## How it was found, and the non-vacuity proof

`modern_ndx_sequential_never_panics` (proptest) hit it on an unrelated PR
after 726 successes. It is randomised, so it can surface on any PR — the
minimal input it reduced to is now pinned as a deterministic regression test:

```
data = [254, 255, 0, 193, 255, 254, 63, 0]
```

The first `0xFE`/high-bit full form seeds `prev_positive` near `i32::MAX`;
the second `0xFE` adds a 16128 diff on top. The pin asserts the seed really
does land within one 16-bit diff of the ceiling, so the fixture cannot
silently stop discriminating.

**Mutation:** changing the bound to `if false` reddens the pin with

```
the overflowing diff must be refused: -2147483648
```

— i.e. the wrapped index, which is exactly the silent-corruption outcome a
release build would have taken. The ordinary-short-diff companion stays
green, so the guard is not simply rejecting everything.

## Citations

The three `io.c` line references on the decode helpers were 3.4.4-era and no
longer resolved against the 3.5.0 pin (`io.c:2290` is `sleep_for_bwlimit`
there, not `read_ndx`). Retargeted in the same change.

## Verification

- `protocol` lib: **3780 passed / 0 failed**
- `proptest_wire_format_fuzz` (the suite that found it): **76 passed / 0 failed**
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p protocol --all-targets --all-features`: **zero hits in the
  changed file**; the crate's residual `collapsible_if` /
  `manual_is_multiple_of` warnings are pre-existing on master under local
  clippy 1.94 and are not flagged by CI's toolchain.
