### PR TITLE
docs(cargo): stop promising 20-40% faster I/O from the io_uring feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,15 @@ parallel = ["cli/parallel", "checksums/parallel"]
 
 # io_uring support for Linux 5.6+ - batched async I/O syscalls
 # Requirements: Linux kernel 5.6+ (runtime fallback on older kernels)
-# Benefits: 20-40% faster I/O on supported systems via syscall batching
+# Benefits: fewer I/O syscalls via submission batching. This buys syscall
+#   count, NOT throughput: an on/off A/B measured end-to-end transfer time at
+#   parity with standard read(2)/write(2) (within +/-2% on both bulk and
+#   high-fan-out shapes). Do not restate a throughput percentage here - the
+#   20-40% figure this line used to carry describes USER-TIME instruction
+#   count on a small-file workload, and is qualified as "<5% on disk-bound
+#   workloads" at its source in docs/audits/disk-commit-iouring-batching.md.
+#   Promoting that into an end-to-end "faster I/O" promise is what made this
+#   comment false. See the io_uring kernel-tier section in README.md.
 # Trade-offs: Linux-only, requires modern kernel, adds ~100KB to binary
 io_uring = ["transfer/io_uring", "fast_io/io_uring"]
 


### PR DESCRIPTION
## The claim

`Cargo.toml`'s `io_uring` feature block promised, unconditionally:

```toml
# Benefits: 20-40% faster I/O on supported systems via syscall batching
```

That is an end-to-end throughput promise on a shipped feature flag. Two
independent on/off measurements put the real figure at parity with standard
`read(2)`/`write(2)` — within ±2% on both a bulk shape and a high-fan-out
shape, in *both* directions.

## The figure is misapplied, not invented

This is the interesting part, and it is why the fix is a rewrite rather than
a deletion. The number has a real source — the design note at
`docs/audits/disk-commit-iouring-batching.md:307-311`:

> Empirically the saving in CPU instructions on a small-file workload
> (`cp`-style copy of many tiny files) on io_uring is usually **20-40% in
> user time**, but **disk-bound workloads see <5%** because the bottleneck is
> the device.

Two things happened between there and `Cargo.toml`:

1. the quantity changed — **user-time instruction count** became
   **"faster I/O"**, i.e. wall clock;
2. the qualifier in the same sentence (`<5%` when disk-bound) was dropped.

Both moves were in the favourable direction, which is why the line read
plausibly and survived. The audit sentence itself is **deliberately left
untouched** — it is accurate for the quantity it actually names, and
"correcting" it would replace a true statement with a false one.

## Why here and not elsewhere

`grep` finds `20-40%` at nine sites. Eight are **not** this claim and are not
touched:

- `README.md:179`, `docs/oc-rsync.1.md:1345`, and the SSH-config audit
  describe **SSH+rsync double-compression CPU cost** — a different subject
  entirely;
- four checksum audits describe the **`DoubleBufferedReader` pipelined-hash**
  win — a different mechanism, and unmeasured by the io_uring A/B;
- the io_uring audit itself is the correctly-qualified source quoted above.

`Cargo.toml:71` was the only site making an unconditional end-to-end io_uring
throughput promise.

It is also a **positional sibling**: the README's version of this claim was
already reconciled against the same measurement in an earlier pass, and this
site was missed. The two now agree.

## The replacement

States the mechanism actually delivered, and records *why* no percentage
belongs on this line, so the user-time-to-wall-clock promotion cannot
silently recur:

```toml
# Benefits: fewer I/O syscalls via submission batching. This buys syscall
#   count, NOT throughput: an on/off A/B measured end-to-end transfer time at
#   parity with standard read(2)/write(2) (within +/-2% on both bulk and
#   high-fan-out shapes). Do not restate a throughput percentage here - ...
```

## Verification

- No functional change: the feature's dependency list
  (`["transfer/io_uring", "fast_io/io_uring"]`) is byte-identical, confirmed
  by re-parsing the manifest and reading the value back.
- `Cargo.toml` still parses.
- Comment-only diff: 1 file, +9/-1.
