### PR TITLE
fix(ci): verify APT packages are installed instead of trusting the cache

### DIFF
--- a/.github/workflows/_interop.yml
+++ b/.github/workflows/_interop.yml
@@ -23,6 +23,9 @@ on:
 permissions:
   contents: read
 
+env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool acl libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+
 jobs:
   interop:
     name: interop with upstream rsync
@@ -52,8 +55,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool acl libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: ${{ inputs.cache_version }}
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync
         id: cache-rsync

--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -57,6 +57,9 @@ on:
 permissions:
   contents: read
 
+env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+
 jobs:
   upstream-testsuite:
     # DELIBERATELY A LITERAL, not an expression on `transport`. MEASURED on run
@@ -114,8 +117,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: ${{ env.CACHE_VERSION }}
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync source
         id: cache-upstream
@@ -284,8 +293,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: ${{ env.CACHE_VERSION }}
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync source
         id: cache-upstream

--- a/.github/workflows/differential-fuzzer-overnight.yml
+++ b/.github/workflows/differential-fuzzer-overnight.yml
@@ -38,6 +38,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
   CARGO_TERM_COLOR: always
   FUZZ_DURATION: ${{ github.event.inputs.duration || '1800' }}
 
@@ -81,8 +82,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2

--- a/.github/workflows/filter-fuzzer-overnight.yml
+++ b/.github/workflows/filter-fuzzer-overnight.yml
@@ -36,6 +36,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
   CARGO_TERM_COLOR: always
   FUZZ_DURATION: ${{ github.event.inputs.duration || '3600' }}
 
@@ -79,8 +80,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2

--- a/.github/workflows/fuzz-coverage-report.yml
+++ b/.github/workflows/fuzz-coverage-report.yml
@@ -41,6 +41,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev lcov
   CARGO_TERM_COLOR: always
   FUZZ_DURATION: ${{ github.event.inputs.duration || '300' }}
 
@@ -127,8 +128,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev lcov
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@37f7c5781271959fb65b6b35224e28652ff2b63d # v2

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -30,6 +30,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
   CARGO_TERM_COLOR: always
   FUZZ_DURATION: '60'
 
@@ -63,8 +64,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       # Prebuilt binary, matching the overnight fuzz workflows. Compiling
       # cargo-fuzz from source runs under the repo's pinned stable toolchain

--- a/.github/workflows/interop-validation.yml
+++ b/.github/workflows/interop-validation.yml
@@ -38,6 +38,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
   CACHE_VERSION: ${{ vars.CACHE_VERSION || 'v1' }}
@@ -65,8 +66,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: ${{ env.CACHE_VERSION }}
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync
         id: cache-rsync

--- a/.github/workflows/known-failures.yml
+++ b/.github/workflows/known-failures.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+
 jobs:
   check-known-failures:
     name: Track known failure status
@@ -42,8 +45,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync
         id: cache-rsync

--- a/.github/workflows/track-3.5.0dev-testsuite.yml
+++ b/.github/workflows/track-3.5.0dev-testsuite.yml
@@ -70,6 +70,9 @@ on:
 permissions:
   contents: read
 
+env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev python3 git
+
 jobs:
   track-3-5-0dev:
     # Full coverage of the 3.5.0dev suite is a privilege x transport matrix:
@@ -121,8 +124,14 @@ jobs:
         with:
           # Same autotools/dev set as the 3.4.4 gate, plus python3 for
           # runtests.py (the git-ref suite is Python) and git for the clone.
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev python3 git
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Build oc-rsync (release)
         run: cargo build --locked --release --bin oc-rsync

--- a/.github/workflows/validate-daemon-environmental.yml
+++ b/.github/workflows/validate-daemon-environmental.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
 
 env:
+  APT_PACKAGES: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
   RUSTFLAGS: "-D warnings"
@@ -40,8 +41,14 @@ jobs:
       - name: Cache APT packages
         uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
-          packages: build-essential pkg-config zlib1g-dev curl autoconf automake libtool libacl1-dev libattr1-dev libzstd-dev liblz4-dev libxxhash-dev
+          packages: ${{ env.APT_PACKAGES }}
           version: v1
+
+      - name: Verify APT packages are installed
+        # The cache reports a hit from its own manifest, not from
+        # the machine, so a payload-less entry installs nothing
+        # and reports success. Ask dpkg instead. See the script.
+        run: tools/ci/ensure_apt_packages.sh $APT_PACKAGES
 
       - name: Cache upstream rsync source
         id: cache-upstream

--- a/tools/ci/ensure_apt_packages.sh
+++ b/tools/ci/ensure_apt_packages.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Guarantee the named APT packages are actually installed.
+#
+# WHY THIS EXISTS
+#
+# `awalsh128/cache-apt-pkgs-action` restores a cache and then reports which
+# packages it believes are present by reading `manifest_main.log` out of that
+# cache. The manifest is data the cache carries, not an observation of the
+# machine, so a cache entry saved without its package payload restores as:
+#
+#     Cache hit for: cache-apt-pkgs_fe10c55f565538c3338c7fd7f037618c
+#     Cache Size: ~0 MB (1229 B)
+#     Found 3 files in the cache.
+#     - cache_key.md5
+#     - install.log
+#     - manifest_main.log
+#     Reading from main requested packages manifest...
+#     - libacl1-dev=2.3.2-1build1.1
+#
+# Every requested package is announced as installed, nothing is installed, and
+# the step exits 0. The failure surfaces much later and somewhere else - the
+# upstream rsync oracle stops linking:
+#
+#     /usr/bin/ld: cannot find -lacl: No such file or directory
+#     /usr/bin/ld: cannot find -lxxhash: No such file or directory
+#
+# with no oracle binary the testsuite cells that need one report `got skip`
+# rather than their expected outcome, and a required context goes red for a
+# reason that has nothing to do with the commit under test.
+#
+# Deleting a poisoned entry does not fix it: the entry is re-saved by the next
+# run that takes the same path. Measured 2026-09-02, key fe10c55f... was
+# deleted and re-created ~10 minutes later on two refs at 1214 B and 1220 B.
+#
+# THE CONTRACT
+#
+# The cache is an OPTIMISATION. It is never the thing that makes the packages
+# present. This script asks dpkg what is actually installed - the machine, not
+# the manifest - and installs whatever is missing. A cache hit that delivered
+# its payload makes this a no-op; a poisoned one costs an install and emits a
+# warning so the poisoning is visible instead of silent.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: $0 <package>..." >&2
+    exit 2
+fi
+
+# dpkg-query exits non-zero for an unknown package, which is one of the two
+# ways a package can be missing; `-e` must not abort on it.
+is_installed() {
+    local status
+    status=$(dpkg-query -W -f='${Status}' "$1" 2>/dev/null) || return 1
+    [ "$status" = "install ok installed" ]
+}
+
+# Accept both `$APT_PACKAGES` and `"$APT_PACKAGES"`. Callers pass a single
+# space-separated variable, and whether it word-splits depends on a pair of
+# quotes someone will eventually "correct" in either direction. Splitting here
+# makes both spellings mean the same thing instead of making one of them fail
+# with dpkg complaining about a package whose name is the whole list.
+requested=()
+for arg in "$@"; do
+    for pkg in $arg; do
+        requested+=("$pkg")
+    done
+done
+
+missing=()
+for pkg in "${requested[@]}"; do
+    if ! is_installed "$pkg"; then
+        missing+=("$pkg")
+    fi
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+    echo "All ${#requested[@]} requested APT packages are installed."
+    exit 0
+fi
+
+# A GitHub warning annotation, not a silent repair: a cache that reported a hit
+# and delivered nothing is a defect worth seeing in the run summary.
+printf '::warning::APT cache restored without payload; installing %d missing package(s): %s\n' \
+    "${#missing[@]}" "${missing[*]}"
+
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends "${missing[@]}"
+
+# Re-ask dpkg. `apt-get install` can exit 0 having skipped a package it could
+# not resolve, so trusting its status here would rebuild the same hole this
+# script exists to close.
+still_missing=()
+for pkg in "${missing[@]}"; do
+    if ! is_installed "$pkg"; then
+        still_missing+=("$pkg")
+    fi
+done
+
+if [ "${#still_missing[@]}" -ne 0 ]; then
+    printf '::error::APT packages still missing after install: %s\n' "${still_missing[*]}"
+    exit 1
+fi
+
+echo "Installed ${#missing[@]} package(s) the cache did not provide."

--- a/tools/tests/test_ensure_apt_packages.py
+++ b/tools/tests/test_ensure_apt_packages.py
@@ -1,0 +1,171 @@
+"""Unit tests for tools/ci/ensure_apt_packages.sh.
+
+The script exists because `awalsh128/cache-apt-pkgs-action` reports package
+presence from a manifest the restored cache carries, not from the machine, so a
+payload-less cache entry announces every package installed and installs none.
+The repair path is therefore the whole point of the script - and it is the path
+a CI run cannot be relied on to exercise, because whether the cache is poisoned
+on any given run is not something the run controls. A green workflow proves the
+step is wired; only these tests prove it repairs.
+
+`dpkg-query` and `sudo` are stubbed on PATH so the tests are hermetic: they
+install nothing, need no root, and run identically on a developer machine and on
+a CI runner. The stubs share a state file, which is what lets a test decide
+whether the simulated install succeeds or silently does nothing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "tools" / "ci" / "ensure_apt_packages.sh"
+
+# Reports "installed" for any package listed in $STATE_FILE, and exits non-zero
+# otherwise - dpkg-query's own behaviour for an unknown package, which is one of
+# the two ways a package can be missing.
+DPKG_STUB = """#!/bin/sh
+# Invoked as `dpkg-query -W -f=${Status} <pkg>`, so the package name is $3.
+pkg=$3
+if grep -qx "$pkg" "$STATE_FILE" 2>/dev/null; then
+    printf 'install ok installed'
+    exit 0
+fi
+printf 'unknown'
+exit 1
+"""
+
+# `apt-get install` appends to the state file, so a later dpkg-query sees the
+# package. `apt-get update` is a no-op.
+SUDO_INSTALL_STUB = """#!/bin/sh
+echo "STUB $*" >> "$LOG_FILE"
+if [ "$2" = "install" ]; then
+    for a in "$@"; do
+        case "$a" in
+            sudo|apt-get|install|-y|--no-install-recommends) ;;
+            *) echo "$a" >> "$STATE_FILE" ;;
+        esac
+    done
+fi
+exit 0
+"""
+
+# Exits 0 while installing NOTHING. This is the shape that matters: `apt-get`
+# can exit 0 having skipped a package it could not resolve, so a script that
+# trusted its exit code would report success here.
+SUDO_NOOP_STUB = """#!/bin/sh
+echo "STUB $*" >> "$LOG_FILE"
+exit 0
+"""
+
+
+class EnsureAptPackagesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tempdir.name)
+        self.state = self.tmp / "installed.txt"
+        self.log = self.tmp / "calls.log"
+        self.state.write_text("")
+        self.log.write_text("")
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        self._write_stub("dpkg-query", DPKG_STUB)
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _write_stub(self, name: str, body: str) -> None:
+        path = self.bin / name
+        path.write_text(body)
+        path.chmod(0o755)
+
+    def _installed(self, *packages: str) -> None:
+        self.state.write_text("".join(f"{p}\n" for p in packages))
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["STATE_FILE"] = str(self.state)
+        env["LOG_FILE"] = str(self.log)
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def _calls(self) -> str:
+        return self.log.read_text()
+
+    def test_all_installed_is_a_no_op(self) -> None:
+        self._write_stub("sudo", SUDO_NOOP_STUB)
+        self._installed("libacl1-dev", "libxxhash-dev")
+
+        result = self._run("libacl1-dev", "libxxhash-dev")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("All 2 requested APT packages are installed", result.stdout)
+        self.assertEqual(self._calls(), "", "a healthy cache must not invoke apt-get")
+
+    def test_quoted_and_unquoted_package_lists_are_equivalent(self) -> None:
+        # Callers pass `$APT_PACKAGES`; whether it word-splits depends on a pair
+        # of quotes someone will eventually "correct" in either direction. Both
+        # spellings must mean the same thing rather than one of them failing
+        # with dpkg complaining about a package named after the whole list.
+        self._write_stub("sudo", SUDO_NOOP_STUB)
+        self._installed("libacl1-dev", "libxxhash-dev")
+
+        split = self._run("libacl1-dev", "libxxhash-dev")
+        joined = self._run("libacl1-dev libxxhash-dev")
+
+        self.assertEqual(split.returncode, 0, split.stderr)
+        self.assertEqual(joined.returncode, 0, joined.stderr)
+        self.assertEqual(split.stdout, joined.stdout)
+
+    def test_missing_package_is_installed_and_only_the_missing_one(self) -> None:
+        self._write_stub("sudo", SUDO_INSTALL_STUB)
+        self._installed("libacl1-dev")
+
+        result = self._run("libacl1-dev", "libxxhash-dev")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("::warning::", result.stdout)
+        self.assertIn("libxxhash-dev", result.stdout)
+        calls = self._calls()
+        self.assertIn("apt-get install", calls)
+        self.assertIn("libxxhash-dev", calls)
+        self.assertNotIn(
+            "libacl1-dev",
+            calls.split("install", 1)[1],
+            "an already-installed package must not be reinstalled",
+        )
+
+    def test_install_that_exits_zero_without_installing_still_fails(self) -> None:
+        # The decisive case. The stub exits 0 and installs nothing, so a script
+        # that inherited apt-get's verdict would report success. Re-asking dpkg
+        # is what makes the guard fail closed.
+        self._write_stub("sudo", SUDO_NOOP_STUB)
+        self._installed("libacl1-dev")
+
+        result = self._run("libacl1-dev", "libxxhash-dev")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("::error::", result.stdout)
+        self.assertIn("still missing after install", result.stdout)
+        self.assertIn("libxxhash-dev", result.stdout)
+
+    def test_no_arguments_is_a_usage_error(self) -> None:
+        self._write_stub("sudo", SUDO_NOOP_STUB)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The defect

`awalsh128/cache-apt-pkgs-action` reports which packages are present by reading `manifest_main.log` **out of the restored cache**. The manifest is data the cache carries, not an observation of the machine. So a cache entry saved without its package payload restores like this — measured on run 33648341770, job 100316791350:

```
Cache hit for: cache-apt-pkgs_fe10c55f565538c3338c7fd7f037618c
Cache Size: ~0 MB (1229 B)
Found 3 files in the cache.
- cache_key.md5
- install.log
- manifest_main.log
Reading from main requested packages manifest...
- libacl1-dev=2.3.2-1build1.1
```

Three metadata files, no payload. Every requested package is announced as installed, **nothing is installed**, and the step exits 0.

The failure then surfaces somewhere else entirely — upstream rsync stops linking:

```
/usr/bin/ld: cannot find -lacl: No such file or directory
/usr/bin/ld: cannot find -lxxhash: No such file or directory
```

With no oracle binary, the testsuite cells that need one report `got skip` instead of their expected outcome, `overall result is 2`, and a **required context goes red for a reason unrelated to the commit under test**.

## Why deleting the entry is not the fix

The entry is re-saved by the next run that takes the same path. Key `fe10c55f...` was deleted and re-created about ten minutes later on two refs, at 1214 B and 1220 B; `master` carries `1514e109...` (1235 B) and another PR carries `02d36ff9...` (1173 B). **A ~1.2 KB entry is the tell** — a healthy one is ~226 KB.

## The fix

Treat the cache as an optimisation, never as the thing that makes the packages present.

`tools/ci/ensure_apt_packages.sh` asks **dpkg** what is actually installed and installs whatever is missing, emitting a `::warning` so a payload-less restore is visible instead of silent. It re-checks with dpkg afterwards, because `apt-get install` can exit 0 having skipped a package it could not resolve.

The package list moves to a workflow-level `APT_PACKAGES` consumed by **both** the cache step and the verify step, so there is exactly one definition per workflow — a copied list is what drifts.

11 call sites across 10 workflows, including both required contexts (`_upstream-testsuite.yml`, `_interop.yml`).

## Verification

All three branches exercised on Linux:

| case | result |
|---|---|
| all packages installed, `$APT_PACKAGES` unquoted | `All 2 requested APT packages are installed.` rc=0 |
| all packages installed, `"$APT_PACKAGES"` quoted | identical — both spellings mean the same thing |
| one absent package, `sudo` stubbed to exit 0 | warning emitted, install attempted for **only** the missing package, then `::error::APT packages still missing after install` rc=1 |

The third case is the non-vacuity proof: the stubbed `sudo` **exited 0**, so a script that trusted `apt-get`'s exit code would have reported success. The dpkg re-check caught it.

Every workflow re-parsed with `yaml.safe_load` after the edit.
