### PR TITLE
fix(daemon): bound the client argument vector and stop logging it verbatim

### DIFF
--- a/crates/cli/src/frontend/server/run.rs
+++ b/crates/cli/src/frontend/server/run.rs
@@ -114,7 +114,12 @@ where
     // re-runs parse_arguments() on the server side.
     let effective_args: Vec<OsString>;
     let effective_slice: &[OsString] = if secluded_args {
-        match protocol::secluded_args::recv_secluded_args(&mut stdin, None) {
+        // `None` for the argument ceiling is deliberate and matches upstream:
+        // `read_args()` applies MAX_DAEMON_ARGS only under `if (mod_name &&
+        // ...)` (`io.c:1476`), and this is the rsh/server path, where
+        // `mod_name` is NULL. The peer here is whoever already got a shell,
+        // so the daemon's anti-amplification bound does not apply.
+        match protocol::secluded_args::recv_secluded_args(&mut stdin, None, None) {
             Ok(received_args) => {
                 // Discard the synthetic "rsync" arg0 from the wire and
                 // prepend the command-line tail so the server-options

--- a/crates/cli/src/frontend/server/tests.rs
+++ b/crates/cli/src/frontend/server/tests.rs
@@ -2015,7 +2015,7 @@ fn server_mode_merges_cmdline_and_stdin_secluded_args() {
     //   rsync\0.\0/home/ofer/reproA/from/\0\0
     let wire: &[u8] = b"rsync\0.\0/home/ofer/reproA/from/\0\0";
     let mut reader = Cursor::new(wire);
-    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None, None)
         .expect("recv should succeed");
     assert_eq!(
         received,
@@ -2058,7 +2058,7 @@ fn server_mode_merges_cmdline_and_stdin_standalone_s_flag() {
 
     let wire: &[u8] = b"rsync\0.\0/srv/data/\0\0";
     let mut reader = Cursor::new(wire);
-    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+    let received = protocol::secluded_args::recv_secluded_args(&mut reader, None, None)
         .expect("recv should succeed");
 
     let mut received_iter = received.into_iter();

--- a/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/tests.rs
@@ -989,7 +989,7 @@ mod protect_args_daemon_tests {
         );
 
         let mut cursor = Cursor::new(wire);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv");
         assert_eq!(received, sent);
     }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -105,6 +105,13 @@ fn unescape_phase1_option_args(args: Vec<String>) -> Vec<String> {
 /// For protocol >= 30: arguments are null-byte terminated
 /// For protocol < 30: arguments are newline terminated
 /// An empty argument marks the end of the list.
+///
+/// The argument count is bounded by
+/// [`protocol::secluded_args::MAX_DAEMON_ARGS`]. Upstream applies that ceiling
+/// inside this same loop (`io.c:1476-1479`) under `if (mod_name && ...)`, and
+/// every caller of this function is serving a module, so the bound is
+/// unconditional here. Without it a client can make the daemon accumulate an
+/// unbounded argument vector before a single argument is parsed.
 fn read_client_arguments<R: BufRead>(
     reader: &mut R,
     protocol: Option<ProtocolVersion>,
@@ -113,6 +120,13 @@ fn read_client_arguments<R: BufRead>(
     let mut arguments = Vec::new();
 
     loop {
+        // upstream: io.c:1476 - checked per read line, before the argument is
+        // appended, so the peer is cut off while it is still sending rather
+        // than after the whole vector is resident.
+        if arguments.len() >= protocol::secluded_args::MAX_DAEMON_ARGS - 1 {
+            return Err(protocol::secluded_args::too_many_daemon_arguments());
+        }
+
         if use_nulls {
             let mut buf = Vec::new();
             let bytes_read = reader.read_until(b'\0', &mut buf)?;
@@ -187,6 +201,34 @@ fn has_secluded_args_flag(args: &[String]) -> bool {
     })
 }
 
+/// Renders the daemon's per-connection client-argument log line.
+///
+/// Takes the argument vector and renders only its LENGTH. Upstream never
+/// writes the client's argument vector to the daemon log at all. Echoing it
+/// verbatim turns a connection into a log-amplification primitive: every byte
+/// a peer sends before authentication is appended to the operator's log file,
+/// and neither the token count nor the per-token length is under the daemon's
+/// control. `MAX_DAEMON_ARGS` bounds the count but not the total bytes, so the
+/// bound alone does not close this - the payload has to go.
+///
+/// The count is retained because it is daemon-derived, is bounded by
+/// construction, and is what an operator actually needs in order to correlate
+/// a connection with a refusal.
+fn client_args_log_line(
+    request: &str,
+    host_display: &str,
+    peer_ip: IpAddr,
+    client_args: &[String],
+) -> String {
+    format!(
+        "module '{}' from {} ({}): {} client args",
+        request,
+        host_display,
+        peer_ip,
+        client_args.len()
+    )
+}
+
 /// Reads and logs client arguments, handling the two-phase secluded-args
 /// protocol when the client sends `--protect-args` / `-s`.
 ///
@@ -245,7 +287,11 @@ fn read_and_log_client_args(
         // the `if (!protect_args ...)` guard at `options.c:2551` skips
         // the WILD_CHARS escape when `protect_args` is set - so no
         // `unbackslash_arg()` pass is needed on either phase.
-        match protocol::secluded_args::recv_secluded_args(ctx.reader, None) {
+        match protocol::secluded_args::recv_secluded_args(
+            ctx.reader,
+            None,
+            Some(protocol::secluded_args::MAX_DAEMON_ARGS),
+        ) {
             Ok(full_args) => merge_secluded_args(phase1_args, full_args),
             Err(err) => {
                 let error = AtError::message(format!("failed to read secluded args: {err}"));
@@ -263,14 +309,7 @@ fn read_and_log_client_args(
     };
 
     if let Some(log) = ctx.log_sink {
-        let args_str = client_args.join(" ");
-        let text = format!(
-            "module '{}' from {} ({}): client args: {}",
-            ctx.request,
-            ctx.host_display(),
-            ctx.peer_ip,
-            args_str
-        );
+        let text = client_args_log_line(ctx.request, ctx.host_display(), ctx.peer_ip, &client_args);
         let message = rsync_info!(text).with_role(Role::Daemon);
         log_message(log, &message);
     }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -4121,7 +4121,10 @@ mod daemon_client_arg_logging_tests {
             !line.contains("--server"),
             "a peer-supplied argument reached the daemon log: {line}"
         );
-        assert_eq!(line, "module 'data' from client.example (203.0.113.7): 3 client args");
+        assert_eq!(
+            line,
+            "module 'data' from client.example (203.0.113.7): 3 client args"
+        );
     }
 
     /// Non-vacuity companion: the count is real, so the line above is not

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -841,7 +841,7 @@ mod module_access_tests {
         assert!(has_secluded_args_flag(&phase1));
 
         // Read phase 2
-        let full_args = protocol::secluded_args::recv_secluded_args(&mut reader, None)
+        let full_args = protocol::secluded_args::recv_secluded_args(&mut reader, None, None)
             .expect("should read secluded args");
         assert_eq!(full_args[0], "rsync");
         let effective: Vec<&str> = full_args.iter().skip(1).map(String::as_str).collect();
@@ -4042,5 +4042,97 @@ mod module_access_tests {
         let mut cfg = ServerConfig::default();
         apply_module_transfer_directives(&module, &mut cfg);
         assert!(cfg.flags.numeric_ids.is_off());
+    }
+}
+
+/// Pins upstream's `MAX_DAEMON_ARGS` ceiling on the phase-1 argument read.
+///
+/// upstream: `io.c:1476-1479` - `if (mod_name && argc >= MAX_DAEMON_ARGS - 1)`
+/// then `rprintf(FERROR, "too many daemon arguments\n")` and
+/// `exit_cleanup(RERR_PROTOCOL)`.
+#[cfg(test)]
+mod daemon_argv_limit_tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn null_terminated_args(count: usize) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(count * 2 + 1);
+        for _ in 0..count {
+            buf.extend_from_slice(b"a\0");
+        }
+        buf.push(0);
+        buf
+    }
+
+    #[test]
+    fn read_client_arguments_refuses_past_the_daemon_ceiling() {
+        let input = null_terminated_args(protocol::secluded_args::MAX_DAEMON_ARGS + 10);
+        let mut reader = BufReader::new(Cursor::new(input));
+
+        let err = read_client_arguments(&mut reader, Some(ProtocolVersion::V30))
+            .expect_err("the daemon must refuse an unbounded argument vector");
+
+        assert_eq!(err.to_string(), "too many daemon arguments");
+    }
+
+    /// Non-vacuity companion: an ordinary vector still reads. Without it the
+    /// refusal above would also pass if the reader had stopped working.
+    #[test]
+    fn read_client_arguments_still_accepts_an_ordinary_vector() {
+        let input = null_terminated_args(64);
+        let mut reader = BufReader::new(Cursor::new(input));
+
+        let args = read_client_arguments(&mut reader, Some(ProtocolVersion::V30))
+            .expect("an ordinary argument vector must still be read");
+
+        assert_eq!(args.len(), 64);
+    }
+}
+
+/// Pins that the daemon's client-argument log line carries the argument
+/// COUNT and never the argument bytes.
+///
+/// Upstream writes no argument vector to the daemon log at any verbosity, so
+/// there is no upstream line to mirror - the pin is that a peer cannot get its
+/// own bytes appended to the operator's log file.
+#[cfg(test)]
+mod daemon_client_arg_logging_tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr};
+
+    const PEER: IpAddr = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+
+    #[test]
+    fn the_log_line_reports_the_count_and_not_the_arguments() {
+        let payload = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let args = vec![
+            "--server".to_string(),
+            payload.to_string(),
+            payload.to_string(),
+        ];
+
+        let line = client_args_log_line("data", "client.example", PEER, &args);
+
+        assert!(
+            !line.contains(payload),
+            "a peer-supplied argument reached the daemon log: {line}"
+        );
+        assert!(
+            !line.contains("--server"),
+            "a peer-supplied argument reached the daemon log: {line}"
+        );
+        assert_eq!(line, "module 'data' from client.example (203.0.113.7): 3 client args");
+    }
+
+    /// Non-vacuity companion: the count is real, so the line above is not
+    /// merely constant text that would pass however the arguments were
+    /// handled.
+    #[test]
+    fn the_reported_count_tracks_the_vector_length() {
+        let empty: Vec<String> = Vec::new();
+        let one = vec!["-r".to_string()];
+
+        assert!(client_args_log_line("data", "h", PEER, &empty).ends_with("0 client args"));
+        assert!(client_args_log_line("data", "h", PEER, &one).ends_with("1 client args"));
     }
 }

--- a/crates/protocol/src/secluded_args.rs
+++ b/crates/protocol/src/secluded_args.rs
@@ -121,6 +121,34 @@ fn write_secluded_arg<W: Write>(
     Ok(())
 }
 
+/// Upstream's ceiling on a single `read_args()` argument vector.
+///
+/// upstream: `rsync.h:202` - `#define MAX_ARGS 1000`
+pub const MAX_ARGS: usize = 1000;
+
+/// Upstream's ceiling on the argument vector a *daemon module* connection may
+/// send.
+///
+/// upstream: `io.c:1452` - `#define MAX_DAEMON_ARGS (MAX_ARGS * 16)`
+///
+/// This bounds a peer-controlled allocation: without it a client can make the
+/// daemon accumulate an unbounded argument vector before any of it is parsed.
+/// Upstream applies the ceiling only when serving a module (`io.c:1476`), so
+/// this constant must reach the reader as a caller-supplied bound rather than
+/// being enforced unconditionally - see [`recv_secluded_args`].
+pub const MAX_DAEMON_ARGS: usize = MAX_ARGS * 16;
+
+/// The refusal upstream emits when a daemon client sends too many arguments.
+///
+/// upstream: `io.c:1477-1478` - `rprintf(FERROR, "too many daemon arguments\n")`
+/// followed by `exit_cleanup(RERR_PROTOCOL)`.
+///
+/// The wording is upstream's verbatim, so a peer or a log reader sees the same
+/// string from either implementation.
+pub fn too_many_daemon_arguments() -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, "too many daemon arguments")
+}
+
 /// Deserializes a null-separated argument list from a reader.
 ///
 /// Reads bytes one at a time, collecting characters into arguments separated
@@ -135,18 +163,29 @@ fn write_secluded_arg<W: Write>(
 ///
 /// Returns `Ok(args)` with the parsed argument vector on success.
 ///
+/// `max_args` bounds how many arguments will be accumulated. It is
+/// `Some(MAX_DAEMON_ARGS)` for a daemon module connection and `None`
+/// everywhere else, mirroring upstream's `mod_name` gate: `read_args()`
+/// applies its ceiling only under `if (mod_name && ...)` (`io.c:1476`), so
+/// the rsh/server argument read is deliberately unbounded on both
+/// implementations. The bound is a parameter rather than a constant here for
+/// exactly that reason - the caller decides, because only the caller knows
+/// whether it is serving a module.
+///
 /// # Upstream Reference
 ///
 /// Mirrors the protected-args reading logic in upstream `io.c:1240-1289`
-/// `read_line()` with the `RL_CONVERT` flag.
+/// `read_line()` with the `RL_CONVERT` flag, plus the `MAX_DAEMON_ARGS`
+/// ceiling at `io.c:1476-1479`.
 ///
 /// # Errors
 ///
-/// Returns an error if the reader encounters an I/O error or reaches EOF
-/// before the terminating empty argument.
+/// Returns an error if the reader encounters an I/O error, reaches EOF
+/// before the terminating empty argument, or exceeds `max_args`.
 pub fn recv_secluded_args<R: Read>(
     reader: &mut R,
     iconv: Option<&FilenameConverter>,
+    max_args: Option<usize>,
 ) -> io::Result<Vec<String>> {
     let mut args = Vec::new();
     let mut current = Vec::new();
@@ -185,6 +224,14 @@ pub fn recv_secluded_args<R: Read>(
                     format!("invalid UTF-8 in secluded arg: {e}"),
                 )
             })?;
+            // upstream: io.c:1476-1479 - the ceiling is checked before the
+            // argument is appended, so the vector never exceeds the bound.
+            // Refusing here rather than after the loop is what makes this a
+            // memory bound and not just a report: a peer that keeps sending
+            // must be cut off while it is still sending.
+            if max_args.is_some_and(|max| args.len() >= max.saturating_sub(1)) {
+                return Err(too_many_daemon_arguments());
+            }
             args.push(arg);
         } else {
             current.push(byte[0]);
@@ -205,7 +252,7 @@ mod tests {
         send_secluded_args(&mut buf, &args, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(received, args);
     }
 
@@ -216,7 +263,7 @@ mod tests {
         send_secluded_args(&mut buf, &args, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert!(received.is_empty());
     }
 
@@ -235,7 +282,7 @@ mod tests {
         send_secluded_args(&mut buf, &args, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(received, args);
     }
 
@@ -270,7 +317,7 @@ mod tests {
         // Stream ends without terminator
         let buf = b"arg1\0arg2";
         let mut cursor = io::Cursor::new(&buf[..]);
-        let result = recv_secluded_args(&mut cursor, None);
+        let result = recv_secluded_args(&mut cursor, None, None);
         assert!(result.is_err());
     }
 
@@ -278,7 +325,7 @@ mod tests {
     fn recv_from_empty_stream_returns_error() {
         let buf = b"";
         let mut cursor = io::Cursor::new(&buf[..]);
-        let result = recv_secluded_args(&mut cursor, None);
+        let result = recv_secluded_args(&mut cursor, None, None);
         assert!(result.is_err());
     }
 
@@ -293,7 +340,7 @@ mod tests {
         send_secluded_args(&mut buf, &args, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(received, args);
     }
 
@@ -305,7 +352,7 @@ mod tests {
         send_secluded_args(&mut buf, &args_refs, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(received, args);
     }
 
@@ -352,7 +399,7 @@ mod tests {
 
         let mut cursor = io::Cursor::new(&wire);
         let received =
-            recv_secluded_args(&mut cursor, Some(&reader_iconv)).expect("recv with iconv");
+            recv_secluded_args(&mut cursor, Some(&reader_iconv), None).expect("recv with iconv");
         assert_eq!(received, args);
     }
 
@@ -363,10 +410,12 @@ mod tests {
         let wire: &[u8] = b"alpha\0beta\0gamma\0\0";
 
         let mut cursor_with = io::Cursor::new(wire);
-        let with = recv_secluded_args(&mut cursor_with, Some(&identity)).expect("recv with iconv");
+        let with =
+            recv_secluded_args(&mut cursor_with, Some(&identity), None).expect("recv with iconv");
 
         let mut cursor_without = io::Cursor::new(wire);
-        let without = recv_secluded_args(&mut cursor_without, None).expect("recv without iconv");
+        let without =
+            recv_secluded_args(&mut cursor_without, None, None).expect("recv without iconv");
 
         assert_eq!(with, without);
         assert_eq!(with, vec!["alpha", "beta", "gamma"]);
@@ -427,7 +476,7 @@ mod tests {
         send_secluded_args(&mut buf, &args, None).expect("send should succeed");
 
         let mut cursor = io::Cursor::new(buf);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(
             received,
             vec!["--server", ".", "."],
@@ -449,7 +498,7 @@ mod tests {
         wire.extend_from_slice(b"@RSYNCD");
 
         let mut cursor = io::Cursor::new(&wire);
-        let received = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let received = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert_eq!(received, vec!["alpha", ".", "omega"]);
 
         let mut leftover = Vec::new();
@@ -484,7 +533,7 @@ mod tests {
         let wire: &[u8] = b"--server\0--sender\0-logDtpr\0.\0/path\0\0";
         let mut cursor = io::Cursor::new(wire);
 
-        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let args = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
 
         assert_eq!(args.len(), 5);
         assert_eq!(args[0], "--server");
@@ -510,7 +559,7 @@ mod tests {
         let wire: &[u8] = b"\0";
         let mut cursor = io::Cursor::new(wire);
 
-        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let args = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
 
         assert!(args.is_empty());
         assert_eq!(
@@ -526,7 +575,7 @@ mod tests {
         let wire: &[u8] = b"arg1\0arg2";
         let mut cursor = io::Cursor::new(wire);
 
-        let err = recv_secluded_args(&mut cursor, None)
+        let err = recv_secluded_args(&mut cursor, None, None)
             .expect_err("recv should fail when terminator is missing");
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
@@ -547,7 +596,7 @@ mod tests {
         let terminator_end = wire.len() - 1;
         let mut cursor = io::Cursor::new(wire);
 
-        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let args = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
 
         assert_eq!(args, vec!["--server", "--sender", ".", "/path"]);
         assert_eq!(
@@ -586,7 +635,7 @@ mod tests {
         let wire: &[u8] = b"--server\0-vlogDtpre.iLsfxCIvu\0.\0src/\0\0EXTRA";
         let mut cursor = io::Cursor::new(wire);
 
-        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let args = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
 
         assert_eq!(args, vec!["--server", "-vlogDtpre.iLsfxCIvu", ".", "src/"]);
 
@@ -609,7 +658,7 @@ mod tests {
         let wire: &[u8] = b"\0NEXT";
         let mut cursor = io::Cursor::new(wire);
 
-        let args = recv_secluded_args(&mut cursor, None).expect("recv should succeed");
+        let args = recv_secluded_args(&mut cursor, None, None).expect("recv should succeed");
         assert!(args.is_empty());
 
         let mut leftover = Vec::new();
@@ -620,5 +669,61 @@ mod tests {
             leftover, b"NEXT",
             "empty arg list must consume only the terminator NUL"
         );
+    }
+}
+
+#[cfg(test)]
+mod daemon_arg_ceiling_tests {
+    use super::*;
+
+    /// Encodes `count` one-byte args plus the empty-string terminator.
+    fn wire_with_args(count: usize) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(count * 2 + 1);
+        for _ in 0..count {
+            buf.extend_from_slice(b"a\0");
+        }
+        buf.push(0);
+        buf
+    }
+
+    #[test]
+    fn a_daemon_bound_refuses_a_vector_past_max_daemon_args() {
+        let wire = wire_with_args(MAX_DAEMON_ARGS + 10);
+        let mut cursor = io::Cursor::new(wire);
+
+        let err = recv_secluded_args(&mut cursor, None, Some(MAX_DAEMON_ARGS))
+            .expect_err("a daemon connection must refuse an oversized argument vector");
+
+        // upstream: io.c:1477 - the wording is upstream's, verbatim.
+        assert_eq!(err.to_string(), "too many daemon arguments");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Non-vacuity companion: the SAME oversized wire is accepted when no
+    /// ceiling is supplied. Without this the refusal test would also pass if
+    /// the reader had simply become unable to read a long vector at all, and
+    /// it pins the deliberate rsh/server divergence - upstream gates the
+    /// ceiling on `mod_name` (`io.c:1476`), so the non-daemon read is
+    /// unbounded on both implementations.
+    #[test]
+    fn b_no_ceiling_accepts_the_same_oversized_vector() {
+        let wire = wire_with_args(MAX_DAEMON_ARGS + 10);
+        let mut cursor = io::Cursor::new(wire);
+
+        let args = recv_secluded_args(&mut cursor, None, None)
+            .expect("an unbounded read must accept the vector the daemon refuses");
+
+        assert_eq!(args.len(), MAX_DAEMON_ARGS + 10);
+    }
+
+    #[test]
+    fn c_a_vector_inside_the_ceiling_is_still_accepted() {
+        let wire = wire_with_args(8);
+        let mut cursor = io::Cursor::new(wire);
+
+        let args = recv_secluded_args(&mut cursor, None, Some(MAX_DAEMON_ARGS))
+            .expect("an ordinary argument vector must still be read");
+
+        assert_eq!(args.len(), 8);
     }
 }


### PR DESCRIPTION
Two coupled defects on the daemon's post-`@RSYNCD: OK` argument read. Task 820 RC-2 asked for both in one commit, each with its own pin.

## 1. No `MAX_DAEMON_ARGS` ceiling

Upstream bounds the argument vector a daemon module connection may send:

```c
#define MAX_DAEMON_ARGS (MAX_ARGS * 16)          /* io.c:1452, MAX_ARGS 1000 at rsync.h:202 */
...
if (mod_name && argc >= MAX_DAEMON_ARGS - 1) {   /* io.c:1476-1479 */
        rprintf(FERROR, "too many daemon arguments\n");
        exit_cleanup(RERR_PROTOCOL);
}
```

oc had no such bound at either phase, so a client could make the daemon accumulate an unbounded argument vector before a single argument was parsed. Zero hits for `MAX_ARGS` / `MAX_DAEMON_ARGS` anywhere in `crates/` beforehand.

The ceiling reaches the reader as a caller-supplied `Option<usize>` rather than a constant, because that mirrors upstream's own gate: `read_args()` applies it only under `if (mod_name && ...)`, so the rsh/server argument read is deliberately unbounded on both implementations. `recv_secluded_args` has exactly two production callers and they sit on opposite sides of that split — `crates/cli/src/frontend/server/run.rs` passes `None` and says why.

## 2. The daemon logged every client argument verbatim

Upstream never writes the argument vector to the daemon log at all. Echoing it made a connection a log-amplification primitive: every byte a peer sent before authentication was appended to the operator's log file, and neither the token count nor the per-token length was under the daemon's control.

The ceiling in (1) bounds the *count* but not the total *bytes* — there is no per-argument length cap — so it does not close this on its own; the payload had to go. The line now reports the argument **count**, which is daemon-derived, bounded by construction, and still lets an operator correlate a connection with a refusal.

## Pins

Each half carries its own pin, and each pin has a non-vacuity companion, since a refusal test would otherwise also pass if the reader had simply stopped working.

| Mutation | Result |
|---|---|
| M1 — drop the `max_args` check in `recv_secluded_args` | `a_daemon_bound_refuses_a_vector_past_max_daemon_args` FAILS, other 6 green |
| M2 — drop the ceiling in `read_client_arguments` | `read_client_arguments_refuses_past_the_daemon_ceiling` FAILS, other 6 green |
| M3 — restore `client_args.join(" ")` in the log line | both logging pins FAIL, both bound pins green |

The protocol companion feeds the **same** oversized wire through an unbounded read and asserts it is accepted, which pins the deliberate rsh/server divergence rather than leaving it as an unstated asymmetry.

## Verification

`cargo fmt --all -- --check` clean. `cargo nextest run -p protocol -p daemon -p cli`: 11656 run, 11655 passed. The single failure is `transfer_request_with_sparse_preserves_holes`, proven **inherited** by running it in a detached worktree at the pristine base `029c2c53b` — it fails there identically (APFS sparse-block accounting), and this diff touches nothing on the sparse or copy path.
