### PR TITLE
docs: document the public items rustdoc could not see, and record ten merged PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,19 @@ jobs:
       - name: Build rustdoc (workspace, all features, no deps)
         run: cargo doc --workspace --all-features --no-deps --locked
 
+      # A SECOND question, not a duplicate of the step above. A link to an item
+      # behind `#[cfg(feature = "...")]` RESOLVES under --all-features and is
+      # unresolvable in a default build, where the item is not compiled at all -
+      # so the all-features step is structurally unable to see that class. Five
+      # such links (`fast_io::adaptive_dispatch` x4, `rsync_io::channel_adapter`)
+      # were live on master while the step above was green.
+      #
+      # `crates/fast_io/src/io_uring` is cfg(all(target_os = "linux", feature =
+      # "io_uring")), so this run deliberately does NOT cover those files; that
+      # is what the all-features step is for. Neither subsumes the other.
+      - name: Build rustdoc (workspace, default features, no deps)
+        run: cargo doc --workspace --no-deps --locked
+
   # ===========================================================================
   # tools/ Unit Tests
   # ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,16 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   `flist.c` applies unconditionally to a real files-from stream (#7460)
 - Don't let the sender widen the receiver's `--delete` scope through an implied
   parent directory (#7446)
+- Reject a non-directory encoding of the synthetic `.` transfer-root entry at
+  decode time, both spellings. The root is exempt from the requested-name
+  filter checks, so a sender that encoded it with regular-file mode made every
+  make-way site see a directory where a non-directory had to be written and,
+  under `--force`, clear the destination root recursively. Refused as a
+  protocol violation where upstream refuses it, in `recv_file_entry`
+  (`flist.c:1127-1134`), not in the obstacle arm - gating the arm would leave
+  the forged entry live for mkdir, rename and backup (#7625)
+- Reject a modern NDX that overflows a signed file index rather than wrapping
+  it (#7630)
 
 ### Added
 
@@ -365,6 +375,20 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   the whole run at `EISDIR`. All six call sites now share one
   `make_way_for_replacement`, which owns both the `rmdir` and the unlink arm
   (#7602)
+- Apply the pre-image's ownership, timestamps and mode to a backup made by the
+  copy tier. The hardlink and rename tiers move or share the inode so the
+  attributes travel with it; the copy tier builds a new one and carried none,
+  which is why upstream calls `set_file_attrs` on that branch alone
+  (`backup.c:420`, reached only from `backup.c:400`) (#7622)
+- Honour `--force` so a populated directory standing where a non-directory must
+  be written is cleared, matching upstream's
+  `delete_mode || force_delete ? DEL_RECURSE : 0`. `--force` was recognised by
+  the stdio server-arg parser and discarded, the daemon's long-form parser had
+  no arm for it, and the obstacle arm consulted neither term - so oc refused at
+  exit 23 in all four flag combinations where 3.5.0 replaces in three of them
+  (#7625)
+- Skip a directory operand instead of transferring it when directory transfer
+  is off, per `flist.c:2723-2726` (#7627)
 
 **Local copy and engine**
 - Size a local copy from the opened file, not the flist record, and clamp the
@@ -445,6 +469,13 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   `@ERROR: invalid gid nobody` behind on a module with a numeric `uid` and a
   defaulted `gid`. Only the three privilege-drop syscalls still run after the
   chroot (#7585)
+- Keep a dead `name converter` apart from an unknown name. The query returned
+  `Option<String>`, collapsing five outcomes into one `None`: no answer, an
+  empty answer, a name carrying a control byte, an over-long request, and a
+  converter whose stream had broken. Upstream can return a bare `BOOL` only
+  because two of those exit instead of returning (`clientserver.c:1324-1334`),
+  so merging them here failed open on exactly the mechanism an operator
+  installs to take ownership decisions away from the peer (#7629)
 
 **CLI and output**
 - Honour the `--` end-of-options marker in server-mode argv (#7402)
@@ -583,6 +614,13 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   recovery - from the `EBUSY` that means a registration is still live. The
   errno had survived only inside the message string, so no caller could branch
   on it and the probe could not be given its siblings' tolerance (#7619)
+- The backup-directory cells probe the directory they claim to check instead of
+  asserting a condition that held whether or not the backup landed (#7621)
+- The citation drift gate scans the 42% of citations its filter could not see,
+  reported non-blocking until the backlog it exposes is worked down (#7623)
+- The APT package cache verifies the packages are installed rather than
+  trusting a cache hit, so a restored-but-empty cache fails its own job instead
+  of reddening unrelated pull requests three jobs later (#7632)
 
 ### Documentation
 
@@ -655,6 +693,11 @@ families, and putting the 3.5.0 test suite in front of every pull request.
   request. Four pull requests had repaired this class post-merge because
   `cargo doc` ran only on push-to-master, so a broken link was discoverable
   only after it landed (#7618)
+- README and SECURITY claims that no longer matched the tree are regrounded
+  against it (#7626)
+- The `io_uring` feature no longer promises 20-40% faster I/O. Measured on
+  kernel 7.1.5 it delivers +1.2% on bulk and -1.2% on fan-out, so the number
+  described an expectation rather than the build it was attached to (#7631)
 
 ### Maintenance
 

--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -183,15 +183,17 @@ pub(crate) fn parse_debug_flags(values: &[OsString]) -> Result<DebugFlagSettings
     Ok(settings)
 }
 
-// upstream: options.c output_item_help (rsync-3.4.1:474-510). Reproduced
-// byte-for-byte from upstream's runtime output so `--debug=help` matches
-// `rsync --debug=help`. Layout matches `"%-10s %s\n"` from options.c:478.
-// ALL/NONE descriptions inline the sentinel's `--debug` help
-// (options.c:489-495). The per-verbosity summary lines are rendered by
-// upstream's `make_output_option` over `debug_verbosity[]`
-// (options.c:228-235) and emit names in `debug_words[]` order
-// (options.c:289-315). Levels 0-1 are empty in `debug_verbosity[]`, so the
-// summary block lists levels 2-5 only.
+/// Body of `--debug=help`, reproduced byte-for-byte from upstream.
+///
+/// upstream: options.c output_item_help (rsync-3.4.1:474-510). Reproduced
+/// byte-for-byte from upstream's runtime output so `--debug=help` matches
+/// `rsync --debug=help`. Layout matches `"%-10s %s\n"` from options.c:478.
+/// ALL/NONE descriptions inline the sentinel's `--debug` help
+/// (options.c:489-495). The per-verbosity summary lines are rendered by
+/// upstream's `make_output_option` over `debug_verbosity[]`
+/// (options.c:228-235) and emit names in `debug_words[]` order
+/// (options.c:289-315). Levels 0-1 are empty in `debug_verbosity[]`, so the
+/// summary block lists levels 2-5 only.
 pub(crate) const DEBUG_HELP_TEXT: &str = "\
 Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\
 \n\

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -31,12 +31,14 @@ pub(crate) struct InfoFlagSpec {
     pub(crate) priority: u8,
 }
 
-// upstream: options.c info_verbosity[] (rsync-3.4.1:239-243) - priority is
-// the verbosity-group index. NONREG sits in group 0 (always-on default),
-// the level-1 group covers COPY/DEL/FLIST/MISC/NAME/STATS/SYMSAFE, and the
-// level-2 group covers BACKUP/MOUNT/REMOVE/SKIP. PROGRESS has no upstream
-// verbosity-group entry; oc-rsync treats it as priority 1 so `--info=all1`
-// enables per-file progress, matching upstream `-v` parity for `--info`.
+/// Every `--info` flag, with the verbosity group that enables it.
+///
+/// upstream: options.c info_verbosity[] (rsync-3.4.1:239-243) - priority is
+/// the verbosity-group index. NONREG sits in group 0 (always-on default),
+/// the level-1 group covers COPY/DEL/FLIST/MISC/NAME/STATS/SYMSAFE, and the
+/// level-2 group covers BACKUP/MOUNT/REMOVE/SKIP. PROGRESS has no upstream
+/// verbosity-group entry; oc-rsync treats it as priority 1 so `--info=all1`
+/// enables per-file progress, matching upstream `-v` parity for `--info`.
 #[rustfmt::skip]
 pub(crate) const INFO_FLAG_SPECS: &[InfoFlagSpec] = &[
     InfoFlagSpec { name: "backup",   max_level: 1, priority: 2 },
@@ -305,14 +307,16 @@ fn parse_info_flags_inner(
     Ok(settings)
 }
 
-// upstream: options.c output_item_help (rsync-3.4.1:474-510). The text is
-// reproduced byte-for-byte from upstream's runtime output so `--info=help`
-// matches `rsync --info=help`. The format string is `"%-10s %s\n"`: each
-// name is left-padded to 10 columns, followed by a single space and the
-// help text. ALL/NONE descriptions inline the sentinel's `--info` help
-// (options.c:489-495). The per-verbosity summary block is rendered by
-// upstream's `make_output_option` over `info_verbosity[]` (options.c:239-
-// 243) and emits one line per non-empty level in `info_words[]` order.
+/// Body of `--info=help`, reproduced byte-for-byte from upstream.
+///
+/// upstream: options.c output_item_help (rsync-3.4.1:474-510). The text is
+/// reproduced byte-for-byte from upstream's runtime output so `--info=help`
+/// matches `rsync --info=help`. The format string is `"%-10s %s\n"`: each
+/// name is left-padded to 10 columns, followed by a single space and the
+/// help text. ALL/NONE descriptions inline the sentinel's `--info` help
+/// (options.c:489-495). The per-verbosity summary block is rendered by
+/// upstream's `make_output_option` over `info_verbosity[]` (options.c:239-
+/// 243) and emits one line per non-empty level in `info_words[]` order.
 pub(crate) const INFO_HELP_TEXT: &str = "\
 Use OPT or OPT1 for level 1 output, OPT2 for level 2, etc.; OPT0 silences.\n\
 \n\

--- a/crates/core/src/client/module_list/socket_options/consts.rs
+++ b/crates/core/src/client/module_list/socket_options/consts.rs
@@ -5,11 +5,18 @@
 //!
 //! This is a small adapter so the rest of the module stays platform-neutral.
 
-// RFC 1349 class selectors - consistent across Unix targets, but libc does not
-// expose them uniformly (e.g. Apple platforms omit the aliases).
+/// IP type-of-service class selector requesting low delay.
+///
+/// RFC 1349 class selectors - consistent across Unix targets, but libc does not
+/// expose them uniformly (e.g. Apple platforms omit the aliases), so the value
+/// is spelled out rather than re-exported.
 #[cfg(not(target_family = "windows"))]
 pub(super) const IPTOS_LOWDELAY: libc::c_int = 0x10;
 
+/// IP type-of-service class selector requesting high throughput.
+///
+/// Defined here for the same reason as [`IPTOS_LOWDELAY`]: libc does not expose
+/// the RFC 1349 aliases uniformly across Unix targets.
 #[cfg(not(target_family = "windows"))]
 pub(super) const IPTOS_THROUGHPUT: libc::c_int = 0x08;
 

--- a/crates/core/src/client/module_list/types.rs
+++ b/crates/core/src/client/module_list/types.rs
@@ -13,11 +13,16 @@ use std::fmt;
 /// only variant reachable in a default build, so default behaviour is
 /// preserved byte-for-byte.
 ///
-/// [`Transport::Quic`] is an opt-in oc extension - a new way to carry the same
+/// `Transport::Quic` is an opt-in oc extension - a new way to carry the same
 /// daemon protocol - compiled only under the off-by-default `quic` cargo
 /// feature (design: `docs/design/quic-transport-policy.md`, Decision D). It is
-/// not yet constructed from the CLI; the `quic://` scheme and `--quic` modifier
-/// land in a follow-up.
+/// selected by the `quic://` scheme (`DaemonRequest::parse`) or by the `--quic`
+/// modifier upgrading an `rsync://` target.
+///
+/// The variant is named here without an intra-doc link on purpose: it does not
+/// exist in a default build, so a link would be unresolvable and
+/// `#![deny(rustdoc::broken_intra_doc_links)]` would fail `cargo doc` on the
+/// default feature set.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Transport {
     /// Plain TCP to the rsync daemon (upstream behaviour, always the default).

--- a/crates/core/src/version/report/renderer.rs
+++ b/crates/core/src/version/report/renderer.rs
@@ -4,8 +4,10 @@ use crate::version::{VersionMetadata, version_metadata, version_metadata_for_pro
 use libc::{ino_t, off_t};
 use std::borrow::Cow;
 
-// libc::time_t is deprecated on musl targets (musl 1.2.0+ uses 64-bit time_t).
-// Provide a platform-safe alias: i64 on musl, libc::time_t elsewhere.
+/// Platform-safe `time_t` alias: `i64` on musl, `libc::time_t` elsewhere.
+///
+/// `libc::time_t` is deprecated on musl targets (musl 1.2.0+ uses 64-bit
+/// `time_t`), so naming it directly would warn on that target alone.
 #[cfg(target_env = "musl")]
 pub(crate) type TimeT = i64;
 #[cfg(not(target_env = "musl"))]

--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -180,7 +180,8 @@ struct PinnedRoot {
 ///
 /// `root` is the root as the caller names it; it should be the same value the
 /// caller published through [`install_session`], and both spellings of it are
-/// then recognised (see [`PinnedRoot`]).
+/// then recognised (see the private `PinnedRoot`, named without a link because
+/// a public item cannot resolve one to a private type).
 ///
 /// # Errors
 ///

--- a/crates/fast_io/src/ewma.rs
+++ b/crates/fast_io/src/ewma.rs
@@ -1,10 +1,15 @@
 //! Shared exponentially-weighted moving average (EWMA) primitive.
 //!
 //! A single, unit-tested EWMA type with two call sites: the adaptive
-//! basis-read dispatcher ([`crate::adaptive_dispatch`]) folds per-backend
+//! basis-read dispatcher (`crate::adaptive_dispatch`) folds per-backend
 //! throughput samples through it today, and the drum-buffer-rope throughput
 //! governor's per-stage telemetry will fold stage samples through the same
 //! type. One implementation, one smoothing rule, no drift between consumers.
+//!
+//! `adaptive_dispatch` is named without an intra-doc link throughout this
+//! module: it is gated behind the off-by-default `adaptive-basis-dispatch`
+//! feature, so a link would be unresolvable in a default build and
+//! `#![deny(rustdoc::broken_intra_doc_links)]` would fail `cargo doc`.
 //!
 //! # Smoothing rule
 //!
@@ -27,7 +32,7 @@
 ///
 /// The type is deliberately storage-agnostic: it holds the smoothing factor and
 /// the current value only. Callers that need lock-free or atomic persistence
-/// (e.g. [`crate::adaptive_dispatch`], which stores the value in an `AtomicU64`)
+/// (e.g. `crate::adaptive_dispatch`, which stores the value in an `AtomicU64`)
 /// reconstruct an `Ewma` from their own storage via [`Ewma::with_seed`], fold a
 /// sample, and write the result back.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -176,10 +176,15 @@ pub mod zero_detect;
 pub mod adaptive_dispatch;
 
 /// Shared exponentially-weighted moving average primitive. One implementation
-/// with two call sites: [`adaptive_dispatch`]'s per-backend throughput
-/// tracker consumes it now, and the throughput governor's per-stage telemetry
-/// will consume it later. Always compiled - unlike [`adaptive_dispatch`] it is
-/// not feature-gated, so both consumers share the same smoothing rule.
+/// with two call sites: `adaptive_dispatch`'s per-backend throughput tracker
+/// consumes it now, and the throughput governor's per-stage telemetry will
+/// consume it later. Always compiled - unlike `adaptive_dispatch` it is not
+/// feature-gated, so both consumers share the same smoothing rule.
+///
+/// `adaptive_dispatch` is named without an intra-doc link because it does not
+/// exist in a default build (see its own gate above), so the link would be
+/// unresolvable and `#![deny(rustdoc::broken_intra_doc_links)]` would fail
+/// `cargo doc` on the default feature set.
 pub mod ewma;
 
 /// Linux `FICLONERANGE` partial-reflink wrapper for the delta-apply COPY-token

--- a/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
+++ b/crates/rsync_io/src/ssh/embedded/sync_bridge.rs
@@ -1,6 +1,10 @@
 //! Sync/async bridge primitives for embedded SSH streams.
 //!
-//! This module provides the inverse of [`crate::channel_adapter`]: instead of
+//! This module provides the inverse of `crate::channel_adapter` (named without
+//! an intra-doc link: that module is gated behind the off-by-default
+//! `async-ssh` feature, so the link would be unresolvable in a default build
+//! and `#![deny(rustdoc::broken_intra_doc_links)]` would fail `cargo doc`):
+//! instead of
 //! wrapping a sync byte stream as `AsyncRead`/`AsyncWrite`, it wraps an
 //! `AsyncRead + AsyncWrite` stream (specifically `russh`'s channel I/O) as
 //! `std::io::Read`/`std::io::Write` so the existing synchronous multiplex and

--- a/crates/transfer/src/receiver/directory/mod.rs
+++ b/crates/transfer/src/receiver/directory/mod.rs
@@ -8,13 +8,17 @@
 
 mod backup;
 mod creation;
-// `pub(in crate::receiver)` so the receiver context can name `DeletedEntry`
-// for its deferred `--delete-delay` victim queue.
+/// Directory deletion, including the deferred `--delete-delay` queue.
+///
+/// `pub(in crate::receiver)` so the receiver context can name `DeletedEntry`
+/// for its deferred `--delete-delay` victim queue.
 pub(in crate::receiver) mod deletion;
 mod links;
 mod missing_args;
-// `pub(in crate::receiver)` so the regular-file candidate pass can name
-// `MakeWayFor` for its `DEL_FOR_FILE` removal (generator.c:2149).
+/// Removal of a destination entry obstructing the incoming one.
+///
+/// `pub(in crate::receiver)` so the regular-file candidate pass can name
+/// `MakeWayFor` for its `DEL_FOR_FILE` removal (generator.c:2149).
 pub(in crate::receiver) mod obstacle;
 mod special;
 


### PR DESCRIPTION
Two commits, one question each. Both answer "does what the code says actually
reach the reader who needs it?"

## 1. `docs(rustdoc)` - the public items rustdoc could not see, plus the gate

**Seven `//` blocks documented a `pub` item**, so their text never reached the
generated docs. Found positionally - a `//` run whose next non-attribute line
declares a `pub` item - not by content. A census keyed on comment CONTENT is
false-positive dominated; this one is mechanical.

Nine sites matched, and **two are deliberately left as `//`**: in
`local_copy/overrides.rs` and `local_copy/plan/report.rs` the comment justifies
the `#[cfg_attr]` / `#[allow]` beneath it, not the item. Promoting those would
attach a lint rationale to a public surface as if it described the surface.

Text is preserved verbatim, upstream citations included. The one rewrite is
`socket_options/consts.rs`, where a single group note covered two constants;
split per item, matching the file's own house style.

**Five intra-doc links could not resolve in a default build**, and the existing
gate is structurally unable to see them:

| site | target | why unresolvable by default |
|---|---|---|
| `fast_io/src/lib.rs`, `ewma.rs` (x4) | `adaptive_dispatch` | `adaptive-basis-dispatch` feature, off by default |
| `rsync_io/.../sync_bridge.rs` | `crate::channel_adapter` | `async-ssh` feature, off by default |
| `fast_io/src/confinement.rs` | `PinnedRoot` | a **private** struct |

plus one already on the branch in `module_list/types.rs`, where the link was
`Transport::Quic` and its prose still described the variant as unbuilt.

Every crate denies `rustdoc::broken_intra_doc_links`, so each is a hard failure.
**Measured on the pristine base:**

```
cargo doc --no-deps --workspace                 ->  7 errors (fast_io, rsync_io)
cargo doc --no-deps --workspace --all-features  ->  clean
```

**That gap is the point.** Under `--all-features` the gated items exist, the
link resolves, and the gate is green. `ci.yml`'s `rustdoc-links` job runs only
`--all-features`, deliberately mirroring `pages.yml` - correct for the question
Pages asks, and structurally unable to ask this one. So the fix is paired with a
**second step on default features**. Neither subsumes the other:
`crates/fast_io/src/io_uring` is `cfg(all(target_os = "linux", feature =
"io_uring"))` and only the all-features run compiles it.

Names stay in backticks with the reason stated at each site, rather than being
deleted - the prose still says what it said, and the next reader learns why it
is not a link.

After: **both invocations document all 25 crates cleanly, 0 errors.**

## 2. `docs(changelog)` - the ten PRs merged since the last sweep

#7624 brought Unreleased up to #7620 and then stopped being true. #7621-#7632
landed after it (#7624 is that pass; #7628 never merged).

Each entry is placed in the subsection its change belongs to, and **#7625 is
split across two** because it is two changes: wiring `--force` is a receiver
fix, the synthetic-transfer-root guard that wiring made necessary is a
peer-supplied input bound. Filing it once would hide whichever half the reader
wanted.

Wording comes from each merge commit's body, not its title - the titles compress
away the part that matters.

## Measured, not assumed

The large "comment cleanup" premise **does not reproduce at scale**, and that is
worth stating rather than quietly doing less:

- 72% of comment lines are already rustdoc
- all 25 crates already `#![deny(missing_docs)]` - which is *why* only nine
  positional sites exist
- the "commented-out code" and "separator" classes are style, not defects

## Verification

- `cargo doc --no-deps --workspace` - 0 errors (was 7)
- `cargo doc --no-deps --workspace --all-features` - 0 errors
- `cargo fmt --all -- --check` clean
- clippy on the five touched crates: no new diagnostics; the residual
  `collapsible_if` / `is_multiple_of` warnings are a newer local toolchain on
  files this branch does not touch
- `ci.yml` validated by loading the committed YAML and reading back the job's
  actual `run` list, not by inspecting the diff
