### PR TITLE
fix(daemon): keep the DOTDIR marker on a module operand ending in /.

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -70,14 +70,29 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 /// rather than `PathBuf::join`, which would emit `\` on Windows for a path that
 /// is about to be compared against module-relative wire names.
 ///
+/// ⚠ A dropped `.` or `..` component leaves the separator that PRECEDED it in
+/// place. Upstream does not walk components and rejoin them; it copies each one
+/// "through next slash" (`util1.c:1201`), so the slash is already in the output
+/// buffer by the time the next component is examined and discarded. That is why
+/// `sub/.` sanitizes to `sub/` and not to `sub`: the surviving trailing slash is
+/// upstream's DOTDIR marker, which `flist.c:2589-2594` turns into `DOTDIR_NAME`
+/// and `flist.c:2696` then reads as the `name_type != NORMAL_NAME` disjunct of
+/// `link_stat()`'s follow decision. Rejoining the kept components discards that
+/// slash, so `rsync://host/mod/sym-to-dir/.` was `lstat`ed and shipped as a
+/// symlink where upstream follows it and ships the directory's CONTENTS.
+/// Delegating to the shared `sanitize_path` keeps the two from drifting again.
+///
+/// The empty string, not `"."`, means "collapsed to nothing" here; upstream
+/// spells that case `"."` (`util1.c:1204-1206`) and the callers below turn the
+/// empty string into the module root, which is the same destination.
+///
 /// Deliberately NOT `lexically_normalize`, which walks the same components but
 /// PRESERVES an unpoppable leading `..` so its caller's `starts_with` containment
 /// check can reject an escaping alt-basis path. Four differences - input type,
 /// output type, separator policy, leading-`..` policy - so they are two
 /// functions with two contracts, not one to be deduplicated.
 fn collapse_module_relative(tail: &str) -> String {
-    let mut out: Vec<&str> = Vec::new();
-    // Splits on `/` ONLY. `tail` is a peer-supplied wire path, and the wire is
+    // Inspects `/` ONLY. `tail` is a peer-supplied wire path, and the wire is
     // `/`-separated on every host (upstream `pathjoin()`); upstream's own
     // `sanitize_path` tests `== '/'` at every separator check and has no `\`
     // arm at all, so a `\` is copied through as an ordinary byte of the
@@ -85,19 +100,21 @@ fn collapse_module_relative(tail: &str) -> String {
     // separator silently relocates a legitimately-named file - `a\b` becomes
     // `a/b` - and strips a trailing one. Contrast the `module_path` checks
     // below, which DO accept `\` because they inspect an operator-configured
-    // LOCAL path that may legitimately be Windows-style.
-    for segment in tail.split('/') {
-        match segment {
-            "" | "." => {}
-            ".." => {
-                // upstream util1.c:1183-1191 - back up one component, or drop
-                // the `..` outright when already at the start (depth 0).
-                out.pop();
-            }
-            other => out.push(other),
-        }
+    // LOCAL path that may legitimately be Windows-style. `sanitize_path`
+    // inspects only the ASCII `/` and `.` bytes, so it upholds that policy.
+    //
+    // `drop_dot_dirs` is on, matching upstream's `util1.c:1141`
+    // `!relative_paths || !(flags & SP_KEEP_DOT_DIRS)`: the daemon's
+    // `options.c:2405` call passes `SP_KEEP_DOT_DIRS`, but the flag only takes
+    // effect under `--relative`, and under `--relative` a surviving `sub/.`
+    // is reduced to the same `sub/` by `clean_fname(CFN_DROP_TRAILING_DOT_DIR
+    // | CFN_KEEP_TRAILING_SLASH)` at `flist.c:2634` anyway.
+    let collapsed = filters::sanitize_path::sanitize_path(tail);
+    if collapsed == "." {
+        String::new()
+    } else {
+        collapsed
     }
-    out.join("/")
 }
 
 /// Resolves the receiver's on-disk destination directory from the client's
@@ -146,16 +163,18 @@ fn resolve_receiver_dest(
     // make-a-directory branch on `file_total > 1 || trailing_slash`: it mkdirs
     // the dest, chdirs into it and returns a NULL local_name, so a single
     // source file lands INSIDE. Without the slash the dest names the file
-    // itself. `collapse_module_relative` splits on `/` and drops the empty
-    // trailing segment, so the signal dies here unless it is re-appended -
-    // and the receiver then silently writes a FILE where the peer asked for a
-    // directory. oc's local path already implements the upstream rule
-    // correctly (measured); only the daemon was losing the input to it.
+    // itself. oc's local path already implements the upstream rule correctly
+    // (measured); only the daemon was losing the input to it.
+    //
+    // The slash is read off `collapsed`, NOT off `tail`: upstream's
+    // `sanitize_path` is what decides whether the sanitized arg ends in `/`,
+    // and it emits one for shapes the raw tail does not end with - `sub/.` and
+    // `sub/x/..` both sanitize to `sub/`. Testing the raw tail dropped those.
     //
     // Built by pushing onto the OsString rather than `PathBuf::join`, which
     // normalises a trailing separator away, for the same reason
     // `resolve_sender_sources` below does it by hand.
-    if tail.ends_with('/') {
+    if collapsed.ends_with('/') {
         let mut buf = module_path.as_os_str().to_owned();
         if !buf
             .as_encoded_bytes()
@@ -165,7 +184,6 @@ fn resolve_receiver_dest(
             buf.push("/");
         }
         buf.push(&collapsed);
-        buf.push("/");
         return std::path::PathBuf::from(buf);
     }
     module_path.join(collapsed)
@@ -226,16 +244,21 @@ fn resolve_sender_sources(
             sources.push(module_root_dotdir(module_path));
             continue;
         }
-        // Preserve the trailing slash so the sender can detect a dotdir-style
-        // source (upstream flist.c:2312-2322 appends `.` and sets DOTDIR_NAME
-        // for any `fbuf[len-1] == '/'`). Upstream rsync joins module-relative
-        // paths with a literal `/` regardless of host OS (util1.c pathjoin()),
-        // so build the result the same way instead of going through
-        // PathBuf::join, which on Windows inserts `\` and on macOS leaves
-        // a trailing `/` that doubles when we re-append.
+        // `trimmed` already carries the trailing slash whenever upstream's
+        // sanitize would leave one, so the sender can detect a dotdir-style
+        // source (upstream flist.c:2589-2594 appends `.` and sets DOTDIR_NAME
+        // for any `fbuf[len-1] == '/'`). That covers the shapes the RAW tail
+        // does not end with: `sym-to-dir/.` and `sym-to-dir/x/..` both sanitize
+        // to `sym-to-dir/`, and without the marker flist.c:2696's
+        // `copy_dirlinks || name_type != NORMAL_NAME` follow decision fails
+        // over, so a symlinked directory ships as a symlink instead of its
+        // contents. Upstream rsync joins module-relative paths with a literal
+        // `/` regardless of host OS (util1.c pathjoin()), so build the result
+        // the same way instead of going through PathBuf::join, which on Windows
+        // inserts `\` and on macOS leaves a trailing `/` that doubles when we
+        // re-append.
         // upstream flist.c tests `fbuf[len-1] == '/'` only - a trailing `\` is
         // part of the NAME on Unix, not a dotdir marker.
-        let trailing = tail.ends_with('/');
         let mut buf = module_path.as_os_str().to_owned();
         let needs_leading_sep = !buf
             .as_encoded_bytes()
@@ -245,14 +268,6 @@ fn resolve_sender_sources(
             buf.push("/");
         }
         buf.push(trimmed);
-        if trailing
-            && !buf
-                .as_encoded_bytes()
-                .last()
-                .is_some_and(|b| *b == b'/' || *b == b'\\')
-        {
-            buf.push("/");
-        }
         sources.push(std::path::PathBuf::from(buf));
     }
     if all_empty {

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3423,6 +3423,103 @@ mod module_access_tests {
         assert_eq!(lossy, vec!["/srv/upload/d1/d2/".to_owned()]);
     }
 
+    // Upstream's `sanitize_path` copies each component THROUGH its trailing
+    // slash (util1.c:1201) and only then examines the next one, so discarding a
+    // `.` (util1.c:1163-1172) leaves that slash in the output: `d1/.` sanitizes
+    // to `d1/`, not `d1`. The surviving slash is upstream's DOTDIR marker
+    // (flist.c:2589-2594), and it is the `name_type != NORMAL_NAME` disjunct of
+    // `link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)`
+    // (flist.c:2696) - so losing it makes a symlinked directory ship as a
+    // symlink instead of its contents. oc split on `/`, dropped the `.` segment
+    // AND its separator, and re-attached a slash only when the RAW tail ended in
+    // one, which `d1/.` does not.
+    //
+    // ⚠ Asserts on the lossy STRING, not on PathBuf equality: `Path::new("a/")
+    // == Path::new("a")` is TRUE because Path compares components and discards
+    // a trailing separator, so a PathBuf assertion would pass both before and
+    // after the fix and could not see the thing under test.
+    #[test]
+    fn resolve_sender_sources_keeps_the_dotdir_marker_on_a_trailing_dot() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/d2/.".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let lossy: Vec<String> = sources
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(lossy, vec!["/srv/upload/d1/d2/".to_owned()]);
+    }
+
+    // Same rule reached through the `..` arm: upstream backs `sanp` up to just
+    // past the previous separator (util1.c:1186-1190), so `d1/d2/..` also ends
+    // in a slash and also carries the marker.
+    #[test]
+    fn resolve_sender_sources_keeps_the_dotdir_marker_through_a_dotdot_collapse() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/d2/..".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let lossy: Vec<String> = sources
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(lossy, vec!["/srv/upload/d1/".to_owned()]);
+    }
+
+    // Non-vacuity companion for the two cells above: the marker must be EARNED,
+    // never appended. Its verdict does not depend on the fix, so a green
+    // companion beside a red pin proves the assertion is about the marker and
+    // not about a resolver that decorates every source with a slash.
+    #[test]
+    fn resolve_sender_sources_does_not_invent_a_dotdir_marker() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/d1/d2".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let lossy: Vec<String> = sources
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(lossy, vec!["/srv/upload/d1/d2".to_owned()]);
+    }
+
+    // The filed claim for the second defect was that every `.` operand is
+    // stripped and nothing transfers. It is not: a lone `.` is short-circuited
+    // to the module root WITH the marker before the collapse is ever reached.
+    // Pinned so the claim cannot become true later.
+    #[test]
+    fn resolve_sender_sources_bare_dot_operand_keeps_the_module_root_marker() {
+        let module_path = std::path::Path::new("/srv/upload");
+        for tail in ["upload/.", "upload/./", "upload/./."] {
+            let args = vec![".".to_owned(), tail.to_owned()];
+            let sources = resolve_sender_sources(module_path, &args, "upload");
+            let lossy: Vec<String> = sources
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect();
+            assert_eq!(
+                lossy,
+                vec!["/srv/upload/".to_owned()],
+                "`{tail}` names the module root with upstream's DOTDIR marker \
+                 (flist.c:2601-2604); an empty list is the stripped-to-nothing \
+                 shape the note claimed"
+            );
+        }
+    }
+
+    // Receiver-side counterpart of the sender pin: the same `sanitize_path`
+    // rule feeds `get_local_name()`'s `trailing_slash` (main.c:741), which
+    // decides whether a single incoming file lands INSIDE the destination or
+    // renames it.
+    #[test]
+    fn resolve_receiver_dest_keeps_the_slash_through_a_trailing_dot_dir() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/realdir/.".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        assert_eq!(
+            dest.as_os_str(),
+            std::ffi::OsStr::new("/srv/upload/realdir/")
+        );
+    }
+
     #[test]
     fn resolve_sender_sources_collapses_parent_dir_under_module_root() {
         // The escape clamps at the module root instead of being refused, which

--- a/crates/transfer/tests/daemon_pull_dotdir_operand_marker.rs
+++ b/crates/transfer/tests/daemon_pull_dotdir_operand_marker.rs
@@ -1,0 +1,351 @@
+//! A daemon-served operand ending in `/.` must keep upstream's DOTDIR marker.
+//!
+//! # Background
+//!
+//! Upstream's daemon runs every client positional through
+//! `sanitize_path(NULL, argv[i], "", 0, SP_KEEP_DOT_DIRS)` (`options.c:2402-2405`,
+//! gated on the `sanitize_paths` that `clientserver.c:1068` sets for every
+//! connection with a module dir). That sanitizer does NOT split the path into
+//! components and rejoin them: it copies each component *through the next
+//! slash* (`util1.c:1201`) and only then examines the following one, so a
+//! discarded `.` (`util1.c:1163-1172`) or `..` (`util1.c:1183-1191`) leaves the
+//! separator that preceded it in the output buffer. `sym-to-dir/.` therefore
+//! sanitizes to `sym-to-dir/`, not to `sym-to-dir`.
+//!
+//! That surviving slash is load-bearing. `send_file_list()` reads it at
+//! `flist.c:2589-2594` and sets `name_type = DOTDIR_NAME`, and the operand's
+//! stat is then taken as
+//! `link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)`
+//! (`flist.c:2696`). The second disjunct is the marker: with it, a symlink whose
+//! target is a directory is followed and the directory's CONTENTS are sent
+//! (`flist.c:286-299`); without it the operand is `lstat`ed and ships as a
+//! symlink under its own basename.
+//!
+//! oc-rsync's daemon resolved the client tail by splitting on `/`, dropping
+//! every `.`/`..` segment and rejoining the survivors, then re-attached a
+//! trailing slash only when the RAW tail ended in one. `sym-to-dir/.` does not,
+//! so the marker was destroyed before the sender ever saw the operand.
+//!
+//! # Why this matters (Rule 9)
+//!
+//! `rsync -a rsync://host/mod/current/. DEST` where `current -> releases/2026-08-25`
+//! is an ordinary release-pointer pull. MEASURED on a loopback daemon against
+//! real rsync 3.5.0: upstream delivers the release directory's contents; oc
+//! delivered a single dangling symlink named `current` and exited 0.
+//!
+//! # Cells
+//!
+//! Each defect gets one discriminating cell and one non-vacuity companion. A
+//! companion is a cell whose verdict does not depend on the fix, so a green
+//! companion beside a red pin proves the fixture is live rather than inert.
+//!
+//! - `dotdir_marker_on_a_trailing_dot_follows_the_symlinked_directory` - the pin
+//!   for the dropped marker.
+//! - `an_operand_without_the_marker_still_ships_the_symlink_itself` - its
+//!   companion. It asserts the OPPOSITE outcome for the marker-less spelling, so
+//!   it fails if the symlink is missing, unreachable or already followed, and it
+//!   also refuses a "fix" that simply follows every operand.
+//! - `a_bare_dot_operand_transfers_the_whole_module` - the pin for the filed
+//!   claim that a `.` operand is stripped and nothing transfers.
+//! - `a_bare_module_root_operand_transfers_the_whole_module` - its companion:
+//!   the same payload requested with the spelling that never carried a `.`, so
+//!   it stays green whatever happens to dot handling and fails only if the
+//!   module itself is unservable.
+//!
+//! # Platform gate
+//!
+//! `#![cfg(unix)]` - the fixture plants a symlink and the daemon is spawned with
+//! `use chroot = false`, matching the sibling daemon-spawning tests.
+//!
+//! # Skip semantics
+//!
+//! Self-skips (prints `skipping:` and returns) when a tempdir cannot be made or
+//! the daemon fails to start. Any other divergence is a real regression.
+//!
+//! # Upstream References
+//!
+//! - `rsync-3.5.0/options.c:2402-2405` - the daemon's per-arg `sanitize_path()`
+//! - `rsync-3.5.0/clientserver.c:1068` - `if (module_dirlen) sanitize_paths = 1`
+//! - `rsync-3.5.0/util1.c:1163-1172` - a `.` component is skipped
+//! - `rsync-3.5.0/util1.c:1201` - each component is copied *through* its slash
+//! - `rsync-3.5.0/flist.c:2589-2594` - a trailing `/` sets `DOTDIR_NAME`
+//! - `rsync-3.5.0/flist.c:2696` - `copy_dirlinks || name_type != NORMAL_NAME`
+//! - `rsync-3.5.0/flist.c:286-299` - `link_stat()`'s `follow_dirlinks` arm
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use tempfile::{TempDir, tempdir};
+
+/// Payload inside the symlinked directory. Reaching it is the proof the link
+/// was followed; a status-only assertion cannot see the difference.
+const PAYLOAD: &[u8] = b"dotdir-marker payload\n";
+
+const MODULE: &str = "dotmod";
+
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [{MODULE}]\n\
+         path = {root}\n\
+         comment = dotdir operand marker regression\n\
+         read only = true\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        root = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Kills the daemon child on drop so a panicking cell never leaks the listener.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
+}
+
+/// The module tree every cell serves:
+///
+/// ```text
+/// <module>/realdir/f.txt
+/// <module>/sym-to-dir -> realdir
+/// ```
+struct Fixture {
+    _tmp: TempDir,
+    config: PathBuf,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Option<Self> {
+        let tmp = tempdir().ok()?;
+        // macOS resolves `/tmp -> /private/tmp`; canonicalise before planting
+        // the fixture's own symlink so the ambient prefix is not what is
+        // measured.
+        let root = fs::canonicalize(tmp.path()).ok()?;
+        let module_root = root.join("module");
+        let realdir = module_root.join("realdir");
+        fs::create_dir_all(&realdir).ok()?;
+        fs::write(realdir.join("f.txt"), PAYLOAD).ok()?;
+        symlink("realdir", module_root.join("sym-to-dir")).ok()?;
+        let config = root.join("rsyncd.conf");
+        write_daemon_config(
+            &config,
+            &root.join("rsyncd.pid"),
+            &root.join("rsyncd.log"),
+            &module_root,
+        )
+        .ok()?;
+        Some(Self {
+            config,
+            root,
+            _tmp: tmp,
+        })
+    }
+}
+
+/// Everything a cell needs to judge a pull: exit status, stderr, and the
+/// destination tree as `/`-joined relative paths in sorted order.
+struct Pulled {
+    status: std::process::ExitStatus,
+    stderr: String,
+    tree: Vec<String>,
+}
+
+/// Pulls `rsync://127.0.0.1:<port>/dotmod/<tail>` into a fresh destination.
+fn pull(tail: &str) -> Option<Pulled> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(fixture) = Fixture::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return None;
+    };
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &fixture.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return None;
+        }
+    };
+
+    let dest = fixture.root.join("dest");
+    fs::create_dir_all(&dest).expect("create destination");
+
+    let src_url = OsString::from(format!("rsync://127.0.0.1:{port}/{MODULE}/{tail}"));
+    let mut dest_arg = dest.clone().into_os_string();
+    dest_arg.push("/");
+    let args: &[&OsStr] = &[OsStr::new("-a"), &src_url, &dest_arg];
+
+    let output = Command::new(&oc_bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn oc-rsync client (daemon pull)");
+
+    Some(Pulled {
+        status: output.status,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        tree: collect_tree(&dest, &dest),
+    })
+}
+
+/// Relative `/`-joined names of everything under `dir`, sorted. Symlinks are
+/// listed but never descended, so a followed link and a shipped link produce
+/// visibly different trees.
+fn collect_tree(root: &Path, dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .into_owned();
+        let is_dir = fs::symlink_metadata(&path).is_ok_and(|m| m.file_type().is_dir());
+        out.push(rel);
+        if is_dir {
+            out.extend(collect_tree(root, &path));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// The pin for defect A: the marker survives the daemon's path resolution, so
+/// the symlinked directory is followed and its CONTENTS arrive.
+#[test]
+fn dotdir_marker_on_a_trailing_dot_follows_the_symlinked_directory() {
+    let Some(pulled) = pull("sym-to-dir/.") else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/sym-to-dir/.` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["f.txt".to_owned()],
+        "a `/.` operand carries upstream's DOTDIR marker (flist.c:2589-2594), so \
+         link_stat follows the symlinked directory (flist.c:2696) and the \
+         CONTENTS arrive; a tree containing `sym-to-dir` means the marker was \
+         dropped and the operand was lstat'ed",
+    );
+}
+
+/// Non-vacuity companion for defect A. Its verdict does not depend on the fix:
+/// it fails if the fixture's symlink is missing or unreachable, and it fails if
+/// a "fix" followed every operand instead of only marked ones.
+#[test]
+fn an_operand_without_the_marker_still_ships_the_symlink_itself() {
+    let Some(pulled) = pull("sym-to-dir") else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/sym-to-dir` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["sym-to-dir".to_owned()],
+        "without the DOTDIR marker `link_stat`'s follow_dirlinks argument is \
+         `copy_dirlinks` alone (flist.c:2696), which is off here, so the operand \
+         must ship as the symlink it is",
+    );
+}
+
+/// The pin for defect B as filed: a bare `.` operand must not be stripped.
+#[test]
+fn a_bare_dot_operand_transfers_the_whole_module() {
+    let Some(pulled) = pull(".") else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/.` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec![
+            "realdir".to_owned(),
+            "realdir/f.txt".to_owned(),
+            "sym-to-dir".to_owned(),
+        ],
+        "a lone `.` operand names the module root with the DOTDIR marker \
+         (flist.c:2601-2604), so the module's whole contents transfer; an empty \
+         tree is the `.`-stripped-to-nothing shape",
+    );
+}
+
+/// Non-vacuity companion for defect B: the same payload requested with the
+/// spelling that never carried a `.`. It stays green whatever happens to dot
+/// handling, so a red pin beside it means dot handling, not an unservable
+/// module.
+#[test]
+fn a_bare_module_root_operand_transfers_the_whole_module() {
+    let Some(pulled) = pull("") else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec![
+            "realdir".to_owned(),
+            "realdir/f.txt".to_owned(),
+            "sym-to-dir".to_owned(),
+        ],
+        "the module root spelled without any `.` must serve its whole tree",
+    );
+}


### PR DESCRIPTION
The daemon sender destroyed the DOTDIR marker on a module operand ending in `/.`, so `rsync://host/mod/sym-to-dir/.` shipped the symlink itself instead of the directory it points at.

## Upstream

`sanitize_path` never splits and rejoins. Each component is copied **through** its separator:

```c
/* util1.c:1201 */
while (*p && (*sanp++ = *p++) != '/') {}
```

so the slash is already in the output buffer when the next component is discarded (`util1.c:1163-1172` skips a `.`). `sym-to-dir/.` therefore sanitizes to `sym-to-dir/`, and `flist.c:2589-2594` reads that trailing slash as `DOTDIR_NAME`, which `flist.c:2696` turns into a following `link_stat`.

The daemon runs every positional through this (`options.c:2402-2405`, enabled for any module with a dir at `clientserver.c:1068`).

## Defect

`collapse_module_relative` (`path_resolution.rs:78`) split on `/`, dropped `""`/`"."` segments, and re-joined — then both call sites re-attached a trailing slash only when the **raw** tail ended in one. `sym-to-dir/.` does not, so the marker was gone before the sender's stat decision.

Fix delegates the collapse to the shared `filters::sanitize_path`, which already implements the copy-through-the-slash walk, and reads the trailing slash off the **sanitized** result. `..` gets the same repair for free (`d1/d2/..` → `d1/`). Containment is unchanged: same depth-0 `..` collapse, same `/`-only separator policy, `\` still an ordinary filename byte.

## Measured against the real 3.5.0 binary

Client is always upstream 3.5.0; only the daemon differs.

| operand | upstream | before | after |
|---|---|---|---|
| `sym-to-dir/.` | `deep/ deep/g.txt f.txt` | `sym-to-dir` | `deep/ deep/g.txt f.txt` |
| `realdir/.` | `deep/ deep/g.txt f.txt` | `realdir/ realdir/deep/… realdir/f.txt` | `deep/ deep/g.txt f.txt` |
| `realdir/./.` | same | `realdir/ …` | same |
| `realdir/deep/../.` | same | `realdir/ …` | same |
| 12 other shapes | — | already matched | unchanged |

**12/16 → 16/16.** Cross-bisect localises it to the sender: with arg `sym-to-dir/.`, `daemon=up` gives `./f.txt` for either client, `daemon=oc` gives `./sym-to-dir` for either.

Local, SSH and `--files-from` legs were already correct (26/26 before any change) — this is daemon-only.

## Pins

`crates/transfer/tests/daemon_pull_dotdir_operand_marker.rs` (4 end-to-end daemon cells) + 5 resolver unit cells.

Mutation-proven — with the fix reverted and the tests kept: daemon `34 run: 31 passed, 3 failed`, transfer `4 run: 3 passed, 1 failed`. With the fix: 34/34 and 4/4. The reddening cell `dotdir_marker_on_a_trailing_dot_follows_the_symlinked_directory` fails `["sym-to-dir"]` vs `["f.txt"]` — the defect's exact signature.

Companions stay green in both arms, so the fixture cannot be inert: `resolve_sender_sources_does_not_invent_a_dotdir_marker`, `an_operand_without_the_marker_still_ships_the_symlink_itself` (asserts the opposite outcome, so it also refuses a follow-everything fix), `a_bare_dot_operand_transfers_the_whole_module`, `a_bare_module_root_operand_transfers_the_whole_module`.

## Gates

`check_rustfmt_all.py` clean (3389 files); `clippy -p daemon --all-targets` and `-p transfer --tests` clean on touched files; `nextest -p daemon` 1801 passed. `-p transfer -p core -p cli` 9422/9424 — the 2 failures are `run_client_sparse_copy_creates_holes` and `transfer_request_with_sparse_preserves_holes`, verified failing on the pristine base, pre-existing APFS sparse-block noise.

## Found while measuring, filed separately

The daemon `--relative` sender leaks absolute module paths: `-aR rsync://h/m/<anything>` diverges in 14 of 16 shapes because oc hands the sender an absolute module path where upstream `change_dir`s so names are module-relative. Architectural, larger than this fix, and provably untouched by it — the same 14 cells diverge identically before and after.
