### PR TITLE
test(ci): build the old-rsync oracles the 3.5.0 testsuite asserts against

### DIFF
--- a/.github/workflows/_upstream-testsuite.yml
+++ b/.github/workflows/_upstream-testsuite.yml
@@ -53,6 +53,22 @@ on:
           contexts they declare - are unchanged.
         type: string
         default: 'pipe'
+      legacy_oracles:
+        description: >-
+          `on` builds the historical rsync binaries the 3.5.0 testsuite looks
+          for in old_versions/ (see tools/ci/run_upstream_testsuite.sh,
+          ensure_legacy_oracles) so the tests that name a release assert
+          against that release. `off` (default) builds none, and the harness
+          NAMES every test that will therefore assert against a static fallback
+          instead - the degradation stays visible either way.
+
+          Off by default because putting those binaries on disk un-skips
+          daemon-max-alloc-zero, i.e. it MOVES rows in this leg's
+          --expect-result manifest. Manifest rows may only be re-baselined from
+          a measured run, so a leg opts in when someone is ready to measure the
+          move, never as a side effect of an unrelated change.
+        type: string
+        default: 'off'
 
 permissions:
   contents: read
@@ -86,6 +102,7 @@ jobs:
       TRANSPORT: ${{ inputs.transport }}
       USE_TCP: ${{ inputs.transport == 'tcp' && 'yes' || 'no' }}
       DAEMON_TESTS_ONLY: ${{ inputs.transport == 'tcp' && 'yes' || 'no' }}
+      LEGACY_ORACLES: ${{ inputs.legacy_oracles }}
 
     steps:
       - name: Validate transport input
@@ -128,11 +145,16 @@ jobs:
 
       - name: Cache upstream rsync source
         id: cache-upstream
+        # The cached tree also carries old_versions/rsync_<ver>, the legacy
+        # daemon oracle the harness builds for the tests that assert against a
+        # real old rsync rather than a static prediction of one - so
+        # build_old_rsync_oracle.sh is part of the key: change how the oracle is
+        # built and the tree holding it must be rebuilt, not restored.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             target/interop/upstream-src/rsync-${{ env.UPSTREAM_RSYNC_VERSION }}
-          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh') }}-${{ runner.os }}
+          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh', 'tools/ci/build_old_rsync_oracle.sh') }}-${{ runner.os }}
 
       - name: Build oc-rsync (release)
         uses: ./.github/actions/build-oc-rsync
@@ -265,6 +287,7 @@ jobs:
       TRANSPORT: ${{ inputs.transport }}
       USE_TCP: ${{ inputs.transport == 'tcp' && 'yes' || 'no' }}
       DAEMON_TESTS_ONLY: ${{ inputs.transport == 'tcp' && 'yes' || 'no' }}
+      LEGACY_ORACLES: ${{ inputs.legacy_oracles }}
 
     steps:
       - name: Validate transport input
@@ -304,11 +327,16 @@ jobs:
 
       - name: Cache upstream rsync source
         id: cache-upstream
+        # The cached tree also carries old_versions/rsync_<ver>, the legacy
+        # daemon oracle the harness builds for the tests that assert against a
+        # real old rsync rather than a static prediction of one - so
+        # build_old_rsync_oracle.sh is part of the key: change how the oracle is
+        # built and the tree holding it must be rebuilt, not restored.
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             target/interop/upstream-src/rsync-${{ env.UPSTREAM_RSYNC_VERSION }}
-          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh') }}-${{ runner.os }}
+          key: upstream-testsuite-src-${{ env.UPSTREAM_RSYNC_VERSION }}-${{ hashFiles('tools/ci/run_upstream_testsuite.sh', 'tools/ci/build_old_rsync_oracle.sh') }}-${{ runner.os }}
 
       - name: Build oc-rsync (release)
         uses: ./.github/actions/build-oc-rsync
@@ -336,6 +364,7 @@ jobs:
             "EMIT_EXPECT_RESULT=${EMIT_EXPECT_RESULT:-}" \
             "USE_TCP=${USE_TCP:-no}" \
             "DAEMON_TESTS_ONLY=${DAEMON_TESTS_ONLY:-no}" \
+            "LEGACY_ORACLES=${LEGACY_ORACLES:-off}" \
             "GITHUB_ACTIONS=${GITHUB_ACTIONS:-}" \
             "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}" \
             bash tools/ci/run_upstream_testsuite.sh 2>&1 \

--- a/.github/workflows/upstream-testsuite-root-tcp.yml
+++ b/.github/workflows/upstream-testsuite-root-tcp.yml
@@ -30,3 +30,19 @@ jobs:
       variant: 'root'
       transport: 'tcp'
       expect_result_root: tools/ci/upstream-3.5.0-expect.root.tcp.txt
+      # The only leg that can run daemon-symlink-escape-matrix (it needs root
+      # AND a real TCP peer), and that test takes the expected value of 100 of
+      # its 200 cells from a live rsync 3.2.7 daemon when one is on disk and
+      # from a hand-written prediction of 3.2.7 when one is not - reporting PASS
+      # either way. So this leg builds the archive rather than asserting a
+      # prediction, and it is the leg where the change is affordable: nightly,
+      # not a required check, and already carrying 26 known failures.
+      #
+      # EXPECTED, NOT YET MEASURED: the same binary un-skips
+      # daemon-max-alloc-zero, which stats old_versions/rsync_3.2.7 and calls
+      # test_skipped() when it is missing, and enables the md5-downgrade half of
+      # daemon-auth-digest-floor (old_versions/rsync_3.1.3). Both rows in
+      # upstream-3.5.0-expect.root.tcp.txt will move. Re-baseline them from this
+      # workflow's EMIT_EXPECT_RESULT artifact after the first run - never by
+      # guessing the new outcome here.
+      legacy_oracles: 'on'

--- a/docs/interop-status.md
+++ b/docs/interop-status.md
@@ -389,6 +389,7 @@ These scenarios produce different behavior between oc-rsync and upstream rsync:
 | `tools/ci/run_interop.sh` | Primary CI interop runner (11K+ lines, all versions/features) |
 | `tools/ci/run_interop_smoke.sh` | Portable smoke harness (macOS, Windows) |
 | `tools/ci/run_upstream_testsuite.sh` | Upstream testsuite runner against oc-rsync |
+| `tools/ci/build_old_rsync_oracle.sh` | Builds a historical rsync release into an upstream tree's `old_versions/`, for the tests that assert against a real old daemon |
 | `tools/ci/known_failures.conf` | Known failure registry for interop suite |
 | `tools/ci/upstream_testsuite_known_failures.conf` | Known failure registry for upstream testsuite |
 
@@ -413,3 +414,16 @@ bash tools/ci/run_upstream_testsuite.sh
 
 Upstream rsync source is downloaded to `target/interop/upstream-src/`. If
 already present, the scripts reuse the cached build.
+
+Some upstream tests take their expected value from a REAL old rsync in the
+tree's `old_versions/` directory and fall back to a static prediction of it when
+the binary is absent - which the release tarball always is, since it ships that
+directory's README and build script but no binaries. `LEGACY_ORACLES=on` makes
+`run_upstream_testsuite.sh` build what those tests ask for; off (the default) it
+names each test that will therefore assert against its fallback. Which releases
+and which tests is not listed anywhere - `ensure_legacy_oracles()` reads it out
+of the extracted testsuite, so it cannot drift from what the tests do.
+
+Enabling it on a leg moves that leg's `--expect-result` rows (a test that skips
+for want of the binary starts running), so re-baseline from the run's
+`EMIT_EXPECT_RESULT` artifact rather than editing the manifest by hand.

--- a/tools/ci/build_old_rsync_oracle.sh
+++ b/tools/ci/build_old_rsync_oracle.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# build_old_rsync_oracle.sh - build a historical upstream rsync release and
+# install it into an upstream tree's old_versions/ directory, where the 3.5.0
+# testsuite looks for a legacy-behaviour oracle.
+#
+# WHY THIS EXISTS
+#
+# rsync 3.5.0 ships tests that pin a behaviour against a REAL old daemon when
+# one is on disk and fall back to a hand-written static prediction when it is
+# not. testsuite/daemon-symlink-escape-matrix_test.py is the current consumer:
+#
+#     elif (_repo / 'old_versions' / 'rsync_3.2.7').is_file():
+#         ORACLE_BIN = str(_repo / 'old_versions' / 'rsync_3.2.7')
+#     ...
+#     want, src = static_followed(...), 'contract'
+#
+# upstream: rsync-3.5.0/old_versions/README.md documents the directory and
+# ships build_static.sh to populate it, but the RELEASE TARBALL carries no
+# binaries - MEASURED on a pristine 3.5.0 extraction, old_versions/ holds
+# exactly README.md and build_static.sh. So on a stock CI runner the oracle is
+# always absent, every oracle-backed cell quietly asserts the static prediction
+# instead, and the test still reports PASS: runtests.py only shows a test's
+# stdout when it does NOT pass (3.5.0 runtests.py:621), so the one line that
+# names the degradation is never printed on the green path.
+#
+# This script closes that gap by BUILDING the oracle, so the contract the test
+# says it enforces is the contract it actually enforces.
+#
+# Not upstream's build_static.sh: that one checks a git TAG out of a local
+# rsync worktree (RSYNC_REPO, default ../rsync.4), links statically, and exists
+# to produce an architecture-portable archive binary. CI has no such worktree
+# and needs no portability - the binary is built and consumed on one machine -
+# so this builds the release TARBALL dynamically. The one flag that is not
+# optional is _FORTIFY_SOURCE=0; see below.
+#
+# Usage:
+#   tools/ci/build_old_rsync_oracle.sh <version> <old_versions_dir> [workdir]
+#
+# Idempotent: a target binary that already reports <version> is left alone.
+
+set -euo pipefail
+
+VERSION="${1:?usage: build_old_rsync_oracle.sh <version> <old_versions_dir> [workdir]}"
+DEST_DIR="${2:?usage: build_old_rsync_oracle.sh <version> <old_versions_dir> [workdir]}"
+WORKDIR="${3:-${DEST_DIR}/.build}"
+
+# Upstream's own naming convention for the archive - the testsuite stats this
+# exact path. upstream: rsync-3.5.0/old_versions/README.md ("named
+# `rsync_<version>`").
+TARGET_BIN="${DEST_DIR}/rsync_${VERSION}"
+TARBALL_BASE_URL="${RSYNC_TARBALL_BASE_URL:-https://rsync.samba.org/ftp/rsync/src}"
+
+# `--version` is the acceptance test, not `-x`: a binary that cannot run on
+# this host (wrong arch, missing shared library) is still present and
+# executable, and would be handed to the testsuite as a working oracle. The
+# consuming test runs the same probe for the same reason.
+oracle_is_usable() {
+    [[ -x "$TARGET_BIN" ]] || return 1
+    "$TARGET_BIN" --version 2>/dev/null | head -1 | grep -q "version ${VERSION}"
+}
+
+if oracle_is_usable; then
+    echo "==> rsync ${VERSION} oracle already present: ${TARGET_BIN}" >&2
+    "$TARGET_BIN" --version | head -1 >&2
+    exit 0
+fi
+
+build_jobs() {
+    if command -v nproc >/dev/null 2>&1; then
+        nproc
+    elif command -v sysctl >/dev/null 2>&1; then
+        sysctl -n hw.ncpu
+    else
+        echo 2
+    fi
+}
+
+mkdir -p "$DEST_DIR" "$WORKDIR"
+tarball="${WORKDIR}/rsync-${VERSION}.tar.gz"
+srcdir="${WORKDIR}/rsync-${VERSION}"
+
+if [[ ! -f "$tarball" ]]; then
+    echo "==> Fetching rsync ${VERSION} source..." >&2
+    curl -fsSL --connect-timeout 30 --max-time 300 \
+        "${TARBALL_BASE_URL}/rsync-${VERSION}.tar.gz" -o "${tarball}.part"
+    mv "${tarball}.part" "$tarball"
+fi
+
+rm -rf "$srcdir"
+tar xzf "$tarball" -C "$WORKDIR"
+
+# _FORTIFY_SOURCE=0 is LOAD-BEARING, not tidiness. Modern distributions default
+# it to =3, whose object-size checks turn latent (historically benign)
+# over-reads in old rsync into a hard "*** buffer overflow detected ***" abort
+# when the binary runs as a server/daemon - which is exactly how this oracle is
+# used. upstream: rsync-3.5.0/old_versions/README.md note 6 names 3.1.3 and
+# 3.2.7 specifically as "unusable as peers" without it. A fortified oracle
+# would not fail loudly here; it would abort mid-session, and the consuming
+# test would read the aborted transfer as "did not follow" - a WRONG oracle
+# answer rather than a missing one.
+#
+# -Wno-error and the implicit-declaration downgrades keep a release from an
+# older toolchain era compiling under a current one; upstream's build_static.sh
+# carries the same set for the same reason.
+oracle_cflags="-O2 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -Wno-error"
+oracle_cflags+=" -Wno-implicit-function-declaration -Wno-int-conversion"
+oracle_cflags+=" -Wno-incompatible-pointer-types"
+
+echo "==> Configuring rsync ${VERSION} oracle..." >&2
+(
+    cd "$srcdir"
+    # The --disable list is DETERMINISM, not taste. 3.2.7's configure ABORTS
+    # ("Aborting configure run") when it finds a feature's header missing
+    # instead of quietly proceeding, so which of openssl/xxhash/zstd/lz4 happen
+    # to be installed on the runner image decides whether the oracle builds at
+    # all - and, if it does, which digests and compressors it advertises. Naming
+    # them makes the oracle identical on every host.
+    #
+    # Safe for what the oracle is ASKED: it is consulted about symlink and path
+    # resolution in the daemon (send_directory / change_dir / basis_link_stat),
+    # which no compression or checksum backend touches. rsync implements MD4/MD5
+    # natively, so --disable-openssl only drops an alternative implementation of
+    # digests it still has - upstream's own old_versions/build_static.sh drops
+    # openssl for the same reason. --disable-md2man drops manpage generation
+    # (it wants python3-commonmark).
+    CFLAGS="$oracle_cflags" ./configure --disable-md2man \
+        --disable-openssl --disable-xxhash --disable-zstd --disable-lz4 \
+        >configure.log 2>&1 || { tail -40 configure.log >&2; exit 1; }
+    echo "==> Building rsync ${VERSION} oracle..." >&2
+    make -j"$(build_jobs)" >make.log 2>&1 || {
+        grep -E 'error:|\*\*\*' make.log | head -20 >&2
+        exit 1
+    }
+)
+
+install -m 0755 "${srcdir}/rsync" "$TARGET_BIN"
+
+if ! oracle_is_usable; then
+    echo "ERROR: built oracle at ${TARGET_BIN} does not report version ${VERSION}." >&2
+    "$TARGET_BIN" --version 2>&1 | head -1 >&2 || true
+    rm -f "$TARGET_BIN"
+    exit 1
+fi
+
+echo "==> Installed rsync ${VERSION} oracle: ${TARGET_BIN}" >&2
+"$TARGET_BIN" --version | head -1 >&2

--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -774,6 +774,223 @@ python_suite_available() {
     compgen -G "${upstream_src_dir}/testsuite/*_test.py" >/dev/null 2>&1
 }
 
+# --------------------------------------------------------------------------
+# Legacy-behaviour oracles (upstream's old_versions/ archive).
+#
+# The 3.5.0 suite ships tests that pin a behaviour against a REAL old rsync
+# when one is on disk and degrade when it is not. MEASURED over the 345 tests
+# of the 3.5.0 tarball, three consult the archive from CODE (the rest only
+# mention it in a docstring), and they degrade three different ways:
+#
+#   daemon-symlink-escape-matrix  old_versions/rsync_3.2.7  root + tcp
+#       100 of its 200 cells (`insecure links = yes`) take their expected
+#       value from a live 3.2.7 daemon when the binary is there and from
+#       static_followed(), a hand-written prediction of 3.2.7, when it is not:
+#           want, src = attempt(url_oracle, ...)[0], '327'
+#           want, src = static_followed(...),        'contract'
+#       SILENT: which one ran is printed only on the test's own stdout, and
+#       runtests.py shows that just when a test does NOT pass (3.5.0
+#       runtests.py:621 `show_log = always_log or (result not in (Exit.PASS,
+#       Exit.SKIP, Exit.XFAIL))`). A green leg therefore cannot be read to say
+#       which contract it enforced.
+#
+#   daemon-auth-digest-floor      old_versions/rsync_3.1.3  any leg
+#       SILENT in the same way: `raise SystemExit(0)` drops the md5-downgrade
+#       case and the test still reports PASS.
+#
+#   daemon-max-alloc-zero         old_versions/rsync_3.2.7  any leg
+#       COUNTED: `test_skipped(f"{OLD_CLIENT} not present")`, which lands in
+#       the run's skip column and in the expect manifests. This is the outcome
+#       the other two should have had.
+#
+# The absence is not an edge case, it is every run: upstream ships
+# old_versions/README.md and old_versions/build_static.sh but no binaries -
+# MEASURED on a pristine 3.5.0 extraction, that directory holds exactly those
+# two files - and build_static.sh wants a local rsync git worktree
+# (RSYNC_REPO, default ../rsync.4) that CI does not have.
+#
+# LEGACY_ORACLES=on builds what the reachable consumers ask for, so those cells
+# assert against the release instead of a prediction of it. Off, the same
+# enumeration still runs and every degraded consumer is NAMED, because the one
+# thing worse than a weak assertion is a weak assertion nobody can see.
+#
+# Off by DEFAULT, and per leg: putting a binary in old_versions/ un-skips
+# daemon-max-alloc-zero, i.e. it MOVES expect-manifest rows. Those rows may
+# only be re-baselined from a measured run (EMIT_EXPECT_RESULT), so a leg opts
+# in when someone is ready to measure the move - never as a side effect.
+# --------------------------------------------------------------------------
+
+# on: build every oracle a consumer on this leg can reach. off: build none and
+# report which consumers are running degraded.
+legacy_oracles_mode="${LEGACY_ORACLES:-off}"
+case "$legacy_oracles_mode" in
+    on | off) ;;
+    *)
+        echo "ERROR: LEGACY_ORACLES must be 'on' or 'off', got '${legacy_oracles_mode}'." >&2
+        exit 1
+        ;;
+esac
+
+# Emit a GitHub Actions warning annotation. Same shape as gha_annotate_fail,
+# and a no-op outside GHA. Used where a degradation must be visible without
+# failing the leg.
+gha_annotate_warn() {
+    [[ -z "${GITHUB_ACTIONS:-}" ]] && return 0
+    local title=$1 message=$2
+    local sanitized=${message//$'\n'/ }
+    sanitized=${sanitized//$'\r'/ }
+    sanitized=${sanitized//%/%25}
+    printf '::warning file=tools/ci/run_upstream_testsuite.sh,title=%s::%s\n' \
+        "$title" "$sanitized"
+}
+
+# One TSV row per (oracle version, consuming test): version, test base name,
+# whether that test needs the TCP transport, whether it needs root.
+#
+# DISCOVERED from the tests, never listed here. A second copy of "3.2.7" in
+# this file would drift the moment upstream retargets the oracle, and the drift
+# is exactly the invisible kind: the consumer would degrade to its fallback and
+# keep passing. Reading the version out of the test that stats it makes the two
+# unable to disagree. Same for the preconditions - `require_tcp()` and the
+# `os.geteuid()` gate are the test's own, so a future consumer with different
+# ones is classified by ITS source, not by this leg's assumptions.
+#
+# The scan is over the AST, not the file text. MEASURED: a plain grep for
+# `old_versions` + `rsync_<ver>` over the 3.5.0 testsuite returns 10 files, and
+# 7 of them only say "Cross-version: expected identical against
+# --rsync-bin=old_versions/rsync_3.2.7" in a DOCSTRING - they never stat it. A
+# text scan would build oracles for tests that cannot consume them and, worse,
+# would report those tests as degraded when they are not. Docstrings are
+# excluded explicitly and comments never enter the AST, so what is left is the
+# string literals real code evaluates.
+legacy_oracle_requirements() {
+    (cd "$upstream_src_dir" && python3 - <<'PY'
+import ast
+import glob
+import os
+import re
+import sys
+
+BINARY = re.compile(r'^rsync_(\d+\.\d+(?:\.\d+)?)$')
+
+def code_string_literals(tree):
+    """Every str constant the module evaluates, minus its docstrings."""
+    docstrings = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef,
+                                 ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        body = getattr(node, 'body', None)
+        if (body and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)):
+            docstrings.add(id(body[0].value))
+    return [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in docstrings]
+
+rows = []
+for path in sorted(glob.glob(os.path.join('testsuite', '*_test.py'))):
+    with open(path, encoding='utf-8') as fh:
+        text = fh.read()
+    if 'old_versions' not in text:
+        continue
+    try:
+        tree = ast.parse(text, filename=path)
+    except SyntaxError as exc:
+        sys.exit('%s: cannot parse to find its legacy-oracle use: %s' % (path, exc))
+    literals = code_string_literals(tree)
+    if 'old_versions' not in literals:
+        continue                      # docstring/comment mention only
+    versions = sorted({m.group(1) for m in
+                       (BINARY.match(lit) for lit in literals) if m})
+    if not versions:
+        # The test evaluates 'old_versions' but names no rsync_<version>
+        # literal, so the binary it wants cannot be derived - e.g. it moved to
+        # an f-string. Guessing would build the wrong oracle and the test would
+        # degrade exactly as if none had been built, silently.
+        sys.exit('%s uses old_versions/ but names no rsync_<version> literal; '
+                 'the oracle it wants cannot be derived from its source' % path)
+    needs_tcp = 'yes' if 'require_tcp(' in text else 'no'
+    needs_root = 'yes' if 'geteuid()' in text else 'no'
+    base = os.path.basename(path)[:-len('_test.py')]
+    for version in versions:
+        rows.append('\t'.join((version, base, needs_tcp, needs_root)))
+print('\n'.join(rows))
+PY
+    )
+}
+
+# Put every legacy oracle a test on THIS leg can reach onto disk, or - with
+# LEGACY_ORACLES=off - name the consumers that will run degraded.
+#
+# Scoped to reachable consumers: an oracle no selected test can consult buys
+# nothing, and a build is not free. Each skip is announced with its reason, so
+# "not built" is never confused with "built and unused".
+ensure_legacy_oracles() {
+    local requirements
+    if ! requirements=$(legacy_oracle_requirements); then
+        echo "ERROR: could not enumerate the testsuite's legacy-oracle needs." >&2
+        echo "       Refusing to continue: an unreadable requirement list would" >&2
+        echo "       build nothing and hand every oracle-backed cell to its" >&2
+        echo "       fallback, which is the failure this enumeration exists to" >&2
+        echo "       prevent." >&2
+        exit 1
+    fi
+    if [[ -z "$requirements" ]]; then
+        echo "==> Legacy oracles: no test in this tree consults old_versions/." >&2
+        return 0
+    fi
+
+    local old_versions_dir="${upstream_src_dir}/old_versions"
+    local oracle_workdir="${workspace_root}/target/interop/old-versions-build"
+    local euid=${EUID:-$(id -u)}
+    local built=0 unreachable=0 degraded=0
+    local degraded_names=""
+    local version test_name needs_tcp needs_root reason
+    while IFS=$'\t' read -r version test_name needs_tcp needs_root; do
+        [[ -n "$version" ]] || continue
+        reason=""
+        if [[ "$needs_tcp" == "yes" && "${USE_TCP:-no}" != "yes" ]]; then
+            reason="it needs the TCP transport, this leg runs the stdio-pipe default"
+        elif [[ "$needs_root" == "yes" && "$euid" -ne 0 ]]; then
+            reason="it needs root, this leg runs as uid ${euid}"
+        elif [[ -n "$expect_result_file" ]] \
+            && ! grep -qE "^[[:space:]]*${test_name}[[:space:]]" "$expect_result_file"; then
+            reason="the expected-outcome manifest does not name it, so it will not run"
+        fi
+        if [[ -n "$reason" ]]; then
+            echo "==> Legacy oracle rsync ${version}: not needed - ${test_name} cannot run on this leg (${reason})." >&2
+            unreachable=$((unreachable + 1))
+            continue
+        fi
+        if [[ "$legacy_oracles_mode" == "off" ]]; then
+            echo "==> Legacy oracle rsync ${version}: NOT BUILT (LEGACY_ORACLES=off) - ${test_name} runs on this leg and will assert against its fallback, not against rsync ${version}." >&2
+            degraded=$((degraded + 1))
+            degraded_names+="${degraded_names:+, }${test_name} (rsync ${version})"
+            continue
+        fi
+        echo "==> Legacy oracle rsync ${version}: ${test_name} runs on this leg and asserts against it." >&2
+        if ! bash "${workspace_root}/tools/ci/build_old_rsync_oracle.sh" \
+            "$version" "$old_versions_dir" "$oracle_workdir" >&2; then
+            echo "ERROR: could not put the rsync ${version} oracle on disk for ${test_name}." >&2
+            echo "       This is fatal ON PURPOSE. Missing, that test does not fail:" >&2
+            echo "       it swaps the live oracle for its fallback, asserts the weaker" >&2
+            echo "       contract and still reports PASS - so the leg would report" >&2
+            echo "       success over a contract it never checked." >&2
+            gha_annotate_fail "legacy rsync oracle unavailable" \
+                "${test_name} asserts against a real rsync ${version} daemon; the build of ${old_versions_dir}/rsync_${version} failed, and without it the test degrades to its fallback and still passes."
+            exit 1
+        fi
+        built=$((built + 1))
+    done <<< "$requirements"
+    if (( degraded > 0 )); then
+        gha_annotate_warn "legacy rsync oracles not built" \
+            "LEGACY_ORACLES=off on this leg, so ${degraded} test(s) assert against a static fallback rather than the release they name: ${degraded_names}. Set legacy_oracles: 'on' for this leg once its expect manifest can be re-measured."
+    fi
+    echo "==> Legacy oracles: ${built} on disk, ${degraded} consumer(s) running degraded, ${unreachable} not needed on this leg." >&2
+}
+
 # Drive upstream's own runtests.py against oc-rsync.
 #
 # Used for any tree shipping the Python suite - the 3.5.0 release tarball and
@@ -804,6 +1021,10 @@ run_python_suite_mode() {
         # tools runtests.py needs (upstream Makefile.in:381).
         make check-progs >make.log 2>&1 || { tail -120 make.log; exit 1; }
     )
+
+    # After the tree is extracted (the requirements are read out of it) and
+    # before runtests.py runs (the tests stat the binary at import time).
+    ensure_legacy_oracles
 
     rm -rf "$log_root"
     mkdir -p "$log_root"
@@ -1162,6 +1383,13 @@ cleanup_run() {
     cleanup_published_bin
 }
 
-trap cleanup_run EXIT
-
-main "$@"
+# Executed: install the cleanup trap and run. Sourced: define the functions and
+# stop, so tools/tests/ can drive one of them (ensure_legacy_oracles) against a
+# synthetic tree without launching a 45-minute suite - and without the EXIT trap
+# tearing down the sourcing shell's mounts. `$0` is the sourcing program when
+# sourced and this file when executed, so the comparison distinguishes the two
+# without a mode flag anyone has to remember to pass.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    trap cleanup_run EXIT
+    main "$@"
+fi

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -1,0 +1,361 @@
+"""Unit tests for the legacy-oracle machinery in tools/ci/.
+
+WHAT IS BEING GUARDED
+
+The rsync 3.5.0 testsuite has tests that assert against a REAL old rsync when
+one sits in the tree's old_versions/ directory and degrade when one does not.
+The release tarball ships no such binaries, so on a stock runner the degraded
+path is the only path ever taken - and for two of the three consumers the
+degradation is invisible:
+
+  * daemon-symlink-escape-matrix swaps a live 3.2.7 daemon for
+    static_followed(), a hand-written prediction of 3.2.7, across 100 of its
+    200 cells, and reports PASS;
+  * daemon-auth-digest-floor drops its md5-downgrade case with
+    `raise SystemExit(0)`, and reports PASS;
+  * daemon-max-alloc-zero calls test_skipped(), which is counted.
+
+runtests.py prints a passing test's stdout only under --always-log, so the
+lines those tests print about which oracle they used never reach a green log.
+
+So the machinery under test has two jobs, and a green CI run demonstrates
+neither of them: put the binary on disk when a leg asks for it, and make a
+failure to do so loud instead of letting the suite quietly assert less. Both
+are exercised here against synthetic trees and a stub builder - hermetic, no
+network, no compiler, no root, identical on a laptop and on a runner.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import tarfile
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+HARNESS = REPO / "tools" / "ci" / "run_upstream_testsuite.sh"
+BUILDER = REPO / "tools" / "ci" / "build_old_rsync_oracle.sh"
+
+# A test that really consults the archive: it evaluates the string literals, so
+# the AST scan must find it. Shaped like daemon-symlink-escape-matrix.
+CONSUMER = '''\
+"""A consuming test."""
+
+from pathlib import Path
+
+ORACLE = Path(__file__).resolve().parents[1] / 'old_versions' / 'rsync_3.2.7'
+print(ORACLE)
+'''
+
+# The false-positive shape: 7 of the 10 files a text grep matches in the real
+# 3.5.0 tree look exactly like this - the archive is named in a DOCSTRING as a
+# cross-version note and never stat'd.
+PROSE_ONLY = '''\
+"""Pure local client behaviour: no daemon/root/tcp.  Cross-version: expected
+identical against --rsync-bin=old_versions/rsync_3.2.7.
+"""
+
+print('nothing to do with the archive')
+'''
+
+# Evaluates 'old_versions' but names no rsync_<version> literal, so which
+# binary it wants cannot be derived.
+UNDERIVABLE = '''\
+"""A consumer whose oracle name is computed."""
+
+from pathlib import Path
+
+VER = '3.2.7'
+ORACLE = Path(__file__).resolve().parents[1] / 'old_versions' / ('rsync_' + VER)
+print(ORACLE)
+'''
+
+
+def consumer_needing(tcp: bool, root: bool) -> str:
+    """A consuming test carrying the preconditions the harness reads."""
+    body = CONSUMER
+    if tcp:
+        body += "require_tcp('needs a real TCP peer')\n"
+    if root:
+        body += "import os\nif os.geteuid() != 0:\n    raise SystemExit(0)\n"
+    return body
+
+
+class LegacyOracleDiscoveryTests(unittest.TestCase):
+    """legacy_oracle_requirements(): what the tree actually asks for."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.tree = self.tmp / "rsync-3.5.0"
+        (self.tree / "testsuite").mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _test(self, name: str, body: str) -> None:
+        (self.tree / "testsuite" / f"{name}_test.py").write_text(body)
+
+    def _run(self) -> subprocess.CompletedProcess[str]:
+        program = textwrap.dedent(
+            f"""
+            source {shlex.quote(str(HARNESS))}
+            upstream_src_dir={shlex.quote(str(self.tree))}
+            legacy_oracle_requirements
+            """
+        )
+        return subprocess.run(
+            ["bash", "-c", program], capture_output=True, text=True, check=False
+        )
+
+    def test_code_reference_is_discovered_with_its_preconditions(self) -> None:
+        self._test("matrix", consumer_needing(tcp=True, root=True))
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "3.2.7\tmatrix\tyes\tyes")
+
+    def test_preconditions_are_read_from_the_test_not_assumed(self) -> None:
+        self._test("plain", consumer_needing(tcp=False, root=False))
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "3.2.7\tplain\tno\tno")
+
+    def test_docstring_mention_is_not_a_consumer(self) -> None:
+        # The whole reason the scan is over the AST. A text scan reports this
+        # test as needing an oracle, which both builds a binary nothing reads
+        # and - worse - names a healthy test as degraded.
+        self._test("prose", PROSE_ONLY)
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_underivable_oracle_name_is_refused_not_ignored(self) -> None:
+        # Silently skipping it would leave the test asserting its fallback,
+        # which is exactly the condition this machinery exists to end.
+        self._test("computed", UNDERIVABLE)
+        result = self._run()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("cannot be derived", result.stderr)
+
+    def test_the_pinned_upstream_tree_names_its_consumers(self) -> None:
+        # A shape check against the real thing when it happens to be extracted:
+        # every row must be version/test/yes-or-no/yes-or-no. Skipped rather
+        # than faked when the tree is absent, so it never reports on a
+        # population it did not read.
+        tree = REPO / "target" / "interop" / "upstream-src" / "rsync-3.5.0"
+        if not (tree / "testsuite").is_dir():
+            self.skipTest(f"{tree} is not extracted here")
+        self.tree = tree
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for line in result.stdout.splitlines():
+            version, name, needs_tcp, needs_root = line.split("\t")
+            self.assertRegex(version, r"^\d+\.\d+(\.\d+)?$")
+            self.assertTrue(name)
+            self.assertIn(needs_tcp, ("yes", "no"))
+            self.assertIn(needs_root, ("yes", "no"))
+
+
+class EnsureLegacyOraclesTests(unittest.TestCase):
+    """ensure_legacy_oracles(): builds, refuses, or names the degradation."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.workspace = self.tmp / "workspace"
+        (self.workspace / "tools" / "ci").mkdir(parents=True)
+        self.tree = self.tmp / "rsync-3.5.0"
+        (self.tree / "testsuite").mkdir(parents=True)
+        (self.tree / "testsuite" / "matrix_test.py").write_text(
+            consumer_needing(tcp=False, root=False)
+        )
+        self.calls = self.tmp / "builder-calls"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _builder(self, exit_code: int) -> None:
+        """Stand in for build_old_rsync_oracle.sh at the path the harness uses."""
+        stub = self.workspace / "tools" / "ci" / "build_old_rsync_oracle.sh"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$*" >> {shlex.quote(str(self.calls))}\n'
+            f"exit {exit_code}\n"
+        )
+        stub.chmod(0o755)
+
+    def _run(self, env_overrides: dict, extra: str = "") -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env.pop("LEGACY_ORACLES", None)
+        env.pop("USE_TCP", None)
+        env.pop("EXPECT_RESULT", None)
+        env.update(env_overrides)
+        program = textwrap.dedent(
+            f"""
+            source {shlex.quote(str(HARNESS))}
+            workspace_root={shlex.quote(str(self.workspace))}
+            upstream_src_dir={shlex.quote(str(self.tree))}
+            {extra}
+            ensure_legacy_oracles
+            """
+        )
+        return subprocess.run(
+            ["bash", "-c", program], capture_output=True, text=True,
+            check=False, env=env,
+        )
+
+    def test_on_builds_the_oracle_the_consumer_names(self) -> None:
+        self._builder(0)
+        result = self._run({"LEGACY_ORACLES": "on"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        call = self.calls.read_text().split()
+        self.assertEqual(call[0], "3.2.7")
+        self.assertEqual(call[1], str(self.tree / "old_versions"))
+        self.assertIn("1 on disk", result.stderr)
+
+    def test_a_failed_build_fails_the_leg(self) -> None:
+        # THE point of the module. Without this the leg keeps running and the
+        # consumer asserts its fallback while reporting PASS, so the run is
+        # green over a contract it never checked.
+        self._builder(1)
+        result = self._run({"LEGACY_ORACLES": "on"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("matrix", result.stderr)
+        self.assertIn("3.2.7", result.stderr)
+        self.assertIn("still reports PASS", result.stderr)
+
+    def test_off_names_every_consumer_that_will_run_degraded(self) -> None:
+        self._builder(0)
+        result = self._run({"LEGACY_ORACLES": "off"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.calls.exists(), "off must not build anything")
+        self.assertIn("NOT BUILT", result.stderr)
+        self.assertIn("matrix", result.stderr)
+        self.assertIn("1 consumer(s) running degraded", result.stderr)
+
+    def test_off_annotates_the_degradation_on_github(self) -> None:
+        self._builder(0)
+        result = self._run(
+            {"LEGACY_ORACLES": "off", "GITHUB_ACTIONS": "true"}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("::warning ", result.stdout + result.stderr)
+
+    def test_a_consumer_that_cannot_run_here_is_not_built_and_not_degraded(self) -> None:
+        (self.tree / "testsuite" / "matrix_test.py").write_text(
+            consumer_needing(tcp=True, root=False)
+        )
+        self._builder(0)
+        result = self._run({"LEGACY_ORACLES": "on", "USE_TCP": "no"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.calls.exists())
+        self.assertIn("not needed", result.stderr)
+        self.assertIn("0 consumer(s) running degraded", result.stderr)
+
+    def test_a_consumer_the_manifest_omits_is_not_built(self) -> None:
+        manifest = self.tmp / "expect.txt"
+        manifest.write_text("# ledger\nsomething-else pass\n")
+        self._builder(0)
+        result = self._run(
+            {"LEGACY_ORACLES": "on", "EXPECT_RESULT": str(manifest)}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(self.calls.exists())
+        self.assertIn("does not name it", result.stderr)
+
+    def test_an_unknown_mode_is_refused(self) -> None:
+        self._builder(0)
+        result = self._run({"LEGACY_ORACLES": "yes"})
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be 'on' or 'off'", result.stderr)
+
+
+class BuildOldRsyncOracleTests(unittest.TestCase):
+    """build_old_rsync_oracle.sh: what it installs and what it refuses.
+
+    Hermetic: a pre-placed source tarball means curl is never reached, and the
+    tarball's ./configure writes a Makefile whose `all` emits a shell script
+    standing in for the built rsync. Real tar and real make, no compiler.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.dest = self.tmp / "old_versions"
+        self.workdir = self.tmp / "build"
+        self.workdir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _plant_source(self, version: str, reports: str) -> None:
+        """A fake rsync-<version>.tar.gz whose build reports `reports`."""
+        src = self.tmp / "src" / f"rsync-{version}"
+        src.mkdir(parents=True)
+        (src / "configure").write_text(
+            "#!/bin/sh\n"
+            "printf 'all:\\n\\tprintf \"#!/bin/sh\\\\necho \\\\\"rsync  version "
+            f"{reports}  protocol version 31\\\\\"\\\\n\" > rsync\\n"
+            "\\tchmod +x rsync\\n' > Makefile\n"
+            "touch configured.marker\n"
+        )
+        (src / "configure").chmod(0o755)
+        with tarfile.open(self.workdir / f"rsync-{version}.tar.gz", "w:gz") as tar:
+            tar.add(src, arcname=f"rsync-{version}")
+
+    def _run(self, version: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", str(BUILDER), version, str(self.dest), str(self.workdir)],
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_a_build_reporting_the_requested_version_is_installed(self) -> None:
+        self._plant_source("3.2.7", "3.2.7")
+        result = self._run("3.2.7")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        installed = self.dest / "rsync_3.2.7"
+        self.assertTrue(installed.is_file())
+        self.assertIn("3.2.7", subprocess.run(
+            [str(installed), "--version"], capture_output=True, text=True).stdout)
+
+    def test_a_build_reporting_another_version_is_refused_and_removed(self) -> None:
+        # A binary that is present and executable but is not the release asked
+        # for is the worst outcome available: the consuming test would accept
+        # it as its oracle and pin the wrong behaviour. Leaving it on disk
+        # would also make the next run's idempotence check step over it.
+        self._plant_source("3.2.7", "3.4.1")
+        result = self._run("3.2.7")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not report version 3.2.7", result.stderr)
+        self.assertFalse((self.dest / "rsync_3.2.7").exists())
+
+    def test_an_unfetchable_version_fails(self) -> None:
+        # No tarball planted and no network reachable for a version that does
+        # not exist: the script must fail rather than install nothing quietly.
+        env = dict(os.environ)
+        env["RSYNC_TARBALL_BASE_URL"] = "file:///nonexistent-oracle-source"
+        result = subprocess.run(
+            ["bash", str(BUILDER), "0.0.1", str(self.dest), str(self.workdir)],
+            capture_output=True, text=True, check=False, env=env,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse((self.dest / "rsync_0.0.1").exists())
+
+    def test_an_already_good_binary_is_not_rebuilt(self) -> None:
+        self._plant_source("3.2.7", "3.2.7")
+        self.assertEqual(self._run("3.2.7").returncode, 0)
+        marker = self.workdir / "rsync-3.2.7" / "configured.marker"
+        self.assertTrue(marker.is_file())
+        marker.unlink()
+        result = self._run("3.2.7")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(marker.exists(), "a second run reconfigured the tree")
+        self.assertIn("already present", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three tests in the pinned 3.5.0 testsuite assert against a **live old-rsync daemon**. No workflow ever built one, so they silently fell back to weaker contracts and reported green.

## What was unassertable

`daemon-symlink-escape-matrix` nests `insecure(2) x munge(2) x origin(2) x vector(5) x type(5)` = **200 cells, of which exactly 100** (the `insecure links = yes` half) are oracle-backed. Each should read `want = attempt(url_oracle, ...)` — a *measurement* of rsync 3.2.7. Without the binary each instead reads `want = static_followed(...)`, a hand-written *prediction*: `origin=preexist` → `want=1` for all 50 regardless of vector or symlink type; `origin=uploaded` → `want=1` only for the 5 `rel-within`/`munge=off` cells and `want=0` for the other 45. So 55 cells asserted "followed" and 45 asserted "did not follow" against nobody's observed behaviour.

The test's own docstring claims the opposite — *"we assert this against a REAL 3.2.7 daemon oracle"*. That half never ran.

The fallback is invisible. The only report is the test's own final `print`, and `runtests.py:621` is `show_log = always_log or (result not in (Exit.PASS, Exit.SKIP, Exit.XFAIL))` — a passing test's stdout is never shown. A green log cannot say which contract it enforced.

## Two more consumers, found by AST scan

A text grep for `old_versions/` finds ten tests; seven only name it in a docstring. Scanning for a `rsync_<version>` literal in actual code finds three:

| test | oracle | degradation |
|---|---|---|
| `daemon-symlink-escape-matrix` | `rsync_3.2.7` | **silent** — static prediction, PASS |
| `daemon-auth-digest-floor` | `rsync_3.1.3` | **silent** — `raise SystemExit(0)` drops the md5-downgrade case, PASS |
| `daemon-max-alloc-zero` | `rsync_3.2.7` | **counted** — `test_skipped()`, visible as `skip` in all four manifests |

`daemon-max-alloc-zero` is the reason-carrying pattern the other two should have had.

## Why the interop version list could not have fixed this

`run_interop.sh` builds `versions=(3.0.9 3.1.3 3.4.4 3.5.0)` + `extra_build_versions=(2.6.9)` into `target/interop/upstream-install/<ver>/bin/rsync`. 3.2.7 is in none of them — and adding it there would not help: the testsuite runs in a different workflow with a different cache and stats `…/upstream-src/rsync-3.5.0/old_versions/rsync_3.2.7`, a path the interop install root never populates. Upstream's own `old_versions/build_static.sh` needs a local rsync git worktree (`RSYNC_REPO`, default `../rsync.4`) that CI does not have.

## This change

- `tools/ci/build_old_rsync_oracle.sh` builds a release tarball into a tree's `old_versions/` under upstream's `rsync_<version>` name, and **verifies the built binary reports that version** before installing it. `_FORTIFY_SOURCE=0` is load-bearing (upstream's README names 3.1.3 and 3.2.7 as unusable as peers without it). The `--disable openssl/xxhash/zstd/lz4` list is determinism: 3.2.7's configure *aborts* on a missing optional header, so otherwise the runner image would decide whether the oracle builds at all.
- `ensure_legacy_oracles()` reads versions and preconditions **out of the tests over the AST** — no version is listed anywhere, so nothing can drift. A failed build is **fatal**, not a silent skip.
- `LEGACY_ORACLES=off` by default, `on` for the root+tcp leg only. When off, the enumeration still runs and every degraded consumer is named on stderr and as a `::warning`, so the remaining gap is visible rather than a bare `exit 0`.

Evidence it works: built real rsync 3.2.7 with the script (`rsync version 3.2.7 protocol version 31`), ran it as a daemon, and asked it the matrix's `read`/`rel-outside`/`preexist` question — `followed=1`. That cell's prediction happens to be right; it is now measured instead of assumed.

## Non-vacuity

`tools/tests/test_upstream_testsuite_oracle.py`, 16 hermetic tests (no network, compiler, or root) on the blocking `tools unit tests` job. Three deliberate breaks, each observed red then reverted:

1. Removed the `exit 1` from the failed-build path → `test_a_failed_build_fails_the_leg` FAILED (`0 == 0`).
2. Replaced the AST scan with a text scan → `test_docstring_mention_is_not_a_consumer` FAILED (`testsuite/prose_test.py uses old_versions/ but names no rsync_<version> literal`).
3. Deleted the built-binary version verification → `test_a_build_reporting_another_version_is_refused_and_removed` FAILED.

Restored files hash-verified against pristine. `run_tools_tests.sh` 78 OK; `shellcheck -S warning` clean; `cargo xtask citations` exit 0. Both edited workflows validated by loading the **committed** YAML with `yaml.safe_load` and reading out the step lists — not by re-testing a hand copy.

## No manifest re-baselined

Enabling the oracle on root+tcp also un-skips `daemon-max-alloc-zero` and enables the second half of `daemon-auth-digest-floor`, so **two rows in `upstream-3.5.0-expect.root.tcp.txt` will move**. They are not guessed here; re-baseline from that workflow's `EMIT_EXPECT_RESULT` artifact after the first nightly run. `daemon-symlink-escape-matrix` stays `fail` on that leg, but its *content* changes from prediction to measurement.

That leg is `workflow_dispatch` + nightly and not required, which is why it is the one that opts in. The two required pipe legs are untouched (`legacy_oracles` defaults off), so their two degraded consumers still run degraded — but the harness now *names* them each run instead of hiding it.

**Limitation:** the 3.2.7 build and daemon probe were done on darwin/arm64, not the CI image — no Linux container was available. The compile flags come from upstream's documented Linux recipe, and a build failure on the runner is fatal and loud rather than silent.
