### PR TITLE
fix(cli): reject an unknown --info/--debug item the way upstream does

### DIFF
--- a/crates/cli/src/frontend/execution/flags/debug.rs
+++ b/crates/cli/src/frontend/execution/flags/debug.rs
@@ -5,7 +5,7 @@ use core::{
     rsync_error,
 };
 
-use super::output_words::{self, OutputWord};
+use super::output_words::{self, OutputWord, TokenFlow};
 
 /// Parsed `--debug` flag settings controlling diagnostic output levels.
 #[derive(Debug, Default)]
@@ -112,22 +112,25 @@ impl DebugFlagSettings {
         self.iocp = Some(level);
     }
 
-    pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
-        let lower = token.to_ascii_lowercase();
-
-        let (normalized, level) = match output_words::classify(&lower) {
+    /// Applies one `--debug=` token.
+    ///
+    /// Returns [`TokenFlow::Stop`] for a `help` token: upstream prints the
+    /// word table and calls `exit_cleanup(0)` right there (options.c:465-468),
+    /// so every later token in the list is never examined.
+    pub(super) fn apply(&mut self, token: &str) -> Result<TokenFlow, Message> {
+        let (name, level) = match output_words::classify(token) {
             OutputWord::Help => {
                 self.help_requested = true;
-                return Ok(());
+                return Ok(TokenFlow::Stop);
             }
             OutputWord::Every(level) => {
                 self.set_all(level);
-                return Ok(());
+                return Ok(TokenFlow::Continue);
             }
             OutputWord::Named { name, level } => (name, level),
         };
 
-        match normalized {
+        match name.to_ascii_lowercase().as_str() {
             "acl" => self.acl = Some(level),
             "backup" => self.backup = Some(level),
             "bind" => self.bind = Some(level),
@@ -156,19 +159,24 @@ impl DebugFlagSettings {
             "clone" => self.clone = Some(level),
             "sockopt" => self.sockopt = Some(level),
             "iocp" => self.iocp = Some(level),
-            _ => return Err(debug_flag_error(display)),
+            _ => return Err(debug_flag_error(name)),
         }
 
-        Ok(())
+        Ok(TokenFlow::Continue)
     }
 }
 
-fn debug_flag_error(display: &str) -> Message {
-    rsync_error!(
-        1,
-        format!("invalid --debug flag '{display}': use --debug=help for supported flags")
-    )
-    .with_role(Role::Client)
+/// Builds the unknown-item diagnostic for `--debug=`.
+///
+/// upstream: options.c:484-488 -
+/// `rprintf(FERROR, "Unknown %s item: \"%.*s\"\n", words[j].help, len, str);`
+/// followed by `exit_cleanup(RERR_SYNTAX)`. `words[j]` is the table's NULL
+/// sentinel, whose `help` field is the literal `"--debug"` (options.c:333), and
+/// `len` is the token length with the level suffix already stripped. The text
+/// goes to `FERROR` (stderr) and the exit code is `RERR_SYNTAX` = 1
+/// (errcode.h:25).
+fn debug_flag_error(name: &str) -> Message {
+    rsync_error!(1, format!("Unknown --debug item: \"{name}\"")).with_role(Role::Client)
 }
 
 /// Parses `--debug` flag values into resolved settings.
@@ -177,7 +185,13 @@ pub(crate) fn parse_debug_flags(values: &[OsString]) -> Result<DebugFlagSettings
 
     for value in values {
         let text = value.to_string_lossy();
-        output_words::for_each_token(&text, |token| settings.apply(token, token))?;
+        // A `help` token stops the walk here as well as inside the value:
+        // upstream exits from `parse_output_words` itself, so a later
+        // `--debug=` argument is never parsed.
+        let flow = output_words::for_each_token(&text, |token| settings.apply(token))?;
+        if matches!(flow, TokenFlow::Stop) {
+            break;
+        }
     }
 
     Ok(settings)

--- a/crates/cli/src/frontend/execution/flags/info.rs
+++ b/crates/cli/src/frontend/execution/flags/info.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use super::super::super::progress::{NameOutputLevel, ProgressSetting};
-use super::output_words::{self, OutputWord};
+use super::output_words::{self, OutputWord, TokenFlow};
 
 /// Per-flag descriptor for an `--info=` token.
 ///
@@ -172,8 +172,12 @@ impl InfoFlagSettings {
         apply("symsafe", self.symsafe);
     }
 
+    /// upstream: options.c:475 matches the table with `strncasecmp`, so the
+    /// lookup is case-insensitive.
     fn spec_for(name: &str) -> Option<&'static InfoFlagSpec> {
-        INFO_FLAG_SPECS.iter().find(|spec| spec.name == name)
+        INFO_FLAG_SPECS
+            .iter()
+            .find(|spec| spec.name.eq_ignore_ascii_case(name))
     }
 
     /// Returns the explicitly-set `(name, level)` info categories in upstream
@@ -219,30 +223,34 @@ impl InfoFlagSettings {
     }
 
     #[cfg(test)]
-    pub(super) fn apply(&mut self, token: &str, display: &str) -> Result<(), Message> {
-        self.apply_with_mode(token, display, false)
+    pub(super) fn apply(&mut self, token: &str) -> Result<TokenFlow, Message> {
+        self.apply_with_mode(token, false)
     }
 
     /// Applies a single `--info` token.
     ///
     /// When `am_server` is `true`, an unrecognised token is silently
     /// accepted instead of producing an error, mirroring upstream rsync's
-    /// `parse_output_words()` (`options.c:465`) where the
+    /// `parse_output_words()` (options.c:484) where the
     /// `if (len && !words[j].name && !am_server)` guard skips the
     /// `RERR_SYNTAX` exit. This preserves cross-version compatibility when a
     /// newer client forwards info tokens this server build does not know.
     ///
-    /// upstream: options.c parse_output_words
+    /// Returns [`TokenFlow::Stop`] for a `help` token: upstream prints the
+    /// word table and calls `exit_cleanup(0)` right there (options.c:465-468),
+    /// so every later token in the list is never examined.
+    ///
+    /// upstream: options.c:443-490 parse_output_words
     pub(super) fn apply_with_mode(
         &mut self,
         token: &str,
-        display: &str,
         am_server: bool,
-    ) -> Result<(), Message> {
-        let lower = token.to_ascii_lowercase();
-
-        match output_words::classify(&lower) {
-            OutputWord::Help => self.help_requested = true,
+    ) -> Result<TokenFlow, Message> {
+        match output_words::classify(token) {
+            OutputWord::Help => {
+                self.help_requested = true;
+                return Ok(TokenFlow::Stop);
+            }
             OutputWord::Every(level) => self.enable_all_at_level(level),
             OutputWord::Named { name, level } => {
                 // The `am_server` branch mirrors upstream's
@@ -253,25 +261,30 @@ impl InfoFlagSettings {
                 // at the source.
                 let Some(spec) = Self::spec_for(name) else {
                     return if am_server {
-                        Ok(())
+                        Ok(TokenFlow::Continue)
                     } else {
-                        Err(info_flag_error(display))
+                        Err(info_flag_error(name))
                     };
                 };
                 self.assign(spec.name, level);
             }
         }
 
-        Ok(())
+        Ok(TokenFlow::Continue)
     }
 }
 
-fn info_flag_error(display: &str) -> Message {
-    rsync_error!(
-        1,
-        format!("invalid --info flag '{display}': use --info=help for supported flags")
-    )
-    .with_role(Role::Client)
+/// Builds the unknown-item diagnostic for `--info=`.
+///
+/// upstream: options.c:484-488 -
+/// `rprintf(FERROR, "Unknown %s item: \"%.*s\"\n", words[j].help, len, str);`
+/// followed by `exit_cleanup(RERR_SYNTAX)`. `words[j]` is the table's NULL
+/// sentinel, whose `help` field is the literal `"--info"` (options.c:301), and
+/// `len` is the token length with the level suffix already stripped. The text
+/// goes to `FERROR` (stderr) and the exit code is `RERR_SYNTAX` = 1
+/// (errcode.h:25).
+fn info_flag_error(name: &str) -> Message {
+    rsync_error!(1, format!("Unknown --info item: \"{name}\"")).with_role(Role::Client)
 }
 
 /// Parses `--info` flag values into resolved settings.
@@ -299,9 +312,15 @@ fn parse_info_flags_inner(
     let mut settings = InfoFlagSettings::default();
     for value in values {
         let text = value.to_string_lossy();
-        output_words::for_each_token(&text, |token| {
-            settings.apply_with_mode(token, token, am_server)
+        // A `help` token stops the walk here as well as inside the value:
+        // upstream exits from `parse_output_words` itself, so a later
+        // `--info=` argument is never parsed.
+        let flow = output_words::for_each_token(&text, |token| {
+            settings.apply_with_mode(token, am_server)
         })?;
+        if matches!(flow, TokenFlow::Stop) {
+            break;
+        }
     }
 
     Ok(settings)

--- a/crates/cli/src/frontend/execution/flags/output_words.rs
+++ b/crates/cli/src/frontend/execution/flags/output_words.rs
@@ -6,6 +6,17 @@
 //! same syntax and differ only in which names they recognise. This module is
 //! that tokenizer; each caller keeps its own table and applies the result.
 
+/// Whether the token walk should carry on to the next comma-separated item.
+///
+/// upstream: options.c:465-468 - a `help` item prints the word table and calls
+/// `exit_cleanup(0)` from inside `parse_output_words()`, so nothing after it is
+/// ever examined.
+#[derive(Debug)]
+pub(super) enum TokenFlow {
+    Continue,
+    Stop,
+}
+
 /// Largest level any `word<N>` token may select.
 ///
 /// upstream: options.c `#define MAX_OUT_LEVEL 4`. Upstream clamps to this
@@ -23,15 +34,19 @@ pub(super) enum OutputWord<'a> {
     /// to 0 so the table loop matches every entry, with `none` additionally
     /// forcing the level to 0 regardless of any suffix.
     Every(u8),
-    /// A category name and its level. The caller resolves the name against its
-    /// own table and reports an unknown name.
+    /// A category name and its level. `name` is the token with its level
+    /// suffix removed but its case preserved, because upstream matches the
+    /// table with `strncasecmp` yet reports an unknown item with `"%.*s"` over
+    /// the original bytes (options.c:475, 485-486): `--debug=BOGUS2` is
+    /// reported as `BOGUS`. The caller resolves it case-insensitively against
+    /// its own table and reports an unknown name verbatim.
     Named { name: &'a str, level: u8 },
 }
 
-/// Classifies one already-trimmed token.
+/// Classifies one comma-delimited token, verbatim.
 ///
-/// upstream: options.c `parse_output_words()`. The trailing-digit scan is
-/// skipped when the token itself starts with a digit (`if (!isDigit(str))`),
+/// upstream: options.c:455-472 `parse_output_words()`. The trailing-digit scan
+/// is skipped when the token itself starts with a digit (`if (!isDigit(str))`),
 /// so a bare integer such as `2` stays its own name and falls through to the
 /// unknown-item error rather than selecting a level.
 pub(super) fn classify(token: &str) -> OutputWord<'_> {
@@ -65,19 +80,29 @@ pub(super) fn classify(token: &str) -> OutputWord<'_> {
 
 /// Splits one `--info=`/`--debug=` value into tokens, dropping empty ones.
 ///
-/// upstream: options.c `parse_output_words()` walks the comma list and does
-/// `if (!len) continue;`, so `--info=`, `--info=,` and `--info=name,` are all
-/// accepted no-ops rather than errors.
+/// upstream: options.c:448-454 `parse_output_words()` walks the comma list and
+/// does `if (!len) continue;`, so `--info=`, `--info=,` and `--info=name,` are
+/// all accepted no-ops rather than errors.
+///
+/// Tokens are passed on verbatim. Upstream compares `str` against the word
+/// table with `strncasecmp` over the raw segment bytes and never trims
+/// surrounding whitespace, so `--debug= flist` is the unknown item `" flist"`
+/// and exits `RERR_SYNTAX` (options.c:484-488) rather than selecting `flist`.
+///
+/// `apply` returns [`TokenFlow::Stop`] to end the walk, which is how a `help`
+/// token short-circuits the rest of the list the way upstream's
+/// `exit_cleanup(0)` does at options.c:465-468.
 pub(super) fn for_each_token<E>(
     value: &str,
-    mut apply: impl FnMut(&str) -> Result<(), E>,
-) -> Result<(), E> {
+    mut apply: impl FnMut(&str) -> Result<TokenFlow, E>,
+) -> Result<TokenFlow, E> {
     for token in value.split(',') {
-        let token = token.trim_matches(|ch: char| ch.is_ascii_whitespace());
         if token.is_empty() {
             continue;
         }
-        apply(token)?;
+        if matches!(apply(token)?, TokenFlow::Stop) {
+            return Ok(TokenFlow::Stop);
+        }
     }
-    Ok(())
+    Ok(TokenFlow::Continue)
 }

--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -65,14 +65,14 @@ fn a_bare_integer_is_a_word_name_not_a_level() {
 fn info_flag_apply_help() {
     let mut settings = InfoFlagSettings::default();
     assert!(!settings.help_requested);
-    settings.apply("help", "help").unwrap();
+    settings.apply("help").unwrap();
     assert!(settings.help_requested);
 }
 
 #[test]
 fn info_flag_apply_all() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
+    settings.apply("all").unwrap();
     assert_eq!(settings.progress, ProgressSetting::PerFile);
     assert_eq!(settings.stats, Some(1));
 }
@@ -80,8 +80,8 @@ fn info_flag_apply_all() {
 #[test]
 fn info_flag_apply_none() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("none", "none").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("none").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Disabled);
     assert_eq!(settings.stats, Some(0));
 }
@@ -89,21 +89,21 @@ fn info_flag_apply_none() {
 #[test]
 fn info_flag_apply_progress() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("progress", "progress").unwrap();
+    settings.apply("progress").unwrap();
     assert_eq!(settings.progress, ProgressSetting::PerFile);
 }
 
 #[test]
 fn info_flag_apply_progress2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("progress2", "progress2").unwrap();
+    settings.apply("progress2").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Overall);
 }
 
 #[test]
 fn info_flag_apply_invalid() {
     let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("invalid", "invalid");
+    let result = settings.apply("invalid");
     assert!(result.is_err());
 }
 
@@ -169,7 +169,7 @@ fn a_debug_word_shares_the_info_token_grammar() {
 #[test]
 fn debug_flag_apply_all() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all", "all").unwrap();
+    settings.apply("all").unwrap();
     assert_eq!(settings.io, Some(1));
     assert_eq!(settings.flist, Some(1));
 }
@@ -177,8 +177,8 @@ fn debug_flag_apply_all() {
 #[test]
 fn debug_flag_apply_none() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("none", "none").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("none").unwrap();
     assert_eq!(settings.io, Some(0));
     assert_eq!(settings.flist, Some(0));
 }
@@ -186,7 +186,7 @@ fn debug_flag_apply_none() {
 #[test]
 fn debug_flag_apply_io() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("io", "io").unwrap();
+    settings.apply("io").unwrap();
     assert_eq!(settings.io, Some(1));
 }
 
@@ -195,14 +195,14 @@ fn debug_flag_apply_io() {
 #[test]
 fn debug_flag_apply_io_level_clamped_to_max() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("io5", "io5").unwrap();
+    settings.apply("io5").unwrap();
     assert_eq!(settings.io, Some(4));
 }
 
 #[test]
 fn debug_flag_apply_invalid() {
     let mut settings = DebugFlagSettings::default();
-    let result = settings.apply("invalid", "invalid");
+    let result = settings.apply("invalid");
     assert!(result.is_err());
 }
 
@@ -230,140 +230,140 @@ fn parse_debug_flags_comma_separated() {
 #[test]
 fn info_flag_progress0_disables() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("progress2", "progress2").unwrap();
+    settings.apply("progress2").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Overall);
-    settings.apply("progress0", "progress0").unwrap();
+    settings.apply("progress0").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Disabled);
 }
 
 #[test]
 fn info_flag_stats2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("stats2", "stats2").unwrap();
+    settings.apply("stats2").unwrap();
     assert_eq!(settings.stats, Some(2));
 }
 
 #[test]
 fn info_flag_stats3() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("stats3", "stats3").unwrap();
+    settings.apply("stats3").unwrap();
     assert_eq!(settings.stats, Some(3));
 }
 
 #[test]
 fn info_flag_name0() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("name0", "name0").unwrap();
+    settings.apply("name0").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
 }
 
 #[test]
 fn info_flag_name1() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("name", "name").unwrap();
+    settings.apply("name").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedOnly));
 }
 
 #[test]
 fn info_flag_name2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("name2", "name2").unwrap();
+    settings.apply("name2").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
 }
 
 #[test]
 fn info_flag_name_high_level_accepted() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("name5", "name5").unwrap();
+    settings.apply("name5").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
 }
 
 #[test]
 fn info_flag_flist0() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("flist0", "flist0").unwrap();
+    settings.apply("flist0").unwrap();
     assert_eq!(settings.flist, Some(0));
 }
 
 #[test]
 fn info_flag_flist2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("flist2", "flist2").unwrap();
+    settings.apply("flist2").unwrap();
     assert_eq!(settings.flist, Some(2));
 }
 
 #[test]
 fn info_flag_misc2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("misc2", "misc2").unwrap();
+    settings.apply("misc2").unwrap();
     assert_eq!(settings.misc, Some(2));
 }
 
 #[test]
 fn info_flag_skip2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("skip2", "skip2").unwrap();
+    settings.apply("skip2").unwrap();
     assert_eq!(settings.skip, Some(2));
 }
 
 #[test]
 fn info_flag_backup_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("backup", "backup").unwrap();
+    settings.apply("backup").unwrap();
     assert_eq!(settings.backup, Some(1));
     // upstream clamps every explicit level to MAX_OUT_LEVEL (4).
-    settings.apply("backup5", "backup5").unwrap();
+    settings.apply("backup5").unwrap();
     assert_eq!(settings.backup, Some(4));
 }
 
 #[test]
 fn info_flag_copy_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("copy", "copy").unwrap();
+    settings.apply("copy").unwrap();
     assert_eq!(settings.copy, Some(1));
-    settings.apply("copy3", "copy3").unwrap();
+    settings.apply("copy3").unwrap();
     assert_eq!(settings.copy, Some(3));
 }
 
 #[test]
 fn info_flag_del_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("del", "del").unwrap();
+    settings.apply("del").unwrap();
     assert_eq!(settings.del, Some(1));
 }
 
 #[test]
 fn info_flag_mount_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("mount", "mount").unwrap();
+    settings.apply("mount").unwrap();
     assert_eq!(settings.mount, Some(1));
 }
 
 #[test]
 fn info_flag_nonreg_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("nonreg", "nonreg").unwrap();
+    settings.apply("nonreg").unwrap();
     assert_eq!(settings.nonreg, Some(1));
 }
 
 #[test]
 fn info_flag_remove_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("remove", "remove").unwrap();
+    settings.apply("remove").unwrap();
     assert_eq!(settings.remove, Some(1));
 }
 
 #[test]
 fn info_flag_symsafe_any_level() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("symsafe", "symsafe").unwrap();
+    settings.apply("symsafe").unwrap();
     assert_eq!(settings.symsafe, Some(1));
 }
 
 #[test]
 fn info_flag_numeric_1_enables_all() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all1", "all1").unwrap();
+    settings.apply("all1").unwrap();
     assert_eq!(settings.progress, ProgressSetting::PerFile);
     assert_eq!(settings.stats, Some(1));
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedOnly));
@@ -382,8 +382,8 @@ fn info_flag_numeric_1_enables_all() {
 #[test]
 fn info_flag_numeric_0_disables_all() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("all0", "all0").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("all0").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Disabled);
     assert_eq!(settings.stats, Some(0));
     assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
@@ -402,31 +402,31 @@ fn info_flag_numeric_0_disables_all() {
 #[test]
 fn info_flag_all_case_insensitive() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("ALL", "ALL").unwrap();
+    settings.apply("ALL").unwrap();
     assert_eq!(settings.stats, Some(1));
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("All", "All").unwrap();
+    settings.apply("All").unwrap();
     assert_eq!(settings.stats, Some(1));
 }
 
 #[test]
 fn info_flag_none_case_insensitive() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("NONE", "NONE").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("NONE").unwrap();
     assert_eq!(settings.stats, Some(0));
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("None", "None").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("None").unwrap();
     assert_eq!(settings.stats, Some(0));
 }
 
 #[test]
 fn info_flag_help_case_insensitive() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("HELP", "HELP").unwrap();
+    settings.apply("HELP").unwrap();
     assert!(settings.help_requested);
 }
 
@@ -483,22 +483,23 @@ fn parse_info_flags_help_terminates_early() {
 #[test]
 fn info_flag_error_message_contains_flag_name() {
     let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("bogus", "bogus");
+    let result = settings.apply("bogus");
     assert!(result.is_err());
     let msg = format!("{:?}", result.unwrap_err());
     assert!(msg.contains("bogus"), "error should mention the flag name");
 }
 
+// upstream: options.c:485-486 -
+// `rprintf(FERROR, "Unknown %s item: \"%.*s\"\n", words[j].help, len, str)`.
+// The sentinel's help field is the bare option name, so the diagnostic is
+// exactly `Unknown --info item: "bogus"` with no trailing hint. oc previously
+// invented `invalid --info flag 'bogus': use --info=help for supported flags`.
 #[test]
-fn info_flag_error_suggests_help() {
+fn info_flag_error_uses_the_upstream_wording() {
     let mut settings = InfoFlagSettings::default();
-    let result = settings.apply("bogus", "bogus");
-    assert!(result.is_err());
-    let msg = format!("{:?}", result.unwrap_err());
-    assert!(
-        msg.contains("--info=help"),
-        "error should suggest --info=help"
-    );
+    let err = settings.apply("bogus").expect_err("bogus is unknown");
+    assert_eq!(err.text(), "Unknown --info item: \"bogus\"");
+    assert_eq!(err.code(), Some(1));
 }
 
 #[test]
@@ -528,7 +529,7 @@ fn info_flag_all_keywords_accepted() {
     ];
     for keyword in &keywords {
         let mut settings = InfoFlagSettings::default();
-        let result = settings.apply(keyword, keyword);
+        let result = settings.apply(keyword);
         assert!(
             result.is_ok(),
             "keyword '{keyword}' should be accepted but got: {result:?}"
@@ -545,7 +546,7 @@ fn debug_flag_all_keywords_accepted() {
     ];
     for keyword in &keywords {
         let mut settings = DebugFlagSettings::default();
-        let result = settings.apply(keyword, keyword);
+        let result = settings.apply(keyword);
         assert!(
             result.is_ok(),
             "debug keyword '{keyword}' should be accepted but got: {result:?}"
@@ -560,60 +561,60 @@ fn debug_flag_all_keywords_accepted() {
 fn debug_flag_level_clamping() {
     // Within-range levels are stored as-is.
     let mut settings = DebugFlagSettings::default();
-    settings.apply("backup2", "backup2").unwrap();
+    settings.apply("backup2").unwrap();
     assert_eq!(settings.backup, Some(2));
 
-    settings.apply("del3", "del3").unwrap();
+    settings.apply("del3").unwrap();
     assert_eq!(settings.del, Some(3));
 
-    settings.apply("deltasum4", "deltasum4").unwrap();
+    settings.apply("deltasum4").unwrap();
     assert_eq!(settings.deltasum, Some(4));
 
-    settings.apply("io4", "io4").unwrap();
+    settings.apply("io4").unwrap();
     assert_eq!(settings.io, Some(4));
 
     // Beyond MAX_OUT_LEVEL: clamped to 4.
     let mut settings = DebugFlagSettings::default();
-    settings.apply("backup5", "backup5").unwrap();
+    settings.apply("backup5").unwrap();
     assert_eq!(settings.backup, Some(4));
 
-    settings.apply("connect9", "connect9").unwrap();
+    settings.apply("connect9").unwrap();
     assert_eq!(settings.connect, Some(4));
 
-    settings.apply("cmd7", "cmd7").unwrap();
+    settings.apply("cmd7").unwrap();
     assert_eq!(settings.cmd, Some(4));
 
-    settings.apply("del8", "del8").unwrap();
+    settings.apply("del8").unwrap();
     assert_eq!(settings.del, Some(4));
 
-    settings.apply("deltasum5", "deltasum5").unwrap();
+    settings.apply("deltasum5").unwrap();
     assert_eq!(settings.deltasum, Some(4));
 
-    settings.apply("exit6", "exit6").unwrap();
+    settings.apply("exit6").unwrap();
     assert_eq!(settings.exit, Some(4));
 
-    settings.apply("filter5", "filter5").unwrap();
+    settings.apply("filter5").unwrap();
     assert_eq!(settings.filter, Some(4));
 
-    settings.apply("flist9", "flist9").unwrap();
+    settings.apply("flist9").unwrap();
     assert_eq!(settings.flist, Some(4));
 
-    settings.apply("fuzzy5", "fuzzy5").unwrap();
+    settings.apply("fuzzy5").unwrap();
     assert_eq!(settings.fuzzy, Some(4));
 
-    settings.apply("hlink5", "hlink5").unwrap();
+    settings.apply("hlink5").unwrap();
     assert_eq!(settings.hlink, Some(4));
 
-    settings.apply("iconv7", "iconv7").unwrap();
+    settings.apply("iconv7").unwrap();
     assert_eq!(settings.iconv, Some(4));
 
-    settings.apply("io5", "io5").unwrap();
+    settings.apply("io5").unwrap();
     assert_eq!(settings.io, Some(4));
 
-    settings.apply("own9", "own9").unwrap();
+    settings.apply("own9").unwrap();
     assert_eq!(settings.own, Some(4));
 
-    settings.apply("time6", "time6").unwrap();
+    settings.apply("time6").unwrap();
     assert_eq!(settings.time, Some(4));
 }
 
@@ -622,7 +623,7 @@ fn debug_flag_level_clamping() {
 #[test]
 fn debug_flag_all_with_level() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all4", "all4").unwrap();
+    settings.apply("all4").unwrap();
     assert_eq!(settings.io, Some(4));
     assert_eq!(settings.flist, Some(4));
     assert_eq!(settings.hlink, Some(4));
@@ -630,7 +631,7 @@ fn debug_flag_all_with_level() {
 
     // Level beyond MAX_OUT_LEVEL is clamped.
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all9", "all9").unwrap();
+    settings.apply("all9").unwrap();
     assert_eq!(settings.io, Some(4));
     assert_eq!(settings.hlink, Some(4));
 }
@@ -638,7 +639,7 @@ fn debug_flag_all_with_level() {
 #[test]
 fn debug_flag_numeric_1_enables_all() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all1", "all1").unwrap();
+    settings.apply("all1").unwrap();
     assert_eq!(settings.io, Some(1));
     assert_eq!(settings.proto, Some(1));
     assert_eq!(settings.flist, Some(1));
@@ -648,8 +649,8 @@ fn debug_flag_numeric_1_enables_all() {
 #[test]
 fn debug_flag_numeric_0_disables_all() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("all", "all").unwrap();
-    settings.apply("all0", "all0").unwrap();
+    settings.apply("all").unwrap();
+    settings.apply("all0").unwrap();
     assert_eq!(settings.io, Some(0));
     assert_eq!(settings.proto, Some(0));
     assert_eq!(settings.flist, Some(0));
@@ -659,9 +660,9 @@ fn debug_flag_numeric_0_disables_all() {
 #[test]
 fn debug_flag_iter_enabled_flags_returns_nonzero() {
     let mut settings = DebugFlagSettings::default();
-    settings.apply("io2", "io2").unwrap();
-    settings.apply("flist", "flist").unwrap();
-    settings.apply("del0", "del0").unwrap();
+    settings.apply("io2").unwrap();
+    settings.apply("flist").unwrap();
+    settings.apply("del0").unwrap();
 
     let enabled: Vec<_> = settings.iter_enabled_flags().collect();
     assert!(enabled.contains(&("io", 2)));
@@ -820,7 +821,7 @@ fn debug_help_text_includes_opt_preface() {
 #[test]
 fn info_flag_numeric_2_enables_all_at_level_2() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all2", "all2").unwrap();
+    settings.apply("all2").unwrap();
     assert_eq!(settings.progress, ProgressSetting::Overall);
     assert_eq!(settings.stats, Some(2));
     assert_eq!(settings.name, Some(NameOutputLevel::UpdatedAndUnchanged));
@@ -840,7 +841,7 @@ fn info_flag_numeric_2_enables_all_at_level_2() {
 #[test]
 fn info_flag_numeric_3_clamps_per_flag() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all3", "all3").unwrap();
+    settings.apply("all3").unwrap();
     // STATS supports level 3.
     assert_eq!(settings.stats, Some(3));
     // PROGRESS, NAME, FLIST, MISC, SKIP clamp at 2.
@@ -856,8 +857,8 @@ fn info_flag_numeric_3_clamps_per_flag() {
 #[test]
 fn info_flag_numeric_then_named_override() {
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all2", "all2").unwrap();
-    settings.apply("name0", "name0").unwrap();
+    settings.apply("all2").unwrap();
+    settings.apply("name0").unwrap();
     assert_eq!(settings.name, Some(NameOutputLevel::Disabled));
     // Other flags retained from the numeric pre-fill.
     assert_eq!(settings.stats, Some(2));
@@ -876,7 +877,7 @@ fn parse_info_flags_numeric_then_named_in_one_arg() {
 fn info_flag_numeric_high_value_saturates() {
     // Out-of-range integers saturate at per-flag caps rather than erroring.
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all99", "all99").unwrap();
+    settings.apply("all99").unwrap();
     assert_eq!(settings.stats, Some(3));
     assert_eq!(settings.flist, Some(2));
     assert_eq!(settings.copy, Some(1));
@@ -887,7 +888,7 @@ fn info_flag_numeric_overflow_does_not_panic() {
     // A value that overflows u8 falls back to u8::MAX inside the parser,
     // which still saturates to per-flag caps.
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all999", "all999").unwrap();
+    settings.apply("all999").unwrap();
     assert_eq!(settings.stats, Some(3));
 }
 
@@ -919,7 +920,7 @@ fn info_flag_numeric_n_caps_each_priority_group_at_per_flag_max() {
     // `--info=2` enables every priority<=2 flag; per-flag caps still apply
     // (stats caps at 3, flist/misc/skip/name/progress at 2, others at 1).
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all2", "all2").unwrap();
+    settings.apply("all2").unwrap();
     for spec in INFO_FLAG_SPECS {
         if spec.priority > 2 {
             continue;
@@ -967,9 +968,9 @@ fn apply_to_thread_local_individual_flags() {
     logging::init(logging::VerbosityConfig::default());
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("copy", "copy").unwrap();
-    settings.apply("del", "del").unwrap();
-    settings.apply("flist2", "flist2").unwrap();
+    settings.apply("copy").unwrap();
+    settings.apply("del").unwrap();
+    settings.apply("flist2").unwrap();
     settings.apply_to_thread_local();
 
     assert!(logging::info_gte(logging::InfoFlag::Copy, 1));
@@ -985,7 +986,7 @@ fn apply_to_thread_local_all_token() {
     logging::init(logging::VerbosityConfig::default());
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all", "all").unwrap();
+    settings.apply("all").unwrap();
     settings.apply_to_thread_local();
 
     // All flags should be at level 1 (capped by max_level)
@@ -1012,7 +1013,7 @@ fn apply_to_thread_local_none_token() {
 
     // Then apply none - should zero all flags
     let mut settings = InfoFlagSettings::default();
-    settings.apply("none", "none").unwrap();
+    settings.apply("none").unwrap();
     settings.apply_to_thread_local();
 
     assert!(!logging::info_gte(logging::InfoFlag::Copy, 1));
@@ -1028,7 +1029,7 @@ fn apply_to_thread_local_numeric_level() {
     logging::init(logging::VerbosityConfig::default());
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("all2", "all2").unwrap();
+    settings.apply("all2").unwrap();
     settings.apply_to_thread_local();
 
     // Level 2 enables all flags, capped by per-flag max_level
@@ -1079,7 +1080,7 @@ fn apply_to_thread_local_progress_levels() {
     logging::init(logging::VerbosityConfig::default());
 
     let mut settings = InfoFlagSettings::default();
-    settings.apply("progress2", "progress2").unwrap();
+    settings.apply("progress2").unwrap();
     settings.apply_to_thread_local();
 
     assert!(logging::info_gte(logging::InfoFlag::Progress, 2));
@@ -1087,7 +1088,7 @@ fn apply_to_thread_local_progress_levels() {
     // Reset and test progress disabled
     logging::init(logging::VerbosityConfig::from_verbose_level(1));
     let mut settings = InfoFlagSettings::default();
-    settings.apply("progress0", "progress0").unwrap();
+    settings.apply("progress0").unwrap();
     settings.apply_to_thread_local();
 
     assert!(!logging::info_gte(logging::InfoFlag::Progress, 1));
@@ -1161,7 +1162,7 @@ fn no_debug_word_accepts_a_negation_prefix() {
 fn info_flag_progress3_is_clamped_not_rejected() {
     let mut settings = InfoFlagSettings::default();
     settings
-        .apply("progress3", "progress3")
+        .apply("progress3")
         .expect("upstream clamps an out-of-range level, it never rejects one");
     assert_eq!(settings.progress, ProgressSetting::Overall);
 }
@@ -1170,7 +1171,7 @@ fn info_flag_progress3_is_clamped_not_rejected() {
 fn info_flag_stats4_is_clamped_not_rejected() {
     let mut settings = InfoFlagSettings::default();
     settings
-        .apply("stats4", "stats4")
+        .apply("stats4")
         .expect("upstream clamps an out-of-range level, it never rejects one");
     assert_eq!(settings.stats, Some(4));
 }
@@ -1179,7 +1180,7 @@ fn info_flag_stats4_is_clamped_not_rejected() {
 fn info_flag_flist3_is_clamped_not_rejected() {
     let mut settings = InfoFlagSettings::default();
     settings
-        .apply("flist3", "flist3")
+        .apply("flist3")
         .expect("upstream clamps an out-of-range level, it never rejects one");
     assert_eq!(settings.flist, Some(3));
 }
@@ -1188,7 +1189,7 @@ fn info_flag_flist3_is_clamped_not_rejected() {
 fn info_flag_misc3_is_clamped_not_rejected() {
     let mut settings = InfoFlagSettings::default();
     settings
-        .apply("misc3", "misc3")
+        .apply("misc3")
         .expect("upstream clamps an out-of-range level, it never rejects one");
     assert_eq!(settings.misc, Some(3));
 }
@@ -1197,7 +1198,139 @@ fn info_flag_misc3_is_clamped_not_rejected() {
 fn info_flag_skip3_is_clamped_not_rejected() {
     let mut settings = InfoFlagSettings::default();
     settings
-        .apply("skip3", "skip3")
+        .apply("skip3")
         .expect("upstream clamps an out-of-range level, it never rejects one");
     assert_eq!(settings.skip, Some(3));
+}
+
+// ---------------------------------------------------------------------------
+// Unknown-item rejection parity (upstream options.c:443-490).
+//
+// MEASURED against target/interop/upstream-src/rsync-3.5.0/rsync. Each of the
+// four pins below reproduces one cell where oc diverged from that binary; the
+// `still` companions are the non-vacuity controls that stop "reject
+// everything" from satisfying the pins.
+// ---------------------------------------------------------------------------
+
+// upstream: options.c:448-454 splits on ',' and skips only ZERO-LENGTH
+// segments (`if (!len) continue;`); it never trims surrounding whitespace, and
+// options.c:475 then compares the raw segment bytes with `strncasecmp`. So
+// `--debug= flist` is the unknown item `" flist"` and exits RERR_SYNTAX.
+// oc used to trim the token first and silently accept it.
+#[test]
+fn a_whitespace_padded_word_is_an_unknown_item_not_a_trimmed_one() {
+    for token in [" flist", "flist ", "\tflist", " "] {
+        let err = parse_debug_flags(&[OsString::from(token)]).expect_err(
+            "upstream does not trim a --debug item, so a padded word is an unknown item",
+        );
+        assert_eq!(err.text(), format!("Unknown --debug item: \"{token}\""));
+    }
+
+    for token in [" progress", "progress ", "\tprogress", " "] {
+        let err = parse_info_flags(&[OsString::from(token)]).expect_err(
+            "upstream does not trim an --info item, so a padded word is an unknown item",
+        );
+        assert_eq!(err.text(), format!("Unknown --info item: \"{token}\""));
+    }
+}
+
+// Non-vacuity companion: the same words WITHOUT the padding must still parse,
+// so the pin above cannot be satisfied by rejecting every token.
+#[test]
+fn an_unpadded_word_is_still_accepted() {
+    let settings = parse_debug_flags(&[OsString::from("flist")]).expect("`flist` is a debug word");
+    assert_eq!(settings.flist, Some(1));
+
+    let settings =
+        parse_info_flags(&[OsString::from("progress")]).expect("`progress` is an info word");
+    assert_eq!(settings.progress, ProgressSetting::PerFile);
+}
+
+// upstream: options.c:455-458 strips the trailing digits BEFORE the table
+// lookup and options.c:485-486 then prints `"%.*s"` with that shortened `len`,
+// so `--debug=BOGUS2` reports `BOGUS` - the level suffix is absent and the
+// original case is preserved. oc used to echo the whole raw token.
+#[test]
+fn an_unknown_item_is_reported_without_its_level_suffix() {
+    let err = parse_debug_flags(&[OsString::from("BOGUS2")]).expect_err("BOGUS is not a word");
+    assert_eq!(err.text(), "Unknown --debug item: \"BOGUS\"");
+
+    let err = parse_info_flags(&[OsString::from("bogus9")]).expect_err("bogus is not a word");
+    assert_eq!(err.text(), "Unknown --info item: \"bogus\"");
+
+    // A token that STARTS with a digit skips the strip entirely
+    // (`if (!isDigit(str))`), so it is reported whole.
+    let err = parse_debug_flags(&[OsString::from("2flist")]).expect_err("2flist is not a word");
+    assert_eq!(err.text(), "Unknown --debug item: \"2flist\"");
+}
+
+// Non-vacuity companion: a KNOWN word carrying the same level suffix must
+// still be accepted and must still select that level.
+#[test]
+fn a_known_word_with_a_level_suffix_is_still_accepted() {
+    let settings = parse_debug_flags(&[OsString::from("FLIST2")]).expect("FLIST2 is a debug word");
+    assert_eq!(settings.flist, Some(2));
+
+    let settings = parse_info_flags(&[OsString::from("stats3")]).expect("stats3 is an info word");
+    assert_eq!(settings.stats, Some(3));
+}
+
+// upstream: options.c:465-468 - `help` calls `output_item_help()` and then
+// `exit_cleanup(0)` from inside the token loop, so nothing after it in the
+// list (or in a later `--debug=` argument) is ever examined. oc used to
+// validate the whole list first and so failed `--debug=help,bogus` with
+// exit 1 where upstream prints the help and exits 0.
+#[test]
+fn a_help_item_short_circuits_the_rest_of_the_list() {
+    let settings = parse_debug_flags(&[OsString::from("help,bogus")])
+        .expect("`help` exits before `bogus` is examined");
+    assert!(settings.help_requested);
+
+    let settings = parse_debug_flags(&[OsString::from("help"), OsString::from("bogus")])
+        .expect("`help` exits before a later --debug= argument is parsed");
+    assert!(settings.help_requested);
+
+    let settings = parse_info_flags(&[OsString::from("help,bogus")])
+        .expect("`help` exits before `bogus` is examined");
+    assert!(settings.help_requested);
+}
+
+// Non-vacuity companion: an unknown item BEFORE `help` still errors, so the
+// short-circuit above cannot be satisfied by ignoring unknown items whenever
+// `help` appears anywhere in the value.
+#[test]
+fn an_unknown_item_before_help_still_errors() {
+    let err = parse_debug_flags(&[OsString::from("bogus,help")])
+        .expect_err("`bogus` is reached before `help`");
+    assert_eq!(err.text(), "Unknown --debug item: \"bogus\"");
+
+    let err = parse_info_flags(&[OsString::from("bogus,help")])
+        .expect_err("`bogus` is reached before `help`");
+    assert_eq!(err.text(), "Unknown --info item: \"bogus\"");
+}
+
+// upstream: options.c:484-488 - the diagnostic is `Unknown <opt> item: "<tok>"`
+// on FERROR (stderr) and the exit is `RERR_SYNTAX` = 1 (errcode.h:25). oc used
+// to invent `invalid --debug flag '<tok>': use --debug=help for supported
+// flags`.
+#[test]
+fn the_unknown_item_diagnostic_matches_upstream_wording() {
+    let err = parse_debug_flags(&[OsString::from("bogus")]).expect_err("bogus is not a word");
+    assert_eq!(err.text(), "Unknown --debug item: \"bogus\"");
+    assert_eq!(err.code(), Some(1));
+
+    let err = parse_info_flags(&[OsString::from("bogus")]).expect_err("bogus is not a word");
+    assert_eq!(err.text(), "Unknown --info item: \"bogus\"");
+    assert_eq!(err.code(), Some(1));
+}
+
+// Non-vacuity companion: the server-side decoder must stay permissive, because
+// upstream's `!am_server` guard (options.c:484) skips the RERR_SYNTAX exit so a
+// newer client's unknown word cannot kill the connection.
+#[test]
+fn the_server_side_decoder_still_ignores_an_unknown_item() {
+    let settings = parse_info_flags_server(&[OsString::from("progress,bogus,stats")])
+        .expect("the server side ignores an unknown item");
+    assert_eq!(settings.progress, ProgressSetting::PerFile);
+    assert_eq!(settings.stats, Some(1));
 }

--- a/crates/cli/src/frontend/tests/info_debug.rs
+++ b/crates/cli/src/frontend/tests/info_debug.rs
@@ -114,7 +114,7 @@ fn info_rejects_unknown_flag() {
     assert_eq!(code, 1);
     assert!(stdout.is_empty());
     let rendered = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(rendered.contains("invalid --info flag"));
+    assert!(rendered.contains(r#"Unknown --info item: ""#));
 }
 
 #[test]
@@ -551,7 +551,7 @@ fn info_unknown_flag_exit_code_1() {
     let (code, _stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--info=notaflag")]);
     assert_eq!(code, 1);
     let rendered = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(rendered.contains("invalid --info flag"));
+    assert!(rendered.contains(r#"Unknown --info item: ""#));
     assert!(rendered.contains("notaflag"));
 }
 
@@ -561,7 +561,50 @@ fn debug_rejects_unknown_flag() {
         run_with_args([OsStr::new(RSYNC), OsStr::new("--debug=notaflag")]);
     assert_eq!(code, 1);
     let rendered = String::from_utf8(stderr).expect("stderr utf8");
-    assert!(rendered.contains("invalid --debug flag"));
+    assert!(rendered.contains(r#"Unknown --debug item: ""#));
+}
+
+// End-to-end companion for the parser-level pin in
+// `execution::flags::tests::a_whitespace_padded_word_is_an_unknown_item_not_a_trimmed_one`:
+// no layer between argv and `parse_debug_flags` may re-introduce a trim.
+//
+// upstream: options.c:448-454 skips only ZERO-LENGTH comma segments and
+// options.c:475 then compares the raw bytes, so ` flist` is an unknown item.
+// MEASURED: `rsync --debug=" flist"` from rsync 3.5.0 prints
+// `Unknown --debug item: " flist"` and exits 1.
+#[test]
+fn debug_rejects_a_whitespace_padded_flag_through_the_cli() {
+    let (code, _stdout, stderr) = run_with_args([OsStr::new(RSYNC), OsStr::new("--debug= flist")]);
+    assert_eq!(code, 1);
+    let rendered = String::from_utf8(stderr).expect("stderr utf8");
+    assert!(
+        rendered.contains(r#"Unknown --debug item: " flist""#),
+        "padded item must be reported verbatim: {rendered:?}"
+    );
+}
+
+// Non-vacuity companion: the unpadded spelling must still reach the parser and
+// be accepted, so the pin above cannot be met by rejecting every `--debug`.
+//
+// The trailing `--debug=help` is what makes the cell exit rather than start a
+// transfer; it is parsed AFTER `flist`, so `--debug=bogus --debug=help` exits 1
+// on this same path. (`--version` would NOT work here: it short-circuits before
+// `--debug` is parsed at all, which would make this control vacuous.)
+#[test]
+fn debug_still_accepts_the_unpadded_flag_through_the_cli() {
+    let (code, _stdout, stderr) = run_with_args([
+        OsStr::new(RSYNC),
+        OsStr::new("--debug=flist"),
+        OsStr::new("--debug=help"),
+    ]);
+    assert_eq!(code, 0, "stderr: {:?}", String::from_utf8_lossy(&stderr));
+
+    let (code, _stdout, _stderr) = run_with_args([
+        OsStr::new(RSYNC),
+        OsStr::new("--debug=bogus"),
+        OsStr::new("--debug=help"),
+    ]);
+    assert_eq!(code, 1, "the control must discriminate an unknown item");
 }
 
 #[test]

--- a/docs/audits/debug-flags-audit.md
+++ b/docs/audits/debug-flags-audit.md
@@ -32,8 +32,7 @@ The **upstream max** column is the largest level `N` ever used in any
 `DEBUG_GTE(FLAG, N)` site in the upstream tree (so it bounds the useful
 range; upstream caps any user-supplied level at `MAX_OUT_LEVEL = 4`).
 The **our max** column is the level cap enforced in
-`crates/cli/src/frontend/execution/flags/debug.rs::apply` - tokens
-exceeding the cap return `invalid --debug flag '<token>'`.
+`crates/cli/src/frontend/execution/flags/debug.rs::apply`.
 "Yes" in the **parity** column means the cap matches upstream's
 documented range and our gating sites cover the levels actually used.
 
@@ -99,7 +98,7 @@ Our parser
 | `0`                | Treated as `NONE`                           | `disable_all()`.                                                                               | Yes |
 | `NONE` / `none`    | Zero every flag                             | `disable_all()` sets every flag to `Some(0)`.                                                  | Yes |
 | `no<flag>` / `-<flag>` | `parse_output_words` does not recognise these (level digits only) | `parse_flag_and_level` strips `no`/`-` prefix and forces level 0 (oc-rsync extension).    | Extension - upstream silently rejects, we accept. |
-| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1    | `invalid --debug flag '<tok>': use --debug=help for supported flags`, exit 1.                  | Functional parity (different wording). |
+| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1    | `Unknown --debug item: "<tok>"`, exit 1.                                                      | Yes. |
 
 ## Numbered subcategories (`FLIST3`, `DELTASUM4`, ...)
 

--- a/docs/audits/debug-flags-matrix.md
+++ b/docs/audits/debug-flags-matrix.md
@@ -111,7 +111,7 @@ entry in `debug_words[]` services every level for the flag.
 | `NONE0`            | Same as `NONE`                                        | Falls through `apply_flag_and_level` and is rejected as unknown token                           | Gap    |
 | `no<flag>` / `-<flag>` | Not recognised by `parse_output_words`            | `parse_flag_and_level` strips `no`/`-` and forces level 0 (oc-rsync extension)                  | Extension |
 | `<flag><digit>`    | Trailing digits parse as level, clamp at `MAX_OUT_LEVEL` | `parse_flag_and_level` trims trailing digits and parses suffix as `u8`; per-flag arm in `apply` enforces the documented per-flag cap | Yes (with caveats below) |
-| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1               | `invalid --debug flag '<tok>': use --debug=help for supported flags`, exit 1                    | Functional parity (different wording) |
+| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1               | `Unknown --debug item: "<tok>"`, exit 1                                                        | Yes |
 
 ## `-v` ladder
 

--- a/docs/audits/debug-flags-verbosity-matrix.md
+++ b/docs/audits/debug-flags-verbosity-matrix.md
@@ -92,9 +92,7 @@ The **upstream max** column is the largest `N` ever passed to
 range; upstream silently clamps user-supplied levels at
 `MAX_OUT_LEVEL = 4` regardless). The **oc-rsync cap** column is the
 level cap enforced in
-`crates/cli/src/frontend/execution/flags/debug.rs::apply` - tokens
-exceeding the cap return `invalid --debug flag '<tok>': use
---debug=help for supported flags` (`flags/debug.rs:317-322`). The
+`crates/cli/src/frontend/execution/flags/debug.rs::apply`. The
 **oc-rsync status** column is one of:
 
 - **impl** - parser accepts the flag, at least one production
@@ -170,14 +168,14 @@ tokens before consulting the `debug_words[]` lookup:
 |--------------------|--------------------|--------------------|--------|
 | `help`             | `output_item_help`, then `exit_cleanup(0)` (`options.c:446-449`) | `parse_debug_flags` sets `settings.help_requested = true` (`flags/debug.rs:343-345`); the drive layer prints `DEBUG_HELP_TEXT` (`flags/debug.rs:354-384`) before exiting 0. | yes (different help layout - see section 5) |
 | `ALL` / `all`      | `len = 0` after `strncasecmp(..., "all", 3)`; loop body assigns level 1 (or trailing digit if present) to every entry (`options.c:452-453`, `:454-463`) | `apply` recognises bare `all`/`1` and calls `enable_all()` (`flags/debug.rs:128-131`) | yes |
-| `ALL2` ... `ALL4`  | Trailing digit parsed as level, clamped to 4 (`options.c:443-445`); every entry set to that level (`options.c:454-460`) | Falls through `parse_flag_and_level` (`flags/debug.rs:291-310`), which trims trailing digits but rejects `all` because `KNOWN_FLAGS` does not include it; the per-flag arm in `apply` returns `invalid --debug flag` (`flags/debug.rs:279`) | **gap (G1)** |
+| `ALL2` ... `ALL4`  | Trailing digit parsed as level, clamped to 4 (`options.c:455-464`); every entry set to that level (`options.c:471-483`) | `output_words::classify` strips the trailing digit and returns `OutputWord::Every(level)`; `DebugFlagSettings::set_all` applies it | yes |
 | `1`                | Parsed as `lev = 1, len = 0` (`options.c:439-443`), behaves like `ALL` (level 1) | `apply` recognises bare `1` and calls `enable_all()` (`flags/debug.rs:128-131`) | yes |
 | `0`                | `len = 0, lev = 0`, zeroes every flag (`options.c:454-463`) | `apply` recognises bare `0` and calls `disable_all()` (`flags/debug.rs:133-136`) | yes |
 | `NONE` / `none`    | `len = lev = 0`; loop body zeroes every entry (`options.c:450-451`, `:454-463`) | `apply` recognises bare `none`/`0` and calls `disable_all()` (`flags/debug.rs:133-136`) | yes |
-| `NONE0`            | Trailing `0` accepted, equivalent to `NONE` (`options.c:443-445`, `:450-451`) | Falls through `parse_flag_and_level`; `none` not in `KNOWN_FLAGS`, rejected | **gap (G1)** |
+| `NONE0`            | Trailing `0` accepted, equivalent to `NONE` (`options.c:455-464`, `:469-470`) | `output_words::classify` returns `OutputWord::Every(0)` for `none` with or without a suffix | yes |
 | `no<flag>` / `-<flag>` | Not recognised; upstream `parse_output_words` does not strip these prefixes. The token reaches the loop, fails the `strncasecmp` against every `debug_words[].name`, and falls into the `Unknown --debug item` error at `options.c:465-469`. | `parse_flag_and_level` strips `no` or `-` prefix and forces level 0 (`flags/debug.rs:303-307`); the per-flag arm then sets the flag to 0 | **extension** (oc-rsync accepts, upstream rejects; documented in `DEBUG_HELP_TEXT` at `flags/debug.rs:382`) |
 | `<flag><digit>`    | Trailing digits parsed as level; clamped at `MAX_OUT_LEVEL = 4` (`options.c:443-445`) | `parse_flag_and_level` trims trailing digits, validates the base against `KNOWN_FLAGS`, and parses the suffix as `u8` (`flags/debug.rs:292-298`); the per-flag arm in `apply` enforces the per-flag cap | yes for flags whose upstream max is documented; **gap (G2)** for flags whose upstream max is 1 (`acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send`) - oc-rsync accepts any `u8` value while upstream silently clamps to 4. |
-| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1 (`options.c:465-469`) | `invalid --debug flag '<tok>': use --debug=help for supported flags`, exit 1 (`flags/debug.rs:317-322`) | functional parity (different wording) |
+| Unknown token      | `Unknown --debug item: "<tok>"`, exit 1 (`options.c:484-488`) | `Unknown --debug item: "<tok>"`, exit 1 (`flags/debug.rs` `debug_flag_error`) | yes |
 
 ## 4. `-v` cumulative ladder
 
@@ -298,7 +296,7 @@ requested level before the event materialises.
 
 | ID | Severity | Status | Description |
 |----|----------|--------|-------------|
-| G1 | Low | open | `ALL<N>` and `NONE0` syntactic forms are rejected as unknown tokens (`flags/debug.rs:279`). Upstream accepts them (`options.c:443-445`, `:452-453`, `:450-451`) and applies the trailing digit. Fix: extend `DebugFlagSettings::apply` to detect `all<digit>` and `none<digit>` before falling through to `parse_flag_and_level`, then call `enable_all_to_level(N)` / `disable_all()`. Cap N at 4 to match `MAX_OUT_LEVEL`. |
+| G1 | Low | resolved | `ALL<N>` and `NONE<N>` are handled by `output_words::classify`, which strips the trailing digit, clamps it at `MAX_OUT_LEVEL = 4` and returns `OutputWord::Every` (`options.c:455-464`, `:469-472`). Verified against `target/interop/upstream-src/rsync-3.5.0/rsync`: `--debug=ALL2`, `--debug=all9` and `--debug=none2` all exit 0 on both. |
 | G2 | Low | open | Per-flag cap missing for upstream-max-1 flags. `acl`, `bind`, `chdir`, `dup`, `genr`, `hash`, `nstr`, `proto`, `recv`, `send` accept any `u8` value (no `if level > N` guard in `flags/debug.rs::apply`). Upstream silently clamps to `MAX_OUT_LEVEL = 4`. Fix: add `if level > 4 { return Err(debug_flag_error(display)); }` guards on those arms, or a single shared cap before the per-flag dispatch. |
 | G3 | High | open | 2 flags have no production producer (FUZZY, HLINK). The previously listed ACL, BACKUP, BIND, CHDIR, CMD, GENR, HASH, ICONV, NSTR, OWN, and SEND emissions are now wired (D14, I-ACL, I-ICONV, NSTR follow-up, OWN follow-up, D13 RESOLVED, BACKUP RESOLVED, HASH RESOLVED, CMD RESOLVED, CHDIR RESOLVED, BIND RESOLVED, NSTR RESOLVED with byte-for-byte helpers in `crates/protocol/src/nstr/trace.rs` plus the daemon-auth-checksum sites in `crates/core/src/client/remote/daemon_transfer/connection/mod.rs`). Owning crates for the remaining producers: `metadata` (HLINK), `engine` (FUZZY). |
 | G4 | Low | open | `limit_output_verbosity` (upstream `options.c:527-553`) is not implemented. User-supplied per-flag levels are not clamped to the peer's `-v` ceiling during option exchange. Mitigation: implement on `server_options` parsing path and re-run the ladder with `LIMIT_PRIORITY` to compute the cap. |

--- a/docs/audits/info-flags-verbosity-matrix.md
+++ b/docs/audits/info-flags-verbosity-matrix.md
@@ -251,10 +251,10 @@ only spelling shown to users.
 
 oc-rsync surfaces unknown info tokens with `rsync_error!(1, ...)` at
 `info.rs:194-200`. Upstream uses `RERR_SYNTAX` (1) at
-`options.c:466-468`. Same numeric code, but the message string differs:
+`options.c:484-488`. Both the numeric code and the message string match:
 
 - Upstream: `Unknown --info item: "FOO"`.
-- oc-rsync: `invalid --info flag 'FOO': use --info=help for supported flags`.
+- oc-rsync: `Unknown --info item: "FOO"`.
 
 ### 4.5 Server-side tolerance
 
@@ -296,7 +296,7 @@ re-evaluated and the implementation already matches upstream.
 | I11 | All       | Medium   | OPEN   | `should_show_*` and the parse-cap layer collapse level 2/3 to level 1 because no production code differentiates levels beyond `> 0`. Closing I1-I10 individually addresses this category. |
 | I12 | All       | Low      | RESOLVED | `--info=N` (bare digit) now accepted as a usability extension; oc-rsync's `apply()` in `info.rs` delegates to `enable_all_at_level(N)` with the same per-flag caps as upstream's `all<N>` token (`options.c parse_output_words`). |
 | I13 | All       | Low      | RESOLVED | `--info=no<flag>` / `--info=-<flag>` are an internal-only extension not advertised in `--info=help`; the parser still accepts them for backwards compatibility and server-mode token forwarding, but the user-facing surface only shows the upstream suffix form. |
-| I14 | All       | Low      | OPEN   | Unknown-token message text differs: upstream `Unknown --info item: "FOO"`, oc-rsync `invalid --info flag 'FOO': use --info=help for supported flags`. Same exit code (1). |
+| I14 | All       | Low      | RESOLVED | Unknown-token message text now matches upstream verbatim: `Unknown --info item: "FOO"` on stderr, exit 1 (`options.c:484-488`). The level suffix is stripped before the token is reported, as upstream's `"%.*s"` does. |
 | I15 | All       | Low      | OPEN   | Server-side mode (`am_server`) should suppress unknown-token errors (`options.c:465`); oc-rsync errors unconditionally. |
 | I16 | All       | Low      | RESOLVED | `InfoFlagSpec::priority` on every `INFO_FLAG_SPECS` entry now mirrors upstream's `info_verbosity[]` group index (`options.c:239-243`); a daemon-side `limit_output_verbosity()` consumer can read priorities from the spec table without re-deriving them. |
 | I17 | Help text | Low      | RESOLVED | `INFO_HELP_TEXT` in `crates/cli/src/frontend/execution/flags/info.rs` now reproduces upstream's `output_item_help()` (`options.c:474-509`) byte-for-byte: the `"%-10s %s\n"` table, the ALL/NONE/HELP synthetic rows that quote the sentinel's `--info` help, and the per-verbosity summary block driven by `info_verbosity[]`. C3 done. |


### PR DESCRIPTION
`--debug=" flist"` exited 0 silently where upstream exits 1, and every rejection oc *did* emit used invented wording.

## Upstream

One tokenizer serves both options: `parse_output_words(words, levels, str, priority)` at **options.c:443-490**, called from `OPT_INFO` (`options.c:1877-1880`) and `OPT_DEBUG` (`options.c:1882-1885`).

| lines | shape | decision |
|---|---|---|
| 448-454 | comma split, `if (!len) continue;` | zero-length segments are accepted no-ops — `--debug=`, `,,,`, `name,`. **No whitespace trim anywhere.** |
| 455-458 | `if (!isDigit(str)) while (len && isDigit(str+len-1)) len--;` | trailing digits stripped only when the token does *not* start with a digit |
| 459-464 | `lev = …; if (lev > MAX_OUT_LEVEL \|\| lev < 0) lev = MAX_OUT_LEVEL;` | level clamped to 4 (`options.c:261`), never rejected |
| 465-468 | `len==4 && strncasecmp(str,"help",4)==0` | `output_item_help(); exit_cleanup(0);` — **exits 0 from inside the loop** |
| 469-472 | `none` / `all` | zero or set every word |
| 473-483 | `strncasecmp(str, words[j].name, len)` with `len == namelen` | exact-length, case-insensitive |
| **484-488** | `if (len && !words[j].name && !am_server)` | `rprintf(FERROR, "Unknown %s item: \"%.*s\"\n", words[j].help, len, str); exit_cleanup(RERR_SYNTAX);` |

At :484 `words[j]` is the NULL sentinel whose `help` is the literal `"--info"` (`options.c:301`) / `"--debug"` (`options.c:333`); `len` is the **digit-stripped** length; `RERR_SYNTAX` is 1 (`errcode.h:25`). The `!am_server` half means the **server side stays silent** on an unknown word.

## Measured against the real 3.5.0 binary

Every probed shape that already matched is omitted — `flist`, `flist2`, `all0`, `ALL2`, `none2`, `HELP`, `DeLtAsUm`, `,,,`, `,bogus`, `2flist`, `99999999999999999999`, `nobogus`, `-bogus`, `stats3`, and the `--info=` twins all agreed on rc **and** message before this change.

| argv | upstream | before | after |
|---|---|---|---|
| `--debug= flist` | rc=1 `Unknown --debug item: " flist"` | **rc=0, silent** | matches |
| `--debug=flist ` | rc=1 `Unknown --debug item: "flist "` | **rc=0, silent** | matches |
| `--info="name2, del1"` | rc=1 `Unknown --info item: " del"` | **rc=0, silent** | matches |
| `--debug=bogus2` | rc=1 `Unknown --debug item: "bogus"` | rc=1, invented wording | matches |
| `--debug=help,bogus` | rc=0, prints the table | **rc=1** | matches |
| `--debug=bogus` | rc=1 `Unknown --debug item: "bogus"` | rc=1, invented wording | matches |

Four distinct defects: the trim, the un-stripped token in the message, `help` not short-circuiting, and the invented text.

oc's line keeps the repo-wide branding envelope (`oc-rsync error: … (code 1) at debug.rs(179)`), which is the established convention for **every** option error — `--chmod=zzz` renders identically. The diagnostic *text*, stream and exit code are ported; restructuring `Message` repo-wide is out of scope.

Word-split trap avoided: each cell passed as one argv word via an array, and the non-empty upstream rc=1 rows prove the flags reached the binary.

## Seven parser sites enumerated, three changed

| site | verdict |
|---|---|
| `flags/output_words.rs` — shared tokenizer | **changed** — trim dropped, `TokenFlow` short-circuit, digit-stripped case-preserving base |
| `flags/debug.rs` | **changed** |
| `flags/info.rs` | **changed** (`spec_for` also made case-insensitive per options.c:475) |
| `server/run.rs:198-215` | unchanged — correctly permissive, mirrors the `!am_server` half |
| `server/flags.rs:1160-1165` | unchanged — server `--debug=` captured, never parsed; matches upstream silence |
| `logging/src/config.rs:201-303` | unchanged — downstream applier, every caller does `let _ =`; only sees already-accepted tokens |
| `frontend/info_output.rs:250-300` | unchanged, **flagged**: a second parallel `parse_info_flags` with its own `.trim()` and its own name table. Publicly re-exported, but its only consumer is `tests/output_parity.rs` — off the binary's path. Latent recurrence of this exact defect class if ever wired up. |

## Mutation proof

Filter `test(/flags::tests|info_debug/)`, test files untouched, one predicate reverted per arm:

| arm | result |
|---|---|
| baseline | 155 run: 155 passed |
| **M1** restore the trim | 155 run: **153 passed, 2 failed** |
| **M2** report the raw token | 155 run: **154 passed, 1 failed** |
| **M3** `Help` returns `Continue` | 155 run: **154 passed, 1 failed** |
| **M4** restore the invented wording | 155 run: **146 passed, 9 failed** |

`passed + failed == run` in every arm. Companions stayed green under M1-M3 (`an_unpadded_word_is_still_accepted`, `a_known_word_with_a_level_suffix_is_still_accepted`, `an_unknown_item_before_help_still_errors`, `the_server_side_decoder_still_ignores_an_unknown_item`), so "reject everything" cannot satisfy the pins. The CLI companion deliberately avoids `--version` as terminator — `--version` short-circuits before `--debug` is parsed and would make the control vacuous.

## Gates

Workspace `32627 run: 32622 passed, 5 failed`. All 5 reproduce at pristine HEAD with the changed files reverted (`5 run: 0 passed, 5 failed`) — APFS sparse-block accounting plus one xtask fixture, unrelated. `check_rustfmt_all.py` clean (3389 files); `clippy -p cli --all-targets` silent on touched files; no `--help` snapshot moved and `--debug=help` output is byte-identical.

## Reported, not fixed

`--version` / `--help` **precedence** is a separate divergence: upstream is strictly argv-ordered (popt handles each option where it sits), oc's `maybe_print_help_or_version` runs before option validation and wins regardless of position — so `--debug=bogus --version` exits 0 on oc, 1 upstream. Fixing it means reordering global preflight against every validated option, with broad snapshot blast radius.

Task 775's premise (an oc-invented `no…`/`-…` negation prefix) was **measured not to reproduce**: `--debug=nobogus`, `-bogus`, `noflist`, `--info=nodel`, `-skip` all exit 1 matching upstream, already pinned by pre-existing tests, and no prefix stripping exists at any of the 7 sites.
