### PR TITLE
fix(daemon): clear the master red - rustdoc link, racing converter cause, and a pre-mangled log operand

### DIFF
--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -14,9 +14,8 @@ pub(crate) fn log_list_request(log: &SharedLogSink, host: &str, peer_addr: Socke
 }
 
 pub(crate) fn log_module_request(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
-    let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:787 - `rsync allowed access on module %s from %s (%s)`
-    let text = format!("rsync allowed access on module {module_display} from {host} ({peer_ip})");
+    let text = format!("rsync allowed access on module {module} from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
@@ -27,7 +26,7 @@ pub(crate) fn log_module_request(log: &SharedLogSink, host: &str, peer_ip: IpAdd
 /// Mirrors the global cap warning emitted from
 /// [`log_max_connections_rejection`] so operators see one consistent
 /// shape across both admission paths. Fields are stable and named:
-/// `which` carries the module name (sanitised to strip control chars),
+/// `which` carries the module name verbatim - the log sink escapes it,
 /// `peer` records the rejected client IP, `cap` is the configured limit
 /// that triggered the refusal (negative when the directive disables the
 /// module), and `current` is the active connection count observed at the
@@ -40,9 +39,8 @@ pub(crate) fn log_module_limit(
     limit: i32,
     current: u32,
 ) {
-    let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "max-connections cap reached: which={module_display} peer={host} ({peer_ip}) cap={limit} current={current}"
+        "max-connections cap reached: which={module} peer={host} ({peer_ip}) cap={limit} current={current}"
     );
     let message = rsync_warning!(text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -55,9 +53,8 @@ fn log_module_lock_error(
     module: &str,
     error: &io::Error,
 ) {
-    let module_display = sanitize_module_identifier(module);
     let text = format!(
-        "failed to update lock for module '{module_display}' requested from {host} ({peer_ip}): {error}"
+        "failed to update lock for module '{module}' requested from {host} ({peer_ip}): {error}"
     );
     let message = rsync_error!(FEATURE_UNAVAILABLE_EXIT_CODE, text).with_role(Role::Daemon);
     log_message(log, &message);
@@ -70,10 +67,7 @@ fn log_module_refused_option(
     module: &str,
     refused: &str,
 ) {
-    let module_display = sanitize_module_identifier(module);
-    let text = format!(
-        "refusing option '{refused}' for module '{module_display}' from {host} ({peer_ip})"
-    );
+    let text = format!("refusing option '{refused}' for module '{module}' from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
@@ -85,7 +79,6 @@ pub(crate) fn log_module_auth_failure(
     module: &str,
     suffix: Option<&str>,
 ) {
-    let module_display = sanitize_module_identifier(module);
     // upstream: `auth failed on module %s from %s (%s)` is the common prefix;
     // what follows differs by refusal. authenticate.c:318 / :325 append `: %s`
     // for the digest-floor arms, and :433 appends ` for %s: %s` once a username
@@ -93,26 +86,24 @@ pub(crate) fn log_module_auth_failure(
     // layer just concatenates - one owner for the prefix, one for the tail.
     let text = match suffix {
         Some(suffix) => {
-            format!("auth failed on module {module_display} from {host} ({peer_ip}){suffix}")
+            format!("auth failed on module {module} from {host} ({peer_ip}){suffix}")
         }
-        None => format!("auth failed on module {module_display} from {host} ({peer_ip})"),
+        None => format!("auth failed on module {module} from {host} ({peer_ip})"),
     };
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 pub(crate) fn log_module_denied(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
-    let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:774 - `rsync denied on module %s from %s (%s)`
-    let text = format!("rsync denied on module {module_display} from {host} ({peer_ip})");
+    let text = format!("rsync denied on module {module} from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }
 
 pub(crate) fn log_unknown_module(log: &SharedLogSink, host: &str, peer_ip: IpAddr, module: &str) {
-    let module_display = sanitize_module_identifier(module);
     // upstream: clientserver.c:1568 - `unknown module '%s' tried from %s (%s)`
-    let text = format!("unknown module '{module_display}' tried from {host} ({peer_ip})");
+    let text = format!("unknown module '{module}' tried from {host} ({peer_ip})");
     let message = rsync_info!(text).with_role(Role::Daemon);
     log_message(log, &message);
 }

--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -418,10 +418,25 @@ mod name_converter_tests {
         // The child exits immediately: the answer pipe is at EOF.
         let mut nc = NameConverter::spawn("exit 0").expect("spawn should succeed");
 
+        // Which cause is recorded is a RACE, and both arms are legitimate: if
+        // the child has already exited and closed the pipe, the request WRITE
+        // fails with EPIPE; if it has not, the write lands and the answer READ
+        // hits EOF. Pinning one of them makes this cell fail on whichever host
+        // loses the race - it pinned `UnexpectedEof` and CI measured
+        // `BrokenPipe` on all three nextest retries. What the test is actually
+        // for is that the cause is RECORDED and REPLAYED, so capture whichever
+        // one won and assert the stickiness against it.
         let first = nc.uid_to_name(1000);
+        let recorded = match &first {
+            ConverterOutcome::Failed(err) => err.kind(),
+            other => panic!("EOF from the converter must be a failure, not `unknown`: {other:?}"),
+        };
         assert!(
-            is_failure(&first),
-            "EOF from the converter must be a failure, not `unknown`: {first:?}"
+            matches!(
+                recorded,
+                io::ErrorKind::UnexpectedEof | io::ErrorKind::BrokenPipe
+            ),
+            "a dead converter must fail from the pipe, not some unrelated cause: {recorded:?}"
         );
 
         // Sticky: the death is recorded in the type, so every later lookup
@@ -444,7 +459,7 @@ mod name_converter_tests {
         match nc.uid_to_name(1002) {
             ConverterOutcome::Failed(err) => assert_eq!(
                 err.kind(),
-                io::ErrorKind::UnexpectedEof,
+                recorded,
                 "the recorded cause must be reported, not a fresh one: {err}"
             ),
             other => panic!("a dead converter must keep failing: {other:?}"),

--- a/crates/fast_io/src/io_uring/send_zc.rs
+++ b/crates/fast_io/src/io_uring/send_zc.rs
@@ -29,13 +29,21 @@
 //!
 //! # `ZeroCopySender`
 //!
-//! [`ZeroCopySender`] is the higher-level wrapper exposed when the
+//! `ZeroCopySender` is the higher-level wrapper exposed when the
 //! `iouring-send-zc` cargo feature is enabled. It wraps an existing socket
 //! fd, an `Arc<Mutex<IoUring>>` ring, and an optional
 //! [`RegisteredBufferGroup`] so payload pages can be DMA'd directly from
 //! pinned kernel-registered memory without an extra userspace copy.
 //!
-//! See the [`ZeroCopySender::send_zc`] rustdoc for the buffer-lifetime
+//! ⚠ `ZeroCopySender` is deliberately NOT an intra-doc link here. The type is
+//! `#[cfg(feature = "iouring-send-zc")]`, so in a DEFAULT build it does not
+//! exist and no path can resolve to it. This `//!` block is also concatenated
+//! onto the `///` comment that `io_uring/mod.rs` puts on `pub mod send_zc;`,
+//! which makes rustdoc resolve these links in the OUTER module's scope - where
+//! the re-export is cfg-gated off too. An `--all-features` doc build cannot
+//! see either half of that, which is why the broken link reached master.
+//!
+//! See the `ZeroCopySender::send_zc` rustdoc for the buffer-lifetime
 //! contract (the kernel does not release its page reference until the
 //! notification CQE arrives; the wrapper blocks for that CQE before
 //! returning so callers may reuse or drop the slice immediately).

--- a/tests/daemon_log_file_escaping.rs
+++ b/tests/daemon_log_file_escaping.rs
@@ -3,18 +3,34 @@
 //! Upstream escapes in the *sink*, not in any renderer: `logit()` is the only
 //! function that writes `logfile_fp`, and it hands every line to
 //! `filtered_fwrite(logfile_fp, buf, len, 0, 1, trailing)` (log.c:126-132).
-//! Nothing that reaches the log file can skip it.
+//! Nothing that reaches the log file can skip it, so no call site needs to
+//! pre-clean its operands - and none of upstream's do. oc-rsync ports that
+//! `filtered_fwrite` faithfully in `crates/logging-sink/src/escape.rs`.
 //!
-//! oc-rsync used to escape in the CLI out-format renderer instead. That
-//! covered `--log-file` on the client, and nothing else: the daemon writes its
-//! log through an entirely different path and so recorded a raw `ESC` where
-//! rsync 3.5.0 writes `\#033`. This test pins the daemon half, which is the
-//! half a renderer-side escaper cannot reach by construction.
+//! The vector is the **requested module name**. The peer transmits it on the
+//! `@RSYNCD` wire and the daemon writes it to the module's log file at two
+//! sites, both mirroring `clientserver.c:787`'s
+//! `rprintf(FLOG, "rsync %s %s from %s@%s (%s)\n", ...)`.
 //!
-//! The vector is the client's argument vector, logged verbatim at
-//! `module '%s' from %s: client args: ...` - it carries an operand the peer
-//! chose, before the module has resolved anything, so no fixture can launder
-//! it.
+//! ⚠ This test previously used the client *argument vector* as its vector.
+//! PR #7633 stopped logging that vector verbatim - deliberately, and correctly:
+//! upstream never writes it to the daemon log at all, and echoing it made a
+//! connection a log-amplification primitive. That removal left this test with
+//! no observable subject, which is what its own non-vacuity guard caught. The
+//! module name is a vector upstream does keep, so the subject is re-pinned
+//! there rather than abandoned.
+//!
+//! ⚠ Only `ESC` is exercised, not `LF`. The module name is a *line-terminated*
+//! field on the `@RSYNCD` wire, so an embedded `LF` cannot traverse it by
+//! construction - asserting on one would pin a byte this vector can never
+//! deliver. `escape.rs`'s own unit tests cover the `\#012` rendering.
+//!
+//! ⚠ Deliberately NOT covered here: an *unresolvable* module name. Upstream
+//! logs those too (`clientserver.c:1568`, "unknown module '%s' tried from ..."),
+//! but oc opens a log sink only per resolved module, so nothing before module
+//! resolution reaches a log file at all. That gap is real and separate; it
+//! cannot be asserted from this file without first opening a session-level
+//! sink, and pretending otherwise here would only make the test unrunnable.
 //!
 //! Skip condition (test passes with a printed reason): loopback TCP is
 //! unavailable, or the daemon does not answer.
@@ -22,124 +38,177 @@
 #![cfg(unix)]
 
 use std::fs;
+use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
-/// A requested path carrying the two bytes that forge log output: `ESC`, which
-/// starts a terminal control sequence, and `LF`, which would otherwise open a
-/// second - fully prefix-stamped, therefore authentic-looking - log record.
-const HOSTILE_OPERAND: &str = "A\x1bB\nC";
+/// A module name carrying `ESC`, the byte that starts a terminal control
+/// sequence and so forges log output if it lands raw.
+const HOSTILE_MODULE: &str = "A\x1bB";
 
-/// The same operand as the log file must render it. 0x1B is octal 033, 0x0A is
-/// octal 012; every other byte is ASCII-printable and survives verbatim.
-const ESCAPED_OPERAND: &str = "A\\#033B\\#012C";
+/// The same name as the log file must render it: 0x1B is octal 033, and every
+/// other byte is ASCII-printable and survives verbatim.
+const ESCAPED_MODULE: &str = "A\\#033B";
 
-/// A wholly printable operand, used as the run's non-vacuity control: it must
-/// reach the log unchanged, so a sink that mangled or dropped every operand
-/// could not satisfy both assertions.
-const PLAIN_OPERAND: &str = "plain-name";
+/// The rendering a *pre-cleaning* call site produces instead: control bytes
+/// collapsed to `?`. That is lossy and irreversible, and it is what this test
+/// exists to keep out of the log.
+const MANGLED_MODULE: &str = "A?B";
+
+/// A wholly printable module name, used as the run's non-vacuity control: it
+/// must reach the log unchanged, so a sink that mangled or dropped every
+/// requested name could not satisfy both assertions.
+const PLAIN_MODULE: &str = "plain-name";
 
 fn oc_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
 }
 
-fn free_port() -> Option<u16> {
-    TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|listener| listener.local_addr().ok())
-        .map(|addr| addr.port())
+/// Reserves a loopback port by binding and immediately dropping the listener.
+///
+/// Returns `None` when loopback TCP is unavailable, which is the sandbox
+/// condition this test skips on rather than fails on.
+fn reserve_port() -> Option<u16> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).ok()?;
+    let port = listener.local_addr().ok()?.port();
+    drop(listener);
+    Some(port)
 }
 
-/// Starts a daemon and waits until its port answers, so the client never races
-/// the listener.
-fn spawn_daemon(conf: &Path, port: u16) -> Option<Child> {
-    let mut child = Command::new(oc_binary())
+/// Writes the daemon config: a global `log file` plus the two modules whose
+/// names this test requests.
+fn write_config(dir: &Path, log: &Path, module_root: &Path, port: u16) -> PathBuf {
+    let path = dir.join("rsyncd.conf");
+    let body = format!(
+        "port = {port}\n\
+         use chroot = no\n\
+         log file = {log}\n\
+         \n\
+         [{HOSTILE_MODULE}]\n\
+         \tpath = {root}\n\
+         \tread only = yes\n\
+         \n\
+         [{PLAIN_MODULE}]\n\
+         \tpath = {root}\n\
+         \tread only = yes\n",
+        log = log.display(),
+        root = module_root.display(),
+    );
+    fs::write(&path, body).expect("write daemon config");
+    path
+}
+
+/// Polls the daemon's port until it answers, so the test never races startup.
+fn wait_until_listening(port: u16) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    false
+}
+
+/// Requests one module over a raw `@RSYNCD` handshake.
+///
+/// The bytes are written directly rather than through the client so the module
+/// name reaches the daemon exactly as typed - a client-side operand parser
+/// could launder the very byte under test.
+fn request_module(port: u16, module: &str) -> std::io::Result<()> {
+    let stream = TcpStream::connect(("127.0.0.1", port))?;
+    stream.set_read_timeout(Some(Duration::from_secs(10)))?;
+    stream.set_write_timeout(Some(Duration::from_secs(10)))?;
+
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut greeting = String::new();
+    reader.read_line(&mut greeting)?;
+
+    let mut writer = stream;
+    writer.write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")?;
+    writer.write_all(module.as_bytes())?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+
+    let mut reply = String::new();
+    reader.read_line(&mut reply)?;
+    Ok(())
+}
+
+/// Reaps the daemon whatever the test's outcome, so a failed assertion cannot
+/// leave a listener behind.
+struct DaemonGuard(Child);
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+#[test]
+fn daemon_log_file_escapes_a_peer_requested_module_name() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path();
+    let log = root.join("daemon.log");
+    let module_root = root.join("module");
+    fs::create_dir(&module_root).expect("module root");
+
+    let Some(port) = reserve_port() else {
+        eprintln!("skipping: loopback TCP unavailable");
+        return;
+    };
+    let config = write_config(root, &log, &module_root, port);
+
+    let child = Command::new(oc_binary())
         .arg("--daemon")
         .arg("--no-detach")
-        .arg(format!("--config={}", conf.display()))
+        .arg(format!("--config={}", config.display()))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
         .expect("spawn daemon");
-    let deadline = Instant::now() + Duration::from_secs(10);
-    while Instant::now() < deadline {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return Some(child);
-        }
-        std::thread::sleep(Duration::from_millis(20));
+    let _guard = DaemonGuard(child);
+
+    if !wait_until_listening(port) {
+        eprintln!("skipping: daemon did not answer on 127.0.0.1:{port}");
+        return;
     }
-    let _ = child.kill();
-    let _ = child.wait();
-    None
-}
 
-/// Pulls `operand` from the module. The file does not exist, so the transfer
-/// fails - the log line under test is written before the lookup, and a failing
-/// pull keeps the fixture from having to create a file whose name the host
-/// filesystem may refuse.
-fn request(port: u16, operand: &str, dest: &Path) {
-    let _ = Command::new(oc_binary())
-        .arg("-q")
-        .arg(format!("rsync://127.0.0.1:{port}/m/{operand}"))
-        .arg(dest)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .expect("run client");
-}
+    request_module(port, HOSTILE_MODULE).expect("request the hostile module name");
+    request_module(port, PLAIN_MODULE).expect("request the control module name");
 
-#[test]
-fn daemon_log_file_escapes_a_peer_supplied_operand() {
-    let Some(port) = free_port() else {
-        println!("skipping: loopback TCP unavailable");
-        return;
-    };
-    let root = tempfile::tempdir().expect("temp dir");
-    let log = root.path().join("daemon.log");
-    let module = root.path().join("mod");
-    fs::create_dir_all(&module).expect("module dir");
-    let conf = root.path().join("rsyncd.conf");
-    fs::write(
-        &conf,
-        format!(
-            "port = {port}\n\
-             use chroot = no\n\
-             log file = {log}\n\
-             \n\
-             [m]\n\
-             \tpath = {module}\n\
-             \tread only = yes\n",
-            log = log.display(),
-            module = module.display(),
-        ),
-    )
-    .expect("write config");
+    let contents = fs::read(&log).expect("read daemon log");
+    let rendered = String::from_utf8_lossy(&contents).into_owned();
 
-    let Some(mut daemon) = spawn_daemon(&conf, port) else {
-        println!("skipping: daemon did not answer on 127.0.0.1:{port}");
-        return;
-    };
-    let dest = root.path().join("dest");
-    request(port, HOSTILE_OPERAND, &dest);
-    request(port, PLAIN_OPERAND, &dest);
-    let _ = daemon.kill();
-    let _ = daemon.wait();
-
-    let logged = fs::read(&log).expect("read daemon log");
-    let text = String::from_utf8_lossy(&logged);
+    // Non-vacuity: without the control module in the log, every assertion below
+    // would be satisfiable by a daemon that simply logged nothing.
     assert!(
-        text.contains(PLAIN_OPERAND),
-        "the control operand never reached the log, so the assertions below \
-         would be vacuous:\n{text}"
+        rendered.contains(PLAIN_MODULE),
+        "the control module never reached the log, so the assertions below would be vacuous:\n{rendered}"
     );
+
+    // The subject: the ESC-bearing name is present, reversibly escaped.
     assert!(
-        !logged.contains(&0x1b),
-        "a raw ESC reached the daemon log file:\n{text}"
+        rendered.contains(ESCAPED_MODULE),
+        "the hostile module name must appear escaped as {ESCAPED_MODULE:?}:\n{rendered}"
     );
+
+    // Both sites that name the module must agree. `rsync allowed access on
+    // module ...` (clientserver.c:787) and the client-args line each render the
+    // same peer string; a call site that pre-cleans its operand renders the
+    // mangled form instead, which is lossy and cannot be undone by a reader.
     assert!(
-        text.contains(ESCAPED_OPERAND),
-        "expected {ESCAPED_OPERAND:?} in the daemon log:\n{text}"
+        !rendered.contains(MANGLED_MODULE),
+        "no log line may pre-mangle the module name to {MANGLED_MODULE:?}; \
+         escaping belongs to the sink:\n{rendered}"
+    );
+
+    // The point of escaping: the raw control byte never reaches the file.
+    assert!(
+        !contents.contains(&0x1b),
+        "a raw ESC byte reached the log file:\n{rendered}"
     );
 }


### PR DESCRIPTION
Clears the three failures that have been red on master since #7627, and that
every open PR inherits. Three independent commits; each is separately
mutation-proven and none depends on the others.

## 1. `rustdoc links (informational)` — two unresolved links

Both errors were reported at `crates/fast_io/src/io_uring/mod.rs:117`, the `///`
comment on `pub mod send_zc;`. Two things combine, and neither is visible alone:

- `ZeroCopySender` is `#[cfg(feature = "iouring-send-zc")]` at both the struct
  and the re-export, so in a **default** build no path can resolve to it.
- rustdoc concatenates a `pub mod` `///` comment with that module's own `//!`
  block and resolves the result in the **outer** module's scope — which is why
  the errors point at `mod.rs`, not at the `//!` lines in `send_zc.rs` that
  actually contain them.

An `--all-features` doc build cannot see either half, which is how this reached
master. Both links become plain code spans, and the note at the site says why,
so the next reader does not "fix" them back into links.

## 2. `name_converter` — a first-cause assertion that races

`a_dead_converter_fails_instead_of_answering_unknown` pinned `UnexpectedEof` as
the recorded cause; CI measured `BrokenPipe` on all three nextest retries. Both
arms are legitimate: the child is `exit 0`, so if it has already exited when the
first lookup runs, the request **write** fails with EPIPE; if not, the write
lands and the answer **read** hits EOF.

What the test exists for is that the death is *recorded and replayed*, which is
orthogonal to which errno won. It now captures whichever cause the first failure
recorded and asserts the later lookup reports **that**, plus a bound that the
cause came from the pipe at all (`UnexpectedEof | BrokenPipe`) — without which
"sticky" would be satisfiable by an unrelated failure.

## 3. `daemon_log_file_escaping` — and a real divergence behind it

The test failed at its own **non-vacuity guard**, not at an assertion. #7633
stopped writing the client argument vector to the daemon log — correctly,
upstream never writes it at all — and that vector was this test's only subject.

Re-pointing it at a vector oc *does* log measured a live divergence. Upstream
escapes in the **sink**: `logit()` is the only writer of `logfile_fp` and hands
every line to `filtered_fwrite(...)` (`log.c:126-132`), so no call site
pre-cleans its operands, and `clientserver.c:787` passes the module name
straight through. oc ports `filtered_fwrite` faithfully — but seven daemon log
builders wrapped the module name in `sanitize_module_identifier` first, which
replaces control characters with `?`.

Measured on a module named `A<ESC>B` requested over a raw `@RSYNCD` handshake,
master writes **both** renderings into the **same** log file:

```
rsync allowed access on module A?B from localhost (127.0.0.1)
module 'A\#033B' from localhost (127.0.0.1): 0 client args
```

The second line is already correct — `client_args_log_line` does not sanitise,
so the sink escapes reversibly. The first is lossy: `?` cannot be undone, and a
reader cannot tell an escaped byte from a literal question mark.

The sanitiser call is removed from all seven builders and **deliberately kept**
on the wire `@ERROR` reply path, a different sink with no escaping layer of its
own. One doc comment that claimed the name was "sanitised to strip control
chars" — true when written, false after this change — is corrected in the same
commit.

**Not covered, and said so in the test header:** an *unresolvable* module name.
Upstream logs those too (`clientserver.c:1568`), but oc opens a log sink only
per resolved module, so nothing before module resolution reaches a log file at
all. That is a real separate gap, recorded rather than papered over.

## Verification

- **rustdoc**: `RUSTDOCFLAGS="-D warnings" cargo doc -p fast_io --no-deps` clean
  on a **default** build (the configuration the gate builds).
- **name_converter**: 19/19.
- **escaping**: RED/GREEN proven by restoring the sanitiser calls — the test
  fails on the mangled-form assertion and prints both disagreeing lines.
- daemon 1800/1800; daemon + log-file sweep across the workspace 82/82.
- `cargo fmt --all -- --check` clean.
