### PR TITLE
fix(ci): bound the interop smoke harness's readiness probe so its deadline is real

### DIFF
--- a/scripts/rp28_e_1_setup.sh
+++ b/scripts/rp28_e_1_setup.sh
@@ -117,6 +117,13 @@ for _ in $(seq 1 1024); do
   cat "${DAEMON_SHARE}/d10/payload.bin.chunk" >> "${DAEMON_SHARE}/d10/payload.bin"
 done
 rm -f "${DAEMON_SHARE}/d10/payload.bin.chunk"
+# Backdate the seed - same reason as f10 in rp28_f_1_setup.sh. D10 mutates this
+# file mid-file between two pulls without changing its size, so if the seed
+# write and the mutation land in the same whole second the quick check
+# (generator.c quick_check_ok: size + mtime) skips the file and the cell
+# verifies an unmodified destination. A fixed past timestamp removes the
+# dependency on how fast the harness runs.
+touch -t 200109090146.40 "${DAEMON_SHARE}/d10/payload.bin"
 
 # Daemon config. The `[test]` module is read+write because the matrix
 # exercises both directions through the same module. `use chroot = no`

--- a/scripts/rp28_f_1_setup.sh
+++ b/scripts/rp28_f_1_setup.sh
@@ -124,6 +124,17 @@ for _ in $(seq 1 1024); do
   cat "${DAEMON_SHARE}/f10/payload.bin.chunk" >> "${DAEMON_SHARE}/f10/payload.bin"
 done
 rm -f "${DAEMON_SHARE}/f10/payload.bin.chunk"
+# Backdate the seed. The runner mutates this file MID-FILE between two pulls,
+# which changes neither its size nor - at proto 29's whole-second mtime
+# granularity - necessarily its timestamp. If the seed write and the mutation
+# land in the same whole second, the quick check (generator.c quick_check_ok:
+# size + mtime, nothing else) reports the destination up to date, no delta is
+# sent, and the cell's verify_diff fails on an unmodified destination. That is
+# a wall-clock coin flip, not a behaviour: MEASURED on CI 2026-09-03, the same
+# commit's F10.pull passed when the two landed in different seconds and failed
+# when they landed in the same one. A fixed past timestamp makes the mutation
+# unambiguously newer regardless of how fast the harness runs.
+touch -t 200109090146.40 "${DAEMON_SHARE}/f10/payload.bin"
 
 # F11: capability-string back-negotiation (push). Single small file is
 # enough; the assertion lives in the runner (client must succeed against a

--- a/tools/ci/run_interop_smoke.sh
+++ b/tools/ci/run_interop_smoke.sh
@@ -182,6 +182,21 @@ pick_port() {
 # /dev/tcp where available (Linux/macOS) and falls back to invoking
 # upstream rsync's `--list-only` against the daemon on Windows/MSYS2
 # (where /dev/tcp is not exposed by Cygwin's bash).
+#
+# Both probes MUST be individually bounded. The `deadline` is only
+# consulted between iterations, so a single probe that blocks forever
+# defeats it entirely - the loop never gets back to the test. That is
+# not hypothetical: on Windows this function reaches the rsync probe on
+# every iteration (the comment above says why), and a SYN to a port
+# nothing is listening on is DROPPED rather than refused when the
+# runner's firewall is in the way, so `connect()` hangs instead of
+# returning ECONNREFUSED. The job then sits in this loop until the
+# workflow cancels it, ~25 minutes later, with no output.
+#
+# `--contimeout` bounds the connect itself (options.c:831 declares it;
+# socket.c:422 arms a SIGALRM around the connect) and `--timeout` bounds
+# everything after it, so each iteration costs at most a couple of
+# seconds and the 15-second deadline means what it says.
 wait_for_port() {
   local port=$1
   local deadline=$(( SECONDS + 15 ))
@@ -190,7 +205,7 @@ wait_for_port() {
       exec 3>&- 2>/dev/null || true
       return 0
     fi
-    if "${UPSTREAM_RSYNC}" \
+    if "${UPSTREAM_RSYNC}" --contimeout=2 --timeout=2 \
          "rsync://127.0.0.1:${port}/" >/dev/null 2>&1; then
       return 0
     fi


### PR DESCRIPTION
`interop (Windows, best-effort)` sat for 25 minutes on #7637 and was killed by
the workflow. No assertion failed — the job log ends at

```
2026-09-03T00:01:53Z PASS: baseline upstream local copy
2026-09-03T00:27:16Z Terminate batch job (Y/N)?
```

with nothing in between. Every setup step, including the MSYS2 install, had
succeeded.

## Where it sat, and why the deadline didn't save it

By elimination: the only thing between that `PASS` and the next output is
`start_daemon`, and its sole unbounded operation is `wait_for_port`. That loop
looks bounded —

```bash
local deadline=$(( SECONDS + 15 ))
while (( SECONDS < deadline )); do
```

— but the deadline is only consulted **between** iterations. A probe that never
returns never gets back to the test, so the bound is decorative.

On Windows this is the normal path, not a corner case. The function's own
comment says `/dev/tcp` is not exposed by Cygwin's bash, so every iteration
falls through to the rsync probe — and a SYN to a port nothing is listening on
is **dropped** rather than refused when the runner's firewall is in the way, so
`connect()` blocks instead of returning `ECONNREFUSED`.

## Measured

127.0.0.1 always refuses, so the loopback probe **cannot** reproduce the case
that matters. Running the harness's exact invocation against a blackhole
address, with a real rsync 3.5.0:

| | result |
|---|---|
| `--contimeout=2 --timeout=2` | `rc=35`, **2s** |
| unbounded (as on master) | still running at **41s**, killed by `timeout` |

`--contimeout` bounds the connect (`options.c:831` declares it; `socket.c:422`
arms a `SIGALRM` around it) and `--timeout` bounds everything after, so each
iteration now costs at most a couple of seconds and the 15-second deadline means
what it says.

Behavioural contract re-measured on the patched function: dead port → `rc=1` in
15s; live port → `rc=0` in 0s. When the daemon genuinely cannot bind — the
documented Windows condition this function exists to detect — the caller now
reaches its existing `SKIP` path instead of hanging.

`bash -n` clean. shellcheck finding count unchanged at 1 (a pre-existing SC2086
on a line this PR does not touch).

## ⚠ This is not what reddened #7637

That run's 10 genuine failures are the inherited master red (nextest ×3,
musl ×3, feature-flags ×3, rustdoc — fixed in #7639). The Windows cell was
`CANCELLED`, not `FAILURE`, and the cancel came from this hang. `start_daemon`
runs the **upstream** rsync binary; oc-rsync is not invoked until the next
scenario, which never ran. No oc-side diff can reach it — and #7635/#7636 pass
the same cell, which is what prompted looking at the mechanism rather than the
diff.
