### PR TITLE
fix(receiver): keep a cleared directory's dir_flist slot and refuse it

### DIFF
--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -7,7 +7,6 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::num::NonZeroU8;
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -26,6 +25,7 @@ use crate::shared::ChecksumFactory;
 use crate::transfer_state::TransferPipeline;
 
 use super::basis::BasisFileConfig;
+use super::file_list::DirFlist;
 use super::{
     NDX_CONVERT_CALLS, NDX_CONVERT_CMPS, ParallelThresholds, compile_daemon_filter_set,
     partition_point_depth,
@@ -76,22 +76,19 @@ pub struct ReceiverContext {
     /// - `flist.c:101` - `first_flist` pointer
     /// - `receiver.c:683` - `flist_free(first_flist)` advances `first_flist`
     pub(in crate::receiver) first_segment_idx: usize,
-    /// Count of directory entries received so far across the initial file list
-    /// and every INC_RECURSE sub-list, mirroring upstream's `dir_flist->used`.
+    /// The receiver's directory numbering, addressed by the wire `dir_ndx` of an
+    /// INC_RECURSE sub-list header (`NDX_FLIST_OFFSET - dir_ndx`).
     ///
-    /// The sender frames each sub-list header as `NDX_FLIST_OFFSET - dir_ndx`,
-    /// where `dir_ndx` indexes the directories in reception (growth) order. A
-    /// header referencing a directory that has not been received yet
-    /// (`dir_ndx >= dir_flist_used`) is malformed or malicious and is rejected
-    /// fail-closed. The count is taken pre-prune (the `--prune-empty-dirs` pass
-    /// is receiver-only; the sender numbers `dir_ndx` over every directory it
-    /// ships), so a valid transfer never trips the bound.
+    /// A SECOND numbering, independent of the transfer list's NDX. See
+    /// [`DirFlist`] for why a cleared duplicate directory must keep its slot:
+    /// dropping it shifts every later `dir_ndx` and re-points a hostile sub-list
+    /// at a live sibling instead of refusing it.
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2622-2626` - `if (dir_ndx >= dir_flist->used) ... "refusing
-    ///   invalid dir_ndx %u >= %u" ... exit_cleanup(RERR_PROTOCOL)`.
-    pub(in crate::receiver) dir_flist_used: usize,
+    /// - `flist.c:2993-2999` - the read-loop append that builds it.
+    /// - `flist.c:2906-2918` - the bounds and cleared-slot refusals it serves.
+    pub(in crate::receiver) dir_flist: DirFlist,
     /// Set of `dir_ndx` values that have already been served a sub-list,
     /// mirroring upstream's per-directory `FLAG_GOT_DIR_FLIST`. A second
     /// sub-list for the same directory is a malicious duplicate and is rejected
@@ -103,19 +100,6 @@ pub struct ReceiverContext {
     ///   "refusing malicious duplicate flist for dir %d" ...
     ///   exit_cleanup(RERR_PROTOCOL)`.
     pub(in crate::receiver) served_dir_flists: HashSet<i32>,
-    /// Full relative path of each directory in wire `dir_ndx` order, mirroring
-    /// upstream's `dir_flist->files[]` array. Built from the sorted (and, under
-    /// non-iconv, deduped) file list of the initial flist and each INC_RECURSE
-    /// sub-list, in the exact order the sender assigns `dir_ndx`: initial-list
-    /// directories (including `.`) first, then each sub-list's directories in
-    /// depth-first reception order. Indexed by the wire `dir_ndx` so a received
-    /// sub-list entry can be validated against its declared parent directory.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `flist.c:2720` - `f_name(dir_flist->files[dir_ndx], NULL)` names the
-    ///   parent that every entry in the sub-list must live under.
-    pub(in crate::receiver) dir_flist_names: Vec<PathBuf>,
     /// Cached file list reader for compression state continuity across sub-lists.
     ///
     /// Upstream rsync uses `static` variables in `recv_file_entry()` that persist
@@ -508,9 +492,8 @@ impl ReceiverContext {
             checksum_seed: handshake.checksum_seed,
             ndx_segments: vec![(0, initial_ndx_start)],
             first_segment_idx: 0,
-            dir_flist_used: 0,
+            dir_flist: DirFlist::default(),
             served_dir_flists: HashSet::new(),
-            dir_flist_names: Vec::new(),
             flist_reader_cache: None,
             uid_list: IdList::new(),
             gid_list: IdList::new(),

--- a/crates/transfer/src/receiver/file_list/dir_flist.rs
+++ b/crates/transfer/src/receiver/file_list/dir_flist.rs
@@ -1,0 +1,151 @@
+//! The receiver's second, independent directory numbering.
+//!
+//! An INC_RECURSE sub-list header frames itself by `dir_ndx`, which indexes
+//! `dir_flist` - NOT the transfer file list. The two numberings differ, so
+//! conflating them silently re-points a sub-list at the wrong parent.
+
+use std::path::{Path, PathBuf};
+
+use protocol::flist::{FileEntry, compare_file_entries};
+
+/// What a wire `dir_ndx` resolves to, mirroring upstream's three outcomes at
+/// `flist.c:2906-2918`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::receiver) enum DirSlot {
+    /// A live directory; a sub-list may name it as its parent.
+    Active(PathBuf),
+    /// The slot exists but `flist_sort_and_clean()` cleared its entry. Upstream
+    /// refuses this rather than dereferencing the zeroed struct.
+    Cleared,
+}
+
+/// Upstream's receiver-side `dir_flist`, expressed over owned entries.
+///
+/// # Why a cleared directory must keep its slot
+///
+/// Upstream appends every directory to `dir_flist` **in the read loop**
+/// (`flist.c:2993-2999`), sorts just that appended range (`flist.c:3049`), and
+/// only *then* cleans the transfer list (`flist.c:3065`). Each slot holds a
+/// **pointer** to the same `file_struct` as the transfer list, so when the
+/// clean `clear_file()`s a duplicate directory the shared struct is zeroed and
+/// the slot survives, now **inactive**.
+///
+/// Both halves are load-bearing:
+///
+/// - **Retaining the slot** keeps every later `dir_ndx` aligned. A dense
+///   numbering shifts each subsequent directory down by one, so a `dir_ndx`
+///   upstream refuses as cleared resolves to a different, live directory here
+///   and the sub-list is accepted under the wrong parent.
+/// - **The inactive marker** is what `flist.c:2911-2918` refuses, because
+///   `f_name()` on a cleared entry returns NULL into the dirname comparison.
+///
+/// # Why the slot is not a flat index into `file_list`
+///
+/// That would be the literal transcription of upstream's pointer, and it is
+/// unsafe here. `sorted` is an **alias** of `files` in the default arm
+/// (`flist.c:2460`, `:3046`), so upstream's sort is in-place too and its
+/// pointers simply follow the struct - oc's owned entries move instead, and an
+/// index recorded before the sort would address a different entry after it.
+/// The separate `sorted[]` array exists only under `need_unsorted_flist`
+/// (`--iconv`), for the reason `flist.c:3026-3030` gives.
+///
+/// So the slot records a **name**, captured in two phases that each read real
+/// state rather than re-deriving the clean's tie-break:
+/// [`record_pre_clean`](Self::record_pre_clean) then
+/// [`resolve_survivors`](Self::resolve_survivors).
+#[derive(Debug, Default, Clone)]
+pub(in crate::receiver) struct DirFlist {
+    slots: Vec<DirSlot>,
+}
+
+/// The directories of one just-read list, in the order upstream numbers them.
+///
+/// Held between the two phases so the caller cannot accidentally record without
+/// resolving, which would leave every slot of that range provisionally cleared.
+#[derive(Debug)]
+pub(in crate::receiver) struct PendingDirs {
+    /// Sorted directory names, duplicates adjacent.
+    names: Vec<PathBuf>,
+}
+
+impl DirFlist {
+    /// Upstream's `dir_flist->used`: the number of slots, cleared ones included.
+    pub(in crate::receiver) fn used(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Phase 1 - snapshot the directories of `file_list[from..]` **before** the
+    /// sort/clean pass, in the sorted order upstream numbers them.
+    ///
+    /// This must run before the clean: afterwards a tombstoned directory has a
+    /// zeroed mode, so `is_dir()` is false and the entry is indistinguishable
+    /// from a tombstoned regular file - which is exactly the dense-numbering
+    /// defect this type exists to prevent.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:2993-2999` - the read-loop append.
+    /// - `flist.c:3049` - `fsort(dir_flist->sorted + dstart, ...)` orders just
+    ///   the newly appended range.
+    pub(in crate::receiver) fn record_pre_clean(
+        file_list: &[FileEntry],
+        from: usize,
+    ) -> PendingDirs {
+        let mut dirs: Vec<&FileEntry> = file_list[from..].iter().filter(|e| e.is_dir()).collect();
+        dirs.sort_by(|a, b| compare_file_entries(a, b));
+        PendingDirs {
+            names: dirs.into_iter().map(|e| e.path().clone()).collect(),
+        }
+    }
+
+    /// Phase 2 - append the recorded directories, marking the ones the clean
+    /// tombstoned.
+    ///
+    /// `post_clean` is the same range after `sort_and_clean_file_list`. Survival
+    /// is read from it rather than re-derived, so this cannot drift from the
+    /// clean's own duplicate tie-break (a directory outranks a same-named
+    /// regular file, `flist.c:3355-3360`). Duplicates are adjacent after the
+    /// phase-1 sort and the clean keeps at most one, so the first occurrence of
+    /// a name claims the survivor and every later occurrence is a cleared slot.
+    pub(in crate::receiver) fn append(&mut self, pending: PendingDirs, post_clean: &[FileEntry]) {
+        let mut previous: Option<&Path> = None;
+        for name in &pending.names {
+            let is_repeat = previous == Some(name.as_path());
+            previous = Some(name.as_path());
+            let survives = !is_repeat
+                && post_clean
+                    .iter()
+                    .any(|e| e.is_active() && e.is_dir() && e.path() == name);
+            self.slots.push(if survives {
+                DirSlot::Active(name.clone())
+            } else {
+                DirSlot::Cleared
+            });
+        }
+    }
+
+    /// Seeds active slots for a list the test did not actually receive, standing
+    /// in for an initial flist that already carried those parent directories.
+    #[cfg(test)]
+    pub(in crate::receiver) fn with_active<I, P>(names: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        Self {
+            slots: names
+                .into_iter()
+                .map(|n| DirSlot::Active(n.into()))
+                .collect(),
+        }
+    }
+
+    /// Resolves a wire `dir_ndx`. `None` is upstream's `dir_ndx >=
+    /// dir_flist->used` refusal (`flist.c:2906-2909`); `Some(Cleared)` is the
+    /// inactive-slot refusal (`flist.c:2910-2918`).
+    pub(in crate::receiver) fn resolve(&self, dir_ndx: i32) -> Option<&DirSlot> {
+        usize::try_from(dir_ndx)
+            .ok()
+            .and_then(|n| self.slots.get(n))
+    }
+}

--- a/crates/transfer/src/receiver/file_list/mod.rs
+++ b/crates/transfer/src/receiver/file_list/mod.rs
@@ -20,6 +20,7 @@
 //!   protocol 30+ and pre-30 normalization from (dev, ino) pairs.
 //! - `incremental` - the streaming [`IncrementalFileListReceiver`] type.
 
+mod dir_flist;
 mod filter_recheck;
 mod hardlinks;
 mod id_lists;
@@ -29,4 +30,5 @@ mod prune;
 mod receive;
 mod sanitize;
 
+pub(in crate::receiver) use dir_flist::DirFlist;
 pub use incremental::IncrementalFileListReceiver;

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -177,7 +177,7 @@ mod tests {
     use std::io::Cursor;
     use std::path::PathBuf;
 
-    use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, create_ndx_codec};
+    use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum, create_ndx_codec};
     use protocol::flist::{FileEntry, FileListWriter};
     use protocol::{CompatibilityFlags, ProtocolVersion};
 
@@ -494,17 +494,33 @@ mod tests {
         let mut writer = FileListWriter::new(protocol);
         let mut ndx_codec = create_ndx_codec(PROTOCOL);
         let mut wire = Vec::new();
+        append_segment(&mut wire, &mut writer, &mut ndx_codec, dir_ndx, entries);
+        ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
+        wire
+    }
+
+    /// Appends one sub-list segment (header `dir_ndx` + entries + end marker)
+    /// WITHOUT the stream terminator, so a caller can frame several segments
+    /// back to back. The writer and NDX codec are borrowed rather than created
+    /// per segment because both carry incremental-encoding state that upstream
+    /// also carries across the whole sub-list stream; a fresh codec per segment
+    /// would encode bytes no real sender emits.
+    fn append_segment(
+        wire: &mut Vec<u8>,
+        writer: &mut FileListWriter,
+        ndx_codec: &mut NdxCodecEnum,
+        dir_ndx: i32,
+        entries: &[FileEntry],
+    ) {
         ndx_codec
-            .write_ndx(&mut wire, NDX_FLIST_OFFSET - dir_ndx)
+            .write_ndx(wire, NDX_FLIST_OFFSET - dir_ndx)
             .unwrap();
         for entry in entries {
             let mut e = entry.clone();
             e.set_mtime(1_700_000_000, 0);
-            writer.write_entry(&mut wire, &e).unwrap();
+            writer.write_entry(wire, &e).unwrap();
         }
-        writer.write_end(&mut wire, None).unwrap();
-        ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
-        wire
+        writer.write_end(wire, None).unwrap();
     }
 
     /// A `dir_ndx` equal to, past, or absurdly beyond `dir_flist_used` is
@@ -687,6 +703,51 @@ mod tests {
             ctx.dir_flist_names.len(),
             ctx.dir_flist_used,
             "the name vector must stay index-aligned with dir_flist_used"
+        );
+    }
+
+    /// The dense numbering above is not merely a missing diagnostic: when the
+    /// tombstoned directory is NOT the last one, every later `dir_ndx` shifts
+    /// down by one, so a hostile index that upstream refuses as CLEARED lands on
+    /// a DIFFERENT, live directory in oc and the sub-list is accepted.
+    ///
+    /// Fixture: parent `x` (dir_ndx 0) with children `a`, `d`, `d`, `z`.
+    ///
+    /// | dir_ndx | upstream receiver | oc receiver |
+    /// |---|---|---|
+    /// | 0 | `x`            | `x`   |
+    /// | 1 | `x/a`          | `x/a` |
+    /// | 2 | `x/d`          | `x/d` |
+    /// | 3 | `x/d` CLEARED  | `x/z` |
+    ///
+    /// Upstream refuses `dir_ndx` 3 at `flist.c:2911-2918`. oc's bounds check
+    /// (`flist.c:2906-2909`) cannot: 3 is in range. The peer's entries are
+    /// grafted under `x/z` instead. The `proto-cleared-dirflist` cell happens to
+    /// put the duplicate LAST, where the bounds check does catch it - so that
+    /// cell alone understates the defect.
+    #[test]
+    fn a_cleared_directory_before_others_shifts_every_later_dir_ndx() {
+        let entries = [
+            FileEntry::new_directory(PathBuf::from("x/a"), 0o755),
+            FileEntry::new_directory(PathBuf::from("x/d"), 0o755),
+            FileEntry::new_directory(PathBuf::from("x/d"), 0o755),
+            FileEntry::new_directory(PathBuf::from("x/z"), 0o755),
+        ];
+        let wire = encode_entries_with_dir_ndx(0, &entries);
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        ctx.dir_flist_names = vec![PathBuf::from("x")];
+
+        ctx.receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect("legitimate sub-list must be accepted");
+
+        // Upstream: 5 slots, index 3 inactive. Measuring what oc resolves index
+        // 3 to is the whole point - a name here means the hostile index was
+        // silently re-pointed rather than refused.
+        assert_eq!(
+            ctx.dir_flist_names.get(3).map(PathBuf::as_path),
+            Some(std::path::Path::new("x/d")),
+            "dir_ndx 3 must still name the cleared duplicate, not a later sibling"
         );
     }
 

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -479,6 +479,17 @@ mod tests {
     /// the `dir_ndx` is caller-chosen so a malformed/out-of-range index can be
     /// forced onto the wire.
     fn encode_segment_with_dir_ndx(dir_ndx: i32, entries: &[(&str, u64)]) -> Vec<u8> {
+        let entries: Vec<FileEntry> = entries
+            .iter()
+            .map(|(name, size)| FileEntry::new_file(PathBuf::from(name), *size, 0o100644))
+            .collect();
+        encode_entries_with_dir_ndx(dir_ndx, &entries)
+    }
+
+    /// Frames an INC_RECURSE sub-list around caller-built entries, so a test can
+    /// ship directories as well as regular files. `encode_segment_with_dir_ndx`
+    /// is the regular-file shorthand over this.
+    fn encode_entries_with_dir_ndx(dir_ndx: i32, entries: &[FileEntry]) -> Vec<u8> {
         let protocol = ProtocolVersion::try_from(PROTOCOL).unwrap();
         let mut writer = FileListWriter::new(protocol);
         let mut ndx_codec = create_ndx_codec(PROTOCOL);
@@ -486,8 +497,8 @@ mod tests {
         ndx_codec
             .write_ndx(&mut wire, NDX_FLIST_OFFSET - dir_ndx)
             .unwrap();
-        for (name, size) in entries {
-            let mut e = FileEntry::new_file(PathBuf::from(name), *size, 0o100644);
+        for entry in entries {
+            let mut e = entry.clone();
             e.set_mtime(1_700_000_000, 0);
             writer.write_entry(&mut wire, &e).unwrap();
         }
@@ -635,6 +646,47 @@ mod tests {
             active,
             vec!["x/dup.txt".to_owned(), "x/z.txt".to_owned()],
             "the repeated name is dropped, leaving two active entries"
+        );
+    }
+
+    /// The `file_list` tombstone above keeps NDX aligned, but `dir_flist` is a
+    /// SECOND, independent numbering - and a tombstoned DIRECTORY is invisible
+    /// to it, because both `count_directories` and `record_dir_flist_names`
+    /// select on `is_dir()` and `clear_file()` zeroes the mode.
+    ///
+    /// Upstream keeps the slot: the receiver appends every directory to
+    /// `dir_flist` as it READS it (`flist.c:2996-2998`, before any clean), and
+    /// `dir_flist->files[]` holds POINTERS into the same `file_struct`s as the
+    /// transfer list. When `flist_sort_and_clean()` later `clear_file()`s the
+    /// duplicate, the shared struct is zeroed but the `dir_flist` slot remains,
+    /// now inactive - which is precisely the slot `flist.c:2911-2918` refuses
+    /// with "refusing flist for cleared dir_ndx %d".
+    ///
+    /// This test measures whether oc's `dir_flist` numbering retains that slot.
+    #[test]
+    fn duplicate_directory_keeps_its_dir_flist_slot() {
+        let entries = [
+            FileEntry::new_directory(PathBuf::from("x/d"), 0o755),
+            FileEntry::new_directory(PathBuf::from("x/d"), 0o755),
+            FileEntry::new_file(PathBuf::from("x/z.txt"), 20, 0o100644),
+        ];
+        let wire = encode_entries_with_dir_ndx(0, &entries);
+        let mut ctx = inc_recurse_receiver();
+        ctx.dir_flist_used = 1;
+        ctx.dir_flist_names = vec![PathBuf::from("x")];
+
+        ctx.receive_extra_file_lists(&mut Cursor::new(wire))
+            .expect("legitimate sub-list must be accepted");
+
+        // Upstream: the parent `x` plus BOTH `x/d` slots (the second inactive).
+        assert_eq!(
+            ctx.dir_flist_used, 3,
+            "the tombstoned duplicate directory must keep its dir_flist slot"
+        );
+        assert_eq!(
+            ctx.dir_flist_names.len(),
+            ctx.dir_flist_used,
+            "the name vector must stay index-aligned with dir_flist_used"
         );
     }
 

--- a/crates/transfer/src/receiver/file_list/on_demand.rs
+++ b/crates/transfer/src/receiver/file_list/on_demand.rs
@@ -177,7 +177,11 @@ mod tests {
     use std::io::Cursor;
     use std::path::PathBuf;
 
-    use protocol::codec::{NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum, create_ndx_codec};
+    use protocol::codec::{
+        NDX_FLIST_EOF, NDX_FLIST_OFFSET, NdxCodec, NdxCodecEnum, create_ndx_codec,
+    };
+
+    use super::super::dir_flist::{DirFlist, DirSlot};
     use protocol::flist::{FileEntry, FileListWriter};
     use protocol::{CompatibilityFlags, ProtocolVersion};
 
@@ -262,8 +266,8 @@ mod tests {
         let mut ctx = inc_recurse_receiver();
         // Stand in for an initial flist that already carried the three parent
         // directories (dir0..dir2), so each sub-list's dir_ndx (0..2) passes the
-        // fail-closed `dir_ndx >= dir_flist_used` range check.
-        ctx.dir_flist_used = segments.len();
+        // fail-closed `dir_ndx >= dir_flist.used()` range check.
+        ctx.dir_flist = DirFlist::with_active((0..segments.len()).map(|i| format!("dir{i}")));
         // A fresh INC_RECURSE receiver has no entries yet and is not at EOF.
         assert_eq!(ctx.file_list().len(), 0);
         assert!(!ctx.flist_eof);
@@ -314,9 +318,9 @@ mod tests {
         let (wire, total) = encode_segments(&segments);
 
         let mut ctx = inc_recurse_receiver();
-        // Two parent dirs (s0, s1) were in the initial flist; seed the count so
+        // Two parent dirs (s0, s1) were in the initial flist; seed them so
         // dir_ndx 0 and 1 pass the fail-closed range check.
-        ctx.dir_flist_used = segments.len();
+        ctx.dir_flist = DirFlist::with_active((0..segments.len()).map(|i| format!("s{i}")));
         let mut reader = Cursor::new(wire);
         let mut codec = create_ndx_codec(PROTOCOL);
 
@@ -523,7 +527,7 @@ mod tests {
         writer.write_end(wire, None).unwrap();
     }
 
-    /// A `dir_ndx` equal to, past, or absurdly beyond `dir_flist_used` is
+    /// A `dir_ndx` equal to, past, or absurdly beyond `dir_flist.used()` is
     /// untrusted wire data that references a directory the receiver never saw.
     ///
     /// WHY: upstream `flist.c:2622-2626` aborts with `exit_cleanup(RERR_PROTOCOL)`
@@ -536,7 +540,7 @@ mod tests {
             let wire = encode_segment_with_dir_ndx(bad, &[("x/a.txt", 1)]);
             let mut ctx = inc_recurse_receiver();
             // Only dir_ndx 0 would be in range.
-            ctx.dir_flist_used = 1;
+            ctx.dir_flist = DirFlist::with_active(["x"]);
             let err = ctx
                 .receive_extra_file_lists(&mut Cursor::new(wire))
                 .expect_err("out-of-range dir_ndx must be rejected, not appended");
@@ -584,7 +588,7 @@ mod tests {
         ndx_codec.write_ndx(&mut wire, NDX_FLIST_EOF).unwrap();
 
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
+        ctx.dir_flist = DirFlist::with_active(["dir0"]);
         let err = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect_err("duplicate sub-list for dir 0 must be rejected");
@@ -607,8 +611,7 @@ mod tests {
     fn in_range_sublist_dir_ndx_is_accepted() {
         let wire = encode_segment_with_dir_ndx(0, &[("dir0/a.txt", 3u64), ("dir0/b.txt", 4)]);
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
-        ctx.dir_flist_names = vec![PathBuf::from("dir0")];
+        ctx.dir_flist = DirFlist::with_active(["dir0"]);
         let n = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("in-range dir_ndx must be accepted");
@@ -636,8 +639,7 @@ mod tests {
             &[("x/dup.txt", 10u64), ("x/dup.txt", 10), ("x/z.txt", 20)],
         );
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
-        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        ctx.dir_flist = DirFlist::with_active(["x"]);
         let n = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("legitimate sub-list must be accepted");
@@ -665,10 +667,9 @@ mod tests {
         );
     }
 
-    /// The `file_list` tombstone above keeps NDX aligned, but `dir_flist` is a
-    /// SECOND, independent numbering - and a tombstoned DIRECTORY is invisible
-    /// to it, because both `count_directories` and `record_dir_flist_names`
-    /// select on `is_dir()` and `clear_file()` zeroes the mode.
+    /// The `file_list` tombstone above keeps NDX aligned, and `dir_flist` - a
+    /// SECOND, independent numbering - must keep its own slot for the same
+    /// tombstoned directory.
     ///
     /// Upstream keeps the slot: the receiver appends every directory to
     /// `dir_flist` as it READS it (`flist.c:2996-2998`, before any clean), and
@@ -678,7 +679,8 @@ mod tests {
     /// now inactive - which is precisely the slot `flist.c:2911-2918` refuses
     /// with "refusing flist for cleared dir_ndx %d".
     ///
-    /// This test measures whether oc's `dir_flist` numbering retains that slot.
+    /// [`DirFlist`] reproduces that by recording the directories BEFORE the
+    /// clean and marking the ones it tombstoned.
     #[test]
     fn duplicate_directory_keeps_its_dir_flist_slot() {
         let entries = [
@@ -688,21 +690,26 @@ mod tests {
         ];
         let wire = encode_entries_with_dir_ndx(0, &entries);
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
-        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        ctx.dir_flist = DirFlist::with_active(["x"]);
 
         ctx.receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("legitimate sub-list must be accepted");
 
-        // Upstream: the parent `x` plus BOTH `x/d` slots (the second inactive).
+        // Upstream: the parent `x` plus BOTH `x/d` slots, the second inactive.
         assert_eq!(
-            ctx.dir_flist_used, 3,
+            ctx.dir_flist.used(),
+            3,
             "the tombstoned duplicate directory must keep its dir_flist slot"
         );
         assert_eq!(
-            ctx.dir_flist_names.len(),
-            ctx.dir_flist_used,
-            "the name vector must stay index-aligned with dir_flist_used"
+            ctx.dir_flist.resolve(1),
+            Some(&DirSlot::Active(PathBuf::from("x/d"))),
+            "the surviving duplicate keeps the slot"
+        );
+        assert_eq!(
+            ctx.dir_flist.resolve(2),
+            Some(&DirSlot::Cleared),
+            "the tombstoned duplicate's slot survives as inactive"
         );
     }
 
@@ -735,8 +742,7 @@ mod tests {
         ];
         let wire = encode_entries_with_dir_ndx(0, &entries);
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
-        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        ctx.dir_flist = DirFlist::with_active(["x"]);
 
         ctx.receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("legitimate sub-list must be accepted");
@@ -745,9 +751,14 @@ mod tests {
         // 3 to is the whole point - a name here means the hostile index was
         // silently re-pointed rather than refused.
         assert_eq!(
-            ctx.dir_flist_names.get(3).map(PathBuf::as_path),
-            Some(std::path::Path::new("x/d")),
-            "dir_ndx 3 must still name the cleared duplicate, not a later sibling"
+            ctx.dir_flist.resolve(3),
+            Some(&DirSlot::Cleared),
+            "dir_ndx 3 must still be the cleared duplicate, not a later sibling"
+        );
+        assert_eq!(
+            ctx.dir_flist.resolve(4),
+            Some(&DirSlot::Active(PathBuf::from("x/z"))),
+            "the sibling keeps its own, later slot"
         );
     }
 
@@ -765,9 +776,8 @@ mod tests {
     fn sublist_entry_escaping_parent_is_rejected() {
         let wire = encode_segment_with_dir_ndx(0, &[("y/evil.txt", 9u64)]);
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
         // dir_ndx 0 is the legitimate parent "x"; the entry claims "y".
-        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        ctx.dir_flist = DirFlist::with_active(["x"]);
         let err = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect_err("an entry escaping its parent must be rejected");
@@ -797,8 +807,7 @@ mod tests {
     fn sublist_entry_under_parent_is_accepted() {
         let wire = encode_segment_with_dir_ndx(0, &[("x/a.txt", 1u64), ("x/b.txt", 2)]);
         let mut ctx = inc_recurse_receiver();
-        ctx.dir_flist_used = 1;
-        ctx.dir_flist_names = vec![PathBuf::from("x")];
+        ctx.dir_flist = DirFlist::with_active(["x"]);
         let n = ctx
             .receive_extra_file_lists(&mut Cursor::new(wire))
             .expect("entries under their parent must be accepted");

--- a/crates/transfer/src/receiver/file_list/receive.rs
+++ b/crates/transfer/src/receiver/file_list/receive.rs
@@ -11,9 +11,10 @@ use std::path::Path;
 use logging::debug_log;
 use protocol::CompatibilityFlags;
 use protocol::codec::{NDX_FLIST_OFFSET, create_ndx_codec};
-use protocol::flist::{FileEntry, IncrementalFileListBuilder, sort_and_clean_file_list};
+use protocol::flist::{IncrementalFileListBuilder, sort_and_clean_file_list};
 
 use super::super::ReceiverContext;
+use super::dir_flist::{DirFlist, DirSlot};
 use super::hardlinks::{match_hard_links, normalize_pre30_hardlinks};
 use super::incremental::IncrementalFileListReceiver;
 use super::prune::prune_empty_dirs_pass;
@@ -68,14 +69,15 @@ impl ReceiverContext {
             .compat_flags
             .is_some_and(|f| f.contains(CompatibilityFlags::INC_RECURSE));
 
-        // upstream: flist.c:2695-2701 - every received directory is appended to
-        // dir_flist as the read loop runs, so dir_flist->used counts all dirs in
-        // this list. We track the equivalent count only under INC_RECURSE (the
-        // sole mode that frames sub-list headers by dir_ndx) and take it before
-        // the receiver-only prune pass so it matches the sender's numbering.
-        if inc_recurse {
-            self.dir_flist_used += count_directories(&self.file_list[seg_start..]);
-        }
+        // upstream: flist.c:2993-2999 - every received directory is appended to
+        // dir_flist as the read loop runs, BEFORE flist_sort_and_clean() can
+        // collapse duplicates. Snapshot here, at the same point, and only under
+        // INC_RECURSE (the sole mode that frames sub-list headers by dir_ndx).
+        // The clean below tombstones a duplicate directory by zeroing its mode,
+        // so a snapshot taken afterwards could not tell it from a tombstoned
+        // regular file - see `DirFlist`.
+        let pending_dirs =
+            inc_recurse.then(|| DirFlist::record_pre_clean(&self.file_list, seg_start));
 
         // Without INC_RECURSE the whole list arrives in this single call, so the
         // file list is complete. With INC_RECURSE the sender streams per-directory
@@ -164,16 +166,12 @@ impl ReceiverContext {
             self.file_list = cleaned;
         }
 
-        // upstream: flist.c:recv_file_list() appends every directory to
-        // `dir_flist` as it is read, so a later INC_RECURSE sub-list header's
-        // `dir_ndx` resolves to that directory's full path (flist.c:2685). Record
-        // the same mapping in wire `dir_ndx` order - sorted here (or sender scan
-        // order under iconv) and taken before the receiver-only prune pass, so it
-        // stays aligned with the sender's `dir_ndx` numbering over every shipped
-        // directory. `receive_one_extra_segment()` uses it to reject a sub-list
-        // entry that does not live under its declared parent.
-        if inc_recurse {
-            self.record_dir_flist_names(0);
+        // upstream: flist.c:3049 orders the appended dir_flist range, and the
+        // clean above has now marked which of those directories survived. Commit
+        // both facts together so a cleared duplicate keeps its slot as an
+        // inactive one, exactly as upstream's shared `file_struct` does.
+        if let Some(pending) = pending_dirs {
+            self.dir_flist.append(pending, &self.file_list[seg_start..]);
         }
 
         // upstream: flist.c:3121-3184 - flist_sort_and_clean() runs the
@@ -326,6 +324,11 @@ impl ReceiverContext {
             segment_count += 1;
         }
 
+        // upstream: flist.c:2993-2999 - snapshot this sub-list's directories at
+        // the read loop, before the per-segment sort/clean below tombstones any
+        // duplicate. See `DirFlist` for why the snapshot cannot wait.
+        let pending_dirs = DirFlist::record_pre_clean(&self.file_list, flat_start);
+
         // upstream: flist.c:2684-2695 - every entry in a sub-list must live under
         // the directory named by its header `dir_ndx`; a mismatch is an attempt
         // by a hostile sender to inject a path that escapes its declared parent,
@@ -388,13 +391,12 @@ impl ReceiverContext {
             normalize_pre30_hardlinks(&mut self.file_list[flat_start..]);
         }
 
-        // upstream: flist.c:2695-2701 - directories in this sub-list are appended
-        // to dir_flist, so a later sub-list may legitimately reference them by
-        // dir_ndx. Fold them into the running count and record their full paths in
-        // the same wire dir_ndx order so a deeper sub-list's path-belongs check
-        // resolves this segment's directories.
-        self.dir_flist_used += count_directories(&self.file_list[flat_start..]);
-        self.record_dir_flist_names(flat_start);
+        // upstream: flist.c:3049 - the appended dir_flist range is ordered, and
+        // the clean above has now settled which of those directories survived.
+        // Commit both together so a cleared duplicate keeps its slot as an
+        // inactive one, and a later sub-list's dir_ndx stays aligned.
+        self.dir_flist
+            .append(pending_dirs, &self.file_list[flat_start..]);
 
         // upstream: flist.c:2966 - ndx_start = prev->ndx_start + prev->used + 1
         self.ndx_segments.push((flat_start, seg_ndx_start));
@@ -449,7 +451,7 @@ impl ReceiverContext {
     /// [`protocol::protocol_violation()`]:
     ///
     /// 1. **Range** - a `dir_ndx` that references a directory not yet received
-    ///    (`dir_ndx >= dir_flist_used`) cannot belong to any real sender tree and
+    ///    (`dir_ndx >= dir_flist.used()`) cannot belong to any real sender tree and
     ///    is rejected. `dir_ndx` is always `>= 0` (see the caller), so the single
     ///    `>=` test also covers the negative case upstream checks separately.
     /// 2. **Duplicate** - a second sub-list for a directory already served is a
@@ -460,21 +462,35 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `flist.c:2622-2626` - `if (dir_ndx >= dir_flist->used) ... "refusing
+    /// - `flist.c:2906-2909` - `if (dir_ndx >= dir_flist->used) ... "refusing
     ///   invalid dir_ndx %u >= %u" ... exit_cleanup(RERR_PROTOCOL)`.
-    /// - `flist.c:2627-2632` - `FLAG_GOT_DIR_FLIST` duplicate guard, "refusing
+    /// - `flist.c:2910-2918` - `if (!F_IS_ACTIVE(file)) ... "refusing flist for
+    ///   cleared dir_ndx %d"`. The clean pass can `clear_file()` a duplicate
+    ///   directory while its `dir_flist` slot survives, and naming that slot
+    ///   would put a NULL `f_name()` into the dirname comparison below.
+    /// - `flist.c:2919-2922` - `FLAG_GOT_DIR_FLIST` duplicate guard, "refusing
     ///   malicious duplicate flist for dir %d", `exit_cleanup(RERR_PROTOCOL)`.
     pub(in crate::receiver) fn validate_extra_segment_dir_ndx(
         &mut self,
         dir_ndx: i32,
     ) -> io::Result<()> {
-        if dir_ndx < 0 || dir_ndx as usize >= self.dir_flist_used {
-            return Err(protocol::protocol_violation(format!(
-                "refusing invalid dir_ndx {dir_ndx} >= {} {}{}",
-                self.dir_flist_used,
-                crate::role_trailer::error_location!(),
-                crate::role_trailer::receiver()
-            )));
+        match self.dir_flist.resolve(dir_ndx) {
+            None => {
+                return Err(protocol::protocol_violation(format!(
+                    "refusing invalid dir_ndx {dir_ndx} >= {} {}{}",
+                    self.dir_flist.used(),
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                )));
+            }
+            Some(DirSlot::Cleared) => {
+                return Err(protocol::protocol_violation(format!(
+                    "refusing flist for cleared dir_ndx {dir_ndx} {}{}",
+                    crate::role_trailer::error_location!(),
+                    crate::role_trailer::receiver()
+                )));
+            }
+            Some(DirSlot::Active(_)) => {}
         }
         if !self.served_dir_flists.insert(dir_ndx) {
             return Err(protocol::protocol_violation(format!(
@@ -486,24 +502,6 @@ impl ReceiverContext {
         Ok(())
     }
 
-    /// Records the full relative path of every directory in `file_list[from..]`
-    /// into `dir_flist_names`,
-    /// in the order they appear. Called after each list/sub-list is sorted (and,
-    /// under non-iconv, deduped) so the vector index matches the wire `dir_ndx`
-    /// the sender assigns to that directory.
-    ///
-    /// # Upstream Reference
-    ///
-    /// - `flist.c:2704` - `dir_flist->files[dir_flist->used++] = file` appends
-    ///   each directory so `dir_flist->files[dir_ndx]` names it later.
-    pub(in crate::receiver) fn record_dir_flist_names(&mut self, from: usize) {
-        for entry in &self.file_list[from..] {
-            if entry.is_dir() {
-                self.dir_flist_names.push(entry.path().clone());
-            }
-        }
-    }
-
     /// Validates that every entry in the just-read INC_RECURSE sub-list
     /// (`file_list[flat_start..]`) lives directly under the directory named by
     /// the header's `dir_ndx`. A hostile sender that frames a sub-list for a
@@ -513,8 +511,8 @@ impl ReceiverContext {
     /// offending segment's entries are dropped so nothing escapes into the
     /// transfer.
     ///
-    /// The parent name is looked up in `dir_flist_names` built by
-    /// [`record_dir_flist_names`](Self::record_dir_flist_names). Leading slashes
+    /// The parent name is looked up in the [`DirFlist`] built across the two
+    /// phases of each list's reception. Leading slashes
     /// (present only under `--relative`, where upstream defers stripping to
     /// `flist_sort_and_clean(..., strip_root)`) are ignored on both sides so a
     /// legitimate relative transfer is never falsely rejected.
@@ -528,11 +526,11 @@ impl ReceiverContext {
         dir_ndx: i32,
         flat_start: usize,
     ) -> io::Result<()> {
-        // The range check in validate_extra_segment_dir_ndx guarantees
-        // `dir_ndx < dir_flist_used`; the name vector is kept in lockstep with
-        // that count, so a present entry is expected. If it is somehow absent we
-        // cannot name the parent, so skip rather than falsely abort.
-        let Some(parent) = self.dir_flist_names.get(dir_ndx as usize) else {
+        // validate_extra_segment_dir_ndx has already refused an out-of-range or
+        // cleared `dir_ndx`, so an Active slot is expected here. If it is
+        // somehow absent we cannot name the parent, so skip rather than falsely
+        // abort - refusing on a name we could not read would be a guess.
+        let Some(DirSlot::Active(parent)) = self.dir_flist.resolve(dir_ndx) else {
             return Ok(());
         };
         let parent = strip_leading_slashes(parent);
@@ -664,23 +662,9 @@ impl ReceiverContext {
     }
 }
 
-/// Counts the directory entries in a received file-list slice.
-///
-/// Mirrors upstream's `dir_flist` accounting: every `S_ISDIR` entry read in a
-/// list is appended to `dir_flist`, so this count is what `dir_flist->used`
-/// grows by for that list.
-///
-/// # Upstream Reference
-///
-/// - `flist.c:2695-2701` - `if (S_ISDIR(file->mode)) { ... dir_flist->files[
-///   dir_flist->used++] = file; }`.
-pub(super) fn count_directories(entries: &[FileEntry]) -> usize {
-    entries.iter().filter(|e| e.is_dir()).count()
-}
-
 /// Strips leading path separators so a `--relative` dirname - which carries a
 /// leading `/` until upstream's `strip_root` pass runs - compares equal to the
-/// slash-free parent path recorded in `dir_flist_names`.
+/// slash-free parent path recorded in the [`DirFlist`].
 ///
 /// # Upstream Reference
 ///

--- a/crates/transfer/src/receiver/ndx_stream/tests.rs
+++ b/crates/transfer/src/receiver/ndx_stream/tests.rs
@@ -27,6 +27,7 @@ use protocol::{CompatibilityFlags, ProtocolVersion};
 use super::*;
 use crate::config::ServerConfig;
 use crate::handshake::HandshakeResult;
+use crate::receiver::file_list::DirFlist;
 use crate::role::ServerRole;
 
 const PROTOCOL: u8 = 32;
@@ -63,8 +64,7 @@ fn inc_recurse_receiver(dirs: &[&str]) -> ReceiverContext {
         &test_handshake(Some(CompatibilityFlags::INC_RECURSE)),
         test_config(),
     );
-    ctx.dir_flist_used = dirs.len();
-    ctx.dir_flist_names = dirs.iter().map(PathBuf::from).collect();
+    ctx.dir_flist = DirFlist::with_active(dirs.iter().copied());
     ctx
 }
 


### PR DESCRIPTION
## What

The receiver's `dir_flist` — the second, independent directory numbering that an
INC_RECURSE sub-list header addresses via `dir_ndx` — dropped the slot of a
directory that `flist_sort_and_clean` had cleared. Upstream keeps it, inactive.

Dropping it shifts every later `dir_ndx` down by one, so a sub-list the sender
frames for a cleared directory resolves here to a **different, live** directory
and is accepted under the wrong parent.

## Why upstream keeps the slot

Upstream appends every directory to `dir_flist` **in the read loop**
(`flist.c:2993-2999`), sorts just that appended range (`flist.c:3049`), and only
*then* cleans the transfer list (`flist.c:3065`). Each slot holds a **pointer**
to the same `file_struct` as the transfer list, so when the clean `clear_file()`s
a duplicate directory the shared struct is zeroed and the slot survives, now
inactive. `flist.c:2910-2918` refuses exactly that inactive slot.

## Measured, twice

Both measurements were committed RED first (`e27ed3d9`, `b9a6cca2`) and are the
two tests this change flips:

| assertion | before | upstream / after |
|---|---|---|
| `dir_flist.used()` with one tombstoned duplicate | 2 | 3 |
| `resolve(3)` after a cleared duplicate | `x/z` (a live sibling) | `Cleared` |

The second row is the live defect: a hostile sub-list framed for `dir_ndx 3` was
being accepted under a directory the sender never named.

## Shape

`DirFlist` is the single owner of the receiver's directory numbering, in two
phases so each reads real state rather than re-deriving the clean's tie-break:

- `record_pre_clean` snapshots the directories in the order upstream numbers
  them. It must run **before** the clean — a tombstone has mode 0, so `is_dir()`
  is false and the entry becomes indistinguishable from a tombstoned regular
  file, which is the dense-numbering defect itself.
- `append` marks survival by reading the post-clean range.

The slot records a **name**, not a flat index: oc's sort is in place (upstream's
`sorted` is an alias of `files` outside `--iconv`, `flist.c:2460`/`:3046`), so an
index recorded pre-sort addresses a different entry after it.

This also closes a latent inconsistency inside oc: on the initial list the count
was taken pre-clean while the names were recorded post-clean, so the "kept in
lockstep" comment was false whenever a duplicate directory was cleared. Both
now have one owner.

`validate_extra_segment_dir_ndx` gains upstream's third outcome, and with it the
literal `refusing flist for cleared dir_ndx` that the `proto-cleared-dirflist`
cell greps the daemon log for.

## Verification

- Both measurement tests flip RED to GREEN.
- **Mutation-proven**: reverting `append` to dense numbering (push only
  surviving slots) reddens **both** tests.
- Failure-set diff against the pre-change tree is exactly those two names
  removed, zero regressions.
- `cargo fmt --all -- --check` clean; `clippy -p transfer --all-targets
  --all-features -D warnings` clean.

The Linux VM used for these runs carries an unrelated, pre-existing failure
class in `temp_guard` and `confinement_root_tests` — `FilesystemLoop` on
`mkstemp` under a shared world-writable `/tmp`. Reproduced on the unmodified
base tree; each passes in isolation and fails only under the parallel full run.
Not attributable to this change.
