### PR TITLE
fix(transfer): refuse a transfer-phase NDX naming a cleared file entry

### DIFF
--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -62,6 +62,16 @@ impl FlistMarkerSink for GoodbyeNdxSink<'_> {
         self.0.file_list().len() as i32 - 1
     }
 
+    fn ndx_is_active(&self, ndx: i32) -> bool {
+        // upstream: sender.c:558-563 - `send_files()` tests F_IS_ACTIVE on the
+        // entry the peer named. An out-of-range index is a different fault and
+        // is owned by `last_file_ndx`, so it is not reported as cleared here.
+        usize::try_from(ndx)
+            .ok()
+            .and_then(|flat| self.0.file_list().get(flat))
+            .is_none_or(protocol::flist::FileEntry::is_active)
+    }
+
     fn begin_frame(&mut self) {}
 
     fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -636,6 +636,17 @@ impl ReceiverContext {
         Self::new(handshake, config, pipeline)
     }
 
+    /// Installs `entries` as the receiver's initial file-list segment.
+    ///
+    /// `file_list` is `pub(in crate::receiver)`, so the transfer-phase drivers
+    /// that consume this context as a [`FlistMarkerSink`](super::ndx_stream::FlistMarkerSink)
+    /// cannot build one from their own test modules. Exposed at crate scope so
+    /// they can, without widening the field itself.
+    #[cfg(test)]
+    pub(crate) fn set_file_list_for_test(&mut self, entries: Vec<FileEntry>) {
+        self.file_list = entries;
+    }
+
     /// Advances the pipeline FSM to `DeltaTransfer` for tests that need to
     /// exercise [`finalize_transfer`](Self::finalize_transfer) directly.
     ///

--- a/crates/transfer/src/receiver/ndx_stream.rs
+++ b/crates/transfer/src/receiver/ndx_stream.rs
@@ -114,6 +114,26 @@ pub(crate) trait FlistMarkerSink {
     /// on rejection (`rsync.c:344-350`).
     fn last_file_ndx(&self) -> i32;
 
+    /// Whether `ndx` names a *live* entry - upstream's `F_IS_ACTIVE(file)`
+    /// test.
+    ///
+    /// A peer that sends duplicate file-list entries gets one of them
+    /// `clear_file()`d by `flist_sort_and_clean()`, which zeroes the basename
+    /// and mode but leaves the slot indexable. Upstream refuses a transfer-phase
+    /// index naming such a slot rather than dereferencing the cleared struct,
+    /// because `f_name()` on it returns NULL.
+    ///
+    /// This is deliberately **not** defaulted: only a sink that owns a file list
+    /// can answer, and a blanket `true` default would silently carry the guard
+    /// past every future sink that forgets to override it. Sinks with no list of
+    /// their own state that explicitly.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:871-881` - `recv_files()` refuses the inactive entry.
+    /// - `sender.c:558-563` - `send_files()` refuses it identically.
+    fn ndx_is_active(&self, ndx: i32) -> bool;
+
     /// Captures [`Self::FrameMark`] before the NDX is read.
     fn begin_frame(&mut self) -> Self::FrameMark;
 
@@ -199,6 +219,13 @@ impl FlistMarkerSink for NoLazyFlist {
         self.last_file_ndx
     }
 
+    fn ndx_is_active(&self, _ndx: i32) -> bool {
+        // This sink carries a bound, not a list, so it cannot see a cleared
+        // slot. Reporting every index active leaves the decision to the range
+        // guard above, which is the only one it has the state to make.
+        true
+    }
+
     fn begin_frame(&mut self) {}
 
     fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
@@ -244,6 +271,26 @@ pub(crate) enum NdxFrame {
 pub(crate) fn invalid_file_index(ndx: i32, last: i32, role: StreamRole) -> io::Error {
     protocol::protocol_violation(format!(
         "Invalid file index: {ndx} ({NDX_DONE} - {last}) {}{}",
+        crate::role_trailer::error_location!(),
+        role.trailer()
+    ))
+}
+
+/// Builds upstream's cleared-entry rejection.
+///
+/// Upstream prints the bare `rsync: refusing transfer of cleared file index %d`
+/// at both sites; oc appends its source location and the `[role=VERSION]`
+/// trailer that stands in for `who_am_i()`, as every other diagnostic in this
+/// module does. Tagged as a protocol violation so the exit-code mapper yields
+/// `RERR_PROTOCOL` (2), matching `exit_cleanup(RERR_PROTOCOL)` at both sites.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:871-881` - `recv_files()`.
+/// - `sender.c:558-563` - `send_files()`.
+pub(crate) fn cleared_file_index(ndx: i32, role: StreamRole) -> io::Error {
+    protocol::protocol_violation(format!(
+        "rsync: refusing transfer of cleared file index {ndx} {}{}",
         crate::role_trailer::error_location!(),
         role.trailer()
     ))
@@ -426,6 +473,16 @@ impl FlistMarkerSink for ReceiverContext {
             .expect("initial segment always exists");
         let used = self.file_list.len().saturating_sub(flat_start) as i32;
         ndx_start + used - 1
+    }
+
+    fn ndx_is_active(&self, ndx: i32) -> bool {
+        // upstream: receiver.c:871-881 - `recv_files()` tests F_IS_ACTIVE on
+        // the entry the peer's index resolves to. An NDX outside every segment
+        // is a range fault, not a cleared entry, so it is deferred to the guard
+        // that owns that diagnostic rather than reported as cleared here.
+        self.wire_to_flat_ndx(ndx)
+            .and_then(|flat| self.file_list.get(flat))
+            .is_none_or(protocol::flist::FileEntry::is_active)
     }
 
     fn begin_frame(&mut self) -> u64 {

--- a/crates/transfer/src/receiver/ndx_stream/tests.rs
+++ b/crates/transfer/src/receiver/ndx_stream/tests.rs
@@ -265,6 +265,12 @@ fn sender_drains_del_stats_and_receives_the_counters() {
             9
         }
 
+        fn ndx_is_active(&self, _ndx: i32) -> bool {
+            // No file list here; the cleared-entry test is exercised by the
+            // sinks that own one.
+            true
+        }
+
         fn begin_frame(&mut self) {}
 
         fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {
@@ -380,6 +386,12 @@ fn marker_rejected_by_sender_with_upstream_text() {
 
         fn last_file_ndx(&self) -> i32 {
             5
+        }
+
+        fn ndx_is_active(&self, _ndx: i32) -> bool {
+            // No file list here; the cleared-entry test is exercised by the
+            // sinks that own one.
+            true
         }
 
         fn begin_frame(&mut self) {}

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -351,6 +351,20 @@ fn read_response_header<R: Read>(
         )
     })?;
 
+    // upstream: receiver.c:871-881 - `recv_files()` tests `F_IS_ACTIVE` on the
+    // entry the peer's index resolves to, before doing anything else with it. A
+    // peer that sent a duplicate name had one of the two slots `clear_file()`d
+    // by `flist_sort_and_clean()`; naming that slot again yields an entry with
+    // no name, which upstream would deref. This gate sits ABOVE the ordering
+    // comparison so the specific fault wins over the generic one: a cleared
+    // index is reported as cleared, not as "echoed the wrong NDX".
+    if !flist_sink.ndx_is_active(echoed_ndx) {
+        return Err(crate::receiver::ndx_stream::cleared_file_index(
+            echoed_ndx,
+            flist_sink.role(),
+        ));
+    }
+
     // upstream: sender.c emits responses in NDX order; out-of-order is a protocol violation.
     if echoed_ndx != expected_ndx {
         return Err(io::Error::new(
@@ -742,6 +756,133 @@ mod tests {
                 .windows(2)
                 .any(|w| w == [0x00, 0x98] || w == [0x00, 0x90]),
             "FNAME request must not set ITEM_XNAME_FOLLOWS: {bytes:02x?}"
+        );
+    }
+
+    /// Builds a protocol-31 receiver whose file list holds `names`, with the
+    /// entry at `cleared_ndx` (if any) turned into the tombstone
+    /// `flist_sort_and_clean()` leaves behind for a dropped duplicate.
+    fn receiver_with_file_list(
+        names: &[&str],
+        cleared_ndx: Option<usize>,
+    ) -> crate::receiver::ReceiverContext {
+        use crate::config::ServerConfig;
+        use crate::handshake::HandshakeResult;
+        use protocol::flist::FileEntry;
+
+        let protocol = ProtocolVersion::from_supported(31).expect("31 is supported");
+        let handshake = HandshakeResult {
+            protocol,
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: crate::role::ServerRole::Receiver,
+            protocol,
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![std::ffi::OsString::from(".")],
+            ..Default::default()
+        };
+        let mut entries: Vec<FileEntry> = names
+            .iter()
+            .map(|name| FileEntry::new_file(std::path::PathBuf::from(*name), 0, 0o100644))
+            .collect();
+        if let Some(ndx) = cleared_ndx {
+            entries[ndx].tombstone();
+        }
+        let mut ctx = crate::receiver::ReceiverContext::new_for_test(&handshake, config);
+        ctx.set_file_list_for_test(entries);
+        ctx
+    }
+
+    /// Encodes one per-file echo (NDX + iflags + an all-zero `sum_head`) as the
+    /// sender writes it, so `read_response_header` reads a complete frame.
+    fn echo_bytes(ndx: i32) -> Vec<u8> {
+        use protocol::codec::{MonotonicNdxWriter, NdxCodec};
+        let mut wire = Vec::new();
+        let mut codec = MonotonicNdxWriter::new(31);
+        codec.write_ndx(&mut wire, ndx).expect("ndx encodes");
+        wire.extend_from_slice(&0x8000_u16.to_le_bytes());
+        crate::receiver::SumHead::new(0, 0, 0, 0)
+            .write(&mut wire)
+            .expect("sum_head encodes");
+        wire
+    }
+
+    /// Drives `read_response_header` over `wire` with `expected_ndx` outstanding.
+    fn read_header_for(
+        receiver: &mut crate::receiver::ReceiverContext,
+        wire: Vec<u8>,
+        expected_ndx: i32,
+    ) -> io::Result<ResponseHeader> {
+        use protocol::codec::MonotonicNdxWriter;
+        let config = iflags_request_config();
+        let ctx = ResponseContext {
+            config: &config,
+            #[cfg(unix)]
+            sandbox: None,
+            #[cfg(unix)]
+            dest_dir: None,
+        };
+        let mut reader = crate::reader::ServerReader::new_plain(std::io::Cursor::new(wire));
+        let mut ndx_codec = MonotonicNdxWriter::new(31);
+        let pending = crate::pipeline::PendingTransfer::new_full_transfer(
+            expected_ndx,
+            std::path::PathBuf::from("data.txt"),
+            0,
+        );
+        read_response_header(&mut reader, &mut ndx_codec, pending, &ctx, receiver)
+    }
+
+    /// A sender that names a CLEARED file-list slot is refused with upstream's
+    /// wording, even though the echo arrives in the expected order.
+    ///
+    /// WHY: a peer that sent a duplicate name had one of the two slots
+    /// `clear_file()`d by `flist_sort_and_clean()`. The slot stays indexable, so
+    /// the index resolves, but the entry has no name - upstream refuses rather
+    /// than dereferencing it. Keeping `echoed_ndx == expected_ndx` here is the
+    /// point: it isolates the new guard from the pre-existing ordering check, so
+    /// a pass cannot be produced by the wrong error.
+    ///
+    /// upstream: receiver.c:871-881 - `recv_files()` `!F_IS_ACTIVE(file)`.
+    #[test]
+    fn cleared_file_index_is_refused_with_upstream_wording() {
+        let mut receiver = receiver_with_file_list(&["a.txt", "dup.txt"], Some(1));
+        let Err(err) = read_header_for(&mut receiver, echo_bytes(1), 1) else {
+            panic!("a cleared slot must be refused");
+        };
+        assert!(
+            err.to_string()
+                .contains("refusing transfer of cleared file index 1"),
+            "unexpected diagnostic: {err}"
+        );
+    }
+
+    /// NON-VACUITY COMPANION: a LIVE entry echoed out of order still produces the
+    /// ordering error, not the cleared-entry one.
+    ///
+    /// Without this, the guard could be written to reject every mismatched echo
+    /// and the test above would still pass - the fixture alone would not prove
+    /// that "cleared" is what is being detected.
+    #[test]
+    fn live_entry_echoed_out_of_order_still_reports_the_ordering_violation() {
+        let mut receiver = receiver_with_file_list(&["a.txt", "b.txt"], None);
+        let Err(err) = read_header_for(&mut receiver, echo_bytes(1), 0) else {
+            panic!("an out-of-order echo must be refused");
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("sender echoed NDX 1 but expected 0"),
+            "unexpected diagnostic: {text}"
+        );
+        assert!(
+            !text.contains("cleared file index"),
+            "the ordering fault must not be reported as a cleared entry: {text}"
         );
     }
 }

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -122,7 +122,7 @@ operator-path-traversal-partial-dir-daemon pass
 password-file-symlink skip
 peer-legacy-implied-delete-scope pass
 proto-cleared-dirflist fail
-proto-cleared-ndx fail
+proto-cleared-ndx pass
 proto-hlink-flag-oob skip
 proto-hlink-gnum fail
 proto-msg-info-assert fail

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -122,7 +122,7 @@ operator-path-traversal-partial-dir-daemon pass
 password-file-symlink pass
 peer-legacy-implied-delete-scope pass
 proto-cleared-dirflist fail
-proto-cleared-ndx fail
+proto-cleared-ndx pass
 proto-hlink-flag-oob skip
 proto-hlink-gnum fail
 proto-msg-info-assert fail


### PR DESCRIPTION
## What

Ports upstream's cleared-file-entry guard to the transfer phase. Targets the
3.5.0 testsuite cell `proto-cleared-ndx`.

## Why

`flist_sort_and_clean()` tombstones one of a duplicate pair of file-list
entries. The slot is retained so NDX alignment survives, but `f_name()` on it
returns NULL. Upstream refuses a transfer-phase index naming such a slot at two
structurally identical sites:

- `receiver.c:871-881` — `recv_files()`
- `sender.c:558-563` — `send_files()`

Both emit `rsync: refusing transfer of cleared file index %d` and
`exit_cleanup(RERR_PROTOCOL)`. oc ported neither.

⚠ My first read of this cell concluded oc was *structurally immune*, so the
cell could only green by adding the hole. That was **wrong**: oc already ports
the SIBLING guard (`flist.c:2906-2922`, `refusing flist for cleared dir_ndx`)
with its exact literal, at `receiver/file_list/receive.rs`. This is a missing
port, not an unreachable cell.

## Design notes

**Guard placement.** The gate sits ABOVE the echoed-NDX ordering comparison in
`read_response_header`, so the specific fault wins over the generic one — a
cleared index is reported as cleared, not as "echoed the wrong NDX".

**The trait method is deliberately not defaulted.** `FlistMarkerSink` gains a
required `ndx_is_active`. Only a sink that owns a file list can answer, and a
blanket `true` default would silently carry the guard past every future sink
that forgets to override it. The two sinks with no list of their own say so
explicitly, in a comment that states why.

**Range faults stay where they belong.** An NDX outside every segment is not a
cleared entry; both real implementations defer it to the guard that owns that
diagnostic (`invalid_file_index`) rather than mislabelling it.

**Diagnostic shape** reuses the existing `invalid_file_index` construction in
the same module: upstream's bare text plus oc's source location and the
`[role=VERSION]` trailer that stands in for `who_am_i()`, tagged as a protocol
violation so the exit-code mapper yields `RERR_PROTOCOL` (2).

## Verification

Two mutations, each lethal and each killing **only** its target — the property
that distinguishes a real guard from a test that passes for the wrong reason:

| mutation | result |
|---|---|
| drop the guard | only `cleared_file_index_is_refused_with_upstream_wording` fails (12 passed, 1 failed) |
| `ndx_is_active` → `false` | only `live_entry_echoed_out_of_order_still_reports_the_ordering_violation` fails, with `unexpected diagnostic: rsync: refusing transfer of cleared file index 1…` |

The second is the non-vacuity companion: without it, a guard that fired on
*every* index would still satisfy the first test.

`cargo fmt --all -- --check` clean.

⚠ The full `-p transfer --lib` suite did not complete locally — an unrelated
pre-existing hang on this aarch64 macOS host, in
`receiver::tests::errors_and_timeouts::goodbye_partial_cutoff` and two
`writer::throttle` timing tests, identified by intersecting two `sample`
snapshots 90s apart. None of the three touch the changed code
(`read_ndx_step` is unmodified; the goodbye sink's new method has no caller on
that path). Deferring to CI's Linux full-workspace run as the oracle.
