### PR TITLE
test(matching): pin the want_i adjacent-match length re-check

### DIFF
--- a/crates/matching/src/index/tests.rs
+++ b/crates/matching/src/index/tests.rs
@@ -591,3 +591,57 @@ fn extend_run_rejects_short_target() {
 
     assert_eq!(index.extend_run(0, &target, 4), 0);
 }
+
+/// The adjacent-match hint must refuse a block whose declared length differs
+/// from the index block length, even when that block's own rolling and strong
+/// sums match the bytes it is handed.
+///
+/// upstream: `match.c` `hash_search()` - the `check_want_i` optimisation
+/// substitutes `i = want_i` after matching sum1 and sum2 but, unlike the main
+/// chain loop and the `aligned_i` path, did not re-check
+/// `s->sums[want_i].len == l`. A hostile generator pulling from a
+/// daemon-as-sender forges a sum header whose blocks disagree in length, so the
+/// substituted block describes `remainder` bytes while the caller is positioned
+/// for a full `blength` window; `map_ptr(..., 0)` then returns NULL and
+/// upstream dereferences it - a remote unauthenticated crash of the
+/// per-connection daemon child. oc's `check_block_match_slices` carries the
+/// re-check; this pins it.
+///
+/// The short FINAL block is the reachable shape: every signature of a file
+/// whose length is not a whole multiple of the block length has one, so no
+/// forged header is needed to reach the guard - only to exploit its absence.
+#[test]
+fn hint_refuses_a_block_shorter_than_the_index_block_length() {
+    const BLOCK_LEN: usize = 700;
+    const REMAINDER: usize = 300;
+    let data: Vec<u8> = (0..(BLOCK_LEN + REMAINDER))
+        .map(|i| (i % 251) as u8)
+        .collect();
+
+    let params = SignatureLayoutParams::new(
+        data.len() as u64,
+        Some(std::num::NonZeroU32::new(BLOCK_LEN as u32).unwrap()),
+        ProtocolVersion::NEWEST,
+        NonZeroU8::new(16).unwrap(),
+    );
+    let layout = calculate_signature_layout(params).expect("layout");
+    let signature = generate_file_signature(data.as_slice(), layout, SignatureAlgorithm::Md4)
+        .expect("signature");
+    let index =
+        DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4).expect("index");
+
+    // Fixture precondition: without a genuinely short final block the call
+    // below could not discriminate, and the assertion would hold vacuously.
+    assert_eq!(index.block_count(), 2, "fixture must produce two blocks");
+    assert_eq!(index.block_length, BLOCK_LEN, "full block length");
+    assert_eq!(index.block(1).len(), REMAINDER, "final block must be short");
+
+    // The short block's OWN digest over its OWN bytes: every check downstream
+    // of the length guard would succeed, so a `true` here means the guard is
+    // gone rather than that some other predicate rejected the block.
+    let tail = &data[BLOCK_LEN..];
+    assert!(
+        !index.check_block_match_slices(1, index.block(1).rolling(), tail, &[]),
+        "a block shorter than block_length must not match through the hint path"
+    );
+}


### PR DESCRIPTION
## What

Pins the `want_i` adjacent-match length re-check in
`DeltaSignatureIndex::check_block_match_slices`. Test-only; no production change.

## Why this, and why now

This came out of triaging the 3.5.0 testsuite's `require_asan` gate, which
skips 10 cells on **every** leg. One of them, `match-want-i-nolen`, targets a
NULL deref in upstream's `hash_search()`: the `check_want_i` optimisation
substitutes `i = want_i` after matching sum1 and sum2 but, unlike the main
chain loop and the `aligned_i` path, did not re-check
`s->sums[want_i].len == l`. A hostile generator pulling from a
daemon-as-sender forges a sum header whose blocks disagree in length; after
`matched()` advances the offset, `k = MIN(blength, len - offset) = 0`,
`map_ptr(..., 0)` returns NULL, and upstream dereferences it — a remote
unauthenticated crash of the per-connection daemon child.

I checked oc and found the guard already present at
`crates/matching/src/index/mod.rs:869-871`, on exactly the `want_i` hint path
(`generator.rs:554-557`), and reported oc as independently correct.

**That report was worth very little.** Deleting those three lines left the
entire `-p matching` suite green — `232 passed; 0 failed`. Nothing in the tree
distinguished the guard's presence from its absence, so "oc already has it"
rested on my reading rather than on anything that would survive a refactor.

## Fixture choice

The test uses the **short final block**, not a forged header. That is the
reachable shape: every signature over a file whose length is not a whole
multiple of the block length has one, so no hostile peer is needed to *reach*
the guard — only to exploit its absence. It hands that block its **own**
rolling digest over its **own** bytes, so every check downstream of the length
guard would succeed; a `true` result can therefore only mean the guard is gone,
not that some other predicate happened to reject the block.

Fixture preconditions are asserted, not assumed: two blocks, the second
genuinely shorter than `block_length`. Without those, a layout change could
make the call pass vacuously.

## Verification

| state | result |
|---|---|
| guard present | 233 passed / 0 failed |
| guard removed | **232 passed / 1 failed** — and the one failure is this test |

The same mutation before this commit gave 232 passed / **0** failed, which is
what identifies the hole being closed.

`cargo fmt --all -- --check` clean (verified on cargo's own exit code, not a
pipeline's). Green on the `master` base, not merely on the branch it was
written on.

## Scope note

This pins a guard that is **already correct**; it changes no behaviour. It is
deliberately separate from #7642 (a `transfer` port for a different cell) so
each can be reviewed and reverted on its own.
