### PR TITLE
test(protocol): pin the reserved slot below the daemon-argument ceiling

### DIFF
--- a/crates/protocol/src/secluded_args.rs
+++ b/crates/protocol/src/secluded_args.rs
@@ -726,4 +726,63 @@ mod daemon_arg_ceiling_tests {
 
         assert_eq!(args.len(), 8);
     }
+
+    /// Builds the wire form of an argument vector: each argument
+    /// NUL-terminated, then one empty argument as the terminator.
+    fn secluded_wire(args: &[&str]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for arg in args {
+            buf.extend_from_slice(arg.as_bytes());
+            buf.push(0);
+        }
+        buf.push(0);
+        buf
+    }
+
+    /// `max_args` must admit at most `max - 1` arguments: the ceiling reserves
+    /// one slot, and the reservation is the whole point of the bound.
+    ///
+    /// upstream: `io.c:1476-1479` bounds `read_args()` at `MAX_DAEMON_ARGS`,
+    /// but `glob_expand()` reserves room only for the entry it appends
+    /// (`ENSURE_MEMSPACE(..., glob.argc + 1)`) and not for the trailing NULL
+    /// that `read_args()` stores after the loop - so an argument vector landing
+    /// exactly on `maxargs` puts `argv[argc] = NULL` one slot past the
+    /// allocation. oc cannot reproduce that write, but it inherits the
+    /// BOUNDARY: `saturating_sub(1)` is oc's reservation of the same slot, and
+    /// nothing tested it. Dropping the `- 1` left the whole protocol suite
+    /// green (3785 passed, 0 failed), which is what identifies the arithmetic
+    /// as unpinned rather than merely untested by name.
+    ///
+    /// Live path: the daemon's phase-2 read passes
+    /// `Some(MAX_DAEMON_ARGS)` (`arg_reading.rs`), so the ceiling is reachable
+    /// by any daemon client.
+    #[test]
+    fn max_args_reserves_one_slot_below_the_ceiling() {
+        // With max = 4 the reader must accept 3 and refuse the 4th.
+        let wire = secluded_wire(&["one", "two", "three", "four"]);
+        let mut cursor = io::Cursor::new(wire);
+
+        let err = recv_secluded_args(&mut cursor, None, Some(4))
+            .expect_err("a 4th argument must be refused when max_args is 4");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("too many daemon arguments"),
+            "refusal must be the daemon-argument ceiling, got: {err}",
+        );
+    }
+
+    /// Positive control for `max_args_reserves_one_slot_below_the_ceiling`:
+    /// exactly `max - 1` arguments are accepted. Without this the boundary test
+    /// would also pass against a reader that refused every bounded read.
+    #[test]
+    fn max_args_accepts_exactly_one_below_the_ceiling() {
+        let wire = secluded_wire(&["one", "two", "three"]);
+        let mut cursor = io::Cursor::new(wire);
+
+        let args = recv_secluded_args(&mut cursor, None, Some(4))
+            .expect("max - 1 arguments must be accepted");
+
+        assert_eq!(args, vec!["one", "two", "three"]);
+    }
 }


### PR DESCRIPTION
## What

Pins the off-by-one reservation in `recv_secluded_args`: with `max_args = Some(max)` the reader admits at most `max - 1` arguments, because the ceiling check runs **before** the push and tests `args.len() >= max.saturating_sub(1)`.

## Why it was unpinned

Dropping the `- 1` left the entire protocol suite green: **3785 passed, 0 failed**. That result, not the absence of a test by name, is what identifies the arithmetic as uncovered.

The module already had ceiling tests — a refusal, a non-vacuity companion, and a within-ceiling accept. None of them sits *on* the boundary, so none discriminates the off-by-one. That is precisely why the mutation survived them, and it is the reusable point: a bound can have three tests and still have no test of its edge.

## Upstream connection

`io.c:1476-1479` bounds `read_args()` at `MAX_DAEMON_ARGS`, but `glob_expand()` reserves room only for the entry it appends (`ENSURE_MEMSPACE(..., glob.argc + 1)`) and not for the trailing NULL that `read_args()` stores after the loop. A vector landing exactly on `maxargs` therefore writes `argv[argc] = NULL` one slot past the allocation.

oc cannot reproduce that write — there is no manual NULL terminator in a `Vec`. But it inherits the **boundary**, and `saturating_sub(1)` is oc's reservation of the same slot. This pins the reservation rather than porting a C artefact.

## Reachability

The ceiling is live, not theoretical: the daemon's phase-2 secluded-args read passes `Some(MAX_DAEMON_ARGS)`, so it is reachable by any daemon client. The `None` arm stays deliberately unbounded, mirroring upstream's `mod_name` gate at `io.c:1476` — the pre-existing companion already pins that, so this PR does not restate it.

## Mutation table

| state | result |
|---|---|
| reservation present | 3787 passed / 0 failed |
| `- 1` dropped | **3786 passed / 1 failed** |

The mutation kills exactly the boundary refusal. The positive control — which accepts exactly `max - 1` — stays green, so the refusal test cannot be passing because the reader simply refuses every bounded read.

## Stated limit

⚠ The daemon crate carries its **own** copy of this arithmetic in `read_client_arguments` (`arguments.len() >= MAX_DAEMON_ARGS - 1`). It is **not** covered here and is **not** cleared: `-p daemon --lib` is non-deterministic on the development host — 218 failures unmutated versus 151 mutated, same 1792 total — so it cannot serve as a mutation instrument. Measuring that site needs a host where the daemon suite is stable.

Test-only; no production code changes. `cargo fmt --all -- --check` clean.