### PR TITLE
fix(protocol): report an oversized xattr datum with upstream's own wording

### DIFF
--- a/crates/protocol/src/xattr/cache.rs
+++ b/crates/protocol/src/xattr/cache.rs
@@ -289,14 +289,21 @@ impl XattrCache {
             let name_len = checked_wire_len(read_varint(reader)?, "xattr name_len")?;
             let datum_len = checked_wire_len(read_varint(reader)?, "xattr datum_len")?;
 
-            // upstream: xattrs.c:839 - a single value above the hard per-value
-            // ceiling is a protocol error, not a truncation.
+            // upstream: xattrs.c:839-842 - a single value above the hard
+            // per-value ceiling is a protocol error, not a truncation:
+            //
+            //     rprintf(FERROR, "xattr datum_len exceeds per-value limit [%s]\n", ...);
+            //     exit_cleanup(RERR_PROTOCOL);
+            //
+            // The text is upstream's verbatim and is load-bearing: the 3.5.0
+            // `xattr-wire-cap` cell greps the receiver's output for this exact
+            // literal, so interpolating the two lengths into the middle of it
+            // would refuse the header correctly and still fail the cell.
+            // Upstream reports neither number here.
             if datum_len > MAX_XATTR_VALUE_BYTES {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!(
-                        "xattr datum_len {datum_len} exceeds per-value limit {MAX_XATTR_VALUE_BYTES}"
-                    ),
+                    "xattr datum_len exceeds per-value limit",
                 ));
             }
 
@@ -1205,5 +1212,54 @@ mod tests {
         assert_eq!(cache.find(&list_from(&[(b"user.k", b"aaaa")])), Some(0));
         assert_eq!(cache.find(&list_from(&[(b"user.k", b"bbbb")])), Some(1));
         assert_eq!(cache.find(&list_from(&[(b"user.k", b"cccc")])), None);
+    }
+
+    /// Builds a one-entry literal xattr header that DECLARES `datum_len`
+    /// without supplying that many bytes. A datum over `MAX_FULL_DATUM`
+    /// travels as a digest rather than as the value, so an oversized length is
+    /// expressible in a handful of bytes - which is exactly how a malicious
+    /// peer sends it, and why the guard must fire before any allocation.
+    fn header_declaring_datum_len(name: &[u8], datum_len: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        write_varint(&mut buf, 0).unwrap(); // ndx = 0: a literal list follows
+        write_varint(&mut buf, 1).unwrap(); // count
+        write_varint(&mut buf, (name.len() + 1) as i32).unwrap();
+        write_varint(&mut buf, datum_len as i32).unwrap();
+        buf.extend_from_slice(name);
+        buf.push(0);
+        buf.extend_from_slice(&[0xAA; MAX_XATTR_DIGEST_LEN]);
+        buf
+    }
+
+    /// upstream: xattrs.c:839-842 reports an oversized per-value datum length
+    /// as `xattr datum_len exceeds per-value limit [%s]`, carrying neither the
+    /// offending length nor the ceiling. The 3.5.0 `xattr-wire-cap` cell greps
+    /// the receiver's output for that literal, so refusing the header is
+    /// necessary but not sufficient - the refusal has to name itself in
+    /// upstream's words.
+    #[test]
+    fn the_per_value_refusal_carries_upstreams_literal() {
+        let buf = header_declaring_datum_len(b"user.wirecap", MAX_XATTR_VALUE_BYTES + 1);
+        let mut cache = XattrCache::new();
+        let err = cache
+            .receive_xattr(&mut Cursor::new(buf), false, 1)
+            .expect_err("a datum_len above the per-value ceiling must be refused");
+
+        assert_eq!(err.to_string(), "xattr datum_len exceeds per-value limit");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Non-vacuity companion for the pin above: at EXACTLY the ceiling the
+    /// entry is accepted. Without this, the pin would also pass if the fixture
+    /// were simply malformed, or if a coarser bound (`checked_wire_len`, which
+    /// clamps to `effective_max_alloc` and is far larger) were the one
+    /// deciding. Upstream's test is `>`, not `>=` - xattrs.c:839.
+    #[test]
+    fn a_datum_len_at_the_ceiling_is_accepted() {
+        let buf = header_declaring_datum_len(b"user.wirecap", MAX_XATTR_VALUE_BYTES);
+        let mut cache = XattrCache::new();
+        cache
+            .receive_xattr(&mut Cursor::new(buf), false, 1)
+            .expect("a datum_len exactly at the ceiling is legal");
     }
 }

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -154,5 +154,5 @@ symlink-exclude-leaf pass
 symlink-exclude-meta pass
 symlink-exclude-xattr pass
 variety pass
-xattr-wire-cap fail
+xattr-wire-cap pass
 xrsync pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -154,5 +154,5 @@ symlink-exclude-leaf pass
 symlink-exclude-meta pass
 symlink-exclude-xattr pass
 variety pass
-xattr-wire-cap fail
+xattr-wire-cap pass
 xrsync pass


### PR DESCRIPTION
fix(protocol): report an oversized xattr datum with upstream's own wording

`receive_xattr()` refuses a per-value datum length over the 128 MiB
ceiling, and upstream words that refusal with no numbers in it
(xattrs.c:839-842):

    if (datum_len > MAX_XATTR_VALUE_BYTES) {
            rprintf(FERROR, "xattr datum_len exceeds per-value limit [%s]\n", who_am_i());
            exit_cleanup(RERR_PROTOCOL);
    }

oc interpolated the offending length and the ceiling into the middle of
that sentence, so a malicious daemon-sender's oversized header was
refused correctly but announced as

    xattr datum_len 134217729 exceeds per-value limit 134217728

The refusal was right; only the wording diverged, and the wording is
what the 3.5.0 `xattr-wire-cap` cell greps for. That cell stands up a
Python daemon acting as the sender, streams a one-entry file list whose
xattr block declares `datum_len = 128 MiB + 1`, and requires BOTH a
non-zero exit AND the literal:

    if 'xattr datum_len exceeds per-value limit' not in out:
        test_fail("receiver rejected the malicious xattr stream, but not
                   via the per-value wire cap...")

So the cell cannot be satisfied by refusing correctly: a guard that
declines to name itself in upstream's words reads as the wrong guard
having fired. Measured against the real harness on the pre-fix binary:

    receiver rejected the malicious xattr stream, but not via the
    per-value wire cap. Output:
    oc-rsync error: transfer failed: xattr datum_len 134217729 exceeds
    per-value limit 134217728 (code 23)

and after the fix the same cell reports `PASS xattr-wire-cap`, overall
result 0.

Reachable on the live receiver, not a test-only decoder: `receive_xattr`
is called from `flist/read/mod.rs:837` during `recv_file_list`, citing
upstream's `flist.c:1237-1240` for exactly that call.

Mutation-proven by restoring the interpolated wording:

  | test                                              | mutated |
  |---------------------------------------------------|---------|
  | the_per_value_refusal_carries_upstreams_literal    | FAILED  |
  | a_datum_len_at_the_ceiling_is_accepted (companion) | ok      |

The companion staying green is the non-vacuity proof: it fixes the
boundary at exactly `MAX_XATTR_VALUE_BYTES` (upstream's test is `>`, not
`>=`), so the refusal is attributable to this guard rather than to the
far looser `checked_wire_len` bound or to a malformed fixture.

Both TCP expect-manifest rows flip `fail` -> `pass` in this same commit,
recording the fix rather than re-baselining a regression. The three
non-TCP manifests keep `skip`: the cell calls `require_tcp()`, so it
never runs on those legs.

Deliberately NOT changed: `recv_xattr_values` (the abbreviated-value
path, upstream's second site at xattrs.c:782) bounds its length by
`effective_max_alloc` rather than `MAX_XATTR_VALUE_BYTES`, which is
looser than upstream. It has no production caller - the only reference
is the crate re-export - so tightening it now would be unverifiable.
Filed rather than fixed blind.

protocol 26/26 on the touched area; fmt clean.
