### PR TITLE
fix(daemon): refuse a PROXY header from an untrusted direct peer

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -556,6 +556,7 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         reverse_lookup,
         lock_file,
         proxy_protocol,
+        proxy_protocol_hosts,
         daemon_uid,
         daemon_gid,
         daemon_chroot,
@@ -622,6 +623,12 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
             Arc::new(Vec::new())
         };
 
+    // The async accept path carries the same trust gate as the sync one: a
+    // PROXY header is read only from a listed trusted proxy, and an enabled
+    // feature with no list warns once at startup (clientserver.c:1747-1756).
+    let proxy_policy = ProxyProtocolPolicy::new(proxy_protocol, proxy_protocol_hosts);
+    warn_if_proxy_protocol_trusts_nobody(&proxy_policy, log_sink.as_ref());
+
     let context = ConnectionContext::new(
         modules,
         Arc::new(motd_lines),
@@ -629,7 +636,7 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         client_socket_options,
         bandwidth_limit,
         reverse_lookup,
-        proxy_protocol,
+        proxy_policy,
     );
 
     let bind_addr = std::net::SocketAddr::new(bind_address, port);

--- a/crates/daemon/src/daemon/module_state/mod.rs
+++ b/crates/daemon/src/daemon/module_state/mod.rs
@@ -30,7 +30,8 @@ pub(crate) use definition::{GidSetting, ModuleDefinition};
 pub(crate) use hostname::PeerHost;
 pub(crate) use hostname::module_peer_hostname;
 pub(in crate::daemon) use hostname::{
-    forward_resolve, netgroup_contains, peer_host_display, resolve_peer_hostname,
+    UNDETERMINED_HOSTNAME, forward_resolve, netgroup_contains, peer_host_display,
+    resolve_peer_hostname,
 };
 pub(crate) use max_connections::MaxConnections;
 pub(crate) use runtime::{ModuleConnectionError, ModuleRuntime};

--- a/crates/daemon/src/daemon/runtime_options/config.rs
+++ b/crates/daemon/src/daemon/runtime_options/config.rs
@@ -125,6 +125,10 @@ impl RuntimeOptions {
             self.proxy_protocol = enabled;
         }
 
+        if let Some((patterns, _origin)) = parsed.proxy_protocol_hosts {
+            self.proxy_protocol_hosts = patterns;
+        }
+
         if let Some((chroot_path, _origin)) = parsed.daemon_chroot {
             self.daemon_chroot = Some(chroot_path);
         }

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -115,6 +115,12 @@ pub(crate) struct RuntimeOptions {
     ///
     /// upstream: daemon-parm.h - `proxy_protocol` BOOL, P_GLOBAL, default False.
     proxy_protocol: bool,
+    /// Addresses whose PROXY protocol header the daemon is willing to believe.
+    ///
+    /// upstream: daemon-parm.h - `proxy_protocol_hosts` STRING, P_GLOBAL,
+    /// default "". Empty means trust nobody, not trust everybody
+    /// (access.c:302-303).
+    proxy_protocol_hosts: Vec<HostPattern>,
     /// Directory the daemon chroots into before forking children.
     ///
     /// upstream: daemon-parm.h - `daemon chroot` STRING, P_GLOBAL.
@@ -184,6 +190,7 @@ impl Default for RuntimeOptions {
             socket_options_from_config: false,
             tcp_fastopen: TcpFastOpenMode::Auto,
             proxy_protocol: false,
+            proxy_protocol_hosts: Vec::new(),
             daemon_chroot: None,
             detach: cfg!(unix),
             config_path: None,

--- a/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
@@ -393,6 +393,144 @@ const fn is_wildmatch_metachar(byte: u8) -> bool {
     matches!(byte, b'*' | b'?' | b'[' | b'\\')
 }
 
+/// Warns the operator that `proxy protocol = true` with no trusted-proxy list
+/// rejects every connection.
+///
+/// upstream: clientserver.c:1747-1756
+///
+/// ```c
+/// /* "proxy protocol = true" with no trusted-proxy list rejects every
+///  * connection as an untrusted proxy peer (fail-closed).  That is intended,
+///  * but silent at startup, so warn the operator while stderr is still open. */
+/// if (lp_proxy_protocol()
+///  && (!lp_proxy_protocol_hosts() || !*lp_proxy_protocol_hosts())) {
+///         rprintf(FWARNING, "\"proxy protocol = true\" but \"proxy protocol hosts\" is unset:" ...);
+/// }
+/// ```
+///
+/// The fail-closed default is deliberate, which is exactly why it needs a
+/// voice: without this line the operator sees a daemon that accepts a TCP
+/// connection and then drops every one of them, with the reason recorded only
+/// per-connection.
+pub(in crate::daemon) fn warn_if_proxy_protocol_trusts_nobody(
+    policy: &ProxyProtocolPolicy,
+    log_sink: Option<&SharedLogSink>,
+) {
+    if !policy.rejects_every_peer() {
+        return;
+    }
+
+    let text = concat!(
+        "\"proxy protocol = true\" but \"proxy protocol hosts\" is unset:",
+        " all connections will be rejected as untrusted proxy peers.",
+        "  Set \"proxy protocol hosts\" to your trusted proxy's address."
+    )
+    .to_owned();
+    let message = rsync_warning!(text).with_role(Role::Daemon);
+    if let Some(log) = log_sink {
+        log_message(log, &message);
+    } else {
+        eprintln!("{message}");
+    }
+}
+
+/// What the daemon must do with an incoming connection's PROXY protocol
+/// header, given the configured policy and the peer's real address.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(in crate::daemon) enum ProxyHeaderDecision {
+    /// `proxy protocol = false`: no header is expected, so read none.
+    NotRequired,
+    /// The peer is a listed trusted proxy; believe the header it sends.
+    Trusted,
+    /// A header is required but this peer may not supply one. Upstream logs
+    /// the refusal and drops the connection (clientserver.c:1393-1396,
+    /// 1443-1446).
+    Untrusted,
+}
+
+/// The daemon's PROXY protocol configuration as one value.
+///
+/// upstream keeps `proxy protocol` and `proxy protocol hosts` as two
+/// directives (daemon-parm.h) but reads them at one site: `rsync_module()`
+/// consults `lp_proxy_protocol()` and, if set, calls `proxy_peer_allowed()`,
+/// which consults `lp_proxy_protocol_hosts()` (clientserver.c:1443-1446). The
+/// two are only ever meaningful together - a trusted-proxy list with the
+/// feature off decides nothing, and the feature on without a list rejects
+/// everyone - so oc carries them as one value rather than as a bool and a
+/// list that could drift apart while being threaded to the session handler.
+#[derive(Clone, Debug, Default)]
+pub(in crate::daemon) enum ProxyProtocolPolicy {
+    /// `proxy protocol = false` (upstream's default).
+    #[default]
+    Disabled,
+    /// `proxy protocol = true`, carrying the `proxy protocol hosts` list. An
+    /// empty list is legal configuration and trusts nobody.
+    Enabled(Arc<Vec<HostPattern>>),
+}
+
+impl ProxyProtocolPolicy {
+    /// Builds the policy from the two parsed directives.
+    pub(in crate::daemon) fn new(enabled: bool, trusted: Vec<HostPattern>) -> Self {
+        if enabled {
+            Self::Enabled(Arc::new(trusted))
+        } else {
+            Self::Disabled
+        }
+    }
+
+    /// Decides how to treat a connection arriving from `addr`.
+    pub(in crate::daemon) fn decide(&self, addr: IpAddr) -> ProxyHeaderDecision {
+        match self {
+            Self::Disabled => ProxyHeaderDecision::NotRequired,
+            Self::Enabled(trusted) if allow_proxy_protocol_peer(trusted, addr) => {
+                ProxyHeaderDecision::Trusted
+            }
+            Self::Enabled(_) => ProxyHeaderDecision::Untrusted,
+        }
+    }
+
+    /// Returns whether `proxy protocol = true` was set with no trusted-proxy
+    /// list - the fail-closed combination upstream warns about at startup.
+    ///
+    /// upstream: clientserver.c:1750-1751.
+    pub(in crate::daemon) fn rejects_every_peer(&self) -> bool {
+        matches!(self, Self::Enabled(trusted) if trusted.is_empty())
+    }
+}
+
+/// Returns whether `addr` is a trusted proxy allowed to supply a PROXY
+/// protocol header.
+///
+/// upstream: access.c:300-306
+///
+/// ```c
+/// int allow_proxy_protocol_peer(const char *list, const char *addr, const char **host_ptr)
+/// {
+///         if (!list || !*list)
+///                 return 0;
+///         allow_forward_dns = 0;
+///         return access_match(list, addr, host_ptr, 0);
+/// }
+/// ```
+///
+/// Two properties of that body are the whole gate, and both are deliberate:
+///
+/// 1. **An empty list rejects every peer.** It is not "unset means allow" -
+///    `proxy protocol = true` with no trusted-proxy list fail-closes, which is
+///    why upstream warns about that combination at startup
+///    (clientserver.c:1750-1755).
+/// 2. **No DNS is consulted.** `allow_forward_dns = 0` disables the
+///    forward-resolve half, and the caller passes the `UNDETERMINED` sentinel
+///    rather than a resolved name (clientserver.c:1390-1393), so
+///    `match_hostname` can only compare a token against that sentinel. In
+///    practice the list is matched numerically - a name-based trusted-proxy
+///    token cannot match a real peer. Passing the sentinel here reproduces that
+///    exactly, and costs no lookup.
+fn allow_proxy_protocol_peer(list: &[HostPattern], addr: IpAddr) -> bool {
+    list.iter()
+        .any(|pattern| pattern.matches(addr, module_state::UNDETERMINED_HOSTNAME))
+}
+
 /// Parses a host allow/deny list from a config directive value.
 ///
 /// Splits the value by commas and whitespace, parses each token as a

--- a/crates/daemon/src/daemon/sections/config_helpers/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/tests.rs
@@ -622,4 +622,91 @@ mod config_helpers_tests {
         assert!(pattern.matches("www.example.com"));
         assert!(!pattern.matches("example.com"));
     }
+
+    fn trusted_proxy_policy(tokens: &[&str]) -> ProxyProtocolPolicy {
+        let patterns = tokens
+            .iter()
+            .map(|token| HostPattern::parse(token).expect("valid trusted-proxy token"))
+            .collect();
+        ProxyProtocolPolicy::new(true, patterns)
+    }
+
+    #[test]
+    fn an_unlisted_direct_peer_may_not_supply_a_proxy_header() {
+        let policy = trusted_proxy_policy(&["10.0.0.1"]);
+
+        assert_eq!(
+            policy.decide("127.0.0.1".parse().unwrap()),
+            ProxyHeaderDecision::Untrusted
+        );
+    }
+
+    #[test]
+    fn a_listed_trusted_proxy_may_supply_a_proxy_header() {
+        let policy = trusted_proxy_policy(&["10.0.0.1"]);
+
+        assert_eq!(
+            policy.decide("10.0.0.1".parse().unwrap()),
+            ProxyHeaderDecision::Trusted
+        );
+    }
+
+    #[test]
+    fn proxy_protocol_with_no_trusted_hosts_rejects_every_peer() {
+        // upstream: access.c:302-303 `if (!list || !*list) return 0;` - the
+        // empty list is fail-closed, and clientserver.c:1750 warns about it
+        // precisely because it is silent otherwise.
+        let policy = ProxyProtocolPolicy::new(true, Vec::new());
+
+        assert!(policy.rejects_every_peer());
+        assert_eq!(
+            policy.decide("10.0.0.1".parse().unwrap()),
+            ProxyHeaderDecision::Untrusted
+        );
+    }
+
+    #[test]
+    fn the_gate_is_inert_when_proxy_protocol_is_off() {
+        // The availability half: with the feature off no header is expected,
+        // so the trust gate must not refuse anyone. Upstream reaches
+        // `proxy_peer_allowed()` only inside `if (lp_proxy_protocol())`
+        // (clientserver.c:1443-1444).
+        let policy = ProxyProtocolPolicy::new(false, Vec::new());
+
+        assert!(!policy.rejects_every_peer());
+        assert_eq!(
+            policy.decide("203.0.113.9".parse().unwrap()),
+            ProxyHeaderDecision::NotRequired
+        );
+    }
+
+    #[test]
+    fn a_cidr_trusted_proxy_token_admits_its_range_and_nothing_else() {
+        let policy = trusted_proxy_policy(&["10.0.0.0/24"]);
+
+        assert_eq!(
+            policy.decide("10.0.0.7".parse().unwrap()),
+            ProxyHeaderDecision::Trusted
+        );
+        assert_eq!(
+            policy.decide("10.0.1.7".parse().unwrap()),
+            ProxyHeaderDecision::Untrusted
+        );
+    }
+
+    #[test]
+    fn a_hostname_trusted_proxy_token_matches_no_real_peer() {
+        // upstream: access.c:302 sets `allow_forward_dns = 0` and
+        // clientserver.c:1391-1393 passes the `UNDETERMINED` sentinel rather
+        // than a resolved name, so `match_hostname` can only ever compare a
+        // token against that sentinel. A name-based trusted-proxy token is
+        // therefore inert - and oc must reproduce that rather than resolve,
+        // or the gate would consult DNS where upstream deliberately does not.
+        let policy = trusted_proxy_policy(&["proxy.example.com"]);
+
+        assert_eq!(
+            policy.decide("10.0.0.1".parse().unwrap()),
+            ProxyHeaderDecision::Untrusted
+        );
+    }
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -494,6 +494,25 @@ fn apply_global_directive(
 
             store_global_directive(&mut state.proxy_protocol, parsed, canonical, line_number);
         }
+        "proxyprotocolhosts" => {
+            // upstream: access.c:300-306 `allow_proxy_protocol_peer()` reads
+            // the list with `if (!list || !*list) return 0;`, so an empty
+            // value is legal config that trusts nobody. `parse_host_list`
+            // rejects an empty list for `hosts allow`/`hosts deny`, where
+            // emptiness really is a mistake; here it is upstream's default.
+            let patterns = if value.trim().is_empty() {
+                Vec::new()
+            } else {
+                parse_host_list(value, path, line_number, "proxy protocol hosts")?
+            };
+
+            store_global_directive(
+                &mut state.proxy_protocol_hosts,
+                patterns,
+                canonical,
+                line_number,
+            );
+        }
         "daemonchroot" => {
             let trimmed = value.trim();
             if trimmed.is_empty() {

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
@@ -39,6 +39,7 @@ struct GlobalParseState {
     acceptor_threads: Option<(NonZeroU32, ConfigDirectiveOrigin)>,
     socket_options: Option<(String, ConfigDirectiveOrigin)>,
     proxy_protocol: Option<(bool, ConfigDirectiveOrigin)>,
+    proxy_protocol_hosts: Option<(Vec<HostPattern>, ConfigDirectiveOrigin)>,
     rsync_port: Option<(u16, ConfigDirectiveOrigin)>,
     daemon_chroot: Option<(PathBuf, ConfigDirectiveOrigin)>,
     /// Module sections read so far, still unfinalized: a string-typed P_LOCAL
@@ -89,6 +90,7 @@ impl GlobalParseState {
             acceptor_threads: None,
             socket_options: None,
             proxy_protocol: None,
+            proxy_protocol_hosts: None,
             rsync_port: None,
             daemon_chroot: None,
             modules: Vec::new(),
@@ -191,6 +193,7 @@ impl GlobalParseState {
             acceptor_threads: self.acceptor_threads,
             socket_options: self.socket_options,
             proxy_protocol: self.proxy_protocol,
+            proxy_protocol_hosts: self.proxy_protocol_hosts,
             rsync_port: self.rsync_port,
             daemon_chroot: self.daemon_chroot,
         })

--- a/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/include_merge.rs
@@ -162,6 +162,10 @@ fn merge_included_globals(state: &mut GlobalParseState, included: GlobalParseSta
     merge_optional_directive(&mut state.listen_backlog, included.listen_backlog);
     merge_optional_directive(&mut state.socket_options, included.socket_options);
     merge_optional_directive(&mut state.proxy_protocol, included.proxy_protocol);
+    merge_optional_directive(
+        &mut state.proxy_protocol_hosts,
+        included.proxy_protocol_hosts,
+    );
     merge_optional_directive(&mut state.rsync_port, included.rsync_port);
     merge_optional_directive(&mut state.daemon_chroot, included.daemon_chroot);
 }

--- a/crates/daemon/src/daemon/sections/config_parsing/types.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/types.rs
@@ -74,6 +74,12 @@ pub(crate) struct ParsedConfigModules {
     ///
     /// upstream: daemon-parm.h - `proxy_protocol` BOOL, P_GLOBAL, default False.
     proxy_protocol: Option<(bool, ConfigDirectiveOrigin)>,
+    /// Addresses whose PROXY protocol header the daemon is willing to believe.
+    ///
+    /// upstream: daemon-parm.h - `proxy_protocol_hosts` STRING, P_GLOBAL,
+    /// default "". Read by `allow_proxy_protocol_peer()` (access.c:300), which
+    /// returns 0 for an empty list, so an unset directive rejects every peer.
+    proxy_protocol_hosts: Option<(Vec<HostPattern>, ConfigDirectiveOrigin)>,
     /// TCP port the daemon listens on.
     /// upstream: daemon-parm.txt - `port` INTEGER, P_GLOBAL, default 0.
     rsync_port: Option<(u16, ConfigDirectiveOrigin)>,

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -73,6 +73,7 @@ fn serve_connections(
         daemon_gid,
         daemon_chroot,
         proxy_protocol,
+        proxy_protocol_hosts,
         ..
     } = options;
 
@@ -81,6 +82,9 @@ fn serve_connections(
     } else {
         None
     };
+
+    let proxy_policy = ProxyProtocolPolicy::new(proxy_protocol, proxy_protocol_hosts);
+    warn_if_proxy_protocol_trusts_nobody(&proxy_policy, log_sink.as_ref());
 
     // Apply Linux-only defense-in-depth startup hardenings before the
     // listener binds or any pre-xfer-exec hook is spawned. PR_SET_NO_NEW_PRIVS
@@ -377,7 +381,7 @@ fn serve_connections(
         client_socket_options,
         bandwidth_limit,
         reverse_lookup,
-        proxy_protocol,
+        proxy_policy,
     };
 
     // Select the accept engine once from the bound listener topology, then run

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -26,7 +26,7 @@ struct AcceptLoopState<'a> {
     client_socket_options: Arc<Vec<SocketOption>>,
     bandwidth_limit: Option<NonZeroU64>,
     reverse_lookup: bool,
-    proxy_protocol: bool,
+    proxy_policy: ProxyProtocolPolicy,
 }
 
 /// Checks signal flags and performs maintenance tasks between accept iterations.
@@ -206,7 +206,7 @@ fn spawn_connection_worker(
         Arc::clone(&state.client_socket_options),
         state.bandwidth_limit,
         state.reverse_lookup,
-        state.proxy_protocol,
+        state.proxy_policy.clone(),
     );
     let conn_guard = state.connection_counter.acquire();
 

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
@@ -23,7 +23,7 @@ struct ConnectionContext {
     client_socket_options: Arc<Vec<SocketOption>>,
     bandwidth_limit: Option<NonZeroU64>,
     reverse_lookup: bool,
-    proxy_protocol: bool,
+    proxy_policy: ProxyProtocolPolicy,
 }
 
 impl ConnectionContext {
@@ -37,7 +37,7 @@ impl ConnectionContext {
         client_socket_options: Arc<Vec<SocketOption>>,
         bandwidth_limit: Option<NonZeroU64>,
         reverse_lookup: bool,
-        proxy_protocol: bool,
+        proxy_policy: ProxyProtocolPolicy,
     ) -> Self {
         Self {
             modules,
@@ -46,7 +46,7 @@ impl ConnectionContext {
             client_socket_options,
             bandwidth_limit,
             reverse_lookup,
-            proxy_protocol,
+            proxy_policy,
         }
     }
 
@@ -79,7 +79,7 @@ impl ConnectionContext {
                     daemon_limit: self.bandwidth_limit,
                     log_sink: log_for_worker.clone(),
                     reverse_lookup: self.reverse_lookup,
-                    proxy_protocol: self.proxy_protocol,
+                    proxy_policy: self.proxy_policy.clone(),
                 },
             )
         }));

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -984,7 +984,7 @@ fn test_accept_loop_state<'a>(
         client_socket_options: Arc::new(Vec::new()),
         bandwidth_limit: None,
         reverse_lookup: false,
-        proxy_protocol: false,
+        proxy_policy: ProxyProtocolPolicy::Disabled,
     }
 }
 

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -9,7 +9,7 @@ struct SessionParams<'a> {
     daemon_limit: Option<NonZeroU64>,
     log_sink: Option<SharedLogSink>,
     reverse_lookup: bool,
-    proxy_protocol: bool,
+    proxy_policy: ProxyProtocolPolicy,
 }
 
 /// Parameters for the legacy `@RSYNCD:` session handler.
@@ -50,7 +50,7 @@ fn handle_session(
         daemon_limit,
         log_sink,
         reverse_lookup,
-        proxy_protocol,
+        proxy_policy,
     } = params;
 
     // rsync daemon protocol is ALWAYS the legacy @RSYNCD protocol.
@@ -70,11 +70,41 @@ fn handle_session(
     // "Connection reset by peer". The per-module `timeout` directive still
     // governs the data phase via apply_module_timeout once the module is known.
 
-    // upstream: clientserver.c:1312 - read PROXY protocol header before any
-    // rsync protocol data when `proxy protocol = true` in the config.
+    // upstream: clientserver.c:1443-1446 - `if (lp_proxy_protocol())` reads the
+    // header before any rsync protocol data, but ONLY after the peer clears the
+    // trusted-proxy gate:
+    //
+    //     if (lp_proxy_protocol()) {
+    //             if (!proxy_peer_allowed(f_in) || !read_proxy_protocol_header(f_in))
+    //                     return -1;
+    //     }
+    //
+    // The gate is the security property, not a nicety. A PROXY header names
+    // the address the daemon then treats as the peer - it feeds `hosts allow`
+    // / `hosts deny`, `%h`, and every log line - so believing one from an
+    // arbitrary direct connection lets that connection choose its own source
+    // address. Upstream fail-closes: an unset trusted-proxy list rejects
+    // everyone (access.c:302-303).
     let mut stream = stream;
-    let peer_addr = if proxy_protocol {
-        match parse_proxy_header(&mut stream) {
+    let peer_addr = match proxy_policy.decide(peer_addr.ip()) {
+        ProxyHeaderDecision::NotRequired => peer_addr,
+        ProxyHeaderDecision::Untrusted => {
+            // upstream: clientserver.c:1394 - `rprintf(FLOG, "proxy protocol
+            // rejected from untrusted peer %s (%s)\n", host, addr)`. The
+            // wording is upstream's verbatim; the 3.5.0
+            // `proxy-protocol-trusted-peer` cell greps the daemon log for it.
+            if let Some(log) = log_sink.as_ref() {
+                let host = peer_host_display(None, reverse_lookup);
+                let text = format!(
+                    "proxy protocol rejected from untrusted peer {host} ({})",
+                    peer_addr.ip()
+                );
+                let message = rsync_warning!(text).with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            return Ok(());
+        }
+        ProxyHeaderDecision::Trusted => match parse_proxy_header(&mut stream) {
             Ok(Some(proxied_addr)) => proxied_addr,
             Ok(None) => peer_addr,
             Err(error) => {
@@ -86,9 +116,7 @@ fn handle_session(
                 }
                 return Err(error);
             }
-        }
-    } else {
-        peer_addr
+        },
     };
 
     // upstream: clientname.c `client_name` forward-confirms the reverse-DNS
@@ -605,13 +633,13 @@ mod session_runtime_tests {
             daemon_limit: None,
             log_sink: None,
             reverse_lookup: false,
-            proxy_protocol: false,
+            proxy_policy: ProxyProtocolPolicy::Disabled,
         };
         assert!(params.modules.is_empty());
         assert!(params.motd_lines.is_empty());
         assert!(params.daemon_limit.is_none());
         assert!(!params.reverse_lookup);
-        assert!(!params.proxy_protocol);
+        assert!(matches!(params.proxy_policy, ProxyProtocolPolicy::Disabled));
     }
 
     #[test]
@@ -625,7 +653,7 @@ mod session_runtime_tests {
             daemon_limit: limit,
             log_sink: None,
             reverse_lookup: true,
-            proxy_protocol: false,
+            proxy_policy: ProxyProtocolPolicy::Disabled,
         };
         assert_eq!(params.daemon_limit, NonZeroU64::new(1000));
         assert!(params.reverse_lookup);


### PR DESCRIPTION
With `proxy protocol = true`, oc read the PROXY protocol header from
whatever connected and adopted the address it claimed. That address then
*is* the peer for everything downstream - `hosts allow` / `hosts deny`,
`%h`, `RSYNC_HOST_NAME`, and every log line - so any client that could
reach the listener could choose its own source address and walk straight
through an address-based ACL.

Upstream gates the read on a trusted-proxy list and fails closed
(clientserver.c:1443-1446):

    if (lp_proxy_protocol()) {
            if (!proxy_peer_allowed(f_in) || !read_proxy_protocol_header(f_in))
                    return -1;
    }

`proxy_peer_allowed()` consults `proxy protocol hosts` through
`allow_proxy_protocol_peer()` (access.c:300-306), whose whole body is the
policy:

    if (!list || !*list)
            return 0;
    allow_forward_dns = 0;
    return access_match(list, addr, host_ptr, 0);

Two properties of that body are load-bearing and both are ported here:

  * An EMPTY list rejects everyone. Unset does not mean "trust anybody";
    it means "trust nobody", which is why upstream warns at startup when
    `proxy protocol = true` has no list (clientserver.c:1747-1756) - the
    fail-closed default is correct but otherwise silent.
  * NO DNS is consulted. `allow_forward_dns = 0` kills the forward-resolve
    half, and clientserver.c:1391-1393 passes the `UNDETERMINED` sentinel
    rather than a resolved name, so `match_hostname` can only compare a
    token against that sentinel. The trusted-proxy list is effectively
    address-only. oc passes the same sentinel, so the gate costs no lookup
    - and a test pins that a name-based token matches no real peer, since
    "resolve it properly" is the tempting wrong fix.

oc had no gate at all, so this adds the `proxy protocol hosts` global
directive alongside it. The two directives are carried as one
`ProxyProtocolPolicy` value rather than a bool plus a list: they are only
ever meaningful together (a list with the feature off decides nothing; the
feature on without a list rejects everyone), and they are threaded through
five layers to the session handler, which is exactly the distance over
which a bool and its list drift apart.

Both accept paths carry the gate: the sync accept loop and the
`async-daemon` one (daemon.rs `run_async_daemon`). The async site is
behind a cfg feature, so a default-feature `cargo check` compiles right
past it - it has to be built with `--all-features` to be seen at all.

Measured end to end against the fixed binary, `proxy protocol = true` with
no trusted-proxy list, an unlisted direct peer sending
`PROXY TCP4 10.9.8.7 127.0.0.1 12345 873`:

  * before: the daemon believed the header and served the connection
  * after:  the connection is dropped with no `@RSYNCD` greeting, and the
            startup warning is emitted

Mutation-proven by restoring the fail-open arm (`Enabled(_) => Trusted`):

  | test                                                     | mutated |
  |----------------------------------------------------------|---------|
  | an_unlisted_direct_peer_may_not_supply_a_proxy_header     | FAILED  |
  | proxy_protocol_with_no_trusted_hosts_rejects_every_peer   | FAILED  |
  | a_cidr_trusted_proxy_token_admits_its_range_and_nothing_. | FAILED  |
  | a_hostname_trusted_proxy_token_matches_no_real_peer       | FAILED  |
  | a_listed_trusted_proxy_may_supply_a_proxy_header          | ok      |
  | the_gate_is_inert_when_proxy_protocol_is_off              | ok      |

The two survivors are the non-vacuity proof: the refusal pins cannot pass
by every decision collapsing onto `Untrusted`, and the availability half -
with the feature off the gate refuses nobody - is pinned separately.

The 3.5.0 `proxy-protocol-trusted-peer` cell is NOT closed by this and its
manifest rows are deliberately left at `fail`. Measured: the cell's first
assertion ("daemon trusted a PROXY header from an unlisted direct peer")
now passes, but the remaining two grep a daemon log for the refusal, and
oc's log does not cover the window the refusal happens in.

That second half is a SEPARATE defect in a different subsystem, diagnosed
here rather than fixed. A/B on one fixture - same plain config, same probe,
`log file` set in the global section - against real 3.5.0:

  * upstream's log opens with `rsyncd version 3.5.0 starting, listening on
    port N` and carries a `connect from localhost (127.0.0.1)` line per
    connection, before any module is chosen
  * oc's log is created and written, but its first line is
    `rsync allowed access on module mod` - every pre-module event is absent

So oc opens the log sink once a module has been SELECTED; upstream opens it
at daemon STARTUP. Upstream's `log file` is P_LOCAL (daemon-parm.h:289),
exactly as oc classifies it, but `log_init(0)` at clientserver.c:1768 runs
with `module_id == -1` and log.c:217 takes
`logfile_name = lp_log_file(module_id)` - so the global section's value
opens a daemon-wide sink that covers the listener itself. A proxy-header
refusal is decided at accept time, before any module exists, which is
precisely the window oc's sink does not reach; that is why the startup
warning above lands on stderr. Moving oc's sink to daemon startup changes
where every daemon log line goes and belongs in its own PR.

daemon 1906/1906 (--all-features); fmt clean.
