### PR TITLE
docs(transfer): replace the INC_RECURSE gate's stale rationale with the measured one

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -457,15 +457,36 @@ fn requires_multiplex_output(
 
 /// Decides whether the local side may advertise INC_RECURSE in its compat
 /// flags response. Mirrors upstream `compat.c:161-179 set_allow_inc_recurse`
-/// with one local restriction: the receiver role never advertises INC_RECURSE
-/// because `receive_extra_file_lists` drains the entire sub-list stream
-/// upfront, which deadlocks against upstream's
-/// `MIN_FILECNT_LOOKAHEAD`-throttled `send_extra_file_list` (sender.c:228-232)
-/// on source trees larger than the lookahead window.
+/// with one local restriction upstream does not have: the receiver role never
+/// advertises INC_RECURSE.
+///
+/// That restriction is load-bearing, and the reason is measured rather than
+/// argued. Dropping the role term deadlocks the upstream 3.5.0 testsuite
+/// `hardlinks` cell - an `-aHivv --debug=HLINK5` push over `support/lsh.sh` -
+/// with both peers blocked on I/O at 0% CPU. Bisecting the source tree by
+/// entry count puts the boundary at exactly upstream's `MIN_FILECNT_LOOKAHEAD`
+/// of 1000:
+///
+/// | entries | role term kept | role term dropped |
+/// |---------|----------------|-------------------|
+/// |     400 | pass           | pass              |
+/// |     961 | pass           | pass              |
+/// |    1024 | pass           | deadlock          |
+/// |    1296 | pass           | deadlock          |
+///
+/// So oc-rsync's receiver cannot keep up with an upstream-shaped sender that
+/// paces sub-lists on that window. Which receiver-side site blocks is NOT yet
+/// attributed to a named function - do not restate the mechanism more
+/// precisely than that. In particular `receive_extra_file_lists` is *not* the
+/// culprit: every one of its call sites is inside a `#[cfg(test)]` module, so
+/// it is unreachable on the live path and cannot drain anything in production.
+///
+/// Removing this restriction is the INC_RECURSE-on-pull work, and it needs the
+/// receiver's sub-list consumption to become throttle-safe first. It is not a
+/// one-line change.
 ///
 /// upstream: compat.c:161-179 set_allow_inc_recurse,
-/// sender.c:228-232 (send_extra_file_list throttle),
-/// io.c:1740-1760 (receiver's inline sub-list dispatch oc-rsync does not implement).
+/// sender.c:228-232 (send_extra_file_list throttle).
 pub(crate) fn compute_allow_inc_recurse(recursive: bool, qsort: bool, role: ServerRole) -> bool {
     recursive && !qsort && role == ServerRole::Generator
 }

--- a/crates/transfer/src/tests/allow_inc_recurse.rs
+++ b/crates/transfer/src/tests/allow_inc_recurse.rs
@@ -5,8 +5,7 @@
 //! exceeds upstream's `MIN_FILECNT_LOOKAHEAD` window.
 //!
 //! upstream: compat.c:161-179 set_allow_inc_recurse,
-//! sender.c:228-232 send_extra_file_list throttle,
-//! io.c:1740-1760 receiver inline sub-list dispatch.
+//! sender.c:228-232 send_extra_file_list throttle.
 
 use crate::{ServerRole, compute_allow_inc_recurse};
 
@@ -37,11 +36,12 @@ fn generator_with_qsort_does_not_advertise() {
     ));
 }
 
-/// Receiver MUST never advertise INC_RECURSE - drives the upstream
-/// testsuite `hardlinks` test deadlock fix. Without this restriction,
-/// upstream's sender throttles extra sub-lists at MIN_FILECNT_LOOKAHEAD
-/// (1000 entries) while oc-rsync's `receive_extra_file_lists` keeps
-/// reading sub-lists upfront, deadlocking on any tree > 1000 entries.
+/// Receiver MUST never advertise INC_RECURSE. Measured: dropping the role term
+/// deadlocks the upstream testsuite `hardlinks` cell on a source tree of 1024
+/// entries while 961 still passes, so the boundary is upstream's
+/// MIN_FILECNT_LOOKAHEAD of 1000. See `compute_allow_inc_recurse` for the full
+/// A/B table and for why the receiver-side blocking site is deliberately left
+/// unnamed.
 #[test]
 fn receiver_never_advertises_inc_recurse() {
     assert!(!compute_allow_inc_recurse(


### PR DESCRIPTION
docs(transfer): replace the INC_RECURSE gate's stale rationale with the measured one

`compute_allow_inc_recurse` carries a non-upstream restriction: the receiver
role never advertises INC_RECURSE. Upstream `compat.c:161-179` has no such
role term, so the restriction needs a justification, and the one written down
was checkable and wrong.

It blamed `receive_extra_file_lists` for draining the sub-list stream upfront.
Every one of that function's eight call sites is inside the `#[cfg(test)]`
module opening at `receiver/file_list/on_demand.rs:164`, so it is unreachable
on the live path and cannot drain anything in production. A reader who checks
the stated cause finds it does not hold and concludes the gate is removable.

It is not. Measured on the upstream 3.5.0 testsuite `hardlinks` cell - an
`-aHivv --debug=HLINK5` push over `support/lsh.sh`, the cell's own third
invocation - with the role term dropped and the source tree bisected by entry
count:

    entries   role term kept   role term dropped
        400   pass             pass
        961   pass             pass
       1024   pass             deadlock
       1296   pass             deadlock

Both peers sit in state S at 0.0% CPU, so it is a mutual wait on I/O, not a
spin and not slowness. The boundary is exactly upstream's MIN_FILECNT_LOOKAHEAD
of 1000, which is the window `send_extra_file_list` (sender.c:228-232) paces
on. The conclusion the old comment reached was right; only its named mechanism
was false.

The rewritten comment states the measurement, records the A/B table, and says
explicitly that the receiver-side blocking site is not yet attributed to a
named function - so the next reader is not tempted to restate it more
precisely than the evidence supports.

Third defect in the same block, found while checking it: the citation
`io.c:1740-1760 (receiver's inline sub-list dispatch)` resolves at the 3.5.0
pin to `MSG_DELETED` handling inside the multiplex reader, which is unrelated.
Dropped rather than retargeted, since the mechanism it claimed to name is the
one now deliberately left unnamed.

The existing unit tests already pin the behaviour and are lethal to this exact
mutation: restoring `let _ = role; recursive && !qsort` fails
`receiver_never_advertises_inc_recurse` at
`tests/allow_inc_recurse.rs:47`. No behaviour change; docs only.
transfer allow_inc_recurse 4/4, fmt and clippy clean.
