### PR TITLE
fix(receiver): confine the peer-supplied alternate-basis xname to its basedir

### DIFF
--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -562,6 +562,11 @@ impl ReceiverContext {
             //
             // upstream: io.c perform_io() uses select() for bidirectional I/O,
             // naturally batching writes until the output buffer is full.
+            // Snapshot the operator inputs the wire-basis resolver reads. They
+            // are per-session, not per-file, and the response loop borrows
+            // `self` mutably, so the borrow cannot be held across it.
+            let wire_basis_dirs = self.config.reference_directories.clone();
+            let wire_basis_fuzzy_level = self.config.flags.fuzzy_level;
             let mut flushed_pending: usize = 0;
 
             loop {
@@ -765,6 +770,11 @@ impl ReceiverContext {
                     sandbox: setup.sandbox.as_ref(),
                     #[cfg(unix)]
                     dest_dir: Some(setup.dest_dir.as_path()),
+                    wire_basis: crate::transfer_ops::wire_basis::WireBasis {
+                        entry_relative_path: file_entry.path(),
+                        basis_dirs: &wire_basis_dirs,
+                        fuzzy_level: wire_basis_fuzzy_level,
+                    },
                 };
 
                 let xattr_list = self.resolve_xattr_list(&file_entry);

--- a/crates/transfer/src/receiver/wire.rs
+++ b/crates/transfer/src/receiver/wire.rs
@@ -15,6 +15,36 @@ use protocol::xattr::{MAX_XATTR_VALUE_BYTES, XattrList};
 /// Upstream MAXPATHLEN ceiling for an xname vstring (io.c:1944-1960).
 const MAX_XNAME_LEN: usize = 4096;
 
+/// Confines a peer-supplied basis xname to the basedir the receiver joins it to.
+///
+/// For a basis type (`FNAMECMP_FUZZY` and the alt-dest `FNAMECMP_FUZZY + N`) the
+/// xname is a peer-supplied leaf name that the receiver joins to an
+/// operator-chosen basedir (`--link-dest` / `--compare-dest` / `--copy-dest`, or
+/// the fuzzy dir) and opens as the delta basis. It must never contain a `..` (or
+/// a leading `/`) that escapes that dir: a malicious sender could otherwise walk
+/// the receiver's filesystem - e.g. `--link-dest=/backup` with an xname of
+/// `../../etc/shadow` - and read an out-of-tree file as the basis.
+///
+/// Upstream sanitizes it ALWAYS, not only in the daemon (`sanitize_paths`) case,
+/// because a *client* receiver has `sanitize_paths == 0` and is exactly the
+/// victim: `rsync.c:407-427`. The depth budget is 0, so no leading `..`
+/// survives.
+///
+/// Only the basis types use the xname as a path. The other
+/// `ITEM_XNAME_FOLLOWS` use - the hard-link `"=> target"` display name - is not
+/// a path and is left byte-for-byte.
+///
+/// # Upstream Reference
+///
+/// - `rsync.c:407-427` - `if (fnamecmp_type >= FNAMECMP_FUZZY) sanitize_path(buf, buf, "", 0, SP_DEFAULT)`
+fn sanitize_basis_xname(fnamecmp_type: Option<protocol::FnameCmpType>, xname: Vec<u8>) -> Vec<u8> {
+    if fnamecmp_type.is_some_and(|kind| kind.is_fuzzy()) {
+        filters::sanitize_path::sanitize_path_bytes_default(&xname, 0)
+    } else {
+        xname
+    }
+}
+
 /// Validates and wraps a sender-echoed basis-type byte.
 ///
 /// Used by [`SenderAttrs::read_with_codec_xattr`] to decode the `fnamecmp_type`.
@@ -444,7 +474,7 @@ impl SenderAttrs {
             if xname_len > 0 {
                 let mut xname_buf = vec![0u8; xname_len];
                 reader.read_exact(&mut xname_buf)?;
-                Some(xname_buf)
+                Some(sanitize_basis_xname(fnamecmp_type, xname_buf))
             } else {
                 None
             }

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -40,6 +40,7 @@ mod request;
 mod response;
 mod streaming;
 mod token_loop;
+pub mod wire_basis;
 
 use std::io::{self, Read};
 use std::num::NonZeroU8;
@@ -212,6 +213,12 @@ pub struct ResponseContext<'a> {
     /// keep the path-based fallback. `None` when no anchor is available.
     #[cfg(unix)]
     pub dest_dir: Option<&'a std::path::Path>,
+    /// Operator inputs for resolving a peer-supplied alternate-basis selector.
+    ///
+    /// upstream: `receiver.c:1009-1046` - `recv_files()` rebuilds the basis path
+    /// from the wire `(fnamecmp_type, xname)` pair for the fuzzy and alt-dest
+    /// types. See [`wire_basis::WireBasis`].
+    pub wire_basis: wire_basis::WireBasis<'a>,
 }
 
 /// Decides whether the receiver writes this file straight to its final
@@ -297,6 +304,23 @@ fn resolve_use_inplace(
     inplace && !one_inplace_partial_dir
 }
 
+/// Keeps a wire-named basis only if it opens as a regular file.
+///
+/// Upstream opens the selected basis and then drops it unless `fstat` reports a
+/// regular file, falling back to a no-basis (whole-file) update rather than
+/// failing the transfer. The open itself is the confined
+/// [`fast_io::open_basis_nofollow`] the local basis selection already uses, so a
+/// symlinked leaf is refused here exactly as it is there.
+///
+/// # Upstream Reference
+///
+/// - `receiver.c:1141-1143` - `fd1 == -1` leaves `st.st_size = 0`, i.e. no basis
+/// - `receiver.c:1174-1177` - `!S_ISREG(st.st_mode)` closes the fd and clears it
+fn usable_basis(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let file = fast_io::open_basis_nofollow(path).ok()?;
+    file.metadata().ok()?.is_file().then(|| path.to_path_buf())
+}
+
 /// Reads and validates the echoed NDX and sum_head from the sender response.
 ///
 /// Returns the file path, basis path, signature, target size, sender attributes,
@@ -378,7 +402,20 @@ fn read_response_header<R: Read>(
     // The echoed sum_head carries the existing file length used for the append mode offset.
     let echoed_sum_head = SumHead::read(reader)?;
 
-    let (file_path, basis_path, signature, target_size) = pending.into_parts();
+    let (file_path, local_basis_path, signature, target_size) = pending.into_parts();
+
+    // upstream: receiver.c:1009-1046 - a fuzzy or alt-dest selector names the
+    // basis on the wire, and the receiver joins the sanitized xname to the
+    // operator's basedir rather than reusing its own choice. Every other basis
+    // type keeps the locally selected path.
+    let basis_path = match ctx.wire_basis.resolve(
+        sender_attrs.fnamecmp_type,
+        sender_attrs.xname.as_deref(),
+        &file_path,
+    )? {
+        Some(named) => usable_basis(&named).or(local_basis_path),
+        None => local_basis_path,
+    };
 
     let use_inplace = resolve_use_inplace(
         ctx.config.inplace,
@@ -828,6 +865,11 @@ mod tests {
             sandbox: None,
             #[cfg(unix)]
             dest_dir: None,
+            wire_basis: wire_basis::WireBasis {
+                entry_relative_path: std::path::Path::new(""),
+                basis_dirs: &[],
+                fuzzy_level: 0,
+            },
         };
         let mut reader = crate::reader::ServerReader::new_plain(std::io::Cursor::new(wire));
         let mut ndx_codec = MonotonicNdxWriter::new(31);

--- a/crates/transfer/src/transfer_ops/wire_basis.rs
+++ b/crates/transfer/src/transfer_ops/wire_basis.rs
@@ -1,0 +1,286 @@
+//! Resolution of the peer-supplied alternate-basis selector.
+//!
+//! Upstream's generator and receiver are separate processes, so the generator's
+//! basis choice reaches the receiver by crossing the wire through the sender:
+//! `write_ndx_and_attrs()` carries `fnamecmp_type` plus, for the basis types, an
+//! `ITEM_XNAME_FOLLOWS` leaf name. `recv_files()` then rebuilds the basis path
+//! from that pair (`receiver.c:1009-1046`).
+//!
+//! oc's generator and receiver share a process, so the locally selected
+//! `basis_path` is already available on the pending transfer. This module exists
+//! for the cases where upstream's receiver *overrides* that choice from the
+//! wire: the fuzzy and alt-dest basis types, where `fnamecmp = xname` and the
+//! basedir comes from the entry's own directory or from `basis_dir[]`. Honouring
+//! them is what makes oc's receiver behave like upstream's against any peer -
+//! and the reason the xname is sanitized before it ever reaches here
+//! ([`crate::receiver::wire`], `rsync.c:407-427`).
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::config::ReferenceDirectory;
+
+/// The operator-owned inputs a wire basis selector is resolved against.
+///
+/// Held by [`super::ResponseContext`] so the per-file resolution has everything
+/// upstream's `recv_files()` reads from its globals: the entry's own relative
+/// path (upstream `file->dirname`), the `basis_dir[]` array, and the `--fuzzy`
+/// level that authorises the `FNAMECMP_FUZZY` arm at all.
+#[derive(Clone, Copy)]
+pub struct WireBasis<'a> {
+    /// The entry's path relative to the destination root (upstream `file->dirname`
+    /// is its parent). Used to place the basedir for both fuzzy arms.
+    pub entry_relative_path: &'a Path,
+    /// The operator's `--compare-dest` / `--copy-dest` / `--link-dest` list, in
+    /// declaration order - upstream `basis_dir[]`.
+    pub basis_dirs: &'a [ReferenceDirectory],
+    /// `--fuzzy` level. Upstream refuses a `FNAMECMP_FUZZY` selector outright
+    /// when `fuzzy_basis == 0` (`receiver.c:1009-1012`).
+    pub fuzzy_level: u8,
+}
+
+impl WireBasis<'_> {
+    /// Resolves the basis path the peer named, or `None` to keep the locally
+    /// selected one.
+    ///
+    /// `Some(path)` is returned only for the arms where upstream sets
+    /// `fnamecmp = xname`: `FNAMECMP_FUZZY` (basedir = the entry's own
+    /// directory) and `FNAMECMP_FUZZY + i` for `1 <= i <= basis_dir_cnt`
+    /// (basedir = `basis_dir[i-1]` joined with the entry's directory). Every
+    /// other basis type names a path the receiver already knows - the
+    /// destination, the partial-dir file, the backup - so the locally selected
+    /// `basis_path` stands and `None` is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` for a selector upstream treats as a protocol
+    /// violation: a fuzzy basis with `--fuzzy` off, and a basis-dir index past
+    /// the end of `basis_dir[]`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `receiver.c:1009-1018` - `FNAMECMP_FUZZY`: refuse when `fuzzy_basis == 0`,
+    ///   else `basedir = file->dirname` and `fnamecmp = xname`
+    /// - `receiver.c:1019-1029` - `fnamecmp_type - FNAMECMP_FUZZY <= basis_dir_cnt`:
+    ///   `pathjoin(basis_dir[i], file->dirname)` and `fnamecmp = xname`
+    /// - `receiver.c:1030-1034` - out-of-range index is `RERR_PROTOCOL`
+    pub fn resolve(
+        &self,
+        fnamecmp_type: Option<protocol::FnameCmpType>,
+        xname: Option<&[u8]>,
+        dest_path: &Path,
+    ) -> io::Result<Option<PathBuf>> {
+        let Some(protocol::FnameCmpType::Fuzzy(offset)) = fnamecmp_type else {
+            return Ok(None);
+        };
+        // upstream: rsync.c:410-412 - the basis arms read `xname` as the leaf.
+        // A basis type without one leaves nothing to resolve.
+        let Some(leaf) = xname.filter(|name| !name.is_empty()) else {
+            return Ok(None);
+        };
+
+        let dirname = self
+            .entry_relative_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""));
+
+        let basedir = if offset == 0 {
+            // upstream: receiver.c:1009-1012 - a fuzzy selector with --fuzzy off
+            // is a malicious peer, not a stale one.
+            if self.fuzzy_level == 0 {
+                return Err(refusing_malicious_fuzzy(leaf));
+            }
+            // upstream: receiver.c:1013-1015 - basedir = file->dirname, which
+            // upstream resolves against the destination root it has chdir'd to.
+            // oc carries the entry's already-resolved destination path, so the
+            // same directory is that path's parent.
+            dest_path.parent().unwrap_or(Path::new("")).to_path_buf()
+        } else {
+            let index = usize::from(offset - 1);
+            let Some(basis_dir) = self.basis_dirs.get(index) else {
+                // upstream: receiver.c:1030-1034 "invalid basis_dir index".
+                return Err(invalid_basis_dir_index(offset));
+            };
+            basis_dir.path.join(dirname)
+        };
+
+        Ok(Some(basedir.join(leaf_as_path(leaf))))
+    }
+}
+
+/// Interprets a sanitized xname as a relative path component.
+///
+/// The bytes have already been through
+/// [`filters::sanitize_path::sanitize_path_bytes_default`] with a depth budget
+/// of 0, so no `..` and no leading `/` survive.
+#[cfg(unix)]
+fn leaf_as_path(leaf: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    PathBuf::from(std::ffi::OsStr::from_bytes(leaf))
+}
+
+/// Windows has no byte-oriented path constructor; the xname is decoded lossily,
+/// matching how every other peer-supplied name reaches the filesystem there.
+#[cfg(not(unix))]
+fn leaf_as_path(leaf: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(leaf).into_owned())
+}
+
+/// upstream: `receiver.c:1010-1011` - "refusing malicious fuzzy operation".
+fn refusing_malicious_fuzzy(leaf: &[u8]) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "refusing malicious fuzzy operation for {}{}{}",
+            String::from_utf8_lossy(leaf),
+            crate::role_trailer::error_location!(),
+            crate::role_trailer::receiver()
+        ),
+    )
+}
+
+/// upstream: `receiver.c:1031-1033` - "invalid basis_dir index: %d.".
+fn invalid_basis_dir_index(offset: u8) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "invalid basis_dir index: {}.{}{}",
+            offset - 1,
+            crate::role_trailer::error_location!(),
+            crate::role_trailer::receiver()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ReferenceDirectoryKind;
+
+    fn ref_dir(path: &str) -> ReferenceDirectory {
+        ReferenceDirectory {
+            kind: ReferenceDirectoryKind::Link,
+            path: PathBuf::from(path),
+            requested: PathBuf::from(path),
+        }
+    }
+
+    fn basis<'a>(dirs: &'a [ReferenceDirectory], rel: &'a Path, fuzzy: u8) -> WireBasis<'a> {
+        WireBasis {
+            entry_relative_path: rel,
+            basis_dirs: dirs,
+            fuzzy_level: fuzzy,
+        }
+    }
+
+    #[test]
+    fn non_basis_types_keep_the_local_choice() {
+        let dirs = [ref_dir("/linkdest")];
+        let rel = PathBuf::from("sub/file");
+        let wb = basis(&dirs, &rel, 0);
+        for kind in [
+            protocol::FnameCmpType::Fname,
+            protocol::FnameCmpType::PartialDir,
+            protocol::FnameCmpType::Backup,
+            protocol::FnameCmpType::BasisDir(0),
+        ] {
+            assert_eq!(
+                wb.resolve(Some(kind), Some(b"secret"), Path::new("/dest/sub/file"))
+                    .unwrap(),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn alt_dest_index_joins_the_basis_dir_and_the_entry_dir() {
+        let dirs = [ref_dir("/linkdest")];
+        let rel = PathBuf::from("sub/file");
+        let wb = basis(&dirs, &rel, 0);
+        assert_eq!(
+            wb.resolve(
+                Some(protocol::FnameCmpType::Fuzzy(1)),
+                Some(b"other"),
+                Path::new("/dest/sub/file"),
+            )
+            .unwrap(),
+            Some(PathBuf::from("/linkdest/sub/other"))
+        );
+    }
+
+    #[test]
+    fn a_root_level_entry_resolves_directly_under_the_basis_dir() {
+        let dirs = [ref_dir("/linkdest")];
+        let rel = PathBuf::from("file");
+        let wb = basis(&dirs, &rel, 0);
+        assert_eq!(
+            wb.resolve(
+                Some(protocol::FnameCmpType::Fuzzy(1)),
+                Some(b"secret"),
+                Path::new("/dest/file"),
+            )
+            .unwrap(),
+            Some(PathBuf::from("/linkdest/secret"))
+        );
+    }
+
+    #[test]
+    fn a_fuzzy_dest_basis_resolves_beside_the_entry() {
+        let rel = PathBuf::from("sub/file");
+        let wb = basis(&[], &rel, 1);
+        assert_eq!(
+            wb.resolve(
+                Some(protocol::FnameCmpType::Fuzzy(0)),
+                Some(b"near"),
+                Path::new("/dest/sub/file"),
+            )
+            .unwrap(),
+            Some(PathBuf::from("/dest/sub/near"))
+        );
+    }
+
+    #[test]
+    fn a_fuzzy_selector_without_fuzzy_enabled_is_refused() {
+        let rel = PathBuf::from("file");
+        let wb = basis(&[], &rel, 0);
+        let err = wb
+            .resolve(
+                Some(protocol::FnameCmpType::Fuzzy(0)),
+                Some(b"near"),
+                Path::new("/dest/file"),
+            )
+            .expect_err("upstream exits RERR_PROTOCOL here");
+        assert!(err.to_string().contains("refusing malicious fuzzy"));
+    }
+
+    #[test]
+    fn an_index_past_the_basis_dir_list_is_refused() {
+        let dirs = [ref_dir("/linkdest")];
+        let rel = PathBuf::from("file");
+        let wb = basis(&dirs, &rel, 1);
+        let err = wb
+            .resolve(
+                Some(protocol::FnameCmpType::Fuzzy(2)),
+                Some(b"x"),
+                Path::new("/dest/file"),
+            )
+            .expect_err("upstream exits RERR_PROTOCOL here");
+        assert!(err.to_string().contains("invalid basis_dir index: 1."));
+    }
+
+    #[test]
+    fn a_basis_type_without_an_xname_keeps_the_local_choice() {
+        let dirs = [ref_dir("/linkdest")];
+        let rel = PathBuf::from("file");
+        let wb = basis(&dirs, &rel, 1);
+        assert_eq!(
+            wb.resolve(
+                Some(protocol::FnameCmpType::Fuzzy(1)),
+                None,
+                Path::new("/dest/file"),
+            )
+            .unwrap(),
+            None
+        );
+    }
+}

--- a/crates/transfer/src/transfer_ops/wire_basis.rs
+++ b/crates/transfer/src/transfer_ops/wire_basis.rs
@@ -13,7 +13,7 @@
 //! basedir comes from the entry's own directory or from `basis_dir[]`. Honouring
 //! them is what makes oc's receiver behave like upstream's against any peer -
 //! and the reason the xname is sanitized before it ever reaches here
-//! ([`crate::receiver::wire`], `rsync.c:407-427`).
+//! (`receiver::wire::sanitize_basis_xname`, `rsync.c:407-427`).
 
 use std::io;
 use std::path::{Path, PathBuf};

--- a/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
@@ -41,7 +41,7 @@ backup-dir-repeated-separator-delete pass
 backup-dir-symlink-race skip
 backup-incremental pass
 bare-do-open-symlink-race pass
-basis-xname-traversal fail
+basis-xname-traversal pass
 batch-file-symlink skip
 batch-mode pass
 batch-only-remove-source-regression pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -4,7 +4,7 @@
 acl-symlink-race pass
 alt-dest-symlink-race pass
 bare-do-open-symlink-race pass
-basis-xname-traversal fail
+basis-xname-traversal pass
 batch-mode pass
 chdir-symlink-race pass
 checksum-zero-blocklen pass

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -24,7 +24,7 @@ backup-dir-repeated-separator-delete pass
 backup-dir-symlink-race skip
 backup-incremental pass
 bare-do-open-symlink-race pass
-basis-xname-traversal fail
+basis-xname-traversal pass
 batch-file-symlink skip
 batch-mode pass
 batch-only-remove-source-regression pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -4,7 +4,7 @@
 acl-symlink-race pass
 alt-dest-symlink-race pass
 bare-do-open-symlink-race pass
-basis-xname-traversal fail
+basis-xname-traversal pass
 batch-mode pass
 chdir-symlink-race pass
 checksum-zero-blocklen pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -24,7 +24,7 @@ backup-dir-repeated-separator-delete pass
 backup-dir-symlink-race pass
 backup-incremental pass
 bare-do-open-symlink-race pass
-basis-xname-traversal fail
+basis-xname-traversal pass
 batch-file-symlink pass
 batch-mode pass
 batch-only-remove-source-regression pass


### PR DESCRIPTION

Upstream's generator and receiver are separate processes, so the generator's
basis choice reaches the receiver by crossing the wire through the sender:
`write_ndx_and_attrs()` carries `fnamecmp_type` and, for the basis types, an
`ITEM_XNAME_FOLLOWS` leaf name, and `recv_files()` rebuilds the basis path
from that pair (receiver.c:1009-1046). That is also what lets a malicious
sender choose the receiver's basis - with `--link-dest=/backup` and an xname
of `../../etc/shadow` the client opens an out-of-tree file as the delta basis
(arbitrary read / existence oracle / FIFO hang).

Two changes, and neither is safe without the other:

1. `read_attrs_after_ndx` sanitizes the xname whenever the basis type is
   `FNAMECMP_FUZZY` or above, with a depth budget of 0, so no `..` and no
   leading `/` survive. Upstream applies this ALWAYS, not only under
   `sanitize_paths` (rsync.c:407-427): a *client* receiver has
   `sanitize_paths == 0` and is exactly the victim. The hard-link
   `"=> target"` xname is not a path and is left byte-for-byte.

2. `WireBasis` resolves the wire selector into a basis path for exactly the
   arms where upstream sets `fnamecmp = xname`: `FNAMECMP_FUZZY` (basedir =
   the entry's own directory) and `FNAMECMP_FUZZY + i` for
   `1 <= i <= basis_dir_cnt` (basedir = `basis_dir[i-1]` joined with the
   entry's directory). Every other basis type names a path the receiver
   already knows, so the locally selected `basis_path` stands. A fuzzy
   selector with `--fuzzy` off and an index past `basis_dir[]` are both
   protocol violations, as upstream treats them.

Honouring the wire name is what makes the sanitizer load-bearing rather than
decorative, which is why the two land together. The risk is stated plainly:
the signature the receiver sent was computed from its OWN basis choice, so
reconstructing against a peer-named file is only correct when the two
coincide. For an honest peer they always do - oc's own generator emits the
fuzzy/alt-dest type together with that basis's basename, and upstream's
sender echoes back what the generator sent. For a hostile peer the whole-file
checksum catches the mismatch and drives a redo, exactly as upstream behaves;
the sanitizer, not the coincidence, is the security boundary.

A wire-named basis that does not open as a regular file is dropped rather
than fatal (receiver.c:1141-1143, :1174-1177), so a peer naming a FIFO or a
directory degrades to a whole-file update instead of failing the transfer.
The open goes through `fast_io::open_basis_nofollow`, the same confined open
the local basis selection already uses.

Measured on this macOS host against the freshly built release binary: the
cell was FAIL before (vacuously - neither FIFO opened, so the crafted xname
never reached a basis open at all) and is PASS after, with the DECOY flag
set. That flag is the cell's own non-vacuity guard: it proves the crafted
xname crossed the wire AND resolved inside the --link-dest dir rather than
one level above it. The run's residual 9 failures are the already-owned
macOS cluster plus filter-merge-content-echo; basis-xname-traversal is no
longer among them.

All five manifest rows are flipped. Only the macOS/pipe leg was executed
here; the two Linux pipe legs and the two TCP legs are validated by CI on
this PR. The cell drives its daemon through RSYNC_CONNECT_PROG rather than
a socket and needs no privilege, so it exercises the same code on every leg.
