### PR TITLE
fix(engine): the clonefile fast path must inherit the confined source open

### DIFF
--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/clonefile.rs
@@ -24,6 +24,7 @@ use crate::local_copy::{
 
 use super::super::TransferFlags;
 use super::super::finalize::finalize_guard_and_metadata;
+use super::super::open::open_source_file;
 
 /// Returns whether the current transfer satisfies every clonefile precondition.
 ///
@@ -131,9 +132,29 @@ pub(super) fn try_clone(
     // always stages into a temp and commits with `do_rename_at()`, inheriting
     // confinement from the rename. This keeps oc's optimisation on the same
     // invariant rather than beside it.
+    // The clone READS the source, so the source side takes the SAME confined
+    // open the standard copy path uses (`open_source_file`, which honours the
+    // transfer-root anchor and the leaf policy). Handing `confined_clone_file`
+    // a PATH instead would let it re-resolve the source with the libc
+    // resolver, which follows every parent component - so a parent flipped to
+    // a symlink pointing outside the transfer root would be followed and its
+    // contents cloned into the destination. That is a measured defect, not a
+    // hypothetical one: it is what made the upstream `symlink-race-source`
+    // cell leak on macOS while the confined open refused the same shape.
+    //
+    // upstream: `rsync-3.5.0/sender.c:206-248` `sender_open_confined()` - the
+    // sender's content read is confined, and this CoW fast path is an oc
+    // extension that must not weaken that invariant.
     #[cfg(unix)]
-    let clone_method =
-        match fast_io::confined_clone_file(context.destination_root(), source, destination) {
+    let clone_method = {
+        let reader = open_source_file(
+            source,
+            context.open_noatime_enabled(),
+            context.source_anchor(),
+            context.follow_source_symlinks(),
+        )
+        .map_err(|error| LocalCopyError::io("copy file", source, error))?;
+        match fast_io::confined_clone_file(context.destination_root(), &reader, destination) {
             Ok(fast_io::CloneAttempt::Cloned) => Some(
                 context
                     .options()
@@ -142,7 +163,8 @@ pub(super) fn try_clone(
             ),
             Ok(fast_io::CloneAttempt::Unsupported) => None,
             Err(error) => return Err(LocalCopyError::io("copy file", destination, error)),
-        };
+        }
+    };
     #[cfg(not(unix))]
     let clone_method =
         match context

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -506,11 +506,26 @@ pub enum CloneAttempt {
 ///   fall back to a path-based copy.
 /// - `EEXIST` when `dest` already exists - the same race semantics `O_EXCL`
 ///   gives the plain create.
-/// - Any other error from opening `src` or anchoring `dest`'s parent.
+/// - Any other error from anchoring `dest`'s parent.
 ///
 /// A filesystem that simply cannot reflink reports `Ok(CloneAttempt::Unsupported)`,
 /// never an error.
-pub fn confined_clone_file(root: &Path, src: &Path, dest: &Path) -> io::Result<CloneAttempt> {
+///
+/// # Source confinement
+///
+/// `source` arrives as an ALREADY-OPEN descriptor, and that is load-bearing:
+/// the caller's confined open is what resolved it, so the source side inherits
+/// exactly the walk `open_source_confined` performs. Taking a `&Path` here
+/// instead would make this function re-resolve the source with the libc
+/// resolver, which follows every parent component - the caller's confinement
+/// would be bypassed rather than inherited, and a parent flipped to a symlink
+/// pointing outside the transfer root would be followed. That is not
+/// hypothetical: it is the defect this signature exists to prevent.
+pub fn confined_clone_file(
+    root: &Path,
+    source: &std::fs::File,
+    dest: &Path,
+) -> io::Result<CloneAttempt> {
     use super::rename::anchor_confined_endpoint;
 
     let endpoint = anchor_confined_endpoint(root, dest)?;
@@ -518,7 +533,7 @@ pub fn confined_clone_file(root: &Path, src: &Path, dest: &Path) -> io::Result<C
     let c_name =
         CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
 
-    clone_at(src, dirfd, &c_name)
+    clone_at(source, dirfd, &c_name)
 }
 
 /// macOS: `fclonefileat(2)` publishes the clone under the anchored dirfd.
@@ -528,9 +543,12 @@ pub fn confined_clone_file(root: &Path, src: &Path, dest: &Path) -> io::Result<C
 /// whether the source may be a symlink is the source-confinement decision made
 /// by the caller before it opens the file.
 #[cfg(target_os = "macos")]
-fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<CloneAttempt> {
-    let source = std::fs::File::open(src)?;
-    // SAFETY: `source` is owned here and outlives the call; `dirfd` is the
+fn clone_at(
+    source: &std::fs::File,
+    dirfd: BorrowedFd<'_>,
+    name: &CString,
+) -> io::Result<CloneAttempt> {
+    // SAFETY: `source` is borrowed for the call and outlives it; `dirfd` is the
     // walked parent held by the caller's endpoint; `name` is a valid
     // NUL-terminated string borrowed for the duration of the call.
     #[allow(unsafe_code)]
@@ -557,10 +575,13 @@ fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<Clo
 /// behind - the caller is entitled to treat `Unsupported` as "nothing was
 /// created" and fall through to a data copy that expects to create the file.
 #[cfg(target_os = "linux")]
-fn clone_at(src: &Path, dirfd: BorrowedFd<'_>, name: &CString) -> io::Result<CloneAttempt> {
+fn clone_at(
+    source: &std::fs::File,
+    dirfd: BorrowedFd<'_>,
+    name: &CString,
+) -> io::Result<CloneAttempt> {
     use std::os::fd::FromRawFd;
 
-    let source = std::fs::File::open(src)?;
     let flags = libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     // SAFETY: `dirfd` outlives the call and `name` is a valid NUL-terminated
     // string; the returned descriptor is owned here and closed exactly once by

--- a/crates/fast_io/tests/confined_clone_file.rs
+++ b/crates/fast_io/tests/confined_clone_file.rs
@@ -22,6 +22,14 @@ use std::fs;
 use fast_io::CloneAttempt;
 use tempfile::TempDir;
 
+/// `confined_clone_file` takes an already-OPEN source descriptor, so the caller
+/// owns the source-side confinement decision and cannot have it re-resolved by
+/// the libc resolver behind its back. These tests therefore supply the
+/// descriptor the caller's confined open would have produced.
+fn open_source(path: &std::path::Path) -> fs::File {
+    fs::File::open(path).expect("open source")
+}
+
 /// Non-vacuity companion: with no symlink in play the call reaches the platform
 /// and reports a real outcome rather than failing. Without this, the refusal
 /// tests below would also pass if `confined_clone_file` errored for every input.
@@ -33,7 +41,9 @@ fn confined_clone_file_reaches_the_platform_for_a_plain_destination() {
     fs::write(&src, b"payload").expect("write source");
     let dest = root.path().join("sub").join("f0");
 
-    match fast_io::confined_clone_file(root.path(), &src, &dest).expect("no confinement refusal") {
+    match fast_io::confined_clone_file(root.path(), &open_source(&src), &dest)
+        .expect("no confinement refusal")
+    {
         CloneAttempt::Cloned => {
             assert_eq!(fs::read(&dest).expect("read clone"), b"payload");
         }
@@ -58,8 +68,9 @@ fn confined_clone_file_follows_a_relative_in_tree_parent_symlink() {
     let src = root.path().join("src.bin");
     fs::write(&src, b"payload").expect("write source");
 
-    let outcome = fast_io::confined_clone_file(root.path(), &src, &root.path().join("sub/f0"))
-        .expect("a relative in-tree parent symlink must not be refused");
+    let outcome =
+        fast_io::confined_clone_file(root.path(), &open_source(&src), &root.path().join("sub/f0"))
+            .expect("a relative in-tree parent symlink must not be refused");
 
     if outcome == CloneAttempt::Cloned {
         assert_eq!(
@@ -85,13 +96,69 @@ fn confined_clone_file_refuses_a_parent_symlinked_outside() {
     let src = base.path().join("src.bin");
     fs::write(&src, b"payload").expect("write source");
 
-    let err = fast_io::confined_clone_file(&root, &src, &root.join("sub").join("f0"))
+    let err = fast_io::confined_clone_file(&root, &open_source(&src), &root.join("sub").join("f0"))
         .expect_err("a symlinked destination parent must be refused, not reported Unsupported");
 
     assert!(
         !outside.join("f0").exists(),
         "the clone escaped the destination tree: {err}"
     );
+}
+
+/// The clone must read the descriptor it was HANDED, never re-resolve the
+/// source path. This is the sender TOCTOU the upstream `symlink-race-source`
+/// cell catches: the caller's confined open is what decides the source, and a
+/// re-open by path afterwards can be pointed anywhere in between - including
+/// outside the transfer root.
+///
+/// Taking `&File` makes the escape unspellable, so this is a REVERSION GUARD:
+/// restoring the `&Path` signature and the `File::open(src)` inside `clone_at`
+/// makes it read `OUTSIDE-SECRET` and fail.
+///
+/// upstream: `rsync-3.5.0/syscall.c:2896-2961` - the confined walk refuses an
+/// absolute symlink target, and that refusal is worthless if a later syscall
+/// resolves the same name again with the libc resolver.
+#[test]
+fn confined_clone_file_clones_the_handed_descriptor_not_the_path() {
+    let base = TempDir::new().expect("tempdir");
+    let root = base.path().join("dest");
+    let outside = base.path().join("outside");
+    fs::create_dir(&root).expect("mkdir dest");
+    fs::create_dir(&outside).expect("mkdir outside");
+
+    let src = base.path().join("payload.bin");
+    fs::write(&src, b"IN-TREE").expect("write source");
+    let source = open_source(&src);
+
+    // The window opens here: the descriptor is already resolved, and the name
+    // it came from now points at content outside the tree.
+    fs::remove_file(&src).expect("unlink source");
+    let secret = outside.join("secret.bin");
+    fs::write(&secret, b"OUTSIDE-SECRET").expect("write secret");
+    std::os::unix::fs::symlink(&secret, &src).expect("plant symlink");
+
+    // Non-vacuity control: the fixture only discriminates while the NAME and
+    // the DESCRIPTOR disagree. Reading the name must reach the outside secret;
+    // if the plant silently failed, every assertion below would be empty.
+    assert_eq!(
+        fs::read(&src).expect("read through the planted name"),
+        b"OUTSIDE-SECRET",
+        "the fixture is inert - the source name still resolves in-tree"
+    );
+
+    let dest = root.join("f0");
+    match fast_io::confined_clone_file(&root, &source, &dest).expect("no confinement refusal") {
+        CloneAttempt::Cloned => assert_eq!(
+            fs::read(&dest).expect("read clone"),
+            b"IN-TREE",
+            "the clone re-resolved the source NAME and copied content from \
+             outside the transfer root"
+        ),
+        CloneAttempt::Unsupported => assert!(
+            !dest.exists(),
+            "an Unsupported result must leave nothing behind"
+        ),
+    }
 }
 
 /// An existing destination loses the race rather than being replaced, matching
@@ -104,7 +171,7 @@ fn confined_clone_file_refuses_an_existing_destination() {
     let dest = root.path().join("f0");
     fs::write(&dest, b"original").expect("seed destination");
 
-    let result = fast_io::confined_clone_file(root.path(), &src, &dest);
+    let result = fast_io::confined_clone_file(root.path(), &open_source(&src), &dest);
 
     assert!(
         !matches!(result, Ok(CloneAttempt::Cloned)),

--- a/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
@@ -346,7 +346,7 @@ symlink-ignore pass
 symlink-mknod-fakesuper-symlink-race pass
 symlink-race-dest skip
 symlink-race-relative-dest skip
-symlink-race-source fail
+symlink-race-source pass
 temp-dir pass
 temp-dir-symlink-injection skip
 trimslash pass


### PR DESCRIPTION
## The defect

`confined_clone_file` anchored the **destination** parent per component, but took
the **source** as a bare `&Path` — and `clone_at` opened it with plain
`std::fs::File::open`, which follows every parent component.

So the macOS clonefile fast path bypassed `open_source_confined` entirely. A
source parent flipped to a symlink pointing outside the transfer root was
followed and its contents cloned into the destination. The function's own doc
already asserted the caller owned the source-side confinement decision; the
signature did not enforce it.

This is the upstream `symlink-race-source` cell. It reproduced **6/6 on macOS**
against a freshly built release binary, not intermittently — the leak is a
deterministic property of the fast path, and the cell's negative oracle simply
gave it a window to be observed in.

## The mechanism, isolated

A paired control on **identical static input**:

| primitive | outcome |
|---|---|
| `open_source_confined` | refuses, **ELOOP** |
| the clone tier | **leaked** the out-of-tree payload |

Same fixture, same path, opposite answers — that identifies the clone tier as
the sink rather than inferring it from the cell's label.

## The fix

`confined_clone_file` now takes `&File`. The escape becomes unspellable: the
function cannot re-resolve a name it was never given. The engine caller supplies
the descriptor `open_source_file` produced — the **same** confined open the
standard copy path already uses, honouring the transfer-root anchor and the leaf
policy. The two tiers no longer disagree about what the source is.

## Linux is fixed by the same change

The Linux `clone_at` had the identical unconfined open. It escaped notice only
because the CI filesystem cannot reflink, so the tier reports `Unsupported` and
falls through to the confined standard copy. **The hole is reachable on btrfs
and XFS** — it was latent, not absent.

## Verification

**The cell.** `symlink-race-source` measured **6/6 leaking before**, **6/6
passing after** (macOS, release binary rebuilt from source).

**Mutation-lethal.** Restoring the `&Path` signature and the
`File::open(source)` inside `clone_at` makes the new guard read
`OUTSIDE-SECRET` and fail in isolation, while the other four cells in the file
stay green:

```
5 tests run: 4 passed, 1 failed
assertion `left == right` failed: the clone re-resolved the source NAME and
copied content from outside the transfer root
```

**Non-vacuity.** The guard carries a control asserting the planted name really
does resolve to the outside secret. Without it, a fixture whose symlink plant
silently failed would pass every assertion below it.

## Upstream

- `rsync-3.5.0/sender.c:206-248` — `sender_open_confined()`; the sender's
  content read is confined, and this CoW fast path is an oc extension that must
  not weaken that invariant.
- `rsync-3.5.0/syscall.c:2896-2961` — the confined walk refuses an absolute
  symlink target and a `..` above the anchor. Both refusals are worthless if a
  later syscall resolves the same name again with the libc resolver.

Upstream has no CoW fast path at all: it always stages into a temp and commits
with `do_rename_at()`. This change pins oc's optimisation to the same
invariant rather than removing it.

## Notes

- Local `cargo clippy` reports `collapsible_if` in `copy_file_range.rs`,
  `iocp_stub/rio.rs`, `compress`, `logging` and `test-support` — all files this
  diff does not touch; they are rust 1.94 lints from a newer local toolchain
  than CI's.
- The local `xtask` `manifest_matches_the_pinned_source` cell fails against this
  machine's `target/interop/upstream-src` tree; it reads only the committed TSV
  and that tree, neither of which this diff touches. CI regenerates the tree
  from the pinned tarball.
