### PR TITLE
fix(generator): anchor the sender's directory scan on the transfer root

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -208,15 +208,30 @@ fn resolve_receiver_dest(
 /// Sub-paths containing `..`, and host-absolute sub-paths, are COLLAPSED
 /// against the module root rather than refused - see
 /// [`collapse_module_relative`]. A crafted `rsync://host/mod/../etc/...` URL
-/// therefore resolves to `<module>/etc/...` and cannot enumerate outside the
-/// module root, which is the same containment upstream gets from
-/// `sanitize_path` at depth 0.
+/// therefore resolves to `<module>/etc/...`, which is the same containment
+/// upstream gets from `sanitize_path` at depth 0.
+///
+/// ⚠ That collapse is LEXICAL, so it contains exactly the shapes it folds -
+/// `.`, `..` and a host-absolute spelling - and nothing else. It is NOT a
+/// statement about where the returned path RESOLVES: a symlink is resolved by
+/// the kernel at syscall time and no string operation can see it. Upstream
+/// does not rely on the collapse alone either; it also enters the module with
+/// `change_dir(module_chdir, CD_NORMAL)` (clientserver.c:992) and scans
+/// through the confined `secure_opendir()` (flist.c:2028-2059).
+///
+/// Resolved containment for these operands is therefore owned by the sender,
+/// not by this function: the content open goes through the confined source
+/// open, and the file-list scan is anchored on the transfer's confinement root
+/// rather than read by absolute path. Do not read this collapse as a reason to
+/// leave a downstream operation unconfined - it was read that way once, and an
+/// out-of-module directory reached by a module-root symlink was enumerated
+/// into the file list.
 ///
 /// # Upstream Reference
 ///
-/// - `util1.c:804 glob_expand_module()` - strips the module name from each arg
-/// - `clientserver.c:992 change_dir(module_chdir, CD_NORMAL)` - relativises args
-/// - `flist.c:2338-2349 send_file_list()` - `dir/fn` split per positional
+/// - `util1.c:881 glob_expand_module()` - strips the module name from each arg
+/// - `clientserver.c:1059 change_dir(module_chdir, CD_NORMAL)` - relativises args
+/// - `flist.c:2610-2621 send_file_list()` - `dir/fn` split per positional
 fn resolve_sender_sources(
     module_path: &std::path::Path,
     client_args: &[String],
@@ -236,8 +251,10 @@ fn resolve_sender_sources(
         }
         all_empty = false;
         // Collapse `.` and `..` exactly as upstream's `sanitize_path` does at
-        // depth 0 - see [`collapse_module_relative`]. The result cannot escape
-        // the module root, so there is nothing left to refuse.
+        // depth 0 - see [`collapse_module_relative`]. The result is LEXICALLY
+        // beneath the module root, so there is no traversing spelling left to
+        // refuse; where it RESOLVES is decided by the sender's confined open
+        // and its anchored directory scan, not here.
         let collapsed = collapse_module_relative(tail.trim_start_matches('/'));
         let trimmed = collapsed.as_str();
         if trimmed.is_empty() {

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -154,19 +154,25 @@ fn build_server_config(
         .cloned()
         .unwrap_or_default();
 
-    // upstream: main.c:1203-1204 + util1.c:804 (glob_expand_module) - receivers
+    // upstream: io.c:1497 + util1.c:881 (glob_expand_module) - receivers
     // resolve their destination by joining the module path with the client's
     // module-relative tail (e.g. `upload/realdir/` -> module + `realdir/`).
     // Senders (pull requests) split each positional the same way so the
-    // sender's per-source `dir/fn` (flist.c:2338-2349) walks the requested
+    // sender's per-source `dir/fn` (flist.c:2610-2621) walks the requested
     // sub-tree instead of the entire module root. The original argv[0] is
     // always the module root; legacy tests that push straight into the module
     // root keep that behaviour.
     // Both resolvers are total: they collapse `..` the way upstream's
-    // `sanitize_path` does at depth 0, so the result is confined to the module
-    // root by construction and there is no "resolves outside module root"
-    // rejection to represent. Upstream has no such daemon error either - a
-    // traversing tail is rewritten and served (util1.c:1183).
+    // `sanitize_path` does at depth 0, so no traversing SPELLING survives and
+    // there is no "resolves outside module root" rejection to represent.
+    // Upstream has no such daemon error either - a traversing tail is
+    // rewritten and served (util1.c:1183).
+    // ⚠ Total is not confined. The collapse is a string operation and says
+    // nothing about where the path resolves; a symlink beneath the module root
+    // still points wherever it points. Resolved containment is enforced where
+    // the syscalls are issued - the confined source open and the file-list
+    // scan anchored on the transfer's confinement root - not by these
+    // resolvers.
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
         let dest = resolve_receiver_dest(
             std::path::Path::new(&module.path),

--- a/crates/fast_io/src/pinned_root.rs
+++ b/crates/fast_io/src/pinned_root.rs
@@ -107,6 +107,68 @@ pub fn read_dir(path: &Path) -> io::Result<ReadDir> {
     Ok(ReadDir(Source::Std(std::fs::read_dir(path)?)))
 }
 
+/// Like [`read_dir`], but anchored on a root the CALLER supplies instead of the
+/// ambient session pin.
+///
+/// [`read_dir`] reads its anchor from the process-global session root, which is
+/// only ever correct when the process serves one confinement domain at a time -
+/// upstream's situation, because it forks a child per connection. oc serves
+/// each daemon connection on a worker thread of one process, so a per-connection
+/// root cannot live in a global without two concurrent connections overwriting
+/// each other's boundary. Passing the root in makes the anchor a parameter of
+/// the call rather than ambient state, which is what keeps it correct under
+/// threads.
+///
+/// The walk beneath `root` is the confined one: an absolute symlink target, a
+/// `..` above the anchor, or an excluded component is REFUSED rather than
+/// followed, so a refused scan can never be mistaken for an empty directory.
+///
+/// ⚠ `strip_prefix` is LEXICAL, so "does not lie beneath `root`" here means
+/// NOT ANCHORABLE, never "escapes the root". A relative operand resolves
+/// against the process cwd - which is typically inside the root, since that is
+/// how a restricted shell invokes rsync - and an absolute path can be spelled
+/// differently from the root it is under. Both fall back to the ordinary read,
+/// exactly as [`crate::confinement::pinned_root_relative`] already decides for
+/// the ambient pin: "Returns `None` - meaning resolve `path` the ordinary way -
+/// when no root is pinned, or when `path` does not lie beneath the pinned
+/// root."
+///
+/// Treating a failed `strip_prefix` as an escape and refusing would be the same
+/// error this anchoring exists to fix: a lexical test standing in for a
+/// resolution decision. It refuses directories that were never outside
+/// anything - measured, as `opendir "sub" failed: Cross-device link`.
+///
+/// # Errors
+///
+/// - The walk's refusal (`ELOOP` for an absolute or escaping symlink target,
+///   `..` above the anchor), or the underlying `opendir` error.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/flist.c:2028-2059` `secure_opendir()` - the confined open that
+///   produces `scan_dirfd` for a daemon's directory scan.
+/// - `rsync-3.5.0/syscall.c:136` `confinement_root()` - `am_daemon ? module_dir
+///   : confine_root`, the value this parameter carries.
+#[cfg(unix)]
+pub fn read_dir_under(root: &Path, path: &Path) -> io::Result<ReadDir> {
+    let Ok(relative) = path.strip_prefix(root) else {
+        return read_dir(path);
+    };
+    // `strip_prefix` yields an empty path when `path` IS the root; the walk
+    // spells that directory `.`, matching what upstream's post-`change_dir`
+    // code uses for the same directory (`flist.c:2059`).
+    let relative = if relative.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        relative
+    };
+    let names = crate::confined_readdir::read_dir_confined(root, relative)?;
+    Ok(ReadDir(Source::Names {
+        dir: path.to_path_buf(),
+        names: names.into_iter(),
+    }))
+}
+
 /// Open `path` as an `O_PATH` descriptor, anchored on the pinned root when it
 /// applies.
 ///

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -133,9 +133,10 @@ impl GeneratorContext {
     /// The root is passed to `fast_io` rather than left ambient. `read_dir`'s
     /// own anchor is the process-global session pin, which oc never installs
     /// for a daemon, so this walk silently degraded to an ordinary
-    /// absolute-path read while [`Self::confine_root`] - already daemon-correct
-    /// - was consulted only by the CONTENT open. That split is exactly what let
-    /// a module symlink be enumerated but not read. Installing the global per
+    /// absolute-path read, while [`Self::confine_root`] (already
+    /// daemon-correct) was consulted only by the CONTENT open. That split is
+    /// exactly what let a module symlink be enumerated but not read.
+    /// Installing the global per
     /// connection is not the alternative: oc serves each connection on a worker
     /// thread of one process, so a per-connection value in a global would race
     /// between concurrent connections on different modules.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -122,6 +122,38 @@ impl<'a> WalkScope<'a> {
 }
 
 impl GeneratorContext {
+    /// Enumerates a source directory, confined beneath this transfer's root
+    /// when it has one.
+    ///
+    /// Sole owner of the enumeration-anchor decision for the walk, so the two
+    /// scan sites cannot disagree about whether a directory read is confined -
+    /// the same reason [`Self::confine_root`] is the sole owner of the boundary
+    /// it reads.
+    ///
+    /// The root is passed to `fast_io` rather than left ambient. `read_dir`'s
+    /// own anchor is the process-global session pin, which oc never installs
+    /// for a daemon, so this walk silently degraded to an ordinary
+    /// absolute-path read while [`Self::confine_root`] - already daemon-correct
+    /// - was consulted only by the CONTENT open. That split is exactly what let
+    /// a module symlink be enumerated but not read. Installing the global per
+    /// connection is not the alternative: oc serves each connection on a worker
+    /// thread of one process, so a per-connection value in a global would race
+    /// between concurrent connections on different modules.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync-3.5.0/flist.c:2028-2059` `secure_opendir()` - the confined open
+    ///   producing `scan_dirfd` for a daemon's scan.
+    /// - `rsync-3.5.0/flist.c:1878` - the `opendir` failure diagnostic both call
+    ///   sites report, unchanged by the anchoring.
+    fn scan_source_dir(&self, path: &Path) -> io::Result<fast_io::pinned_root::ReadDir> {
+        #[cfg(unix)]
+        if let Some(root) = self.confine_root() {
+            return fast_io::pinned_root::read_dir_under(&root, path);
+        }
+        fast_io::pinned_root::read_dir(path)
+    }
+
     /// Pre-checks a top-level source entry and walks it if it exists.
     ///
     /// Returns `true` if the entry was processed (exists or was handled as a
@@ -512,7 +544,7 @@ impl GeneratorContext {
         let should_recurse =
             metadata.is_dir() && self.config.flags.recursive && scope.descends_into_subdirs();
         let dir_read = if should_recurse {
-            match fast_io::pinned_root::read_dir(&path) {
+            match self.scan_source_dir(&path) {
                 Ok(entries) => Some(entries),
                 Err(e) => {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
@@ -685,7 +717,7 @@ impl GeneratorContext {
     ) -> io::Result<()> {
         let entries = match opened {
             Some(entries) => entries,
-            None => match fast_io::pinned_root::read_dir(dir_path) {
+            None => match self.scan_source_dir(dir_path) {
                 Ok(entries) => entries,
                 Err(e) => {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)

--- a/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
@@ -129,7 +129,7 @@ daemon-refuse-compress pass
 daemon-refuse-compress-threads-alias skip
 daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
-daemon-scan-dir-escape fail
+daemon-scan-dir-escape pass
 daemon-secrets-file-symlink skip
 daemon-size-arg-overflow pass
 daemon-standalone-detach skip
@@ -320,7 +320,7 @@ scanner-batch-flag-mismatch pass
 scanner-daemon-log-checksum pass
 scanner-delete-delay-overread pass
 secure-relpath-validation pass
-sender-flist-symlink-leak fail
+sender-flist-symlink-leak pass
 sender-readlink-atfd pass
 sender-remove-source-relative-anchor pass
 sender-remove-source-root-anchor skip


### PR DESCRIPTION
A daemon pull of `rsync://host/module/cd/`, where `cd` is a symlink pointing out of the module, enumerated the outside directory into the file list. The content transfer refused the escape; the enumeration followed it. Names and metadata leaked, bytes did not.

## Root cause

The confined enumeration was already routed. `walk.rs` calls `fast_io::pinned_root::read_dir`, which resolves its anchor through `confinement::pinned_root_relative` - the **process-global session root**. Nothing installs that root for a daemon, so `pinned_root_relative` returned `None`, which is documented to mean "resolve the path the ordinary way", and every directory read silently degraded to an unconfined absolute-path read.

Meanwhile `GeneratorContext::confine_root()` was already daemon-correct (`is_daemon_connection => daemon_module_root`, mirroring upstream's `am_daemon ? module_dir : confine_root`, `syscall.c:136`) and was consulted only by the **content** open. That split is exactly the observed behaviour.

The failure is silent by construction: `None` is a designed, documented, legitimate outcome, not an error. Nothing logs and nothing fails.

## The fix

The scan takes the root as a **parameter** rather than reading ambient state.

- `fast_io::pinned_root::read_dir_under(root, path)` performs the same confined walk `read_dir` does for the pinned case.
- `GeneratorContext::scan_source_dir` is the single owner of the anchoring decision for both scan sites, so they cannot disagree.

Installing the global per connection was rejected deliberately. `SESSION_ROOT_FD` is a `static RwLock` and oc serves each daemon connection on a **worker thread** of one process, so two concurrent connections on different modules would overwrite each other's boundary - turning a metadata leak into wrong-module confinement. Upstream's equivalent global is safe only because upstream **forks** a child per connection. Passing the root in is what makes the anchor correct under threads.

## Not-anchorable is not an escape

`strip_prefix` is lexical. A relative operand - which a restricted shell produces routinely - or a differently spelled absolute path falls back to the ordinary read, matching what `pinned_root_relative` already decides for the ambient pin.

Refusing there instead was **measured** to break `rrsync-pull-arg-shapes` and `rrsync-merge-file-confine` with `opendir "sub" failed: Cross-device link` - directories that were never outside anything. Treating a failed `strip_prefix` as an escape would have been the same class of error this anchoring exists to fix: a lexical test standing in for a resolution decision.

## Measured

macOS, freshly built release binary, whole upstream 3.5.0 suite:

| | fail | pass |
|---|---|---|
| before | 8 | 232 |
| after | **6** | **234** |

`sender-flist-symlink-leak` and `daemon-scan-dir-escape` both move `fail -> pass`, confirming they shared one root cause. The remaining six are unchanged and all recorded `fail` in the manifest.

Both macOS manifest rows are flipped in the same commit because the defect is **fixed** - leaving them would report an XPASS and redden CI. All four Linux manifests (nonroot and root, pipe and TCP) already record both cells as `pass` and are untouched - see the note at the end.

## Upstream reference

- `rsync-3.5.0/flist.c:2028-2059` `secure_opendir()` - the confined open producing `scan_dirfd` for a daemon's scan.
- `rsync-3.5.0/syscall.c:136` `confinement_root()` - `am_daemon ? module_dir : confine_root`, the value the new parameter carries.

## ⚠ Note on the manifest asymmetry

All four Linux manifests already recorded both cells as `pass`; only macOS said `fail`. The changed code is `#[cfg(unix)]` with no platform branch, so Linux carried the same absent anchor while its cells stayed green — something there refuses the escape before the userspace hole becomes observable, most plausibly Landlock, which macOS does not have.

That is stated as a **hypothesis, not a measurement** — no Linux A/B was run for it. The discriminating experiment is `OC_RSYNC_NO_LANDLOCK=1` on a base without this fix: if the two cells then fail, Landlock was the masker. Filed separately; it does not gate this PR, and the Linux rows are deliberately left untouched.

The consequence worth flagging: on this defect the macOS leg produced security signal the Linux legs structurally could not.
