### PR TITLE
fix(metadata): preserve a directory's creation time under --crtimes

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -55,7 +55,43 @@ pub fn apply_directory_metadata_with_options(
     }
     // upstream: rsync.c:589 - directories skip atime (`ATTRS_SKIP_ATIME`)
     // regardless of `--atimes`; only files get atime preservation.
+    //
+    // crtime is NOT subject to that rule. upstream: rsync.c:726-730 - the
+    // `S_ISDIR` test that forces `ATTRS_SKIP_ATIME` belongs to atime alone;
+    // the only directory that skips `ATTRS_SKIP_CRTIME` is the root folder of
+    // an HFS+ volume. So a directory's creation time is preserved exactly as a
+    // file's is, and omitting it here left every transferred directory
+    // carrying a creation time derived from its own mtime.
+    if options.crtimes() && !is_volume_root(destination) {
+        timestamps::apply_crtime_from_source_metadata(destination, metadata)?;
+    }
     Ok(())
+}
+
+/// Reports whether `destination` is the root folder of an HFS+ volume, which
+/// upstream refuses to stamp with a creation time.
+///
+/// upstream: rsync.c:728-730 - `if (sxp->st.st_ino == 2 && S_ISDIR(sxp->st.st_mode))`.
+/// `sxp` is the *destination's* stat, so this consults the destination rather
+/// than the source metadata the caller already holds. The extra stat is only
+/// issued under `--crtimes`, and a stat failure answers "not a volume root" so
+/// an unreadable destination degrades to attempting the set - the same
+/// direction upstream takes when it cannot prove the special case.
+#[cfg(unix)]
+fn is_volume_root(destination: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    /// Inode number of an HFS+ volume root.
+    const HFS_VOLUME_ROOT_INO: u64 = 2;
+
+    fs::symlink_metadata(destination).is_ok_and(|meta| meta.ino() == HFS_VOLUME_ROOT_INO)
+}
+
+/// Non-Unix targets have no HFS+ volume-root inode convention, so no directory
+/// is exempt from the creation-time set.
+#[cfg(not(unix))]
+fn is_volume_root(_destination: &Path) -> bool {
+    false
 }
 
 /// Applies metadata from `metadata` to the destination file.

--- a/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
@@ -3,7 +3,7 @@
 # Source: release 3.5.0 (macOS / nonroot / pipe)
 #
 # Baseline: a real full 345-cell run on a local macOS aarch64 host, 2026-09-03.
-# 230 passed / 10 failed / 105 skipped.
+# 236 passed / 4 failed / 105 skipped (re-measured 2026-09-04).
 #
 # WARNING - this baseline is a PREDICTION about the GitHub `macos-latest` runner
 # until the first CI run confirms it. The two hosts can differ in ways this
@@ -15,10 +15,21 @@
 # run's emitted `expect-result.macos.nonroot.txt` artifact and say so; do NOT
 # edit individual rows to make the job green.
 #
-# The 10 `fail` rows are genuine oc-vs-upstream divergences, not platform
-# artefacts: none of them appears in upstream's own
-# testsuite/skiplist/macos.txt. Eight of the ten are invisible to both Linux
-# legs (five pass there, three skip there). See task 1128 for the full split.
+# The 4 `fail` rows were classified 2026-09-04 by running each cell twice on
+# one host, varying ONLY $RSYNC between oc and the real 3.5.0 binary. That
+# upstream arm is the control; without it a failure cannot be attributed.
+#
+#   chmod-setid                             upstream FAILS too - unsatisfiable here
+#   partial-protected-regular-retry-policy  upstream FAILS too - unsatisfiable here
+#   operator-path-partial-dir-daemon        upstream PASSES - real oc defect
+#   filter-merge-content-echo               owned by task 1011
+#
+# Two of the four are therefore NOT oc divergences: the platform (or this
+# host's sysctl state) refuses what the cell asserts, and real rsync lands on
+# the same result. They stay `fail` because the assertion is unsatisfiable
+# here, not because oc is right - re-baselining them would hide the row rather
+# than resolve it. None of the four appears in upstream's own
+# testsuite/skiplist/macos.txt.
 00-hello pass
 acl-symlink-race skip
 acls pass
@@ -73,7 +84,7 @@ connect-prog-nested-singlequote-host-injection pass
 copy-dest-source-symlink pass
 copy-dest-symlink-readleak skip
 copy-xattrs-symlink-race skip
-crtimes fail
+crtimes pass
 cvs-exclude pass
 daemon pass
 daemon-access pass


### PR DESCRIPTION
`oc-rsync -aN src/ dst/` preserved the creation time of every **file** and no **directory**. The upstream 3.5.0 `crtimes` testsuite cell has been failing on the macOS nonroot leg because of it.

## Root cause

`apply_directory_metadata_with_options` (`crates/metadata/src/apply/mod.rs`) applied ownership, permissions and timestamps. It never applied crtime, while all four file-metadata entry points did.

On macOS the result is worse than "left unset". Setting an mtime older than the destination's current creation time drags crtime down to match, so a directory ends up reporting its own mtime as its birth time. That is exactly what the cell measures:

```
--- ls-from
+++ ls-to
@@ -1,2 +1,2 @@
-drwxr-xr-x  ... 2002-02-02 20:22:22 2001-01-01 09:11:11 .
+drwxr-xr-x  ... 2002-02-02 20:22:22 2002-02-02 20:22:22 .
 -rw-r--r--  ... 2002-12-12 20:22:22 2001-11-11 09:11:11 ./foo
```

The `./foo` line is unchanged context - the file's crtime was already correct. Only the directory `.` diverges, and its reported crtime is its mtime.

## Upstream

`rsync.c:726-730` splits the two rules explicitly:

```c
if (!atimes_ndx || S_ISDIR(sxp->st.st_mode))
        flags |= ATTRS_SKIP_ATIME;
/* Don't set the creation date on the root folder of an HFS+ volume. */
if (sxp->st.st_ino == 2 && S_ISDIR(sxp->st.st_mode))
        flags |= ATTRS_SKIP_CRTIME;
```

The `S_ISDIR` skip belongs to **atime**. crtime is skipped only for `omit_dir_times`/`omit_link_times` and for an HFS+ volume root - there is no general directory exclusion. oc's existing comment cites the atime rule correctly; the crtime case appears to have been generalised from it.

The volume-root skip is ported alongside the fix rather than left out. Upstream reads that inode from the **destination's** stat, which this function does not otherwise hold, so it costs one extra `symlink_metadata` - issued only under `--crtimes`. Without it, an ordinary `rsync -aN src/ /Volumes/Backup/` would attempt a creation-time set on the volume root that upstream deliberately avoids, and `set_crtime(...)?` propagates, so that would convert a working transfer into a failing one.

## Ordering, deliberately not upstream's

Upstream sets crtime *before* `set_times`. oc's four file sites do the opposite, and this directory arm matches oc. That is the safer order on this platform for the reason above: an explicit crtime written last cannot be dragged down by an mtime written after it. Adopting upstream's order here would also have meant changing the four working file sites.

## Measured

Full upstream 3.5.0 suite, macOS nonroot leg, release binary built on the **pinned 1.88.0** toolchain:

| | before | after |
|---|---|---|
| passed | 235 | **236** |
| failed | 5 | **4** |

`crtimes` is the only row that moved. Its expect row is flipped in the same commit because the cell is **fixed**.

Differential oracle, same host, varying only `$RSYNC`:

| | oc before | oc after | upstream 3.5.0 |
|---|---|---|---|
| `crtimes` | FAIL | **pass** | pass |

Both binaries advertise `"crtimes": true` under `-VV`, so the cell is non-vacuous on both - it self-skips otherwise, and that check is the first discriminator.

**Mutation-proven**: disabling only the new call (`if false && ...`) and rebuilding restores the original failure exactly; the upstream arm passes throughout as the control.

## Manifest header

The macOS manifest's header counts still read `230 passed / 10 failed` from earlier row flips. Corrected to the measured 236/4.

Its claim that every `fail` row is "a genuine oc-vs-upstream divergence, not platform artefacts" is also replaced, because the oracle run contradicts it. Per-cell classification now recorded in the file:

| cell | verdict |
|---|---|
| `chmod-setid` | upstream FAILS too - unsatisfiable here |
| `partial-protected-regular-retry-policy` | upstream FAILS too - unsatisfiable here |
| `operator-path-partial-dir-daemon` | upstream PASSES - real oc defect, separate fix |
| `filter-merge-content-echo` | owned elsewhere |

The two environmental rows stay `fail`. They are unsatisfiable on this host rather than oc being correct, so re-baselining them would hide the row instead of resolving it.

## Verification

- `cargo fmt --all -- --check` clean on the pinned 1.88.0 toolchain.
- `cargo clippy -p metadata --all-targets --no-deps -- -D warnings` exits 0.
- The new code compares `meta.ino()` against a `u64` constant. `MetadataExt::ino()` is `u64` on every Unix, so there is no conversion for a platform-width lint to object to on either target.
