### PR TITLE
fix(receiver): name the backup destination in `keep_backup failed`

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -107,13 +107,10 @@ pub(super) fn commit_file(
     // `process_whole_file` via `make_backup_copy` prior to the first write.
     let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
-            make_backup(&begin.file_path, backup_config, config.backup_env()).map_err(|e| {
-                crate::temp_guard::attach_commit_op(
-                    crate::temp_guard::CommitOp::Backup,
-                    &begin.file_path,
-                    e,
-                )
-            })?
+            // `make_backup` tags its own failures with CommitOp::Backup AND the
+            // backup destination it chose; re-wrapping here would nest a second
+            // payload and hide that destination from the reporter's downcast.
+            make_backup(&begin.file_path, backup_config, config.backup_env())?
         } else {
             None
         }
@@ -900,8 +897,21 @@ pub(crate) fn make_backup(
         &backup_config.suffix,
     );
 
+    // upstream: backup.c:402-403 reports BOTH operands - `keep_backup failed:
+    // %s -> "%s"` over `full_fname(fname)` and the backup destination `buf`.
+    // `backup_path` is chosen here and nowhere else, so every failure below is
+    // tagged with it at the raising site; the reporter cannot recompute it.
+    let failed = |e: io::Error| {
+        crate::temp_guard::attach_commit_op_between(
+            crate::temp_guard::CommitOp::Backup,
+            file_path,
+            Some(&backup_path),
+            e,
+        )
+    };
+
     if let Some(parent) = backup_path.parent() {
-        create_backup_path_parents(parent, backup_config, env)?;
+        create_backup_path_parents(parent, backup_config, env).map_err(failed)?;
     }
 
     // upstream: backup.c:230-246 - `prefer_rename` is False here (rsync.c:897),
@@ -919,7 +929,7 @@ pub(crate) fn make_backup(
         return Ok(Some(backup_notice(backup_config, file_path, &backup_path)));
     }
 
-    let was_copy = backup_rename_sandboxed(env, file_path, &backup_path)?;
+    let was_copy = backup_rename_sandboxed(env, file_path, &backup_path).map_err(failed)?;
     if was_copy {
         // upstream: backup.c:414 - DEBUG_GTE(BACKUP, 1) "make_backup: COPY %s
         // successful." when the cross-device copy tier moved the pre-image.

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -313,11 +313,8 @@ impl PipelinedReceiver {
             Some(crate::temp_guard::CommitOp::Mkstemp) | None => {
                 format!("rsync: [receiver] mkstemp {name} failed: {reason}")
             }
-            // upstream: rsync-3.5.0/backup.c:401-402 `keep_backup failed: %s -> "%s"`.
-            // oc names the pre-image only; the backup destination is chosen
-            // inside make_backup and is not carried back on the error.
             Some(crate::temp_guard::CommitOp::Backup) => {
-                format!("rsync: [receiver] keep_backup failed: {name}: {reason}")
+                keep_backup_failed_line(&name, error, &reason)
             }
             // upstream: rsync-3.5.0/receiver.c:710-712 `rename failed for %s
             // (from %s)`. oc names the destination only; the `from` operand is
@@ -761,6 +758,29 @@ impl PipelinedReceiver {
 fn is_permission_error(err: &io::Error) -> bool {
     err.kind() == io::ErrorKind::PermissionDenied
 }
+/// Renders upstream's `keep_backup failed` diagnostic, naming both operands of
+/// the failing move when the raising site attached the second one.
+///
+/// The two receiver paths that can fail a backup - the commit path and the
+/// non-regular obstacle path - print the same upstream format string, so they
+/// share this one owner rather than keeping a copy each.
+///
+/// `full_fname` supplies the first pair of quotes and the format string the
+/// second; a failure raised before a destination was chosen has only the one
+/// operand to name, so it renders without the arrow.
+///
+/// upstream: `rsync-3.5.0/backup.c:402-403` - `rsyserr(FERROR, errno,
+/// "keep_backup failed: %s -> \"%s\"", full_fname(fname), buf)`.
+pub(crate) fn keep_backup_failed_line(name: &str, error: &io::Error, reason: &str) -> String {
+    match crate::temp_guard::commit_op_destination(error) {
+        Some(backup) => format!(
+            "rsync: [receiver] keep_backup failed: {name} -> \"{}\": {reason}",
+            backup.display()
+        ),
+        None => format!("rsync: [receiver] keep_backup failed: {name}: {reason}"),
+    }
+}
+
 /// Renders an error the way upstream's `rsyserr` does: `strerror(errno)`
 /// followed by the numeric errno in parentheses.
 ///
@@ -1612,7 +1632,7 @@ mod tests {
     /// `Result`, so a `PermissionDenied` from any of them reaches the same
     /// reporting arm. Upstream gives each site its own text - `mkstemp %s
     /// failed` (`rsync-3.5.0/receiver.c:452-453`), `rename failed for %s`
-    /// (`:710-712`), `keep_backup failed` (`rsync-3.5.0/backup.c:401-402`) -
+    /// (`:710-712`), `keep_backup failed` (`rsync-3.5.0/backup.c:402-403`) -
     /// and oc must not label all three `mkstemp`.
     ///
     /// The untagged arm is the one that matters for regressions: an error
@@ -1675,6 +1695,103 @@ mod tests {
                 "every arm renders strerror + errno like rsyserr: {rendered}"
             );
         }
+    }
+
+    /// upstream prints BOTH operands of the failing copy: `keep_backup failed:
+    /// %s -> "%s"` over `full_fname(fname)` and the backup destination `buf`
+    /// (`rsync-3.5.0/backup.c:402-403`). Naming only the pre-image loses the
+    /// path the backup was going TO, which is the half that identifies WHERE
+    /// the failure happened - under a restricted shell that path is the pinned
+    /// `/proc/self/fd/N/...` handle, and without it the message cannot be told
+    /// apart from an unrelated failure on the same file.
+    ///
+    /// The `->` arrow and the quotes around the destination are upstream's own
+    /// framing, so they are asserted rather than left to taste.
+    #[cfg(unix)]
+    #[test]
+    fn keep_backup_failure_names_the_backup_destination_it_was_moving_to() {
+        let pr = PipelinedReceiver::new(DiskCommitConfig::default()).unwrap();
+        let dest = std::path::Path::new("/srv/mod/payload");
+        let backup_dir = std::path::Path::new("/proc/self/fd/5/payload");
+
+        let both = pr.commit_failure(
+            dest,
+            &crate::temp_guard::attach_commit_op_between(
+                crate::temp_guard::CommitOp::Backup,
+                dest,
+                Some(backup_dir),
+                io::Error::from_raw_os_error(libc::ENOENT),
+            ),
+        );
+        assert!(
+            both.contains("-> \"/proc/self/fd/5/payload\""),
+            "the backup destination must be named, quoted, after the arrow: {both}"
+        );
+        assert!(
+            both.contains("payload") && both.contains("keep_backup failed"),
+            "the pre-image operand and upstream's text both survive: {both}"
+        );
+
+        // Non-vacuity: a backup failure raised before a destination was chosen
+        // still renders, with the one operand it has. Without this companion the
+        // assertion above would also pass for an implementation that printed the
+        // arrow unconditionally with an empty second operand.
+        let one_operand = pr.commit_failure(
+            dest,
+            &crate::temp_guard::attach_commit_op(
+                crate::temp_guard::CommitOp::Backup,
+                dest,
+                io::Error::from_raw_os_error(libc::ENOENT),
+            ),
+        );
+        assert!(
+            one_operand.contains("keep_backup failed") && !one_operand.contains("->"),
+            "with no destination there is no arrow to print: {one_operand}"
+        );
+    }
+
+    /// Pins the shared owner directly, not just through `commit_failure`.
+    ///
+    /// Two receiver paths can fail a backup - the commit path and the
+    /// non-regular obstacle path (`receiver::directory::obstacle`) - and both
+    /// build their line here. Asserting on the owner keeps the contract stated
+    /// once, so the obstacle path cannot drift into printing one operand again
+    /// without this failing.
+    #[cfg(unix)]
+    #[test]
+    fn the_shared_keep_backup_line_names_both_operands() {
+        let backup = std::path::Path::new("/backup/authorized_keys");
+        let tagged = crate::temp_guard::attach_commit_op_between(
+            crate::temp_guard::CommitOp::Backup,
+            std::path::Path::new("./authorized_keys"),
+            Some(backup),
+            io::Error::from_raw_os_error(libc::ENOENT),
+        );
+        assert_eq!(
+            keep_backup_failed_line(
+                "./authorized_keys",
+                &tagged,
+                "No such file or directory (2)"
+            ),
+            "rsync: [receiver] keep_backup failed: ./authorized_keys -> \
+             \"/backup/authorized_keys\": No such file or directory (2)"
+        );
+
+        // Non-vacuity: without a destination there is no arrow, so the
+        // assertion above cannot be satisfied by emitting the arrow always.
+        let untagged = crate::temp_guard::attach_commit_op(
+            crate::temp_guard::CommitOp::Backup,
+            std::path::Path::new("./authorized_keys"),
+            io::Error::from_raw_os_error(libc::ENOENT),
+        );
+        assert_eq!(
+            keep_backup_failed_line(
+                "./authorized_keys",
+                &untagged,
+                "No such file or directory (2)"
+            ),
+            "rsync: [receiver] keep_backup failed: ./authorized_keys: No such file or directory (2)"
+        );
     }
 
     /// The errno must come from the error, not from a literal. A hardcoded

--- a/crates/transfer/src/receiver/directory/backup.rs
+++ b/crates/transfer/src/receiver/directory/backup.rs
@@ -266,6 +266,10 @@ fn place_report_and_clear(
     metadata_opts: &MetadataOptions,
 ) -> io::Result<()> {
     let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
+    // upstream: backup.c:402-403 reports BOTH operands - `keep_backup failed:
+    // %s -> "%s"` over `full_fname(fname)` and the backup destination `buf`.
+    // `backup_path` is chosen here and nowhere else, so the failure is tagged
+    // with it at the raising site; the reporter cannot recompute it.
     let placement = place_existing_backup(
         existing,
         &backup_path,
@@ -273,7 +277,15 @@ fn place_report_and_clear(
         dest_dir,
         backup_dir,
         metadata_opts,
-    )?;
+    )
+    .map_err(|e| {
+        crate::temp_guard::attach_commit_op_between(
+            crate::temp_guard::CommitOp::Backup,
+            existing,
+            Some(&backup_path),
+            e,
+        )
+    })?;
     report_backup(&placement, existing, &backup_path, dest_dir);
     if matches!(placement, BackupPlacement::Hardlinked) {
         // upstream: delete.c:169-170 - the hard-link tier is upstream's `ok == 2`
@@ -302,6 +314,10 @@ fn place_report_and_clear(
     metadata_opts: &MetadataOptions,
 ) -> io::Result<()> {
     let backup_path = engine::compute_backup_path(dest_dir, existing, None, backup_dir, suffix);
+    // upstream: backup.c:402-403 reports BOTH operands - `keep_backup failed:
+    // %s -> "%s"` over `full_fname(fname)` and the backup destination `buf`.
+    // `backup_path` is chosen here and nowhere else, so the failure is tagged
+    // with it at the raising site; the reporter cannot recompute it.
     let placement = place_existing_backup(
         existing,
         &backup_path,
@@ -309,7 +325,15 @@ fn place_report_and_clear(
         dest_dir,
         backup_dir,
         metadata_opts,
-    )?;
+    )
+    .map_err(|e| {
+        crate::temp_guard::attach_commit_op_between(
+            crate::temp_guard::CommitOp::Backup,
+            existing,
+            Some(&backup_path),
+            e,
+        )
+    })?;
     report_backup(&placement, existing, &backup_path, dest_dir);
     if matches!(placement, BackupPlacement::Hardlinked) {
         let _ = fs::remove_file(existing);

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -458,7 +458,7 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `backup.c:400-401` - `rsyserr(FERROR, errno, "keep_backup failed: %s -> \"%s\"", ...)`
+    /// - `backup.c:402-403` - `rsyserr(FERROR, errno, "keep_backup failed: %s -> \"%s\"", ...)`
     /// - `generator.c:2478-2479` - `if (!make_backup(fname, skip_atomic)) return 0;`
     fn report_backup_failure<W>(
         &self,
@@ -469,14 +469,19 @@ impl ReceiverContext {
     where
         W: crate::writer::MsgInfoSender + ?Sized,
     {
-        let _ = self.emit_error_line(
-            writer,
-            &format!(
-                "rsync: [receiver] keep_backup failed: {}: {}\n",
-                relative_path.display(),
-                upstream_errno_text(&error)
-            ),
+        // `place_report_and_clear` attaches the backup destination it chose, so
+        // both operands upstream prints are available here. The line is built by
+        // the shared owner the commit path also uses, so the two receiver paths
+        // that can fail a backup cannot drift apart.
+        let line = format!(
+            "{}\n",
+            crate::pipeline::receiver::keep_backup_failed_line(
+                &relative_path.display().to_string(),
+                &error,
+                &upstream_errno_text(&error),
+            )
         );
+        let _ = self.emit_error_line(writer, &line);
         Err(error)
     }
 }

--- a/crates/transfer/src/temp_guard.rs
+++ b/crates/transfer/src/temp_guard.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 /// Upstream emits one message per site, each naming its own operation:
 /// `mkstemp %s failed` (`rsync-3.5.0/receiver.c:452-453`),
 /// `rename failed for %s (from %s)` (`rsync-3.5.0/receiver.c:710-712`) and
-/// `keep_backup failed: %s -> "%s"` (`rsync-3.5.0/backup.c:401-402`). oc runs
+/// `keep_backup failed: %s -> "%s"` (`rsync-3.5.0/backup.c:402-403`). oc runs
 /// these stages behind one `Result`, so the operation identity has to ride on
 /// the error to survive the trip back to the reporting thread.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,6 +58,7 @@ pub enum CommitOp {
 struct CommitOpError {
     op: CommitOp,
     operand: PathBuf,
+    destination: Option<PathBuf>,
     source: io::Error,
 }
 
@@ -99,14 +100,42 @@ pub fn commit_op_failure(error: &io::Error) -> Option<(CommitOp, &Path)> {
         .map(|e| (e.op, e.operand.as_path()))
 }
 
+/// Returns the second path the failing operation named, for the operations
+/// whose upstream diagnostic prints two operands.
+///
+/// upstream `backup.c:402-403` reports `keep_backup failed: %s -> "%s"` -
+/// `full_fname(fname)` and the backup destination `buf`. Only the code that
+/// chose that destination knows it, so it is attached at the raising site
+/// rather than reconstructed by the reporter. `None` whenever the operation
+/// has a single operand, so callers render the one-operand form.
+pub fn commit_op_destination(error: &io::Error) -> Option<&Path> {
+    error
+        .get_ref()?
+        .downcast_ref::<CommitOpError>()?
+        .destination
+        .as_deref()
+}
+
 /// Tags `source` with the operation that raised it, preserving its
 /// [`io::ErrorKind`] so existing predicates keep classifying it unchanged.
 pub fn attach_commit_op(op: CommitOp, operand: &Path, source: io::Error) -> io::Error {
+    attach_commit_op_between(op, operand, None, source)
+}
+
+/// [`attach_commit_op`] for an operation that moved `operand` to
+/// `destination`, so the reporter can print both halves the way upstream does.
+pub fn attach_commit_op_between(
+    op: CommitOp,
+    operand: &Path,
+    destination: Option<&Path>,
+    source: io::Error,
+) -> io::Error {
     io::Error::new(
         source.kind(),
         CommitOpError {
             op,
             operand: operand.to_path_buf(),
+            destination: destination.map(Path::to_path_buf),
             source,
         },
     )
@@ -322,6 +351,8 @@ fn open_tmpfile_inner(
                     CommitOpError {
                         op: CommitOp::Mkstemp,
                         operand: concrete_path,
+                        // `mkstemp %s failed` names one operand.
+                        destination: None,
                         source: e,
                     },
                 ));

--- a/tools/ci/upstream-3.5.0-expect.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.txt
@@ -273,7 +273,7 @@ rename-mixed-parent-transfer skip
 reverse-daemon-delta pass
 rrsync-alt-dest-inband-pivot pass
 rrsync-archive-mode pass
-rrsync-backup-dir-inband-pivot fail
+rrsync-backup-dir-inband-pivot pass
 rrsync-copy-unsafe-links-denied pass
 rrsync-debug-denied pass
 rrsync-files-from-stdin pass

--- a/tools/ci/upstream-3.5.0-expect.root.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.txt
@@ -273,7 +273,7 @@ rename-mixed-parent-transfer pass
 reverse-daemon-delta pass
 rrsync-alt-dest-inband-pivot pass
 rrsync-archive-mode pass
-rrsync-backup-dir-inband-pivot fail
+rrsync-backup-dir-inband-pivot pass
 rrsync-copy-unsafe-links-denied pass
 rrsync-debug-denied pass
 rrsync-files-from-stdin pass


### PR DESCRIPTION
upstream prints BOTH operands of the failing copy - `keep_backup failed:
%s -> "%s"` over `full_fname(fname)` and the backup destination `buf`
(rsync-3.5.0/backup.c:402-403). oc printed only the pre-image, losing the
path the backup was going TO.

MEASURED on Linux against real rsync 3.5.0 as the control, same fixture,
same run - both arms exit 11, both block the escape, both plant the pivot:

  upstream: rsync: [receiver] keep_backup failed: "<abs>/restricted/authorized_keys"
                   -> "/proc/self/fd/5/authorized_keys": No such file or directory (2)
  oc:       rsync: [receiver] keep_backup failed: "./authorized_keys": ...

The missing operand is the half that says WHERE the failure happened. Under
a restricted shell that path is the pinned `/proc/self/fd/N/...` handle, so
without it the message cannot be told apart from an unrelated failure on the
same file - which is exactly what the upstream testsuite cell
`rrsync-backup-dir-inband-pivot` asserts, via `'/proc/self/fd/' in stderr`.

TWO SITES, not one. Both receiver paths that can fail a backup print this
message: the commit path (`disk_commit::process::commit::make_backup`) and
the non-regular obstacle path (`receiver::directory::obstacle`). Fixing one
would have left the other truncating - the obstacle site's own doc already
quoted upstream's two-operand format string while its code rendered one.

The destination is chosen inside the backup helpers and nowhere else, so it
is attached to the error AT the raising site rather than reconstructed by the
reporter: `CommitOpError` gains an optional `destination`, and both
`make_backup` and `place_report_and_clear` tag their failures with the
`backup_path` they computed. The commit caller's own `attach_commit_op`
wrapper is removed - it would have nested a second payload and hidden the
destination from the reporter's downcast.

Rendering is now owned once, by `keep_backup_failed_line`. The two reporters
held two copies of one upstream format string; a shared owner is what makes
the obstacle path's wording provably identical to the commit path's rather
than merely similar today.

`commit_op_failure` keeps its two-tuple signature so its eight consumers are
untouched; the new `commit_op_destination` accessor serves the reporter.

The nine citations of this diagnostic said `backup.c:401-402` or `:400-401`;
the statement is at `402-403`, measured by grep against the fetched 3.5.0
tarball. All nine retargeted.

MANIFEST: `rrsync-backup-dir-inband-pivot` flipped fail -> pass on both Linux
pipe legs, each MEASURED with the built binary, not inferred from the other:
nonroot and root both report PASS with `/proc/self/fd/5/authorized_keys` in
the stderr the cell greps. macOS already said `pass` - that leg takes the
`not PINS` early-exit branch, so it never exercised this at all. The two TCP
manifests do not carry the cell.

DELIBERATELY NOT CHANGED: oc's first operand is the destination-relative
`./authorized_keys` where upstream prints an absolute path, and oc emits two
`oc-rsync error:` trailers where upstream emits one. Both are separate
divergences on different code (daemon path rendering; the server/sender error
funnel), neither is what the cell asserts, and folding them in here would mix
three unrelated changes.

`CommitOp::Rename` has the same one-operand truncation against upstream's
`rename failed for %s (from %s)` (receiver.c:710-712). The mechanism added
here fits it, but wiring it needs the temp name threaded to that site and is
unmeasured, so it is left alone rather than changed speculatively.

Mutation-proven: making the shared owner ignore the attached destination
reddens both pins and nothing else (2 run / 0 passed / 2 failed - the counts
reconcile, so nextest did not truncate the kill list). Each pin carries its
own non-vacuity companion: a backup failure with no destination must still
render, without an arrow, so neither assertion can be satisfied by printing
the arrow unconditionally with an empty operand.

VERIFICATION LABEL: the commit path's routing is proven behaviourally by the
testsuite cell going RED -> GREEN on both Linux legs. The obstacle path's
routing is STRUCTURAL - it calls the same owner, which is mutation-proven -
not separately executed; reaching it needs a ReceiverContext fixture that
does not exist in this crate.

Verified on the pinned 1.88.0 toolchain: `cargo fmt --all -- --check` clean,
`cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings`
clean, transfer 2454/2454.
