### PR TITLE
fix(receiver): confine the --delay-updates staging path to the module

### DIFF
--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -148,7 +148,7 @@ pub(super) fn commit_file(
                 clear_partial_dir_obstruction(parent)?;
                 create_dir_all_sandboxed(config.backup_env(), parent)?;
             }
-            let result = rename_config_sandboxed(config, cleanup_guard.path(), &staging_path)
+            let result = stage_into_partial_dir(config, cleanup_guard.path(), &staging_path)
                 .map_err(|e| {
                     crate::temp_guard::attach_commit_op(
                         crate::temp_guard::CommitOp::Rename,
@@ -501,6 +501,41 @@ pub(super) fn rename_config_sandboxed(
     {
         rename_with_io_uring_fallback(old_path, new_path)
     }
+}
+
+/// Moves the received temp into the `--delay-updates` staging path through the
+/// ownership walk, bound to the session's confinement root.
+///
+/// The staging path is `<--partial-dir>/<basename>`, and on a daemon receiver
+/// `--partial-dir` is PEER-SUPPLIED: a symlink standing at that name sends the
+/// staged file - a complete copy of the source - outside the served module, and
+/// the later sweep then renames it back over the destination. So this endpoint
+/// takes the confined walk rather than [`rename_config_sandboxed`], whose
+/// sandbox helper falls back to a path-based rename when the anchored open
+/// fails - exactly the drop-to-unconfined that upstream names as wrong.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/util1.c:1518-1530` `handle_partial_dir(..., PDIR_CREATE)` -
+///   the whole retention runs under `operator_path_resolve`.
+/// - `rsync-3.5.0/syscall.c:1891` `do_rename_at()` under that flag.
+#[cfg(unix)]
+fn stage_into_partial_dir(
+    _config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<bool> {
+    fast_io::operator_rename_confined(old_path, new_path, true)?;
+    Ok(false)
+}
+
+#[cfg(not(unix))]
+fn stage_into_partial_dir(
+    config: &DiskCommitConfig,
+    old_path: &Path,
+    new_path: &Path,
+) -> io::Result<bool> {
+    rename_config_sandboxed(config, old_path, new_path)
 }
 
 /// Returns `true` when an I/O error represents a cross-device link (EXDEV).

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -466,7 +466,7 @@ pub(in crate::receiver) enum DeletePassPhase {
 /// glibc's `rename()` lowers to on x86_64.
 #[cfg(unix)]
 fn sweep_rename(old_path: &Path, new_path: &Path) -> io::Result<()> {
-    fast_io::operator_rename(old_path, new_path, true)
+    fast_io::operator_rename_confined(old_path, new_path, true)
 }
 
 #[cfg(not(unix))]

--- a/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
+++ b/tools/ci/upstream-3.5.0-expect.macos.nonroot.txt
@@ -15,20 +15,19 @@
 # run's emitted `expect-result.macos.nonroot.txt` artifact and say so; do NOT
 # edit individual rows to make the job green.
 #
-# The 4 `fail` rows were classified 2026-09-04 by running each cell twice on
+# The 3 `fail` rows were classified 2026-09-04 by running each cell twice on
 # one host, varying ONLY $RSYNC between oc and the real 3.5.0 binary. That
 # upstream arm is the control; without it a failure cannot be attributed.
 #
 #   chmod-setid                             upstream FAILS too - unsatisfiable here
 #   partial-protected-regular-retry-policy  upstream FAILS too - unsatisfiable here
-#   operator-path-partial-dir-daemon        upstream PASSES - real oc defect
 #   filter-merge-content-echo               owned by task 1011
 #
-# Two of the four are therefore NOT oc divergences: the platform (or this
+# Two of the three are therefore NOT oc divergences: the platform (or this
 # host's sysctl state) refuses what the cell asserts, and real rsync lands on
 # the same result. They stay `fail` because the assertion is unsatisfiable
 # here, not because oc is right - re-baselining them would hide the row rather
-# than resolve it. None of the four appears in upstream's own
+# than resolve it. None of the three appears in upstream's own
 # testsuite/skiplist/macos.txt.
 00-hello pass
 acl-symlink-race skip
@@ -250,7 +249,7 @@ operator-path-insecure-links-refused pass
 operator-path-link-dest pass
 operator-path-log-file pass
 operator-path-partial-dir pass
-operator-path-partial-dir-daemon fail
+operator-path-partial-dir-daemon pass
 operator-path-partial-dir-exclude-daemon pass
 operator-path-temp-dir pass
 operator-path-traversal-backup-dir-daemon pass


### PR DESCRIPTION
Closes the `operator-path-partial-dir-daemon` divergence by **refusing** the escaping operand, which is what upstream does and what the Linux baseline already encodes. Supersedes #7657, whose shape (clear the symlink and proceed) was the operand-ignored outcome the cell rejects.

## The defect

On a daemon receiver `--partial-dir` is peer-supplied. `--delay-updates` stages every file through `<--partial-dir>/<basename>` and later renames it onto the destination. **Both** of those renames walked the ownership walk in its `Ancillary` spelling, and `AbsPathTracker::start` returns `Disabled` for anything that is not `PathKind::Confined` — so the session confinement root was never consulted on this path at all.

A symlink standing at the partial-dir name therefore sent the staged file — a complete copy of the source — outside the served module, and the delayed sweep then renamed it back over the destination.

Measured with the cell's own fixture (module `mod` with `blink -> <outside>/secret` planted inside, `-a --delay-updates --partial-dir=/blink src/ <url>mod/`):

| | exit | `mod/f0` | outside `secret/f0` |
|---|---|---|---|
| before | 23 | **replaced** | **destroyed** |
| after | 11 | untouched | intact |

## How it was localised

`create_partial_dir` and `partial_dir_rename` were both excluded by instrumentation first — neither is on this path. Probing every `operator_*` entry point named the two real sinks:

```
ENTRY operator_rename        path=".../mod/blink/f0"     <- receiver/transfer.rs sweep_rename
ENTRY owner_trusted_parent   path=".../mod/blink"        <- Ancillary, tracker DISABLED
```

## Both halves are load-bearing

Measured in isolation, not assumed:

| | exit | dest | victim |
|---|---|---|---|
| neither confined | 23 | REPLACED | DESTROYED |
| sweep only | 23 | untouched | DESTROYED |
| both | 11 | untouched | intact |

Confining the sweep protects the destination; confining the staging rename protects the victim. Neither alone is sufficient.

## Why not `rename_config_sandboxed`

The staging endpoint deliberately does not reuse it. Its `renameat_via_sandbox_or_fallback` helper drops to a path-based rename when the anchored open fails — the drop-to-unconfined that upstream names as wrong. `syscall.c` `open_dir_secure()` signals policy with `errno == 0` precisely so a runtime errno cannot select the unconfined arm.

## Upstream

- `util1.c:1518-1530` `handle_partial_dir(..., PDIR_CREATE)` runs the whole retention under `operator_path_resolve`
- `syscall.c:1891` `do_rename_at()` under that flag
- `receiver.c:546` `do_rename(partialptr, fname)` — the sweep rename

## Verification

- macOS upstream 3.5.0 testsuite on this exact base: **237 passed / 3 failed** (was 235/5). `operator-path-partial-dir-daemon` passes.
- The three residual rows are the ones the manifest header already classifies: `chmod-setid` and `partial-protected-regular-retry-policy` are unsatisfiable on this host (real rsync 3.5.0 lands on the same result), `filter-merge-content-echo` is owned separately.
- macOS nonroot expect manifest flips the row fail -> pass in the same commit; the header's count and classification list are reconciled with it.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features` clean on the pinned 1.88.0 toolchain.
- The relative-operand control is unchanged (exit 11, dest untouched, victim intact) before and after.
