### PR TITLE
fix(filters): redact a merged rule's own text from the unknown-rule error

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -5,7 +5,7 @@ use super::{
     types::{FilterParseError, ParsedFilterDirective},
 };
 use crate::local_copy::filter_program::ExcludeIfPresentRule;
-use filters::FilterRule;
+use filters::{FilterRule, RuleSource};
 use std::fmt;
 
 #[derive(Default)]
@@ -360,8 +360,27 @@ pub(crate) fn parse_filter_directive_line(
         _ => {}
     }
 
+    // upstream: exclude.c:1363 `filter_rule_err("Unknown filter rule", ...)`,
+    // whose text argument is passed through `rule_text` (exclude.c:88-123) -
+    // the chokepoint every diagnostic built from a rule's own text must cross.
+    //
+    // The rule text is REPLACED, not echoed. Both production callers of this
+    // function are inside `load_dir_merge_rules_recursive`, i.e. the contents
+    // of a per-directory merge file. That file is named by a rule the PEER
+    // controls and which travelled over the protocol, so echoing an unparsable
+    // line back turns the filter parser into a read-any-line oracle for any
+    // file this process can open. Upstream describes that provenance as
+    // `a file read earlier` (exclude.c:78) because the naming rule was read and
+    // closed long ago and its origin is not retained.
+    //
+    // ⚠ The replacement is NOT unconditional redaction: upstream still echoes a
+    // rule that came from an ARGUMENT, because that text is the operator's own.
+    // `RuleSource` encodes exactly that distinction, and `Argument` returns the
+    // text unchanged - which is why the funnel is used here rather than a local
+    // `format!`.
     Err(FilterParseError::new(format!(
-        "Unknown filter rule: `{trimmed}'"
+        "Unknown filter rule: {}",
+        RuleSource::FileReadEarlier.rule_text(trimmed)
     )))
 }
 
@@ -750,5 +769,45 @@ mod tests {
             matches!(result, Some(ParsedFilterDirective::DirMerge { .. })),
             "':' short form must emit DirMerge variant"
         );
+    }
+
+    /// MEASURED against rsync 3.5.0 (`filter-merge-content-echo`): a per-directory
+    /// merge file holding an unparsable line makes upstream report
+    /// `<rule from a file read earlier>`, while oc echoed the line itself. The
+    /// merge file is named by a rule the peer controls, so the echo turned the
+    /// filter parser into a read-any-line oracle for any file this process can
+    /// open.
+    ///
+    /// upstream: exclude.c:1363 routes the text through `rule_text`
+    /// (exclude.c:78-123), whose `a file read earlier` arm is exactly this
+    /// provenance.
+    #[test]
+    fn an_unparsable_merged_line_is_not_echoed_back() {
+        const SECRET: &str = "TOP-SECRET-PASSWORD-abc123";
+
+        let error = parse_filter_directive_line(SECRET)
+            .expect_err("an unparsable line must still be refused");
+        let rendered = error.to_string();
+
+        assert!(
+            !rendered.contains(SECRET),
+            "the merged line's contents must not be echoed: {rendered}"
+        );
+        assert!(
+            rendered.contains("a file read earlier"),
+            "the diagnostic must name the rule's provenance: {rendered}"
+        );
+    }
+
+    /// Non-vacuity companion: the redaction is a PROVENANCE decision, not blanket
+    /// suppression. Upstream still echoes a rule that came from an argument,
+    /// because that text is the operator's own (`rule_text` returns it unchanged,
+    /// exclude.c:88-123). Without this, replacing the funnel with a constant
+    /// string would also satisfy the test above.
+    #[test]
+    fn an_argument_sourced_rule_is_still_echoed() {
+        const SECRET: &str = "TOP-SECRET-PASSWORD-abc123";
+
+        assert_eq!(RuleSource::Argument.rule_text(SECRET), SECRET);
     }
 }


### PR DESCRIPTION
## What

`parse_filter_directive_line` echoed the offending line back when a per-directory
merge file held an unparsable rule. That file is named by a rule the **peer**
controls and which travelled over the protocol, so the echo turned the filter
parser into a read-any-line oracle for any file the process can open.

## Upstream

`exclude.c:1363` builds the message from `rule_text` (`exclude.c:78-123`) — the
chokepoint every diagnostic built from a rule's own text must cross. For a rule
whose naming file was read and closed long ago, `rule_text` renders the
provenance as `a file read earlier` rather than the text.

`RuleSource` (`crates/filters/src/rule_source.rs`) is oc's port of that funnel and
is already tested; `crates/filters/src/merge/parse.rs:636` is its one correct
consumer. This site was bypassing it with a local `format!`.

## Not blanket redaction

`RuleSource::Argument` returns the text **unchanged**, because an argument-sourced
rule is the operator's own text and upstream still echoes it. Using the funnel
rather than a constant string is what preserves that distinction — pinned by
`an_argument_sourced_rule_is_still_echoed`.

`FileReadEarlier` is the correct constant here because both production callers of
this function sit inside `load_dir_merge_rules_recursive`
(`dir_merge/load.rs:335`, `:449`) — there is no argument-sourced caller.

## Measured

Upstream 3.5.0's own testsuite fixture (`filter-merge-content-echo`), secret
`TOP-SECRET-PASSWORD-abc123`:

| | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|
| per-dir merge naming `../secret` | `<rule from a file read earlier>` | leaks the secret | `<rule from a file read earlier>` |

## Verification

- `an_unparsable_merged_line_is_not_echoed_back` asserts the secret is **absent**
  and the provenance locator present.
- Mutation-proven: restoring the old `format!` gives `2 tests run: 1 passed, 1 failed`,
  failing with `Unknown filter rule: \`TOP-SECRET-PASSWORD-abc123'`; the
  argument-sourced companion stays green.
- `cargo fmt --all -- --check` clean, `cargo clippy -p engine --all-targets -D warnings`
  clean, `engine --lib` 4719/4719 — all on the pinned 1.88.0 toolchain.

## Scope

Shapes B and C of the same cell (`--filter='. FILE'` and merge-from-merge) leak
through a **different** parser,
`crates/cli/src/frontend/filter_rules/parsing/rules.rs:186`, and are a separate PR.
