### PR TITLE
fix(filters): route the CLI filter parser through the rule-text funnel

### DIFF
--- a/crates/cli/src/frontend/execution/drive/filters.rs
+++ b/crates/cli/src/frontend/execution/drive/filters.rs
@@ -98,7 +98,9 @@ fn push_filter_directive(
     merge_base: &std::path::Path,
     merge_stack: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
-    match parse_filter_directive(rule.as_os_str())? {
+    // The operator typed this `--filter` value, so its text is theirs to see:
+    // `rule_text` returns an argument-sourced rule unchanged (exclude.c:110-116).
+    match parse_filter_directive(rule.as_os_str(), RuleSource::Argument)? {
         FilterDirective::Rule(spec) => filter_rules.push(spec),
         FilterDirective::Merge(directive) => {
             let effective_options =
@@ -136,7 +138,8 @@ fn push_old_prefix_rule(
     default_kind: FilterRuleKind,
 ) -> Result<(), Message> {
     let text = os_string_to_pattern(pattern);
-    match parse_old_prefix_rule(&text, default_kind)? {
+    // Likewise for a `--exclude`/`--include` value given on the command line.
+    match parse_old_prefix_rule(&text, default_kind, RuleSource::Argument)? {
         FilterDirective::Rule(rule) => destination.push(rule),
         FilterDirective::Clear => destination.push(FilterRuleSpec::clear()),
         // A blank `--exclude`/`--include` value contributes nothing.

--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -116,6 +116,13 @@ pub(crate) fn apply_merge_directive(
     // section of the per-merge-file rule list. Mirror that by parsing the
     // merge file into a scope-local buffer so a '!' inside the file cannot
     // wipe parent-scope rules already in `destination`.
+    // upstream: exclude.c:1735-1755 - `named_by_file = TEXT_FROM_FILE(template)`.
+    // When a rule we READ named this file, the file's OWN path is file content
+    // too, so upstream clears `rule_src_file` and reports only the LOCATION that
+    // named it (`rule_src_named_at`), snapshotted once for the whole file. An
+    // argument-named file keeps its own name, because the operator typed it.
+    let named_at = source.describe().map(std::borrow::Cow::into_owned);
+
     let mut local: Vec<FilterRuleSpec> = Vec::new();
     let result = (|| -> Result<(), Message> {
         let contents = if is_stdin {
@@ -132,7 +139,13 @@ pub(crate) fn apply_merge_directive(
         };
 
         parse_merge_contents(
-            &contents, &options, next_base, &display, &mut local, visited,
+            &contents,
+            &options,
+            next_base,
+            &display,
+            named_at.as_deref(),
+            &mut local,
+            visited,
         )
     })();
     visited.pop();
@@ -152,6 +165,7 @@ fn parse_merge_contents(
     options: &DirMergeOptions,
     base_dir: &Path,
     display: &str,
+    named_at: Option<&str>,
     destination: &mut Vec<FilterRuleSpec>,
     visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
@@ -211,7 +225,10 @@ fn parse_merge_contents(
                 options,
                 base_dir,
                 display,
-                RuleSource::FileWordSplit { name: display },
+                match named_at {
+                    None => RuleSource::FileWordSplit { name: display },
+                    Some(location) => RuleSource::FileNamedAt { location },
+                },
                 destination,
                 visited,
             )?;
@@ -266,9 +283,12 @@ fn parse_merge_contents(
             options,
             base_dir,
             display,
-            RuleSource::File {
-                name: display,
-                line: line_number,
+            match named_at {
+                None => RuleSource::File {
+                    name: display,
+                    line: line_number,
+                },
+                Some(location) => RuleSource::FileNamedAt { location },
             },
             destination,
             visited,
@@ -290,7 +310,11 @@ pub(crate) fn process_merge_directive(
     destination: &mut Vec<FilterRuleSpec>,
     visited: &mut Vec<PathBuf>,
 ) -> Result<(), Message> {
-    match parse_filter_directive(OsStr::new(directive)) {
+    // `source` says where this line came from, and every diagnostic the parser
+    // builds from it now crosses `rule_text`/`rule_detail` (exclude.c:88-131).
+    // This is a line out of a merge file whose name the PEER can choose, so an
+    // unparsable line must be described, never echoed.
+    match parse_filter_directive(OsStr::new(directive), source) {
         Ok(FilterDirective::Rule(mut rule)) => {
             // upstream: exclude.c:1447-1456 - when the merge directive named a
             // side and the rule inside the file names one too, the inherit is
@@ -364,16 +388,16 @@ pub(crate) fn process_merge_directive(
             destination.extend(rules);
         }
         Err(error) => {
-            let detail = error.to_string();
-            let message = rsync_error!(
-                1,
-                format!(
-                    "failed to parse filter rule '{}' from merge file '{}': {}",
-                    directive, display, detail
-                )
-            )
-            .with_role(Role::Client);
-            return Err(message);
+            // upstream reports a syntax failure ONCE, from `filter_rule_err`
+            // (exclude.c:132-138), which renders the rule through `rule_text`
+            // and exits RERR_SYNTAX. There is no enclosing wrapper, and adding
+            // one here re-echoed both the rule text the funnel had just replaced
+            // and the merge file's name - which for a nested merge is a path the
+            // peer chose. That is precisely the failure mode upstream's own
+            // comment names: "a message added later cannot reintroduce the leak
+            // by forgetting to check" (exclude.c:96-99). The inner error already
+            // names the rule's provenance, so it is propagated unchanged.
+            return Err(error);
         }
     }
 

--- a/crates/cli/src/frontend/filter_rules/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use directive::MergeDirective;
 pub(crate) use merge::process_merge_directive;
 
 #[cfg(test)]
-pub(crate) use parsing::parse_merge_modifiers;
+pub(crate) use parsing::parse_merge_modifiers_from_argument;
 
 #[cfg(test)]
 pub(crate) use sources::load_filter_file_patterns;

--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -12,10 +12,14 @@ use core::rsync_error;
 
 use super::super::directive::{FilterDirective, MergeDirective};
 use super::merge::parse_merge_modifiers;
+use super::rule_line::RuleLine;
 
 /// Parses a long-form `merge[,MODS] FILE` directive. Returns `None` when the
 /// text does not start with `merge`, or an error when the file path is missing.
-pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
+pub(super) fn parse_long_merge_directive(
+    line: RuleLine<'_>,
+) -> Option<Result<FilterDirective, Message>> {
+    let text = line.text();
     let remainder = text.strip_prefix("merge")?;
     let mut remainder =
         remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
@@ -28,7 +32,7 @@ pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDire
             .unwrap_or("")
             .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
     }
-    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, text, false) {
+    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, line, false) {
         Ok(result) => result,
         Err(error) => return Some(Err(error)),
     };
@@ -40,7 +44,10 @@ pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDire
         } else {
             let message = rsync_error!(
                 1,
-                format!("filter merge directive '{text}' is missing a file path")
+                format!(
+                    "filter merge directive '{}' is missing a file path",
+                    line.shown()
+                )
             )
             .with_role(Role::Client);
             return Some(Err(message));
@@ -60,7 +67,10 @@ pub(super) fn parse_long_merge_directive(text: &str) -> Option<Result<FilterDire
 
 /// Parses a long-form `dir-merge[,MODS] FILE` directive. Returns `None` when
 /// the keyword does not match, or an error when the file name is missing.
-pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
+pub(super) fn parse_dir_merge_alias(
+    line: RuleLine<'_>,
+) -> Option<Result<FilterDirective, Message>> {
+    let trimmed = line.text();
     // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
     // strncmp reached via `case 'd'`, so `DIR-MERGE`/`Dir-Merge` never match the
     // keyword. Compare bytes exactly; "dir-merge" is ASCII, so a matching prefix
@@ -80,7 +90,7 @@ pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirect
             .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
     }
 
-    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, trimmed, true) {
+    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, line, true) {
         Ok(result) => result,
         Err(error) => return Some(Err(error)),
     };
@@ -90,7 +100,10 @@ pub(super) fn parse_dir_merge_alias(trimmed: &str) -> Option<Result<FilterDirect
         if assume_cvsignore {
             path_text = ".cvsignore";
         } else {
-            let text = format!("filter rule '{trimmed}' is missing a file name after '{KEYWORD}'");
+            let text = format!(
+                "filter rule '{}' is missing a file name after '{KEYWORD}'",
+                line.shown()
+            );
             return Some(Err(rsync_error!(1, text).with_role(Role::Client)));
         }
     }

--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -9,11 +9,12 @@ use std::ffi::OsStr;
 use core::client::{FilterRuleKind, FilterRuleSpec};
 use core::message::{Message, Role};
 use core::rsync_error;
-use filters::{ClearToken, classify_clear_token};
+use filters::{ClearToken, RuleSource, classify_clear_token};
 
 use super::super::directive::FilterDirective;
 use super::directives::{parse_dir_merge_alias, parse_long_merge_directive};
 use super::merge::parse_short_merge_directive;
+use super::rule_line::RuleLine;
 use super::rules::{
     parse_exclude_if_present, parse_keyword_rule, parse_short_include_rule, parse_shorthand_rules,
 };
@@ -21,13 +22,16 @@ use super::rules::{
 /// Parses a top-level `--filter` argument into a `FilterDirective`, trying the
 /// short and long merge forms before the general rule dispatcher. Leading
 /// whitespace is preserved to mirror upstream's non-word-split behaviour.
-pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective, Message> {
+pub(crate) fn parse_filter_directive(
+    argument: &OsStr,
+    source: RuleSource<'_>,
+) -> Result<FilterDirective, Message> {
     let text = argument.to_string_lossy();
     // upstream: exclude.c:1100-1213 parse_rule_tok - leading whitespace is only
     // skipped under FILTRULE_WORD_SPLIT, which a top-level `--filter` rule never
     // carries. A leading space therefore reaches the prefix `switch` default and
     // raises "Unknown filter rule" (RERR_SYNTAX). Do not trim the leading edge.
-    let rule: &str = &text;
+    let rule = RuleLine::new(&text, source);
 
     if let Some(result) = parse_short_merge_directive(rule) {
         return result;
@@ -53,6 +57,7 @@ pub(crate) fn parse_filter_directive(argument: &OsStr) -> Result<FilterDirective
 pub(crate) fn parse_old_prefix_rule(
     line: &str,
     default_kind: FilterRuleKind,
+    source: RuleSource<'_>,
 ) -> Result<FilterDirective, Message> {
     debug_assert!(
         matches!(
@@ -91,8 +96,14 @@ pub(crate) fn parse_old_prefix_rule(
     };
 
     if pattern.is_empty() {
-        let message =
-            rsync_error!(1, "filter rule is missing a pattern: '{}'", line).with_role(Role::Client);
+        // The rule text crosses `rule_text` (exclude.c:88-123): an
+        // `--exclude-from`/`--include-from` line is a file's contents.
+        let message = rsync_error!(
+            1,
+            "filter rule is missing a pattern: '{}'",
+            source.rule_text(line)
+        )
+        .with_role(Role::Client);
         return Err(message);
     }
 
@@ -107,7 +118,8 @@ pub(crate) fn parse_old_prefix_rule(
 /// Dispatches a trimmed rule line (no merge prefix) to the matching parser:
 /// `!`/`clear`, CVS convenience, shorthands, `exclude-if-present`, `+`/`-`
 /// short rules, then the long keyword rules.
-pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Message> {
+pub(super) fn parse_rule_directive(line: RuleLine<'_>) -> Result<FilterDirective, Message> {
+    let text = line.text();
     // upstream: exclude.c:1313 parse_rule_tok - the pattern length is strlen, so
     // trailing whitespace is part of the pattern and is never stripped. A rule
     // like `- *.o ` keeps the trailing space in its pattern, so `x.o` is not
@@ -132,7 +144,7 @@ pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Messag
     match classify_clear_token(trimmed.as_bytes()) {
         ClearToken::Clear => return Ok(FilterDirective::Clear),
         ClearToken::TrailingCharacters => {
-            let message = rsync_error!(1, "'!' rule has trailing characters: {}", trimmed)
+            let message = rsync_error!(1, "'!' rule has trailing characters: {}", line.shown())
                 .with_role(Role::Client);
             return Err(message);
         }
@@ -143,27 +155,27 @@ pub(super) fn parse_rule_directive(text: &str) -> Result<FilterDirective, Messag
         return Ok(FilterDirective::CvsDefaults);
     }
 
-    if let Some(result) = parse_shorthand_rules(trimmed) {
+    if let Some(result) = parse_shorthand_rules(line) {
         return result;
     }
 
-    if let Some(result) = parse_exclude_if_present(trimmed) {
+    if let Some(result) = parse_exclude_if_present(line) {
         return result;
     }
 
-    if let Some(result) = parse_short_include_rule(trimmed, '+', FilterRuleSpec::include) {
+    if let Some(result) = parse_short_include_rule(line, '+', FilterRuleSpec::include) {
         return result;
     }
 
-    if let Some(result) = parse_short_include_rule(trimmed, '-', FilterRuleSpec::exclude) {
+    if let Some(result) = parse_short_include_rule(line, '-', FilterRuleSpec::exclude) {
         return result;
     }
 
-    if let Some(result) = parse_dir_merge_alias(trimmed) {
+    if let Some(result) = parse_dir_merge_alias(line) {
         return result;
     }
 
-    parse_keyword_rule(trimmed)
+    parse_keyword_rule(line)
 }
 
 /// Detects the cvs-convenience filter rule (`-C` or `+C`, with an optional

--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -1,6 +1,8 @@
 use core::message::{Message, Role};
 use core::rsync_error;
 
+use super::rule_line::RuleLine;
+
 /// Consumes exactly one rule separator (a single space, `_`, or `,`) that
 /// terminates the rule character and its modifiers, returning the rest of the
 /// line verbatim.
@@ -34,17 +36,30 @@ pub(super) struct InvalidModifier {
 impl InvalidModifier {
     /// Renders upstream's diagnostic for this byte.
     ///
-    /// upstream: exclude.c:1371-1379 - `invalid modifier '%c' at position %d in
-    /// filter rule: %s`, where the position is
-    /// `(int)(s - (const uchar *)*rulestr_ptr)`, i.e. a 0-based byte offset from
-    /// the start of the whole rule. `rule_offset` is where the scanned slice
-    /// begins within `rule`, so a one-character prefix passes 1.
-    pub(super) fn into_message(self, rule_offset: usize, rule: &str) -> Message {
+    /// upstream: exclude.c:1371-1379 - `invalid modifier%s in filter rule: %s`,
+    /// where the position is `(int)(s - (const uchar *)*rulestr_ptr)`, i.e. a
+    /// 0-based byte offset from the start of the whole rule. `rule_offset` is
+    /// where the scanned slice begins within `rule`, so a one-character prefix
+    /// passes 1.
+    ///
+    /// BOTH halves cross a provenance chokepoint. The rule text goes through
+    /// `rule_text` (exclude.c:88-123) and the `'%c' at position %d` detail
+    /// through `rule_detail` (exclude.c:126-131), which upstream describes as
+    /// "the extra detail some messages add ABOUT the text - a character of it,
+    /// an offset into it. Dropped along with the text it describes." Reporting
+    /// the character while hiding the line would still leak it one byte at a
+    /// time.
+    pub(super) fn into_message(self, rule_offset: usize, line: RuleLine<'_>) -> Message {
         let position = rule_offset + self.offset;
         let ch = self.ch;
+        let detail = format!(" '{ch}' at position {position}");
         rsync_error!(
             1,
-            format!("invalid modifier '{ch}' at position {position} in filter rule: {rule}")
+            format!(
+                "invalid modifier{} in filter rule: {}",
+                line.detail(&detail),
+                line.shown()
+            )
         )
         .with_role(Role::Client)
     }
@@ -125,6 +140,12 @@ pub(super) fn split_keyword_modifiers(keyword: &str) -> (&str, &str) {
 
 #[cfg(test)]
 mod tests {
+
+    use filters::RuleSource;
+
+    fn arg(text: &str) -> super::RuleLine<'_> {
+        super::RuleLine::new(text, RuleSource::Argument)
+    }
     use super::*;
 
     #[test]
@@ -286,7 +307,7 @@ mod tests {
         // `invalid modifier '%c' at position %d in filter rule: %s`.
         let invalid =
             split_short_merge_modifiers("n.rsync-filter").expect_err("`.` is not a modifier");
-        let rendered = invalid.into_message(1, ":n.rsync-filter").to_string();
+        let rendered = invalid.into_message(1, arg(":n.rsync-filter")).to_string();
         assert!(
             rendered.contains("invalid modifier '.' at position 2 in filter rule: :n.rsync-filter"),
             "rendered message diverges from upstream: {rendered}"

--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -36,11 +36,12 @@ pub(super) struct InvalidModifier {
 impl InvalidModifier {
     /// Renders upstream's diagnostic for this byte.
     ///
-    /// upstream: exclude.c:1371-1379 - `invalid modifier%s in filter rule: %s`,
-    /// where the position is `(int)(s - (const uchar *)*rulestr_ptr)`, i.e. a
+    /// upstream: exclude.c:1376 - `invalid modifier%s in filter rule: %s`. The
+    /// position is built just above it as
+    /// `(int)(s - (const uchar *)*rulestr_ptr)` (exclude.c:1374-1375), i.e. a
     /// 0-based byte offset from the start of the whole rule. `rule_offset` is
     /// where the scanned slice begins within `rule`, so a one-character prefix
-    /// passes 1.
+    /// passes 1. The enclosing `default: invalid:` arm runs exclude.c:1371-1380.
     ///
     /// BOTH halves cross a provenance chokepoint. The rule text goes through
     /// `rule_text` (exclude.c:88-123) and the `'%c' at position %d` detail

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -6,6 +6,7 @@ use core::rsync_error;
 
 use super::super::directive::{FilterDirective, MergeDirective};
 use super::helpers::split_short_merge_modifiers;
+use super::rule_line::RuleLine;
 
 /// Parses the modifier characters that follow a `.`/`:` merge directive into
 /// `DirMergeOptions`. `is_dir_merge` selects the per-directory (`:`) defaults;
@@ -16,9 +17,9 @@ use super::helpers::split_short_merge_modifiers;
 /// upstream: exclude.c:1256-1264 - `e` (FILTRULE_EXCLUDE_SELF) and `n`
 /// (FILTRULE_NO_INHERIT) are guarded only by `FILTRULE_MERGE_FILE`, which is set
 /// for a plain merge (`.`) as well as a dir-merge (`:`), so both accept them.
-pub(crate) fn parse_merge_modifiers(
+pub(super) fn parse_merge_modifiers(
     modifiers: &str,
-    directive: &str,
+    line: RuleLine<'_>,
     is_dir_merge: bool,
 ) -> Result<(DirMergeOptions, bool), Message> {
     let mut options = if is_dir_merge {
@@ -42,7 +43,10 @@ pub(crate) fn parse_merge_modifiers(
                 if saw_include {
                     let message = rsync_error!(
                         1,
-                        format!("filter rule '{directive}' cannot combine '+' and '-' modifiers")
+                        format!(
+                            "filter rule '{}' cannot combine '+' and '-' modifiers",
+                            line.shown()
+                        )
                     )
                     .with_role(Role::Client);
                     return Err(message);
@@ -54,7 +58,10 @@ pub(crate) fn parse_merge_modifiers(
                 if saw_exclude {
                     let message = rsync_error!(
                         1,
-                        format!("filter rule '{directive}' cannot combine '+' and '-' modifiers")
+                        format!(
+                            "filter rule '{}' cannot combine '+' and '-' modifiers",
+                            line.shown()
+                        )
                     )
                     .with_role(Role::Client);
                     return Err(message);
@@ -67,7 +74,8 @@ pub(crate) fn parse_merge_modifiers(
                     let message = rsync_error!(
                         1,
                         format!(
-                            "filter merge directive '{directive}' cannot combine 'C' with '+' or '-'"
+                            "filter merge directive '{}' cannot combine 'C' with '+' or '-'",
+                            line.shown()
                         )
                     )
                     .with_role(Role::Client);
@@ -115,8 +123,9 @@ pub(crate) fn parse_merge_modifiers(
                 let message = rsync_error!(
                     1,
                     format!(
-                        "filter merge directive '{directive}' uses unsupported modifier '{}'",
-                        modifier
+                        "filter merge directive '{}' uses unsupported modifier{}",
+                        line.shown(),
+                        line.detail(&format!(" '{modifier}'"))
                     )
                 )
                 .with_role(Role::Client);
@@ -135,7 +144,10 @@ pub(crate) fn parse_merge_modifiers(
 /// Parses a short merge directive: `. FILE` (merge) or `: FILE` (dir-merge),
 /// including inline modifiers. Returns `None` when the text starts with neither
 /// `.` nor `:`.
-pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDirective, Message>> {
+pub(super) fn parse_short_merge_directive(
+    line: RuleLine<'_>,
+) -> Option<Result<FilterDirective, Message>> {
+    let text = line.text();
     let mut chars = text.chars();
     let first = chars.next()?;
     let (is_dir_merge, label) = match first {
@@ -149,9 +161,9 @@ pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDir
     // position in upstream's diagnostic is measured from.
     let (modifiers, rest) = match split_short_merge_modifiers(remainder) {
         Ok(split) => split,
-        Err(invalid) => return Some(Err(invalid.into_message(first.len_utf8(), text))),
+        Err(invalid) => return Some(Err(invalid.into_message(first.len_utf8(), line))),
     };
-    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, text, is_dir_merge) {
+    let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, line, is_dir_merge) {
         Ok(result) => result,
         Err(error) => return Some(Err(error)),
     };
@@ -163,14 +175,20 @@ pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDir
         } else if is_dir_merge {
             let message = rsync_error!(
                 1,
-                format!("filter rule '{text}' is missing a file name after '{label}'")
+                format!(
+                    "filter rule '{}' is missing a file name after '{label}'",
+                    line.shown()
+                )
             )
             .with_role(Role::Client);
             return Some(Err(message));
         } else {
             let message = rsync_error!(
                 1,
-                format!("filter merge directive '{text}' is missing a file path")
+                format!(
+                    "filter merge directive '{}' is missing a file path",
+                    line.shown()
+                )
             )
             .with_role(Role::Client);
             return Some(Err(message));
@@ -197,42 +215,48 @@ pub(super) fn parse_short_merge_directive(text: &str) -> Option<Result<FilterDir
 
 #[cfg(test)]
 mod tests {
+
+    use filters::RuleSource;
+
+    fn arg(text: &str) -> super::RuleLine<'_> {
+        super::RuleLine::new(text, RuleSource::Argument)
+    }
     use super::*;
 
     #[test]
     fn parse_merge_modifiers_empty() {
-        let (options, assume_cvsignore) = parse_merge_modifiers("", "test", true).unwrap();
+        let (options, assume_cvsignore) = parse_merge_modifiers("", arg("test"), true).unwrap();
         assert!(!assume_cvsignore);
         assert_eq!(options.enforced_kind(), None);
     }
 
     #[test]
     fn parse_merge_modifiers_exclude() {
-        let (options, _) = parse_merge_modifiers("-", ":- file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("-", arg(":- file"), true).unwrap();
         assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
     }
 
     #[test]
     fn parse_merge_modifiers_include() {
-        let (options, _) = parse_merge_modifiers("+", ":+ file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("+", arg(":+ file"), true).unwrap();
         assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Include));
     }
 
     #[test]
     fn parse_merge_modifiers_conflicting_plus_minus() {
-        let result = parse_merge_modifiers("+-", ":+- file", true);
+        let result = parse_merge_modifiers("+-", arg(":+- file"), true);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_merge_modifiers_conflicting_minus_plus() {
-        let result = parse_merge_modifiers("-+", ":-+ file", true);
+        let result = parse_merge_modifiers("-+", arg(":-+ file"), true);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_merge_modifiers_cvsignore() {
-        let (options, assume_cvsignore) = parse_merge_modifiers("C", ":C", true).unwrap();
+        let (options, assume_cvsignore) = parse_merge_modifiers("C", arg(":C"), true).unwrap();
         assert!(assume_cvsignore);
         assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
         assert!(options.uses_whitespace());
@@ -244,13 +268,13 @@ mod tests {
 
     #[test]
     fn parse_merge_modifiers_cvsignore_with_include_error() {
-        let result = parse_merge_modifiers("+C", ":+C file", true);
+        let result = parse_merge_modifiers("+C", arg(":+C file"), true);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_merge_modifiers_exclude_self_dir_merge() {
-        let (options, _) = parse_merge_modifiers("e", ":e file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("e", arg(":e file"), true).unwrap();
         assert!(options.excludes_self());
     }
 
@@ -258,20 +282,20 @@ mod tests {
     fn parse_merge_modifiers_exclude_self_plain_merge() {
         // upstream exclude.c:1256-1259 guards `e` only by FILTRULE_MERGE_FILE,
         // which a plain merge (`.`) sets too, so `.e FILE` is valid.
-        let (options, _) = parse_merge_modifiers("e", ".e file", false).unwrap();
+        let (options, _) = parse_merge_modifiers("e", arg(".e file"), false).unwrap();
         assert!(options.excludes_self());
     }
 
     #[test]
     fn parse_merge_modifiers_no_inherit_dir_merge() {
-        let (options, _) = parse_merge_modifiers("n", ":n file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("n", arg(":n file"), true).unwrap();
         assert!(!options.inherit_rules());
     }
 
     #[test]
     fn parse_merge_modifiers_no_inherit_plain_merge() {
         // upstream exclude.c:1260-1264 guards `n` the same way as `e`.
-        let (options, _) = parse_merge_modifiers("n", ".n file", false).unwrap();
+        let (options, _) = parse_merge_modifiers("n", arg(".n file"), false).unwrap();
         assert!(!options.inherit_rules());
     }
 
@@ -279,7 +303,7 @@ mod tests {
     fn parse_short_plain_merge_accepts_exclude_self_modifier() {
         // Regression: `.e FILE` previously mis-split, treating `e` as part of
         // the file name ("e FILE") instead of as a modifier.
-        let directive = parse_short_merge_directive(".e rules")
+        let directive = parse_short_merge_directive(arg(".e rules"))
             .expect("recognized")
             .expect("parses");
         match directive {
@@ -293,32 +317,32 @@ mod tests {
 
     #[test]
     fn parse_merge_modifiers_whitespace() {
-        let (options, _) = parse_merge_modifiers("w", ":w file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("w", arg(":w file"), true).unwrap();
         assert!(options.uses_whitespace());
         assert!(!options.allows_comments());
     }
 
     #[test]
     fn parse_merge_modifiers_sender() {
-        let (options, _) = parse_merge_modifiers("s", ":s file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("s", arg(":s file"), true).unwrap();
         assert_eq!(options.sender_side_override(), Some(true));
     }
 
     #[test]
     fn parse_merge_modifiers_receiver() {
-        let (options, _) = parse_merge_modifiers("r", ":r file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("r", arg(":r file"), true).unwrap();
         assert_eq!(options.receiver_side_override(), Some(true));
     }
 
     #[test]
     fn parse_merge_modifiers_perishable() {
-        let (options, _) = parse_merge_modifiers("p", ":p file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("p", arg(":p file"), true).unwrap();
         assert!(options.perishable());
     }
 
     #[test]
     fn parse_merge_modifiers_anchor_root() {
-        let (options, _) = parse_merge_modifiers("/", ":/ file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("/", arg(":/ file"), true).unwrap();
         assert!(options.anchor_root_enabled());
     }
 
@@ -326,13 +350,13 @@ mod tests {
     fn parse_merge_modifiers_unknown() {
         // `z` is outside upstream's modifier set `- + / ! C e n p r s w x`
         // (exclude.c:1381-1441); `x` is in it and must parse.
-        let result = parse_merge_modifiers("z", ":z file", true);
+        let result = parse_merge_modifiers("z", arg(":z file"), true);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_merge_modifiers_combined() {
-        let (options, _) = parse_merge_modifiers("-sp", ":- file", true).unwrap();
+        let (options, _) = parse_merge_modifiers("-sp", arg(":- file"), true).unwrap();
         assert_eq!(options.enforced_kind(), Some(DirMergeEnforcedKind::Exclude));
         assert_eq!(options.sender_side_override(), Some(true));
         assert!(options.perishable());
@@ -340,7 +364,7 @@ mod tests {
 
     #[test]
     fn parse_short_merge_directive_dot() {
-        let result = parse_short_merge_directive(". filter.txt");
+        let result = parse_short_merge_directive(arg(". filter.txt"));
         assert!(result.is_some());
         let directive = result.unwrap().unwrap();
         assert!(matches!(directive, FilterDirective::Merge(_)));
@@ -348,7 +372,7 @@ mod tests {
 
     #[test]
     fn parse_short_merge_directive_colon() {
-        let result = parse_short_merge_directive(": .rsync-filter");
+        let result = parse_short_merge_directive(arg(": .rsync-filter"));
         assert!(result.is_some());
         let directive = result.unwrap().unwrap();
         assert!(matches!(directive, FilterDirective::Rule(_)));
@@ -356,7 +380,7 @@ mod tests {
 
     #[test]
     fn parse_short_merge_directive_cvsignore() {
-        let result = parse_short_merge_directive(":C");
+        let result = parse_short_merge_directive(arg(":C"));
         assert!(result.is_some());
         let directive = result.unwrap().unwrap();
         // CVS ignore implies .cvsignore pattern
@@ -365,13 +389,13 @@ mod tests {
 
     #[test]
     fn parse_short_merge_directive_not_merge() {
-        let result = parse_short_merge_directive("+ include");
+        let result = parse_short_merge_directive(arg("+ include"));
         assert!(result.is_none());
     }
 
     #[test]
     fn parse_short_merge_directive_exclude_modifier() {
-        let result = parse_short_merge_directive(":- filter");
+        let result = parse_short_merge_directive(arg(":- filter"));
         assert!(result.is_some());
         if let Some(Ok(FilterDirective::Rule(spec))) = result {
             // The rule should have exclude enforced
@@ -381,27 +405,27 @@ mod tests {
 
     #[test]
     fn parse_short_merge_directive_include_modifier() {
-        let result = parse_short_merge_directive(":+ filter");
+        let result = parse_short_merge_directive(arg(":+ filter"));
         assert!(result.is_some());
     }
 
     #[test]
     fn parse_short_merge_directive_missing_file_error() {
-        let result = parse_short_merge_directive(":  ");
+        let result = parse_short_merge_directive(arg(":  "));
         assert!(result.is_some());
         assert!(result.unwrap().is_err());
     }
 
     #[test]
     fn parse_short_merge_directive_dot_missing_file_error() {
-        let result = parse_short_merge_directive(".  ");
+        let result = parse_short_merge_directive(arg(".  "));
         assert!(result.is_some());
         assert!(result.unwrap().is_err());
     }
 
     #[test]
     fn parse_short_merge_directive_with_modifiers() {
-        let result = parse_short_merge_directive(":en .filter");
+        let result = parse_short_merge_directive(arg(":en .filter"));
         assert!(result.is_some());
         let directive = result.unwrap().unwrap();
         assert!(matches!(directive, FilterDirective::Rule(_)));

--- a/crates/cli/src/frontend/filter_rules/parsing/mod.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/mod.rs
@@ -11,6 +11,7 @@ mod entry;
 mod helpers;
 mod merge;
 mod modifiers;
+mod rule_line;
 mod rules;
 mod shorthand;
 
@@ -19,9 +20,22 @@ mod tests;
 
 pub(crate) use entry::{parse_filter_directive, parse_old_prefix_rule};
 
-// Only re-exported for the parent module's `#[cfg(test)]` re-export.
+/// Argument-sourced entry point for `parse_merge_modifiers`, used by the
+/// frontend's test shim. Production callers inside this module pass the
+/// `RuleLine` they are already parsing, so the provenance travels with the
+/// text; only a directive the operator typed can be re-paired here.
 #[cfg(test)]
-pub(crate) use merge::parse_merge_modifiers;
+pub(crate) fn parse_merge_modifiers_from_argument(
+    modifiers: &str,
+    directive: &str,
+    is_dir_merge: bool,
+) -> Result<(core::client::DirMergeOptions, bool), core::message::Message> {
+    merge::parse_merge_modifiers(
+        modifiers,
+        rule_line::RuleLine::new(directive, filters::RuleSource::Argument),
+        is_dir_merge,
+    )
+}
 
 // Brought into the hub so the `tests` submodule's `use super::*` resolves the
 // same names that were in scope when the tests lived alongside the parsers.

--- a/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/modifiers.rs
@@ -2,6 +2,8 @@ use core::client::FilterRuleSpec;
 use core::message::{Message, Role};
 use core::rsync_error;
 
+use super::rule_line::RuleLine;
+
 /// Accumulated rule modifiers parsed from a rule prefix or keyword.
 #[derive(Default)]
 pub(super) struct RuleModifierState {
@@ -13,10 +15,17 @@ pub(super) struct RuleModifierState {
     negate: bool,
 }
 
-fn unsupported_modifier(directive: &str, modifier: char) -> Message {
+fn unsupported_modifier(line: RuleLine<'_>, modifier: char) -> Message {
+    // The rule text crosses `rule_text` (exclude.c:88-123) and the offending
+    // character crosses `rule_detail` (exclude.c:126-131): a character of a
+    // hidden line is still a byte of that line.
     rsync_error!(
         1,
-        format!("filter rule '{directive}' uses unsupported modifier '{modifier}'")
+        format!(
+            "filter rule '{}' uses unsupported modifier{}",
+            line.shown(),
+            line.detail(&format!(" '{modifier}'"))
+        )
     )
     .with_role(Role::Client)
 }
@@ -36,7 +45,7 @@ fn unsupported_modifier(directive: &str, modifier: char) -> Message {
 /// valid everywhere (exclude.c:1265-1267).
 pub(super) fn parse_rule_modifiers(
     modifiers: &str,
-    directive: &str,
+    line: RuleLine<'_>,
     allow_perishable: bool,
     allow_xattr: bool,
     prefix_specifies_side: bool,
@@ -52,7 +61,7 @@ pub(super) fn parse_rule_modifiers(
                 // upstream: exclude.c:1275-1276 - `s` is invalid once the prefix
                 // has already fixed the rule's side.
                 if prefix_specifies_side {
-                    return Err(unsupported_modifier(directive, modifier));
+                    return Err(unsupported_modifier(line, modifier));
                 }
                 state.sender = Some(true);
                 if state.receiver.is_none() {
@@ -63,7 +72,7 @@ pub(super) fn parse_rule_modifiers(
                 // upstream: exclude.c:1270-1271 - `r` is invalid once the prefix
                 // has already fixed the rule's side.
                 if prefix_specifies_side {
-                    return Err(unsupported_modifier(directive, modifier));
+                    return Err(unsupported_modifier(line, modifier));
                 }
                 state.receiver = Some(true);
                 if state.sender.is_none() {
@@ -79,18 +88,18 @@ pub(super) fn parse_rule_modifiers(
                 if allow_perishable {
                     state.perishable = true;
                 } else {
-                    return Err(unsupported_modifier(directive, modifier));
+                    return Err(unsupported_modifier(line, modifier));
                 }
             }
             'x' => {
                 if allow_xattr {
                     state.xattr_only = true;
                 } else {
-                    return Err(unsupported_modifier(directive, modifier));
+                    return Err(unsupported_modifier(line, modifier));
                 }
             }
             _ => {
-                return Err(unsupported_modifier(directive, modifier));
+                return Err(unsupported_modifier(line, modifier));
             }
         }
     }
@@ -139,6 +148,12 @@ pub(super) fn apply_rule_modifiers(
 
 #[cfg(test)]
 mod tests {
+
+    use filters::RuleSource;
+
+    fn arg(text: &str) -> super::RuleLine<'_> {
+        super::RuleLine::new(text, RuleSource::Argument)
+    }
     use super::*;
 
     #[test]
@@ -153,7 +168,7 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_empty_string() {
-        let result = parse_rule_modifiers("", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("", arg("+"), true, true, false).expect("parse");
         assert!(!result.anchor_root);
         assert!(result.sender.is_none());
         assert!(result.receiver.is_none());
@@ -161,64 +176,64 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_anchor_root() {
-        let result = parse_rule_modifiers("/", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("/", arg("+"), true, true, false).expect("parse");
         assert!(result.anchor_root);
     }
 
     #[test]
     fn parse_rule_modifiers_sender_only() {
-        let result = parse_rule_modifiers("s", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("s", arg("+"), true, true, false).expect("parse");
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(false));
     }
 
     #[test]
     fn parse_rule_modifiers_receiver_only() {
-        let result = parse_rule_modifiers("r", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("r", arg("+"), true, true, false).expect("parse");
         assert_eq!(result.receiver, Some(true));
         assert_eq!(result.sender, Some(false));
     }
 
     #[test]
     fn parse_rule_modifiers_sender_and_receiver() {
-        let result = parse_rule_modifiers("sr", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("sr", arg("+"), true, true, false).expect("parse");
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(true));
     }
 
     #[test]
     fn parse_rule_modifiers_perishable_when_allowed() {
-        let result = parse_rule_modifiers("p", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("p", arg("+"), true, true, false).expect("parse");
         assert!(result.perishable);
     }
 
     #[test]
     fn parse_rule_modifiers_perishable_when_disallowed() {
-        let result = parse_rule_modifiers("p", "+", false, true, false);
+        let result = parse_rule_modifiers("p", arg("+"), false, true, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_xattr_when_allowed() {
-        let result = parse_rule_modifiers("x", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("x", arg("+"), true, true, false).expect("parse");
         assert!(result.xattr_only);
     }
 
     #[test]
     fn parse_rule_modifiers_xattr_when_disallowed() {
-        let result = parse_rule_modifiers("x", "+", true, false, false);
+        let result = parse_rule_modifiers("x", arg("+"), true, false, false);
         assert!(result.is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_negate() {
-        let result = parse_rule_modifiers("!", "-", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("!", arg("-"), true, true, false).expect("parse");
         assert!(result.negate);
     }
 
     #[test]
     fn parse_rule_modifiers_negate_with_others() {
-        let result = parse_rule_modifiers("!s", "-", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("!s", arg("-"), true, true, false).expect("parse");
         assert!(result.negate);
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(false));
@@ -226,7 +241,7 @@ mod tests {
 
     #[test]
     fn parse_rule_modifiers_unknown_modifier() {
-        let result = parse_rule_modifiers("z", "+", true, true, false);
+        let result = parse_rule_modifiers("z", arg("+"), true, true, false);
         assert!(result.is_err());
     }
 
@@ -235,30 +250,30 @@ mod tests {
         // upstream: exclude.c:1214-1287 - modifiers are matched by literal byte,
         // so the uppercase `S`/`R` reach the `default:` arm and are rejected as
         // invalid modifiers (RERR_SYNTAX). Their lowercase forms remain valid.
-        assert!(parse_rule_modifiers("S", "+", true, true, false).is_err());
-        assert!(parse_rule_modifiers("R", "+", true, true, false).is_err());
-        assert!(parse_rule_modifiers("X", "+", true, true, false).is_err());
+        assert!(parse_rule_modifiers("S", arg("+"), true, true, false).is_err());
+        assert!(parse_rule_modifiers("R", arg("+"), true, true, false).is_err());
+        assert!(parse_rule_modifiers("X", arg("+"), true, true, false).is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_side_prefix_rejects_s_and_r() {
         // upstream: exclude.c:1269-1277 - when the prefix already fixes the side
         // (hide/show/protect/risk), the `s`/`r` modifiers are invalid.
-        assert!(parse_rule_modifiers("s", "protect", false, false, true).is_err());
-        assert!(parse_rule_modifiers("r", "show", false, false, true).is_err());
+        assert!(parse_rule_modifiers("s", arg("protect"), false, false, true).is_err());
+        assert!(parse_rule_modifiers("r", arg("show"), false, false, true).is_err());
     }
 
     #[test]
     fn parse_rule_modifiers_side_prefix_allows_perishable() {
         // upstream: exclude.c:1265-1267 - `p` (perishable) is valid on every
         // rule kind, including the side-bound hide/show/protect/risk rules.
-        let result = parse_rule_modifiers("p", "protect", true, false, true).expect("parse");
+        let result = parse_rule_modifiers("p", arg("protect"), true, false, true).expect("parse");
         assert!(result.perishable);
     }
 
     #[test]
     fn parse_rule_modifiers_complex_combination() {
-        let result = parse_rule_modifiers("/srp", "+", true, true, false).expect("parse");
+        let result = parse_rule_modifiers("/srp", arg("+"), true, true, false).expect("parse");
         assert!(result.anchor_root);
         assert_eq!(result.sender, Some(true));
         assert_eq!(result.receiver, Some(true));

--- a/crates/cli/src/frontend/filter_rules/parsing/rule_line.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rule_line.rs
@@ -1,0 +1,62 @@
+//! The rule line under parse, paired with where its text came from.
+//!
+//! upstream keeps these two together implicitly: `*rulestr_ptr` is the line and
+//! the file-scope `rule_src_*` statics record whether the parser is currently
+//! reading a file's contents (`exclude.c:56-68`). Every diagnostic built from
+//! the line then crosses one of two chokepoints - `rule_text` for the text
+//! itself and `rule_detail` for the extra detail *about* the text
+//! (`exclude.c:88-131`).
+//!
+//! oc has no ambient parser state, so the pair is passed explicitly. Bundling
+//! them in one value is what preserves upstream's stated property: "Doing it
+//! here rather than at each site is the point: a message added later cannot
+//! reintroduce the leak by forgetting to check, and there is one place to
+//! audit." (`exclude.c:96-99`).
+
+use std::borrow::Cow;
+
+use filters::RuleSource;
+
+/// A filter-rule line together with the provenance of its text.
+///
+/// `text()` is the line as the parser must see it - byte-exact, never redacted,
+/// because parsing decisions depend on it. `shown()` is the line as a
+/// diagnostic may render it, which for a rule read out of a file's contents is
+/// a description of where it came from rather than the line itself.
+#[derive(Clone, Copy)]
+pub(super) struct RuleLine<'a> {
+    text: &'a str,
+    source: RuleSource<'a>,
+}
+
+impl<'a> RuleLine<'a> {
+    /// Pairs a rule line with the provenance of its text.
+    pub(super) fn new(text: &'a str, source: RuleSource<'a>) -> Self {
+        Self { text, source }
+    }
+
+    /// The line verbatim, for parsing. Never render this into a message.
+    pub(super) fn text(&self) -> &'a str {
+        self.text
+    }
+
+    /// The line as a diagnostic may render it.
+    ///
+    /// upstream: `rule_text` (exclude.c:103-124). An argument-sourced rule is
+    /// returned unchanged, "because it is the user's own and hiding it only
+    /// makes typos harder to fix"; a rule out of a file's contents is replaced,
+    /// "because the peer chooses which file gets merged and any line of it that
+    /// reaches a message is a line the peer can read back".
+    pub(super) fn shown(&self) -> Cow<'a, str> {
+        self.source.rule_text(self.text)
+    }
+
+    /// Extra detail *about* the text - a character of it, an offset into it.
+    ///
+    /// upstream: `rule_detail` (exclude.c:126-131) - "Dropped along with the
+    /// text it describes." Reporting a character of a hidden line would leak it
+    /// one byte at a time.
+    pub(super) fn detail<'d>(&self, detail: &'d str) -> &'d str {
+        self.source.rule_detail(detail)
+    }
+}

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -12,24 +12,27 @@ use core::rsync_error;
 use super::super::directive::FilterDirective;
 use super::helpers::{split_keyword_modifiers, split_short_rule_modifiers};
 use super::modifiers::{apply_rule_modifiers, parse_rule_modifiers};
+use super::rule_line::RuleLine;
 use super::shorthand::parse_filter_shorthand;
 
 /// Parses the `P`/`H`/`S`/`R` single-letter shorthand rules (protect, hide,
 /// show, risk). Returns `None` when the text is not one of these forms.
-pub(super) fn parse_shorthand_rules(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
-    if let Some(result) = parse_filter_shorthand(trimmed, 'P', "P", FilterRuleSpec::protect) {
+pub(super) fn parse_shorthand_rules(
+    line: RuleLine<'_>,
+) -> Option<Result<FilterDirective, Message>> {
+    if let Some(result) = parse_filter_shorthand(line, 'P', "P", FilterRuleSpec::protect) {
         return Some(result);
     }
 
-    if let Some(result) = parse_filter_shorthand(trimmed, 'H', "H", FilterRuleSpec::hide) {
+    if let Some(result) = parse_filter_shorthand(line, 'H', "H", FilterRuleSpec::hide) {
         return Some(result);
     }
 
-    if let Some(result) = parse_filter_shorthand(trimmed, 'S', "S", FilterRuleSpec::show) {
+    if let Some(result) = parse_filter_shorthand(line, 'S', "S", FilterRuleSpec::show) {
         return Some(result);
     }
 
-    if let Some(result) = parse_filter_shorthand(trimmed, 'R', "R", FilterRuleSpec::risk) {
+    if let Some(result) = parse_filter_shorthand(line, 'R', "R", FilterRuleSpec::risk) {
         return Some(result);
     }
 
@@ -39,7 +42,10 @@ pub(super) fn parse_shorthand_rules(trimmed: &str) -> Option<Result<FilterDirect
 /// Parses an `exclude-if-present=MARKER` directive. Returns `None` when the
 /// text does not start with the `exclude-if-present` keyword, or an error when
 /// the marker file name is missing.
-pub(super) fn parse_exclude_if_present(trimmed: &str) -> Option<Result<FilterDirective, Message>> {
+pub(super) fn parse_exclude_if_present(
+    line: RuleLine<'_>,
+) -> Option<Result<FilterDirective, Message>> {
+    let trimmed = line.text();
     const EXCLUDE_IF_PRESENT_PREFIX: &str = "exclude-if-present";
     if trimmed.len() < EXCLUDE_IF_PRESENT_PREFIX.len() {
         return None;
@@ -60,7 +66,10 @@ pub(super) fn parse_exclude_if_present(trimmed: &str) -> Option<Result<FilterDir
     if pattern_text.is_empty() {
         let message = rsync_error!(
             1,
-            format!("filter rule '{trimmed}' is missing a marker file after 'exclude-if-present'")
+            format!(
+                "filter rule '{}' is missing a marker file after 'exclude-if-present'",
+                line.shown()
+            )
         )
         .with_role(Role::Client);
         return Some(Err(message));
@@ -75,20 +84,21 @@ pub(super) fn parse_exclude_if_present(trimmed: &str) -> Option<Result<FilterDir
 /// applying any rule modifiers to the pattern via `builder`. Returns `None`
 /// when the text does not begin with `prefix`.
 pub(super) fn parse_short_include_rule(
-    trimmed: &str,
+    line: RuleLine<'_>,
     prefix: char,
     builder: fn(String) -> FilterRuleSpec,
 ) -> Option<Result<FilterDirective, Message>> {
+    let trimmed = line.text();
     let remainder = trimmed.strip_prefix(prefix)?;
     // `remainder` starts one byte past the `+`/`-`, so that is the offset the
     // position in upstream's diagnostic is measured from.
     let (modifier_text, remainder) = match split_short_rule_modifiers(remainder) {
         Ok(split) => split,
-        Err(invalid) => return Some(Err(invalid.into_message(prefix.len_utf8(), trimmed))),
+        Err(invalid) => return Some(Err(invalid.into_message(prefix.len_utf8(), line))),
     };
     // `+`/`-` rules never bind a side via their prefix, so the `s`/`r` modifiers
     // stay valid (prefix_specifies_side = false). upstream: exclude.c:1186-1190.
-    let modifiers = match parse_rule_modifiers(modifier_text, trimmed, true, true, false) {
+    let modifiers = match parse_rule_modifiers(modifier_text, line, true, true, false) {
         Ok(state) => state,
         Err(error) => return Some(Err(error)),
     };
@@ -97,9 +107,7 @@ pub(super) fn parse_short_include_rule(
     // is the pattern verbatim. Do not trim further leading whitespace/`_`.
     let pattern = remainder;
     if pattern.is_empty() {
-        let text = format!("filter rule '{trimmed}' is missing a pattern after '{prefix}'");
-        let message = rsync_error!(1, text).with_role(Role::Client);
-        return Some(Err(message));
+        return Some(Err(missing_pattern_after(line, &prefix.to_string())));
     }
 
     let rule = builder(pattern.to_owned());
@@ -113,7 +121,8 @@ pub(super) fn parse_short_include_rule(
 /// Parses a long-form keyword rule (`include`/`exclude`/`show`/`hide`/
 /// `protect`/`risk` plus pattern). Keywords are matched case-sensitively to
 /// mirror upstream; an unknown keyword yields a syntax error.
-pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Message> {
+pub(super) fn parse_keyword_rule(line: RuleLine<'_>) -> Result<FilterDirective, Message> {
+    let trimmed = line.text();
     let mut parts = trimmed.splitn(2, |ch: char| ch.is_ascii_whitespace());
     let keyword = parts.next().expect("split always yields at least one part");
     let remainder = parts.next().unwrap_or("");
@@ -129,14 +138,12 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
                       prefix_specifies_side: bool|
      -> Result<FilterDirective, Message> {
         if pattern.is_empty() {
-            let text = format!("filter rule '{trimmed}' is missing a pattern after '{keyword}'");
-            let message = rsync_error!(1, text).with_role(Role::Client);
-            return Err(message);
+            return Err(missing_pattern_after(line, keyword));
         }
 
         let modifiers = parse_rule_modifiers(
             keyword_modifiers,
-            trimmed,
+            line,
             allow_perishable,
             allow_xattr,
             prefix_specifies_side,
@@ -181,11 +188,29 @@ pub(super) fn parse_keyword_rule(trimmed: &str) -> Result<FilterDirective, Messa
         return build_rule(FilterRuleSpec::risk, true, true, true);
     }
 
+    // upstream: exclude.c:1363 `filter_rule_err("Unknown filter rule", *rulestr_ptr)`
+    // renders the rule through `rule_text` (exclude.c:88-123). This diagnostic is
+    // oc's expanded wording for the same refusal, and it echoes the same text, so
+    // it must cross the same chokepoint: the line may be one the peer chose to
+    // have merged, and echoing it makes the parser a read-any-line oracle.
     let message = rsync_error!(
         1,
         "unsupported filter rule '{}': this build currently supports only '+' (include), '-' (exclude), '!' (clear), 'include PATTERN', 'exclude PATTERN', 'show PATTERN', 'hide PATTERN', 'protect PATTERN', 'risk PATTERN', 'merge[,MODS] FILE' or '.[,MODS] FILE', and 'dir-merge[,MODS] FILE' or ':[,MODS] FILE' directives",
-        trimmed
+        line.shown()
     )
     .with_role(Role::Client);
     Err(message)
+}
+
+/// The rule text crosses `rule_text` (exclude.c:88-123); the prefix or keyword
+/// is oc's own token, not the peer's, so it is printed unconditionally.
+fn missing_pattern_after(line: RuleLine<'_>, after: &str) -> Message {
+    rsync_error!(
+        1,
+        format!(
+            "filter rule '{}' is missing a pattern after '{after}'",
+            line.shown()
+        )
+    )
+    .with_role(Role::Client)
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/shorthand.rs
@@ -5,17 +5,19 @@ use core::rsync_error;
 use super::super::directive::FilterDirective;
 use super::helpers::split_short_rule_modifiers;
 use super::modifiers::{apply_rule_modifiers, parse_rule_modifiers};
+use super::rule_line::RuleLine;
 
 /// Parses a single-character rule prefix (`short`) followed by a separator and
 /// a pattern, building the rule via `builder`. Returns `None` when `short` does
 /// not match case-sensitively or no separator follows; an error when the
 /// pattern is missing.
 pub(super) fn parse_filter_shorthand(
-    trimmed: &str,
+    line: RuleLine<'_>,
     short: char,
     label: &str,
     builder: fn(String) -> FilterRuleSpec,
 ) -> Option<Result<FilterDirective, Message>> {
+    let trimmed = line.text();
     let mut chars = trimmed.chars();
     let first = chars.next()?;
     // upstream: exclude.c:1137-1178 - the single-char rule prefixes H/S/P/R are
@@ -29,9 +31,7 @@ pub(super) fn parse_filter_shorthand(
 
     let remainder = chars.as_str();
     if remainder.is_empty() {
-        let text = format!("filter rule '{trimmed}' is missing a pattern after '{label}'");
-        let message = rsync_error!(1, text).with_role(Role::Client);
-        return Some(Err(message));
+        return Some(Err(missing_pattern(line, label)));
     }
 
     // upstream: exclude.c:1330-1445 - the modifier loop runs for EVERY rule
@@ -42,21 +42,19 @@ pub(super) fn parse_filter_shorthand(
     // through to the unrelated "unsupported filter rule" diagnostic.
     let (modifier_text, pattern) = match split_short_rule_modifiers(remainder) {
         Ok(split) => split,
-        Err(invalid) => return Some(Err(invalid.into_message(short.len_utf8(), trimmed))),
+        Err(invalid) => return Some(Err(invalid.into_message(short.len_utf8(), line))),
     };
 
     // `prefix_specifies_side = true`: H/S/P/R already bind a side, so upstream
     // rejects a redundant `s`/`r` modifier on them (exclude.c:1423-1432) while
     // leaving `p` and `x` unguarded (exclude.c:1421, :1438).
-    let modifiers = match parse_rule_modifiers(modifier_text, trimmed, true, true, true) {
+    let modifiers = match parse_rule_modifiers(modifier_text, line, true, true, true) {
         Ok(state) => state,
         Err(error) => return Some(Err(error)),
     };
 
     if pattern.is_empty() {
-        let text = format!("filter rule '{trimmed}' is missing a pattern after '{label}'");
-        let message = rsync_error!(1, text).with_role(Role::Client);
-        return Some(Err(message));
+        return Some(Err(missing_pattern(line, label)));
     }
 
     let rule = builder(pattern.to_owned());
@@ -66,9 +64,27 @@ pub(super) fn parse_filter_shorthand(
     }
 }
 
+/// The rule text crosses `rule_text` (exclude.c:88-123); the rule PREFIX is
+/// ours, not the peer's, so it is printed unconditionally.
+fn missing_pattern(line: RuleLine<'_>, label: &str) -> Message {
+    rsync_error!(
+        1,
+        format!(
+            "filter rule '{}' is missing a pattern after '{label}'",
+            line.shown()
+        )
+    )
+    .with_role(Role::Client)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use filters::RuleSource;
+
+    fn arg(text: &str) -> RuleLine<'_> {
+        RuleLine::new(text, RuleSource::Argument)
+    }
 
     fn mock_builder(pattern: String) -> FilterRuleSpec {
         FilterRuleSpec::exclude(pattern)
@@ -76,7 +92,7 @@ mod tests {
 
     #[test]
     fn returns_none_for_non_matching_first_char() {
-        let result = parse_filter_shorthand("x pattern", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("x pattern"), 'e', "exclude", mock_builder);
         assert!(result.is_none());
     }
 
@@ -87,7 +103,7 @@ mod tests {
         // modifiers (helpers.rs scan_modifiers, upstream exclude.c:1214-1287),
         // so the first non-modifier byte is reported - it is NOT an unknown
         // rule, and it must not fall through to the keyword parser.
-        let result = parse_filter_shorthand("epattern", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("epattern"), 'e', "exclude", mock_builder);
         assert!(
             result
                 .expect("prefix matched, so the parser must not decline")
@@ -97,28 +113,28 @@ mod tests {
 
     #[test]
     fn parses_with_space_separator() {
-        let result = parse_filter_shorthand("e pattern", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("e pattern"), 'e', "exclude", mock_builder);
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
     }
 
     #[test]
     fn parses_with_underscore_separator() {
-        let result = parse_filter_shorthand("e_pattern", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("e_pattern"), 'e', "exclude", mock_builder);
         assert!(result.is_some());
         assert!(result.unwrap().is_ok());
     }
 
     #[test]
     fn returns_error_for_missing_pattern() {
-        let result = parse_filter_shorthand("e ", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("e "), 'e', "exclude", mock_builder);
         assert!(result.is_some());
         assert!(result.unwrap().is_err());
     }
 
     #[test]
     fn returns_error_for_empty_remainder() {
-        let result = parse_filter_shorthand("e", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("e"), 'e', "exclude", mock_builder);
         assert!(result.is_some());
         assert!(result.unwrap().is_err());
     }
@@ -129,7 +145,7 @@ mod tests {
         // case-sensitive, so an uppercase char never matches a lowercase prefix
         // (and vice versa). This parser must return None so the caller can reject
         // the line as an unknown rule.
-        let result = parse_filter_shorthand("E pattern", 'e', "exclude", mock_builder);
+        let result = parse_filter_shorthand(arg("E pattern"), 'e', "exclude", mock_builder);
         assert!(result.is_none());
     }
 }

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -1,10 +1,17 @@
 //! Unit tests for the filter-rule parsing submodules.
 
 use super::*;
+use filters::RuleSource;
+
+/// These are all ARGUMENT-sourced rules: the operator typed them, so
+/// `rule_text` returns the text unchanged (exclude.c:110-116).
+fn arg(text: &str) -> rule_line::RuleLine<'_> {
+    rule_line::RuleLine::new(text, RuleSource::Argument)
+}
 
 #[test]
 fn parse_include_short() {
-    let result = parse_filter_directive(OsStr::new("+ *.txt"));
+    let result = parse_filter_directive(OsStr::new("+ *.txt"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -16,7 +23,7 @@ fn parse_include_short() {
 
 #[test]
 fn parse_exclude_short() {
-    let result = parse_filter_directive(OsStr::new("- *.log"));
+    let result = parse_filter_directive(OsStr::new("- *.log"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -28,14 +35,14 @@ fn parse_exclude_short() {
 
 #[test]
 fn parse_clear_exclamation() {
-    let result = parse_filter_directive(OsStr::new("!"));
+    let result = parse_filter_directive(OsStr::new("!"), RuleSource::Argument);
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), FilterDirective::Clear));
 }
 
 #[test]
 fn parse_clear_keyword() {
-    let result = parse_filter_directive(OsStr::new("clear"));
+    let result = parse_filter_directive(OsStr::new("clear"), RuleSource::Argument);
     assert!(result.is_ok());
     assert!(matches!(result.unwrap(), FilterDirective::Clear));
 }
@@ -46,19 +53,19 @@ fn parse_clear_keyword_uppercase_is_error() {
     // strncmp reached only via `case 'c'`. `CLEAR` misses it, reaches the inner
     // switch default, and raises "Unknown filter rule" (RERR_SYNTAX). A drop-in
     // must reject it, not silently coerce the case into a clear directive.
-    let result = parse_filter_directive(OsStr::new("CLEAR"));
+    let result = parse_filter_directive(OsStr::new("CLEAR"), RuleSource::Argument);
     assert!(result.is_err());
 }
 
 #[test]
 fn parse_clear_keyword_mixed_case_is_error() {
-    let result = parse_filter_directive(OsStr::new("Clear"));
+    let result = parse_filter_directive(OsStr::new("Clear"), RuleSource::Argument);
     assert!(result.is_err());
 }
 
 #[test]
 fn parse_include_keyword() {
-    let result = parse_filter_directive(OsStr::new("include *.rs"));
+    let result = parse_filter_directive(OsStr::new("include *.rs"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -70,7 +77,7 @@ fn parse_include_keyword() {
 
 #[test]
 fn parse_exclude_keyword() {
-    let result = parse_filter_directive(OsStr::new("exclude *.bak"));
+    let result = parse_filter_directive(OsStr::new("exclude *.bak"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -84,19 +91,19 @@ fn parse_exclude_keyword() {
 fn parse_empty_is_noop() {
     // upstream: exclude.c:1107 parse_rule_tok returns NULL for an empty rule
     // string, so a blank `--filter` value adds nothing and exits 0.
-    let result = parse_filter_directive(OsStr::new(""));
+    let result = parse_filter_directive(OsStr::new(""), RuleSource::Argument);
     assert!(matches!(result, Ok(FilterDirective::Noop)));
 }
 
 #[test]
 fn parse_whitespace_only_returns_error() {
-    let result = parse_filter_directive(OsStr::new("   "));
+    let result = parse_filter_directive(OsStr::new("   "), RuleSource::Argument);
     assert!(result.is_err());
 }
 
 #[test]
 fn rule_directive_protect() {
-    let result = parse_rule_directive("P *.keep");
+    let result = parse_rule_directive(arg("P *.keep"));
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -108,7 +115,7 @@ fn rule_directive_protect() {
 
 #[test]
 fn rule_directive_hide() {
-    let result = parse_rule_directive("H .hidden");
+    let result = parse_rule_directive(arg("H .hidden"));
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -121,7 +128,7 @@ fn rule_directive_hide() {
 
 #[test]
 fn rule_directive_show() {
-    let result = parse_rule_directive("S visible");
+    let result = parse_rule_directive(arg("S visible"));
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -134,7 +141,7 @@ fn rule_directive_show() {
 
 #[test]
 fn rule_directive_risk() {
-    let result = parse_rule_directive("R deletable");
+    let result = parse_rule_directive(arg("R deletable"));
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -146,19 +153,19 @@ fn rule_directive_risk() {
 
 #[test]
 fn rule_directive_clear_with_trailing() {
-    let result = parse_rule_directive("! trailing");
+    let result = parse_rule_directive(arg("! trailing"));
     assert!(result.is_err());
 }
 
 #[test]
 fn rule_directive_unsupported_keyword() {
-    let result = parse_rule_directive("foobar *.txt");
+    let result = parse_rule_directive(arg("foobar *.txt"));
     assert!(result.is_err());
 }
 
 #[test]
 fn exclude_if_present_basic() {
-    let result = parse_exclude_if_present("exclude-if-present .nobackup");
+    let result = parse_exclude_if_present(arg("exclude-if-present .nobackup"));
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -171,41 +178,41 @@ fn exclude_if_present_basic() {
 
 #[test]
 fn exclude_if_present_with_equals() {
-    let result = parse_exclude_if_present("exclude-if-present = marker.txt");
+    let result = parse_exclude_if_present(arg("exclude-if-present = marker.txt"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn exclude_if_present_case_insensitive() {
-    let result = parse_exclude_if_present("EXCLUDE-IF-PRESENT .skip");
+    let result = parse_exclude_if_present(arg("EXCLUDE-IF-PRESENT .skip"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn exclude_if_present_missing_pattern() {
-    let result = parse_exclude_if_present("exclude-if-present");
+    let result = parse_exclude_if_present(arg("exclude-if-present"));
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn exclude_if_present_empty_pattern() {
-    let result = parse_exclude_if_present("exclude-if-present   ");
+    let result = parse_exclude_if_present(arg("exclude-if-present   "));
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn exclude_if_present_non_matching() {
-    let result = parse_exclude_if_present("other-directive");
+    let result = parse_exclude_if_present(arg("other-directive"));
     assert!(result.is_none());
 }
 
 #[test]
 fn short_include_basic() {
-    let result = parse_short_include_rule("+ *.rs", '+', FilterRuleSpec::include);
+    let result = parse_short_include_rule(arg("+ *.rs"), '+', FilterRuleSpec::include);
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -218,7 +225,7 @@ fn short_include_basic() {
 
 #[test]
 fn short_exclude_basic() {
-    let result = parse_short_include_rule("- *.tmp", '-', FilterRuleSpec::exclude);
+    let result = parse_short_include_rule(arg("- *.tmp"), '-', FilterRuleSpec::exclude);
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -231,27 +238,27 @@ fn short_exclude_basic() {
 
 #[test]
 fn short_include_missing_pattern() {
-    let result = parse_short_include_rule("+ ", '+', FilterRuleSpec::include);
+    let result = parse_short_include_rule(arg("+ "), '+', FilterRuleSpec::include);
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn short_include_empty_after_prefix() {
-    let result = parse_short_include_rule("+", '+', FilterRuleSpec::include);
+    let result = parse_short_include_rule(arg("+"), '+', FilterRuleSpec::include);
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn short_include_non_matching_prefix() {
-    let result = parse_short_include_rule("- foo", '+', FilterRuleSpec::include);
+    let result = parse_short_include_rule(arg("- foo"), '+', FilterRuleSpec::include);
     assert!(result.is_none());
 }
 
 #[test]
 fn dir_merge_basic() {
-    let result = parse_dir_merge_alias("dir-merge .rsync-filter");
+    let result = parse_dir_merge_alias(arg("dir-merge .rsync-filter"));
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -267,9 +274,9 @@ fn per_dir_is_not_a_keyword() {
     // upstream: exclude.c recognizes only "dir-merge" (case 'd' RULE_STRCMP);
     // there is no "per-dir" spelling. oc must decline it (returns None) so the
     // caller rejects the unknown rule, rather than accepting an oc-only alias.
-    assert!(parse_dir_merge_alias("per-dir filter-file").is_none());
+    assert!(parse_dir_merge_alias(arg("per-dir filter-file")).is_none());
     // The canonical keyword still parses as a dir-merge directive.
-    let ok = parse_dir_merge_alias("dir-merge filter-file");
+    let ok = parse_dir_merge_alias(arg("dir-merge filter-file"));
     assert!(ok.is_some());
     assert!(ok.unwrap().is_ok());
 }
@@ -280,24 +287,24 @@ fn dir_merge_uppercase_is_not_keyword() {
     // strncmp reached via `case 'd'`. `DIR-MERGE` never matches, so this parser
     // must decline it (returns None) and let the caller error, rather than
     // treating a mixed-case spelling as the dir-merge directive.
-    assert!(parse_dir_merge_alias("DIR-MERGE .filter").is_none());
-    assert!(parse_dir_merge_alias("Dir-Merge .filter").is_none());
+    assert!(parse_dir_merge_alias(arg("DIR-MERGE .filter")).is_none());
+    assert!(parse_dir_merge_alias(arg("Dir-Merge .filter")).is_none());
     // The lowercase keyword still parses as the dir-merge directive.
-    let ok = parse_dir_merge_alias("dir-merge .filter");
+    let ok = parse_dir_merge_alias(arg("dir-merge .filter"));
     assert!(ok.is_some());
     assert!(ok.unwrap().is_ok());
 }
 
 #[test]
 fn dir_merge_missing_filename() {
-    let result = parse_dir_merge_alias("dir-merge");
+    let result = parse_dir_merge_alias(arg("dir-merge"));
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn dir_merge_non_matching() {
-    let result = parse_dir_merge_alias("other-command file");
+    let result = parse_dir_merge_alias(arg("other-command file"));
     assert!(result.is_none());
 }
 
@@ -310,7 +317,7 @@ fn dir_merge_leading_slash_strips_filename_without_anchoring_rules() {
     // and driven by the `/` MODIFIER, not the filename slash. Setting anchor_root
     // here regressed the filter-depth test: `- secret*` in `d1/d2/.rsync-filter`
     // became `/d1/d2/secret*` and stopped matching `d1/d2/d3/secret.deeper`.
-    let result = parse_dir_merge_alias("dir-merge /.rsync-filter");
+    let result = parse_dir_merge_alias(arg("dir-merge /.rsync-filter"));
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -331,7 +338,7 @@ fn dir_merge_slash_modifier_still_anchors_rules() {
     // The `/` MODIFIER (after the comma) IS the real anchor_root source and
     // must keep working: `dir-merge,/ .rsync-filter` anchors loaded rules to
     // the transfer root (upstream FILTRULE_ABS_PATH via the '/' modifier).
-    let result = parse_dir_merge_alias("dir-merge,/ .rsync-filter");
+    let result = parse_dir_merge_alias(arg("dir-merge,/ .rsync-filter"));
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     match directive {
@@ -346,37 +353,37 @@ fn dir_merge_slash_modifier_still_anchors_rules() {
 
 #[test]
 fn keyword_include() {
-    let result = parse_keyword_rule("include *.txt");
+    let result = parse_keyword_rule(arg("include *.txt"));
     assert!(result.is_ok());
 }
 
 #[test]
 fn keyword_exclude() {
-    let result = parse_keyword_rule("exclude *.bak");
+    let result = parse_keyword_rule(arg("exclude *.bak"));
     assert!(result.is_ok());
 }
 
 #[test]
 fn keyword_show() {
-    let result = parse_keyword_rule("show pattern");
+    let result = parse_keyword_rule(arg("show pattern"));
     assert!(result.is_ok());
 }
 
 #[test]
 fn keyword_hide() {
-    let result = parse_keyword_rule("hide pattern");
+    let result = parse_keyword_rule(arg("hide pattern"));
     assert!(result.is_ok());
 }
 
 #[test]
 fn keyword_protect() {
-    let result = parse_keyword_rule("protect important");
+    let result = parse_keyword_rule(arg("protect important"));
     assert!(result.is_ok());
 }
 
 #[test]
 fn keyword_risk() {
-    let result = parse_keyword_rule("risk disposable");
+    let result = parse_keyword_rule(arg("risk disposable"));
     assert!(result.is_ok());
 }
 
@@ -387,30 +394,30 @@ fn keyword_mixed_case_is_error() {
     // first byte (exclude.c:1147/1155). `INCLUDE`/`Exclude` never match; they
     // reach the inner switch default and raise "Unknown filter rule". A drop-in
     // must error rather than coerce the case into the include/exclude rule.
-    assert!(parse_keyword_rule("INCLUDE *.rs").is_err());
-    assert!(parse_keyword_rule("Include *.rs").is_err());
-    assert!(parse_keyword_rule("EXCLUDE *.bak").is_err());
-    assert!(parse_keyword_rule("Merge foo").is_err());
+    assert!(parse_keyword_rule(arg("INCLUDE *.rs")).is_err());
+    assert!(parse_keyword_rule(arg("Include *.rs")).is_err());
+    assert!(parse_keyword_rule(arg("EXCLUDE *.bak")).is_err());
+    assert!(parse_keyword_rule(arg("Merge foo")).is_err());
     // Lowercase keywords still parse as their rule.
-    assert!(parse_keyword_rule("include *.rs").is_ok());
-    assert!(parse_keyword_rule("exclude *.bak").is_ok());
+    assert!(parse_keyword_rule(arg("include *.rs")).is_ok());
+    assert!(parse_keyword_rule(arg("exclude *.bak")).is_ok());
 }
 
 #[test]
 fn keyword_missing_pattern() {
-    let result = parse_keyword_rule("include");
+    let result = parse_keyword_rule(arg("include"));
     assert!(result.is_err());
 }
 
 #[test]
 fn keyword_unknown() {
-    let result = parse_keyword_rule("unknown_keyword pattern");
+    let result = parse_keyword_rule(arg("unknown_keyword pattern"));
     assert!(result.is_err());
 }
 
 #[test]
 fn long_merge_basic() {
-    let result = parse_long_merge_directive("merge filter.rules");
+    let result = parse_long_merge_directive(arg("merge filter.rules"));
     assert!(result.is_some());
     let directive = result.unwrap().unwrap();
     assert!(matches!(directive, FilterDirective::Merge(_)));
@@ -418,14 +425,14 @@ fn long_merge_basic() {
 
 #[test]
 fn long_merge_missing_path() {
-    let result = parse_long_merge_directive("merge");
+    let result = parse_long_merge_directive(arg("merge"));
     assert!(result.is_some());
     assert!(result.unwrap().is_err());
 }
 
 #[test]
 fn long_merge_non_matching() {
-    let result = parse_long_merge_directive("include pattern");
+    let result = parse_long_merge_directive(arg("include pattern"));
     assert!(result.is_none());
 }
 
@@ -435,9 +442,9 @@ fn long_merge_mixed_case_is_not_keyword() {
     // strncmp reached via `case 'm'`. `Merge`/`MERGE` never match the merge
     // directive, so this parser declines them (returns None); the lowercase
     // keyword still parses as a merge directive.
-    assert!(parse_long_merge_directive("Merge filter.rules").is_none());
-    assert!(parse_long_merge_directive("MERGE filter.rules").is_none());
-    assert!(parse_long_merge_directive("merge filter.rules").is_some());
+    assert!(parse_long_merge_directive(arg("Merge filter.rules")).is_none());
+    assert!(parse_long_merge_directive(arg("MERGE filter.rules")).is_none());
+    assert!(parse_long_merge_directive(arg("merge filter.rules")).is_some());
 }
 
 #[test]
@@ -453,46 +460,46 @@ fn filter_directive_mixed_case_keywords_are_errors() {
         "CLEAR",
     ] {
         assert!(
-            parse_filter_directive(OsStr::new(rule)).is_err(),
+            parse_filter_directive(OsStr::new(rule), RuleSource::Argument).is_err(),
             "mixed-case keyword `{rule}` must be rejected"
         );
     }
-    assert!(parse_filter_directive(OsStr::new("merge foo")).is_ok());
-    assert!(parse_filter_directive(OsStr::new("include bar")).is_ok());
-    assert!(parse_filter_directive(OsStr::new("clear")).is_ok());
+    assert!(parse_filter_directive(OsStr::new("merge foo"), RuleSource::Argument).is_ok());
+    assert!(parse_filter_directive(OsStr::new("include bar"), RuleSource::Argument).is_ok());
+    assert!(parse_filter_directive(OsStr::new("clear"), RuleSource::Argument).is_ok());
 }
 
 #[test]
 fn shorthand_protect() {
-    let result = parse_shorthand_rules("P *.important");
+    let result = parse_shorthand_rules(arg("P *.important"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn shorthand_hide() {
-    let result = parse_shorthand_rules("H .hidden");
+    let result = parse_shorthand_rules(arg("H .hidden"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn shorthand_show() {
-    let result = parse_shorthand_rules("S visible");
+    let result = parse_shorthand_rules(arg("S visible"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn shorthand_risk() {
-    let result = parse_shorthand_rules("R temp");
+    let result = parse_shorthand_rules(arg("R temp"));
     assert!(result.is_some());
     assert!(result.unwrap().is_ok());
 }
 
 #[test]
 fn shorthand_non_matching() {
-    let result = parse_shorthand_rules("+ pattern");
+    let result = parse_shorthand_rules(arg("+ pattern"));
     assert!(result.is_none());
 }
 
@@ -501,7 +508,7 @@ fn leading_whitespace_is_rejected() {
     // upstream: exclude.c:1100-1213 parse_rule_tok - a top-level rule never
     // carries FILTRULE_WORD_SPLIT, so leading whitespace is not skipped; it
     // reaches the prefix `switch` default and errors. It must not be trimmed.
-    let result = parse_filter_directive(OsStr::new("   + *.txt"));
+    let result = parse_filter_directive(OsStr::new("   + *.txt"), RuleSource::Argument);
     assert!(result.is_err());
 }
 
@@ -510,7 +517,7 @@ fn trailing_whitespace_is_kept_in_pattern() {
     // upstream: exclude.c:1313 - trailing whitespace is part of the pattern
     // (strlen length), so `- *.o ` keeps its trailing space and `x.o` stays
     // included.
-    let result = parse_filter_directive(OsStr::new("- *.o "));
+    let result = parse_filter_directive(OsStr::new("- *.o "), RuleSource::Argument);
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
@@ -525,7 +532,7 @@ fn multiple_spaces_in_pattern() {
     // upstream: exclude.c:1290-1291,1313 - exactly one separator is consumed
     // after the rule char, so `+   *.txt` (three spaces) keeps the two extra
     // leading spaces in the pattern.
-    match parse_filter_directive(OsStr::new("+   *.txt")).unwrap() {
+    match parse_filter_directive(OsStr::new("+   *.txt"), RuleSource::Argument).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Include);
             assert_eq!(spec.pattern(), "  *.txt");
@@ -538,7 +545,7 @@ fn multiple_spaces_in_pattern() {
 fn single_space_separator_consumed_short_rule() {
     // `-  x` (two spaces) keeps one leading space; verified against rsync 3.4.4
     // which excludes only a file literally named " x".
-    match parse_filter_directive(OsStr::new("-  x")).unwrap() {
+    match parse_filter_directive(OsStr::new("-  x"), RuleSource::Argument).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
             assert_eq!(spec.pattern(), " x");
@@ -550,7 +557,7 @@ fn single_space_separator_consumed_short_rule() {
 #[test]
 fn one_space_separator_leaves_no_leading_space() {
     // `- x` (one space) consumes the single separator; pattern is `x`.
-    match parse_filter_directive(OsStr::new("- x")).unwrap() {
+    match parse_filter_directive(OsStr::new("- x"), RuleSource::Argument).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
             assert_eq!(spec.pattern(), "x");
@@ -563,7 +570,7 @@ fn one_space_separator_leaves_no_leading_space() {
 fn underscore_separator_leaves_following_space() {
     // `-_ x` uses `_` as the single separator, leaving the following space in
     // the pattern (` x`), matching rsync 3.4.4.
-    match parse_filter_directive(OsStr::new("-_ x")).unwrap() {
+    match parse_filter_directive(OsStr::new("-_ x"), RuleSource::Argument).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
             assert_eq!(spec.pattern(), " x");
@@ -576,7 +583,7 @@ fn underscore_separator_leaves_following_space() {
 fn keyword_rule_keeps_extra_separator_in_pattern() {
     // The keyword and its pattern are split on the first whitespace only, so
     // `exclude   x` (three spaces) keeps the two extra leading spaces verbatim.
-    match parse_keyword_rule("exclude   x").unwrap() {
+    match parse_keyword_rule(arg("exclude   x")).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
             assert_eq!(spec.pattern(), "  x");
@@ -588,7 +595,7 @@ fn keyword_rule_keeps_extra_separator_in_pattern() {
 #[test]
 fn shorthand_rule_keeps_extra_separator_in_pattern() {
     // `P  x` (two spaces) consumes one separator, keeping one leading space.
-    match parse_shorthand_rules("P  x").unwrap().unwrap() {
+    match parse_shorthand_rules(arg("P  x")).unwrap().unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Protect);
             assert_eq!(spec.pattern(), " x");
@@ -599,7 +606,7 @@ fn shorthand_rule_keeps_extra_separator_in_pattern() {
 
 #[test]
 fn exclude_negate_modifier_short() {
-    let result = parse_filter_directive(OsStr::new("-! */"));
+    let result = parse_filter_directive(OsStr::new("-! */"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -613,7 +620,7 @@ fn exclude_negate_modifier_short() {
 
 #[test]
 fn exclude_negate_modifier_keyword() {
-    let result = parse_filter_directive(OsStr::new("exclude,! */"));
+    let result = parse_filter_directive(OsStr::new("exclude,! */"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -627,7 +634,7 @@ fn exclude_negate_modifier_keyword() {
 
 #[test]
 fn include_negate_modifier() {
-    let result = parse_filter_directive(OsStr::new("+! *.txt"));
+    let result = parse_filter_directive(OsStr::new("+! *.txt"), RuleSource::Argument);
     assert!(result.is_ok());
     match result.unwrap() {
         FilterDirective::Rule(spec) => {
@@ -640,7 +647,8 @@ fn include_negate_modifier() {
 
 #[test]
 fn old_prefix_minus_space_flips_to_exclude() {
-    let result = parse_old_prefix_rule("- to", FilterRuleKind::Include).unwrap();
+    let result =
+        parse_old_prefix_rule("- to", FilterRuleKind::Include, RuleSource::Argument).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
@@ -652,7 +660,8 @@ fn old_prefix_minus_space_flips_to_exclude() {
 
 #[test]
 fn old_prefix_plus_space_flips_to_include() {
-    let result = parse_old_prefix_rule("+ *.rs", FilterRuleKind::Exclude).unwrap();
+    let result =
+        parse_old_prefix_rule("+ *.rs", FilterRuleKind::Exclude, RuleSource::Argument).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Include);
@@ -673,11 +682,11 @@ fn old_prefix_plus_space_flips_to_include() {
 #[test]
 fn old_prefix_clear_requires_an_exact_bang() {
     assert!(matches!(
-        parse_old_prefix_rule("!", FilterRuleKind::Exclude).unwrap(),
+        parse_old_prefix_rule("!", FilterRuleKind::Exclude, RuleSource::Argument).unwrap(),
         FilterDirective::Clear
     ));
     for line in ["! ", "!  ", "!\t", "!   "] {
-        match parse_old_prefix_rule(line, FilterRuleKind::Exclude).unwrap() {
+        match parse_old_prefix_rule(line, FilterRuleKind::Exclude, RuleSource::Argument).unwrap() {
             FilterDirective::Rule(spec) => assert_eq!(spec.pattern(), line),
             other => panic!("`{line}` must be a literal pattern, got {other:?}"),
         }
@@ -689,7 +698,8 @@ fn old_prefix_bang_with_pattern_is_raw_pattern() {
     // upstream: `!pattern` is NOT a clear - `len > 1` demotes the tentative
     // FILTRULE_CLEAR_LIST back to a literal pattern. Whitespace does not
     // rescue it either; see old_prefix_clear_requires_an_exact_bang.
-    let result = parse_old_prefix_rule("!keepme", FilterRuleKind::Exclude).unwrap();
+    let result =
+        parse_old_prefix_rule("!keepme", FilterRuleKind::Exclude, RuleSource::Argument).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
@@ -701,7 +711,8 @@ fn old_prefix_bang_with_pattern_is_raw_pattern() {
 
 #[test]
 fn old_prefix_bare_pattern_uses_default_kind() {
-    let result = parse_old_prefix_rule("*.log", FilterRuleKind::Include).unwrap();
+    let result =
+        parse_old_prefix_rule("*.log", FilterRuleKind::Include, RuleSource::Argument).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Include);
@@ -715,7 +726,8 @@ fn old_prefix_bare_pattern_uses_default_kind() {
 fn old_prefix_minus_without_space_is_raw_pattern() {
     // upstream: `-` without a trailing space is not the exclude prefix -
     // it's a literal pattern character. Same for `+`.
-    let result = parse_old_prefix_rule("-foo", FilterRuleKind::Exclude).unwrap();
+    let result =
+        parse_old_prefix_rule("-foo", FilterRuleKind::Exclude, RuleSource::Argument).unwrap();
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
@@ -730,7 +742,7 @@ fn old_prefix_empty_is_noop() {
     // upstream: exclude.c:1107 - a blank `--exclude`/`--include` value adds
     // nothing (exit 0), so an empty old-prefix rule is a no-op, not an error.
     assert!(matches!(
-        parse_old_prefix_rule("", FilterRuleKind::Exclude),
+        parse_old_prefix_rule("", FilterRuleKind::Exclude, RuleSource::Argument),
         Ok(FilterDirective::Noop)
     ));
 }
@@ -739,8 +751,8 @@ fn old_prefix_empty_is_noop() {
 fn old_prefix_short_prefix_only_is_error() {
     // upstream: `parse_rule_tok` reports "unexpected end of filter rule"
     // when no pattern follows the prefix.
-    assert!(parse_old_prefix_rule("- ", FilterRuleKind::Include).is_err());
-    assert!(parse_old_prefix_rule("+ ", FilterRuleKind::Exclude).is_err());
+    assert!(parse_old_prefix_rule("- ", FilterRuleKind::Include, RuleSource::Argument).is_err());
+    assert!(parse_old_prefix_rule("+ ", FilterRuleKind::Exclude, RuleSource::Argument).is_err());
 }
 
 #[test]
@@ -770,15 +782,15 @@ fn parse_cvs_convenience_rule_emits_cvs_defaults() {
     // `-C` / `+C` as a filter rule expand to the global CVS default
     // excludes rather than a literal pattern "C".
     assert_eq!(
-        parse_filter_directive(OsStr::new("-C")).unwrap(),
+        parse_filter_directive(OsStr::new("-C"), RuleSource::Argument).unwrap(),
         FilterDirective::CvsDefaults
     );
     assert_eq!(
-        parse_filter_directive(OsStr::new("+C")).unwrap(),
+        parse_filter_directive(OsStr::new("+C"), RuleSource::Argument).unwrap(),
         FilterDirective::CvsDefaults
     );
     assert_eq!(
-        parse_filter_directive(OsStr::new("-,C")).unwrap(),
+        parse_filter_directive(OsStr::new("-,C"), RuleSource::Argument).unwrap(),
         FilterDirective::CvsDefaults
     );
 }
@@ -787,7 +799,7 @@ fn parse_cvs_convenience_rule_emits_cvs_defaults() {
 fn parse_literal_dash_pattern_is_not_cvs() {
     // `- C` (with a space) is an ordinary exclude of the pattern "C", not
     // the cvs-convenience rule.
-    match parse_filter_directive(OsStr::new("- C")).unwrap() {
+    match parse_filter_directive(OsStr::new("- C"), RuleSource::Argument).unwrap() {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
             assert_eq!(spec.pattern(), "C");
@@ -806,15 +818,18 @@ fn short_prefix_uppercase_modifier_is_rejected() {
     // upstream: `+S` / `-R` -> "invalid modifier 'S'/'R'" (exclude.c:1226). The
     // byte after a `+`/`-` prefix is a modifier, matched case-sensitively, so the
     // uppercase form is not silently remapped to a sender/receiver rule.
-    let _ = parse_filter_directive(OsStr::new("+S")).expect_err("+S must be rejected");
-    let _ = parse_filter_directive(OsStr::new("-R")).expect_err("-R must be rejected");
+    let _ = parse_filter_directive(OsStr::new("+S"), RuleSource::Argument)
+        .expect_err("+S must be rejected");
+    let _ = parse_filter_directive(OsStr::new("-R"), RuleSource::Argument)
+        .expect_err("-R must be rejected");
 }
 
 #[test]
 fn merge_prefix_lowercase_c_modifier_is_rejected() {
     // upstream: `:c` -> "invalid modifier 'c'" (exclude.c:1226). The cvs-ignore
     // merge modifier is the uppercase `C`; the lowercase `c` is invalid.
-    let _ = parse_filter_directive(OsStr::new(":c")).expect_err(":c must be rejected");
+    let _ = parse_filter_directive(OsStr::new(":c"), RuleSource::Argument)
+        .expect_err(":c must be rejected");
 }
 
 #[test]
@@ -823,17 +838,19 @@ fn lowercase_single_char_side_prefix_is_unknown_rule() {
     // single-char side prefixes are the uppercase S/H/P/R; a lowercase spelling
     // is only ever the first byte of a long keyword, so a bare `s`/`h` is not a
     // rule and must be rejected rather than treated as show/hide.
-    let _ = parse_filter_directive(OsStr::new("s foo")).expect_err("s foo must be rejected");
-    let _ = parse_filter_directive(OsStr::new("h foo")).expect_err("h foo must be rejected");
+    let _ = parse_filter_directive(OsStr::new("s foo"), RuleSource::Argument)
+        .expect_err("s foo must be rejected");
+    let _ = parse_filter_directive(OsStr::new("h foo"), RuleSource::Argument)
+        .expect_err("h foo must be rejected");
 }
 
 #[test]
 fn keyword_uppercase_modifier_is_rejected() {
     // upstream: `include,X foo` / `exclude,S foo` -> "invalid modifier 'X'/'S'"
     // (exclude.c:1226). Keyword modifiers are case-sensitive too.
-    let _ = parse_filter_directive(OsStr::new("include,X foo"))
+    let _ = parse_filter_directive(OsStr::new("include,X foo"), RuleSource::Argument)
         .expect_err("include,X must be rejected");
-    let _ = parse_filter_directive(OsStr::new("exclude,S foo"))
+    let _ = parse_filter_directive(OsStr::new("exclude,S foo"), RuleSource::Argument)
         .expect_err("exclude,S must be rejected");
 }
 
@@ -843,11 +860,14 @@ fn side_keyword_rejects_s_and_r_modifiers() {
     // prefix_specifies_side, so the `s`/`r` modifiers are invalid there
     // ("invalid modifier", exclude.c:1226). These were previously accepted as a
     // silent side-flip.
-    let _ = parse_filter_directive(OsStr::new("show,r foo")).expect_err("show,r must be rejected");
-    let _ = parse_filter_directive(OsStr::new("protect,s foo"))
+    let _ = parse_filter_directive(OsStr::new("show,r foo"), RuleSource::Argument)
+        .expect_err("show,r must be rejected");
+    let _ = parse_filter_directive(OsStr::new("protect,s foo"), RuleSource::Argument)
         .expect_err("protect,s must be rejected");
-    let _ = parse_filter_directive(OsStr::new("hide,s foo")).expect_err("hide,s must be rejected");
-    let _ = parse_filter_directive(OsStr::new("risk,r foo")).expect_err("risk,r must be rejected");
+    let _ = parse_filter_directive(OsStr::new("hide,s foo"), RuleSource::Argument)
+        .expect_err("hide,s must be rejected");
+    let _ = parse_filter_directive(OsStr::new("risk,r foo"), RuleSource::Argument)
+        .expect_err("risk,r must be rejected");
 }
 
 #[test]
@@ -855,11 +875,14 @@ fn side_keyword_accepts_perishable_modifier() {
     // upstream: exclude.c:1265-1267 - `p` (perishable) carries no side guard, so
     // it is valid on protect/show/etc. (upstream `protect,p foo` exits 0). This
     // was previously rejected as an unsupported modifier.
-    match parse_filter_directive(OsStr::new("protect,p foo")).expect("protect,p foo must parse") {
+    match parse_filter_directive(OsStr::new("protect,p foo"), RuleSource::Argument)
+        .expect("protect,p foo must parse")
+    {
         FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Protect),
         other => panic!("expected protect Rule, got {other:?}"),
     }
-    parse_filter_directive(OsStr::new("show,p foo")).expect("show,p foo must parse");
+    parse_filter_directive(OsStr::new("show,p foo"), RuleSource::Argument)
+        .expect("show,p foo must parse");
 }
 
 #[test]
@@ -867,14 +890,20 @@ fn lowercase_modifiers_and_uppercase_prefixes_still_parse() {
     // Regression guard: the case-sensitivity fix must not reject the forms that
     // upstream accepts. Lowercase `s`/`x` modifiers on include/exclude, and the
     // uppercase single-char S/P prefixes, all remain valid (upstream exit 0).
-    parse_filter_directive(OsStr::new("+s foo")).expect("+s foo must parse");
-    parse_filter_directive(OsStr::new("include,s foo")).expect("include,s foo must parse");
-    parse_filter_directive(OsStr::new("include,x foo")).expect("include,x foo must parse");
-    match parse_filter_directive(OsStr::new("S public/**")).expect("S shorthand must parse") {
+    parse_filter_directive(OsStr::new("+s foo"), RuleSource::Argument).expect("+s foo must parse");
+    parse_filter_directive(OsStr::new("include,s foo"), RuleSource::Argument)
+        .expect("include,s foo must parse");
+    parse_filter_directive(OsStr::new("include,x foo"), RuleSource::Argument)
+        .expect("include,x foo must parse");
+    match parse_filter_directive(OsStr::new("S public/**"), RuleSource::Argument)
+        .expect("S shorthand must parse")
+    {
         FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Include),
         other => panic!("expected show(include) Rule, got {other:?}"),
     }
-    match parse_filter_directive(OsStr::new("P backups/**")).expect("P shorthand must parse") {
+    match parse_filter_directive(OsStr::new("P backups/**"), RuleSource::Argument)
+        .expect("P shorthand must parse")
+    {
         FilterDirective::Rule(spec) => assert_eq!(spec.kind(), FilterRuleKind::Protect),
         other => panic!("expected protect Rule, got {other:?}"),
     }
@@ -942,7 +971,7 @@ enum OldPrefix {
 #[test]
 fn clear_token_grid_matches_upstream_in_full_filter_syntax() {
     for (spelling, expected, _) in CLEAR_TOKEN_GRID {
-        let result = parse_filter_directive(OsStr::new(spelling));
+        let result = parse_filter_directive(OsStr::new(spelling), RuleSource::Argument);
         match (expected, result) {
             (FullSyntax::Clear, Ok(FilterDirective::Clear)) => {}
             (FullSyntax::TrailingCharacters, Err(message)) => {
@@ -970,7 +999,7 @@ fn clear_token_grid_matches_upstream_in_full_filter_syntax() {
 #[test]
 fn clear_token_grid_matches_upstream_in_old_prefix_syntax() {
     for (spelling, _, expected) in CLEAR_TOKEN_GRID {
-        let result = parse_old_prefix_rule(spelling, FilterRuleKind::Exclude)
+        let result = parse_old_prefix_rule(spelling, FilterRuleKind::Exclude, RuleSource::Argument)
             .unwrap_or_else(|e| panic!("`--exclude={spelling}` must parse: {e}"));
         match (expected, result) {
             (OldPrefix::Clear, FilterDirective::Clear) => {}

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -57,7 +57,8 @@ pub(crate) fn append_filter_rules_from_files(
                 // `--exclude-from`/`--include-from` file, which upstream also
                 // redacts - `rule_src_file` is set for the whole read, so
                 // `TEXT_FROM_FILE` holds and the text is replaced by
-                // `FILE line N` (exclude.c:56-68, :103-124). oc does not carry a
+                // `FILE line N` (exclude.c:71, the wording `rule_src_where`
+                // builds at exclude.c:84). oc does not carry a
                 // line number through `load_filter_file_patterns`, and naming the
                 // file without one would claim upstream's word-split arm
                 // (`rule_src_line < 0`) for a line-counted read. Left as

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -53,7 +53,16 @@ pub(crate) fn append_filter_rules_from_files(
         let mut local: Vec<FilterRuleSpec> = Vec::new();
         for pattern in patterns {
             if honor_old_prefixes {
-                match parse_old_prefix_rule(&pattern, kind)? {
+                // ⚠ RESIDUAL: these are the CONTENTS of an
+                // `--exclude-from`/`--include-from` file, which upstream also
+                // redacts - `rule_src_file` is set for the whole read, so
+                // `TEXT_FROM_FILE` holds and the text is replaced by
+                // `FILE line N` (exclude.c:56-68, :103-124). oc does not carry a
+                // line number through `load_filter_file_patterns`, and naming the
+                // file without one would claim upstream's word-split arm
+                // (`rule_src_line < 0`) for a line-counted read. Left as
+                // `Argument` - unchanged behaviour, not a claim that it is right.
+                match parse_old_prefix_rule(&pattern, kind, RuleSource::Argument)? {
                     FilterDirective::Rule(rule) => local.push(rule),
                     FilterDirective::Clear => local.clear(),
                     // A blank line in an exclude-from/include-from file is skipped.

--- a/crates/cli/src/frontend/mod.rs
+++ b/crates/cli/src/frontend/mod.rs
@@ -178,7 +178,7 @@ pub(crate) fn parse_merge_modifiers(
     directive: &str,
     allow_extended: bool,
 ) -> Result<(DirMergeOptions, bool), Message> {
-    filter_rules::parse_merge_modifiers(modifiers, directive, allow_extended)
+    filter_rules::parse_merge_modifiers_from_argument(modifiers, directive, allow_extended)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
+++ b/crates/cli/src/frontend/tests/filter_behavior_comprehensive.rs
@@ -819,8 +819,8 @@ fn filter_order_interleaves_short_f_and_uppercase_f() {
 
 #[test]
 fn parse_filter_directive_include_keyword_via_filter_arg() {
-    let result =
-        parse_filter_directive(OsStr::new("include *.rs")).expect("keyword include parses");
+    let result = parse_filter_directive(OsStr::new("include *.rs"), filters::RuleSource::Argument)
+        .expect("keyword include parses");
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Include);
@@ -832,8 +832,8 @@ fn parse_filter_directive_include_keyword_via_filter_arg() {
 
 #[test]
 fn parse_filter_directive_exclude_keyword_via_filter_arg() {
-    let result =
-        parse_filter_directive(OsStr::new("exclude *.bak")).expect("keyword exclude parses");
+    let result = parse_filter_directive(OsStr::new("exclude *.bak"), filters::RuleSource::Argument)
+        .expect("keyword exclude parses");
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::Exclude);
@@ -845,8 +845,11 @@ fn parse_filter_directive_exclude_keyword_via_filter_arg() {
 
 #[test]
 fn parse_filter_directive_dir_merge_long_keyword() {
-    let result = parse_filter_directive(OsStr::new("dir-merge .rsync-filter"))
-        .expect("dir-merge keyword parses");
+    let result = parse_filter_directive(
+        OsStr::new("dir-merge .rsync-filter"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge keyword parses");
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::DirMerge);
@@ -859,7 +862,8 @@ fn parse_filter_directive_dir_merge_long_keyword() {
 #[test]
 fn parse_filter_directive_colon_dir_merge_shorthand() {
     let result =
-        parse_filter_directive(OsStr::new(": .rsync-filter")).expect("colon dir-merge parses");
+        parse_filter_directive(OsStr::new(": .rsync-filter"), filters::RuleSource::Argument)
+            .expect("colon dir-merge parses");
     match result {
         FilterDirective::Rule(spec) => {
             assert_eq!(spec.kind(), FilterRuleKind::DirMerge);

--- a/crates/cli/src/frontend/tests/merge.rs
+++ b/crates/cli/src/frontend/tests/merge.rs
@@ -182,3 +182,109 @@ fn apply_merge_directive_still_fails_when_the_collapsed_name_is_absent() {
         .is_err()
     );
 }
+
+/// MEASURED against rsync 3.5.0 (`filter-merge-content-echo`): an unparsable
+/// line inside a merge file must be described, never echoed. The merge file is
+/// named by a rule the peer can choose, so echoing any line of it turns the
+/// filter parser into a read-any-line oracle for every file this process can
+/// open.
+///
+/// upstream: `rule_text` (exclude.c:88-123) is the chokepoint, and
+/// `rule_src_where` (exclude.c:71-85) renders an operator-named file as
+/// `FILE line N`.
+#[test]
+fn an_unparsable_line_in_a_merge_file_is_described_not_echoed() {
+    use tempfile::tempdir;
+
+    const SECRET: &str = "TOP-SECRET-PASSWORD-abc123";
+
+    let temp = tempdir().expect("tempdir");
+    let merge_file = temp.path().join("rules");
+    std::fs::write(&merge_file, format!("{SECRET}\n")).expect("write merge rules");
+
+    let directive = MergeDirective::new(merge_file.into_os_string(), None);
+    let mut rules = Vec::new();
+    let mut visited = Vec::new();
+    let error = apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    )
+    .expect_err("an unparsable merged line must be refused");
+    let rendered = error.to_string();
+
+    assert!(
+        !rendered.contains(SECRET),
+        "the merge file's contents must not be echoed: {rendered}"
+    );
+    assert!(
+        rendered.contains("rules line 1"),
+        "the diagnostic must locate the rule instead: {rendered}"
+    );
+}
+
+/// The nested case, and the reason the enclosing provenance has to travel: the
+/// INNER file's own path came out of the OUTER file's contents, so upstream
+/// clears `rule_src_file` and reports only where it was named
+/// (`named_by_file` / `rule_src_named_at`, exclude.c:1735-1755). Reporting the
+/// inner path would leak a name the peer chose.
+#[test]
+fn a_merge_file_named_by_another_file_reports_where_it_was_named() {
+    use tempfile::tempdir;
+
+    const SECRET: &str = "TOP-SECRET-PASSWORD-abc123";
+
+    let temp = tempdir().expect("tempdir");
+    let inner = temp.path().join("inner-bad");
+    std::fs::write(&inner, format!("{SECRET}\n")).expect("write inner");
+    let outer = temp.path().join("outer-known");
+    std::fs::write(&outer, ". inner-bad\n").expect("write outer");
+
+    let directive = MergeDirective::new(outer.into_os_string(), None);
+    let mut rules = Vec::new();
+    let mut visited = Vec::new();
+    let error = apply_merge_directive(
+        directive,
+        temp.path(),
+        &mut rules,
+        &mut visited,
+        filters::RuleSource::Argument,
+    )
+    .expect_err("an unparsable line in the nested file must be refused");
+    let rendered = error.to_string();
+
+    assert!(
+        !rendered.contains(SECRET),
+        "the nested file's contents must not be echoed: {rendered}"
+    );
+    assert!(
+        !rendered.contains("inner-bad line"),
+        "the nested file's own name is peer-chosen and must not locate the rule: {rendered}"
+    );
+    // The outer file is named by the operator, so its path IS printable; the
+    // tempdir prefix makes it absolute here, hence the two-part assertion.
+    assert!(
+        rendered.contains("a file named at") && rendered.contains("outer-known line 1"),
+        "the diagnostic must name where the nested merge was requested: {rendered}"
+    );
+}
+
+/// Non-vacuity companion: the redaction is a PROVENANCE decision. An
+/// argument-sourced rule is still echoed verbatim, because that text is the
+/// operator's own (`rule_text` returns it unchanged, exclude.c:110-116).
+/// Without this, replacing the funnel with blanket suppression would also
+/// satisfy the two tests above.
+#[test]
+fn an_argument_sourced_rule_is_still_echoed_verbatim() {
+    const SECRET: &str = "TOP-SECRET-PASSWORD-abc123";
+
+    let error = parse_filter_directive(OsStr::new(SECRET), filters::RuleSource::Argument)
+        .expect_err("an unparsable argument must still be refused");
+
+    assert!(
+        error.to_string().contains(SECRET),
+        "an operator's own text stays visible: {error}"
+    );
+}

--- a/crates/cli/src/frontend/tests/parse_filter.rs
+++ b/crates/cli/src/frontend/tests/parse_filter.rs
@@ -3,34 +3,41 @@ use super::*;
 
 #[test]
 fn parse_filter_directive_accepts_include_and_exclude() {
-    let include = parse_filter_directive(OsStr::new("+ assets/**")).expect("include rule parses");
+    let include = parse_filter_directive(OsStr::new("+ assets/**"), filters::RuleSource::Argument)
+        .expect("include rule parses");
     assert_eq!(
         include,
         FilterDirective::Rule(FilterRuleSpec::include("assets/**".to_owned()))
     );
 
-    let exclude = parse_filter_directive(OsStr::new("- *.bak")).expect("exclude rule parses");
+    let exclude = parse_filter_directive(OsStr::new("- *.bak"), filters::RuleSource::Argument)
+        .expect("exclude rule parses");
     assert_eq!(
         exclude,
         FilterDirective::Rule(FilterRuleSpec::exclude("*.bak".to_owned()))
     );
 
     let include_keyword =
-        parse_filter_directive(OsStr::new("include logs/**")).expect("keyword include parses");
+        parse_filter_directive(OsStr::new("include logs/**"), filters::RuleSource::Argument)
+            .expect("keyword include parses");
     assert_eq!(
         include_keyword,
         FilterDirective::Rule(FilterRuleSpec::include("logs/**".to_owned()))
     );
 
     let exclude_keyword =
-        parse_filter_directive(OsStr::new("exclude *.tmp")).expect("keyword exclude parses");
+        parse_filter_directive(OsStr::new("exclude *.tmp"), filters::RuleSource::Argument)
+            .expect("keyword exclude parses");
     assert_eq!(
         exclude_keyword,
         FilterDirective::Rule(FilterRuleSpec::exclude("*.tmp".to_owned()))
     );
 
-    let protect_keyword =
-        parse_filter_directive(OsStr::new("protect backups/**")).expect("keyword protect parses");
+    let protect_keyword = parse_filter_directive(
+        OsStr::new("protect backups/**"),
+        filters::RuleSource::Argument,
+    )
+    .expect("keyword protect parses");
     assert_eq!(
         protect_keyword,
         FilterDirective::Rule(FilterRuleSpec::protect("backups/**".to_owned()))
@@ -40,14 +47,16 @@ fn parse_filter_directive_accepts_include_and_exclude() {
 #[test]
 fn parse_filter_directive_accepts_hide_and_show_keywords() {
     let show_keyword =
-        parse_filter_directive(OsStr::new("show images/**")).expect("keyword show parses");
+        parse_filter_directive(OsStr::new("show images/**"), filters::RuleSource::Argument)
+            .expect("keyword show parses");
     assert_eq!(
         show_keyword,
         FilterDirective::Rule(FilterRuleSpec::show("images/**".to_owned()))
     );
 
     let hide_keyword =
-        parse_filter_directive(OsStr::new("hide *.swp")).expect("keyword hide parses");
+        parse_filter_directive(OsStr::new("hide *.swp"), filters::RuleSource::Argument)
+            .expect("keyword hide parses");
     assert_eq!(
         hide_keyword,
         FilterDirective::Rule(FilterRuleSpec::hide("*.swp".to_owned()))
@@ -57,14 +66,16 @@ fn parse_filter_directive_accepts_hide_and_show_keywords() {
 #[test]
 fn parse_filter_directive_accepts_risk_keyword_and_shorthand() {
     let risk_keyword =
-        parse_filter_directive(OsStr::new("risk backups/**")).expect("keyword risk parses");
+        parse_filter_directive(OsStr::new("risk backups/**"), filters::RuleSource::Argument)
+            .expect("keyword risk parses");
     assert_eq!(
         risk_keyword,
         FilterDirective::Rule(FilterRuleSpec::risk("backups/**".to_owned()))
     );
 
     let risk_shorthand =
-        parse_filter_directive(OsStr::new("R logs/**")).expect("shorthand risk parses");
+        parse_filter_directive(OsStr::new("R logs/**"), filters::RuleSource::Argument)
+            .expect("shorthand risk parses");
     assert_eq!(
         risk_shorthand,
         FilterDirective::Rule(FilterRuleSpec::risk("logs/**".to_owned()))
@@ -73,20 +84,22 @@ fn parse_filter_directive_accepts_risk_keyword_and_shorthand() {
 
 #[test]
 fn parse_filter_directive_accepts_shorthand_hide_show_and_protect() {
-    let protect =
-        parse_filter_directive(OsStr::new("P backups/**")).expect("shorthand protect parses");
+    let protect = parse_filter_directive(OsStr::new("P backups/**"), filters::RuleSource::Argument)
+        .expect("shorthand protect parses");
     assert_eq!(
         protect,
         FilterDirective::Rule(FilterRuleSpec::protect("backups/**".to_owned()))
     );
 
-    let hide = parse_filter_directive(OsStr::new("H *.tmp")).expect("shorthand hide parses");
+    let hide = parse_filter_directive(OsStr::new("H *.tmp"), filters::RuleSource::Argument)
+        .expect("shorthand hide parses");
     assert_eq!(
         hide,
         FilterDirective::Rule(FilterRuleSpec::hide("*.tmp".to_owned()))
     );
 
-    let show = parse_filter_directive(OsStr::new("S public/**")).expect("shorthand show parses");
+    let show = parse_filter_directive(OsStr::new("S public/**"), filters::RuleSource::Argument)
+        .expect("shorthand show parses");
     assert_eq!(
         show,
         FilterDirective::Rule(FilterRuleSpec::show("public/**".to_owned()))
@@ -95,15 +108,21 @@ fn parse_filter_directive_accepts_shorthand_hide_show_and_protect() {
 
 #[test]
 fn parse_filter_directive_accepts_exclude_if_present() {
-    let directive = parse_filter_directive(OsStr::new("exclude-if-present marker"))
-        .expect("exclude-if-present with whitespace parses");
+    let directive = parse_filter_directive(
+        OsStr::new("exclude-if-present marker"),
+        filters::RuleSource::Argument,
+    )
+    .expect("exclude-if-present with whitespace parses");
     assert_eq!(
         directive,
         FilterDirective::Rule(FilterRuleSpec::exclude_if_present("marker".to_owned()))
     );
 
-    let equals_variant = parse_filter_directive(OsStr::new("exclude-if-present=.skip"))
-        .expect("exclude-if-present with equals parses");
+    let equals_variant = parse_filter_directive(
+        OsStr::new("exclude-if-present=.skip"),
+        filters::RuleSource::Argument,
+    )
+    .expect("exclude-if-present with equals parses");
     assert_eq!(
         equals_variant,
         FilterDirective::Rule(FilterRuleSpec::exclude_if_present(".skip".to_owned()))
@@ -112,50 +131,57 @@ fn parse_filter_directive_accepts_exclude_if_present() {
 
 #[test]
 fn parse_filter_directive_rejects_exclude_if_present_without_marker() {
-    let error = parse_filter_directive(OsStr::new("exclude-if-present   "))
-        .expect_err("missing marker should error");
+    let error = parse_filter_directive(
+        OsStr::new("exclude-if-present   "),
+        filters::RuleSource::Argument,
+    )
+    .expect_err("missing marker should error");
     let rendered = error.to_string();
     assert!(rendered.contains("missing a marker file"));
 }
 
 #[test]
 fn parse_filter_directive_accepts_clear_directive() {
-    let clear = parse_filter_directive(OsStr::new("!")).expect("clear directive parses");
+    let clear = parse_filter_directive(OsStr::new("!"), filters::RuleSource::Argument)
+        .expect("clear directive parses");
     assert_eq!(clear, FilterDirective::Clear);
 
     // upstream: exclude.c:1211-1213 - leading whitespace is not skipped for a
     // top-level rule, so `  !   ` reaches the prefix `switch` default and errors
     // ("Unknown filter rule") rather than being treated as a clear.
-    let _ =
-        parse_filter_directive(OsStr::new("  !   ")).expect_err("leading whitespace should error");
+    let _ = parse_filter_directive(OsStr::new("  !   "), filters::RuleSource::Argument)
+        .expect_err("leading whitespace should error");
 }
 
 #[test]
 fn parse_filter_directive_accepts_clear_keyword() {
-    let keyword = parse_filter_directive(OsStr::new("clear")).expect("keyword parses");
+    let keyword = parse_filter_directive(OsStr::new("clear"), filters::RuleSource::Argument)
+        .expect("keyword parses");
     assert_eq!(keyword, FilterDirective::Clear);
 
     // upstream: exclude.c:1139 RULE_STRCMP(s, "clear") is a case-sensitive
     // strncmp reached only via `case 'c'`, so `CLEAR` misses it, reaches the
     // inner switch default, and errors with "Unknown filter rule". It is not a
     // clear directive.
-    let _ = parse_filter_directive(OsStr::new("CLEAR")).expect_err("uppercase should error");
+    let _ = parse_filter_directive(OsStr::new("CLEAR"), filters::RuleSource::Argument)
+        .expect_err("uppercase should error");
 
     // upstream: exclude.c:1211-1213 - a leading space errors before any keyword
     // is recognised, and the keyword is case-sensitive besides; neither the
     // whitespace nor the case is normalised away.
-    let _ = parse_filter_directive(OsStr::new("  CLEAR  "))
+    let _ = parse_filter_directive(OsStr::new("  CLEAR  "), filters::RuleSource::Argument)
         .expect_err("surrounding whitespace should error");
 }
 
 #[test]
 fn parse_filter_directive_rejects_clear_with_trailing_characters() {
-    let error =
-        parse_filter_directive(OsStr::new("! comment")).expect_err("trailing text should error");
+    let error = parse_filter_directive(OsStr::new("! comment"), filters::RuleSource::Argument)
+        .expect_err("trailing text should error");
     let rendered = error.to_string();
     assert!(rendered.contains("'!' rule has trailing characters: ! comment"));
 
-    let error = parse_filter_directive(OsStr::new("!extra")).expect_err("suffix should error");
+    let error = parse_filter_directive(OsStr::new("!extra"), filters::RuleSource::Argument)
+        .expect_err("suffix should error");
     let rendered = error.to_string();
     assert!(rendered.contains("'!' rule has trailing characters: !extra"));
 }
@@ -168,18 +194,19 @@ fn parse_filter_directive_rejects_missing_pattern() {
     // NOT empty: `+   ` keeps the two extra spaces as the pattern "  " and is
     // accepted (verified against rsync 3.4.4), so only the single-separator
     // forms error here.
-    let error = parse_filter_directive(OsStr::new("+ ")).expect_err("missing pattern should error");
+    let error = parse_filter_directive(OsStr::new("+ "), filters::RuleSource::Argument)
+        .expect_err("missing pattern should error");
     let rendered = error.to_string();
     assert!(rendered.contains("missing a pattern"));
 
-    let shorthand_error =
-        parse_filter_directive(OsStr::new("P ")).expect_err("shorthand protect requires pattern");
+    let shorthand_error = parse_filter_directive(OsStr::new("P "), filters::RuleSource::Argument)
+        .expect_err("shorthand protect requires pattern");
     let rendered = shorthand_error.to_string();
     assert!(rendered.contains("missing a pattern"));
 
     // A whitespace-only remainder is a valid (if unusual) pattern, not an error.
-    let accepted =
-        parse_filter_directive(OsStr::new("+   ")).expect("whitespace pattern is accepted");
+    let accepted = parse_filter_directive(OsStr::new("+   "), filters::RuleSource::Argument)
+        .expect("whitespace pattern is accepted");
     assert_eq!(
         accepted,
         FilterDirective::Rule(FilterRuleSpec::include("  ".to_owned()))
@@ -188,8 +215,11 @@ fn parse_filter_directive_rejects_missing_pattern() {
 
 #[test]
 fn parse_filter_directive_accepts_merge() {
-    let directive =
-        parse_filter_directive(OsStr::new("merge filters.txt")).expect("merge directive");
+    let directive = parse_filter_directive(
+        OsStr::new("merge filters.txt"),
+        filters::RuleSource::Argument,
+    )
+    .expect("merge directive");
     let (options, _) = parse_merge_modifiers("", "merge filters.txt", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from("filters.txt"), None).with_options(options);
     assert_eq!(directive, FilterDirective::Merge(expected));
@@ -197,8 +227,8 @@ fn parse_filter_directive_accepts_merge() {
 
 #[test]
 fn parse_filter_directive_rejects_merge_without_path() {
-    let error =
-        parse_filter_directive(OsStr::new("merge ")).expect_err("missing merge path should error");
+    let error = parse_filter_directive(OsStr::new("merge "), filters::RuleSource::Argument)
+        .expect_err("missing merge path should error");
     let rendered = error.to_string();
     assert!(rendered.contains("missing a file path"));
 }
@@ -206,7 +236,8 @@ fn parse_filter_directive_rejects_merge_without_path() {
 #[test]
 fn parse_filter_directive_accepts_merge_with_forced_include() {
     let directive =
-        parse_filter_directive(OsStr::new("merge,+ rules")).expect("merge,+ should parse");
+        parse_filter_directive(OsStr::new("merge,+ rules"), filters::RuleSource::Argument)
+            .expect("merge,+ should parse");
     let (options, _) = parse_merge_modifiers("+", "merge,+ rules", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from("rules"), Some(FilterRuleKind::Include))
         .with_options(options);
@@ -216,7 +247,8 @@ fn parse_filter_directive_accepts_merge_with_forced_include() {
 #[test]
 fn parse_filter_directive_accepts_merge_with_forced_exclude() {
     let directive =
-        parse_filter_directive(OsStr::new("merge,- rules")).expect("merge,- should parse");
+        parse_filter_directive(OsStr::new("merge,- rules"), filters::RuleSource::Argument)
+            .expect("merge,- should parse");
     let (options, _) = parse_merge_modifiers("-", "merge,- rules", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from("rules"), Some(FilterRuleKind::Exclude))
         .with_options(options);
@@ -225,7 +257,7 @@ fn parse_filter_directive_accepts_merge_with_forced_exclude() {
 
 #[test]
 fn parse_filter_directive_accepts_xattr_only_rules() {
-    let include = parse_filter_directive(OsStr::new("+x user.keep"))
+    let include = parse_filter_directive(OsStr::new("+x user.keep"), filters::RuleSource::Argument)
         .expect("short include with xattr modifier parses");
     assert_eq!(
         include,
@@ -234,7 +266,7 @@ fn parse_filter_directive_accepts_xattr_only_rules() {
         )
     );
 
-    let exclude = parse_filter_directive(OsStr::new("-x user.skip"))
+    let exclude = parse_filter_directive(OsStr::new("-x user.skip"), filters::RuleSource::Argument)
         .expect("short exclude with xattr modifier parses");
     assert_eq!(
         exclude,
@@ -243,8 +275,11 @@ fn parse_filter_directive_accepts_xattr_only_rules() {
         )
     );
 
-    let keyword = parse_filter_directive(OsStr::new("include,x user.keep"))
-        .expect("keyword include with xattr modifier parses");
+    let keyword = parse_filter_directive(
+        OsStr::new("include,x user.keep"),
+        filters::RuleSource::Argument,
+    )
+    .expect("keyword include with xattr modifier parses");
     assert_eq!(
         keyword,
         FilterDirective::Rule(
@@ -259,14 +294,18 @@ fn parse_filter_directive_accepts_xattr_on_side_bound_rules_keeping_the_side() {
     // upstream: exclude.c:1438 `case 'x'` carries no guard, so it is legal on every
     // prefix, and :1345-1358 shows H/S/P/R are nothing but (include|exclude) x
     // (sender|receiver) - the `x` bit is orthogonal and must not widen the side.
-    let protect = parse_filter_directive(OsStr::new("protect,x secrets"))
-        .expect("upstream accepts protect,x");
+    let protect = parse_filter_directive(
+        OsStr::new("protect,x secrets"),
+        filters::RuleSource::Argument,
+    )
+    .expect("upstream accepts protect,x");
     assert_eq!(
         protect,
         FilterDirective::Rule(FilterRuleSpec::protect("secrets".to_owned()).with_xattr_only(true))
     );
 
-    let show = parse_filter_directive(OsStr::new("show,x meta")).expect("upstream accepts show,x");
+    let show = parse_filter_directive(OsStr::new("show,x meta"), filters::RuleSource::Argument)
+        .expect("upstream accepts show,x");
     assert_eq!(
         show,
         FilterDirective::Rule(FilterRuleSpec::show("meta".to_owned()).with_xattr_only(true))
@@ -276,12 +315,19 @@ fn parse_filter_directive_accepts_xattr_on_side_bound_rules_keeping_the_side() {
     // erases the distinction before transmission (exclude.c:1824-1881
     // get_rule_prefix never emits H/S/P/R).
     assert_eq!(
-        parse_filter_directive(OsStr::new("Px secrets")).expect("upstream accepts Px"),
-        parse_filter_directive(OsStr::new("protect,x secrets")).expect("long form"),
+        parse_filter_directive(OsStr::new("Px secrets"), filters::RuleSource::Argument)
+            .expect("upstream accepts Px"),
+        parse_filter_directive(
+            OsStr::new("protect,x secrets"),
+            filters::RuleSource::Argument
+        )
+        .expect("long form"),
     );
     assert_eq!(
-        parse_filter_directive(OsStr::new("Sx meta")).expect("upstream accepts Sx"),
-        parse_filter_directive(OsStr::new("show,x meta")).expect("long form"),
+        parse_filter_directive(OsStr::new("Sx meta"), filters::RuleSource::Argument)
+            .expect("upstream accepts Sx"),
+        parse_filter_directive(OsStr::new("show,x meta"), filters::RuleSource::Argument)
+            .expect("long form"),
     );
 }
 
@@ -290,14 +336,15 @@ fn parse_filter_directive_still_rejects_a_redundant_side_modifier() {
     // Non-vacuity companion: `x` became legal on these rules, but `s`/`r` must
     // stay rejected because the prefix already binds the side
     // (upstream exclude.c:1423-1432, measured: `Ps user.a` exits 1).
-    let error = parse_filter_directive(OsStr::new("Ps secrets"))
+    let error = parse_filter_directive(OsStr::new("Ps secrets"), filters::RuleSource::Argument)
         .expect_err("s is redundant once P binds the side");
     assert!(error.to_string().contains("unsupported modifier 's'"));
 }
 
 #[test]
 fn parse_filter_directive_accepts_merge_with_cvs_alias() {
-    let directive = parse_filter_directive(OsStr::new("merge,C")).expect("merge,C should parse");
+    let directive = parse_filter_directive(OsStr::new("merge,C"), filters::RuleSource::Argument)
+        .expect("merge,C should parse");
     let (options, _) = parse_merge_modifiers("C", "merge,C", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from(".cvsignore"), Some(FilterRuleKind::Exclude))
         .with_options(options);
@@ -306,8 +353,8 @@ fn parse_filter_directive_accepts_merge_with_cvs_alias() {
 
 #[test]
 fn parse_filter_directive_accepts_short_merge() {
-    let directive =
-        parse_filter_directive(OsStr::new(". per-dir")).expect("short merge directive parses");
+    let directive = parse_filter_directive(OsStr::new(". per-dir"), filters::RuleSource::Argument)
+        .expect("short merge directive parses");
     let (options, _) = parse_merge_modifiers("", ". per-dir", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from("per-dir"), None).with_options(options);
     assert_eq!(directive, FilterDirective::Merge(expected));
@@ -315,8 +362,8 @@ fn parse_filter_directive_accepts_short_merge() {
 
 #[test]
 fn parse_filter_directive_accepts_short_merge_with_cvs_alias() {
-    let directive =
-        parse_filter_directive(OsStr::new(".C")).expect("short merge directive with 'C' parses");
+    let directive = parse_filter_directive(OsStr::new(".C"), filters::RuleSource::Argument)
+        .expect("short merge directive with 'C' parses");
     let (options, _) = parse_merge_modifiers("C", ".C", false).expect("modifiers");
     let expected = MergeDirective::new(OsString::from(".cvsignore"), Some(FilterRuleKind::Exclude))
         .with_options(options);
@@ -325,8 +372,9 @@ fn parse_filter_directive_accepts_short_merge_with_cvs_alias() {
 
 #[test]
 fn parse_filter_directive_accepts_merge_sender_modifier() {
-    let directive = parse_filter_directive(OsStr::new("merge,s rules"))
-        .expect("merge directive with 's' parses");
+    let directive =
+        parse_filter_directive(OsStr::new("merge,s rules"), filters::RuleSource::Argument)
+            .expect("merge directive with 's' parses");
     let expected_options = DirMergeOptions::default()
         .allow_list_clearing(true)
         .sender_modifier();
@@ -337,8 +385,11 @@ fn parse_filter_directive_accepts_merge_sender_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_merge_anchor_and_whitespace_modifiers() {
-    let directive = parse_filter_directive(OsStr::new("merge,/w patterns"))
-        .expect("merge directive with '/' and 'w' parses");
+    let directive = parse_filter_directive(
+        OsStr::new("merge,/w patterns"),
+        filters::RuleSource::Argument,
+    )
+    .expect("merge directive with '/' and 'w' parses");
     let expected_options = DirMergeOptions::default()
         .allow_list_clearing(true)
         .anchor_root(true)
@@ -353,7 +404,7 @@ fn parse_filter_directive_accepts_merge_anchor_and_whitespace_modifiers() {
 fn parse_filter_directive_rejects_merge_with_unknown_modifier() {
     // `z` is outside upstream's modifier set `- + / ! C e n p r s w x`
     // (exclude.c:1381-1441); `x` is in it and must parse.
-    let error = parse_filter_directive(OsStr::new("merge,z rules"))
+    let error = parse_filter_directive(OsStr::new("merge,z rules"), filters::RuleSource::Argument)
         .expect_err("merge with unsupported modifier should error");
     let rendered = error.to_string();
     assert!(rendered.contains("uses unsupported modifier"));
@@ -361,8 +412,11 @@ fn parse_filter_directive_rejects_merge_with_unknown_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_without_modifiers() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge .rsync-filter"))
-        .expect("dir-merge without modifiers parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge .rsync-filter"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge without modifiers parses");
     assert_eq!(
         directive,
         FilterDirective::Rule(FilterRuleSpec::dir_merge(
@@ -377,13 +431,22 @@ fn parse_filter_directive_rejects_per_dir_alias() {
     // "per-dir" is not an upstream keyword; it must be rejected rather than
     // treated as a dir-merge alias. upstream: exclude.c recognizes only
     // "dir-merge" (case 'd').
-    assert!(parse_filter_directive(OsStr::new("per-dir .rsync-filter")).is_err());
+    assert!(
+        parse_filter_directive(
+            OsStr::new("per-dir .rsync-filter"),
+            filters::RuleSource::Argument
+        )
+        .is_err()
+    );
 }
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_remove_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,- .rsync-filter"))
-        .expect("dir-merge with '-' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,- .rsync-filter"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with '-' modifier parses");
     assert_eq!(
         directive,
         FilterDirective::Rule(FilterRuleSpec::dir_merge(
@@ -395,8 +458,11 @@ fn parse_filter_directive_accepts_dir_merge_with_remove_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_include_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,+ .rsync-filter"))
-        .expect("dir-merge with '+' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,+ .rsync-filter"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with '+' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -413,8 +479,8 @@ fn parse_filter_directive_accepts_dir_merge_with_include_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_short_dir_merge() {
-    let directive =
-        parse_filter_directive(OsStr::new(": rules")).expect("short dir-merge directive parses");
+    let directive = parse_filter_directive(OsStr::new(": rules"), filters::RuleSource::Argument)
+        .expect("short dir-merge directive parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -430,7 +496,7 @@ fn parse_filter_directive_accepts_short_dir_merge() {
 
 #[test]
 fn parse_filter_directive_accepts_short_dir_merge_with_exclude_modifier() {
-    let directive = parse_filter_directive(OsStr::new(":- per-dir"))
+    let directive = parse_filter_directive(OsStr::new(":- per-dir"), filters::RuleSource::Argument)
         .expect("short dir-merge with '-' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
@@ -446,8 +512,11 @@ fn parse_filter_directive_accepts_short_dir_merge_with_exclude_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_no_inherit_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,n per-dir"))
-        .expect("dir-merge with 'n' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,n per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with 'n' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -464,8 +533,11 @@ fn parse_filter_directive_accepts_dir_merge_with_no_inherit_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_exclude_self_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,e per-dir"))
-        .expect("dir-merge with 'e' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,e per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with 'e' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -481,8 +553,11 @@ fn parse_filter_directive_accepts_dir_merge_with_exclude_self_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_whitespace_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,w per-dir"))
-        .expect("dir-merge with 'w' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,w per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with 'w' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -497,8 +572,9 @@ fn parse_filter_directive_accepts_dir_merge_with_whitespace_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_cvs_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,C"))
-        .expect("dir-merge with 'C' modifier parses");
+    let directive =
+        parse_filter_directive(OsStr::new("dir-merge,C"), filters::RuleSource::Argument)
+            .expect("dir-merge with 'C' modifier parses");
 
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
@@ -517,16 +593,22 @@ fn parse_filter_directive_accepts_dir_merge_with_cvs_modifier() {
 
 #[test]
 fn parse_filter_directive_rejects_dir_merge_with_conflicting_modifiers() {
-    let error = parse_filter_directive(OsStr::new("dir-merge,+- per-dir"))
-        .expect_err("conflicting modifiers should error");
+    let error = parse_filter_directive(
+        OsStr::new("dir-merge,+- per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect_err("conflicting modifiers should error");
     let rendered = error.to_string();
     assert!(rendered.contains("cannot combine '+' and '-'"));
 }
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_sender_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,s per-dir"))
-        .expect("dir-merge with 's' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,s per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with 's' modifier parses");
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
     };
@@ -539,8 +621,11 @@ fn parse_filter_directive_accepts_dir_merge_with_sender_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_receiver_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,r per-dir"))
-        .expect("dir-merge with 'r' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,r per-dir"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with 'r' modifier parses");
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
     };
@@ -553,8 +638,11 @@ fn parse_filter_directive_accepts_dir_merge_with_receiver_modifier() {
 
 #[test]
 fn parse_filter_directive_accepts_dir_merge_with_anchor_modifier() {
-    let directive = parse_filter_directive(OsStr::new("dir-merge,/ .rules"))
-        .expect("dir-merge with '/' modifier parses");
+    let directive = parse_filter_directive(
+        OsStr::new("dir-merge,/ .rules"),
+        filters::RuleSource::Argument,
+    )
+    .expect("dir-merge with '/' modifier parses");
     let FilterDirective::Rule(rule) = directive else {
         panic!("expected dir-merge rule");
     };


### PR DESCRIPTION
## The defect

Every diagnostic the CLI filter parser built from a rule's own text echoed that text verbatim. When the rule came out of a merge file the peer named, that turns the parser into a read-any-line oracle for any file the process can open.

## Upstream's shape, in its own words

`rule_text()` (`exclude.c:88-123`) is the chokepoint: "Every diagnostic string that is, or is built from, a filter rule's own text ... must be passed through `rule_text()` on its way to `rprintf()`", and

> "Doing it here rather than at each site is the point: a message added later cannot reintroduce the leak by forgetting to check, and there is one place to audit."

`rule_detail()` (`exclude.c:126-131`) covers the detail *about* the text - a character of it, an offset into it - "Dropped along with the text it describes."

`filters::RuleSource` already ports both, with tests. The CLI parser simply never crossed it.

## The change

- **`RuleLine`** pairs the line with its provenance. `text()` is for parsing (byte-exact, never rendered); `shown()` / `detail()` are for messages. The pair cannot be split, which is what preserves upstream's stated property in a codebase with no ambient parser state. Threaded from `parse_filter_directive`, whose two production callers already know the provenance: an operator's `--filter` value is `Argument` and stays visible; a merge file's contents carry the enclosing file's source.
- **The merge wrapper is gone.** It re-echoed the raw rule text *and* the peer-chosen merge-file name, re-adding exactly what the funnel had just replaced - the failure mode upstream's comment warns about. Upstream reports a syntax failure once, from `filter_rule_err` (`exclude.c:132-138`), and exits `RERR_SYNTAX`; there is no enclosing wrapper. The inner error already names the provenance and is propagated unchanged.
- **A merge file named by another file** reports where it was named, not its own path (`named_by_file` / `rule_src_named_at`, `exclude.c:1735-1755`). The inner path is peer-chosen; the outer location is not.

## Measured

Against real rsync 3.5.0 on the testsuite's own fixture (`filter-merge-content-echo`), secret `TOP-SECRET-PASSWORD-abc123`:

| shape | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `--filter='. rules'` | `rules line 1` | leaks the secret | `<rule from ./rules line 1>` |
| merge-from-merge | `a file named at ./outer-known line 1` | leaks the secret **and** names `./inner-bad` | `<rule from a file named at ./outer-known line 1>` |

The per-directory merge shape is the engine parser and ships separately (#7662).

## Mutation evidence

Two mutations, each lethal to exactly its own pin, with the argument-echo companion green under both:

- Restore the merge wrapper's raw echo → both leak pins fail (`3 tests run: 1 passed, 2 failed`); the companion passes.
- Drop the `named_at` derivation → only the nested pin fails (`3 tests run: 2 passed, 1 failed`).

Baseline before either mutation: `3 tests run: 3 passed`.

The non-vacuity companion (`an_argument_sourced_rule_is_still_echoed_verbatim`) is what makes this a provenance decision rather than blanket suppression - without it, replacing the funnel with a constant string would satisfy the leak pins too.

## Residual, deliberately unchanged

The contents of an `--exclude-from` / `--include-from` file still take `Argument` provenance. Upstream redacts those too, reporting `FILE line N`, but oc does not carry a line number through `load_filter_file_patterns`, and naming the file without one would claim upstream's word-split arm (`rule_src_line < 0`) for a line-counted read. Left as-is and marked at the site - unchanged behaviour, not a claim that it is right.

## Gates

Pinned toolchain (1.88.0): `cargo fmt --all -- --check` clean, `cargo clippy -p cli --all-targets --no-deps -- -D warnings` clean, `cargo nextest run -p cli --lib` 3387/3387.
