### PR TITLE
docs(compress): fold shadowed upstream citations into the rustdoc

### DIFF
--- a/crates/compress/src/algorithm.rs
+++ b/crates/compress/src/algorithm.rs
@@ -81,10 +81,11 @@ impl CompressionAlgorithm {
         }
     }
 
-    // upstream: compat.c:valid_compressions_items[] - zstd first, then lz4, zlibx, zlib
     /// Returns the default compression algorithm used when callers enable `--compress`.
     ///
-    /// Matches upstream rsync 3.4.1 negotiation precedence: zstd > lz4 > zlib.
+    /// upstream: `valid_compressions_items[]` (compat.c) lists the negotiation
+    /// precedence in table order - zstd, lz4, zlibx, zlib, none - and that
+    /// order is unchanged in 3.5.0.
     #[must_use]
     pub const fn default_algorithm() -> Self {
         #[cfg(feature = "zstd")]

--- a/crates/compress/src/lz4/raw.rs
+++ b/crates/compress/src/lz4/raw.rs
@@ -26,12 +26,14 @@ use std::io::{self, Read, Write};
 
 use lz4_flex::block::{compress_into, decompress_into, get_maximum_output_size};
 
-// upstream: token.c:DEFLATED_DATA
 /// Flag byte indicating compressed data follows.
+///
+/// upstream: `token.c:DEFLATED_DATA`.
 pub const DEFLATED_DATA: u8 = 0x40;
 
-// upstream: token.c:MAX_DATA_COUNT
 /// Maximum compressed block size in bytes (14-bit field).
+///
+/// upstream: `token.c:MAX_DATA_COUNT`.
 pub const MAX_BLOCK_SIZE: usize = 16383;
 
 /// Maximum decompressed size to prevent memory exhaustion attacks.
@@ -39,8 +41,10 @@ pub const MAX_BLOCK_SIZE: usize = 16383;
 /// Upstream rsync uses 128KB blocks max, but we allow for larger custom configs.
 pub const MAX_DECOMPRESSED_SIZE: usize = 64 * 1024 * 1024;
 
-// upstream: token.c - 2-byte header encodes DEFLATED_DATA flag + 14-bit size
 /// Minimum header size for a compressed block.
+///
+/// upstream: `token.c` - the 2-byte header encodes the `DEFLATED_DATA` flag
+/// plus a 14-bit size.
 pub const HEADER_SIZE: usize = 2;
 
 /// Error returned when compression or decompression fails.

--- a/crates/compress/src/zlib/encoder.rs
+++ b/crates/compress/src/zlib/encoder.rs
@@ -8,9 +8,11 @@ use flate2::write::DeflateEncoder as FlateEncoder;
 use super::CompressionLevel;
 use crate::common::{CountingSink, CountingWriter};
 
-// upstream: token.c:send_deflated_token() - deflateInit2(..., -15, 8, Z_DEFAULT_STRATEGY)
-// uses raw deflate (negative windowBits) without zlib header/trailer.
 /// Streaming encoder that records the number of compressed bytes produced.
+///
+/// upstream: `send_deflated_token()` (token.c) calls
+/// `deflateInit2(..., -15, 8, Z_DEFAULT_STRATEGY)`, so the stream is raw
+/// deflate - the negative `windowBits` suppresses the zlib header and trailer.
 ///
 /// The encoder implements [`std::io::Write`], enabling integration with APIs
 /// such as [`std::io::copy`], [`write!`](std::write), and

--- a/crates/compress/src/zlib/level.rs
+++ b/crates/compress/src/zlib/level.rs
@@ -5,9 +5,11 @@ use std::num::NonZeroU8;
 use flate2::Compression;
 use thiserror::Error;
 
-// upstream: token.c:init_compression_level() - zlib range 0..=9,
-// default 6 (Z_DEFAULT_COMPRESSION is -1 but upstream remaps to 6).
 /// Compression levels recognised by the zlib encoder.
+///
+/// upstream: `init_compression_level()` (token.c) accepts the zlib range
+/// `0..=9` and defaults to 6 - `Z_DEFAULT_COMPRESSION` is -1, which upstream
+/// remaps to 6 rather than passing through.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompressionLevel {
     /// No compression (level 0) - data is stored without deflation.


### PR DESCRIPTION
## The shape

Six sites in `crates/compress` carried the upstream provenance in a plain `//`
line sitting **directly above** a `///` block:

```rust
// upstream: token.c:DEFLATED_DATA
/// Flag byte indicating compressed data follows.
pub const DEFLATED_DATA: u8 = 0x40;
```

The `///` renders in the docs. The `//` does not. So the citation that makes
the port auditable was precisely the half a reader of the rendered
documentation never saw. Folding it in keeps the text verbatim and makes it
visible.

## One stale claim, corrected from the source

`default_algorithm` said *"Matches upstream rsync 3.4.1 negotiation precedence:
zstd > lz4 > zlib"*. Read from the pinned tree
(`target/interop/upstream-src/rsync-3.5.0/compat.c:101-112`):

```c
struct name_num_item valid_compressions_items[] = {
        { CPRES_ZSTD, 0, "zstd", NULL },
        { CPRES_LZ4,  0, "lz4",  NULL },
        { CPRES_ZLIBX, 0, "zlibx", NULL },
        { CPRES_ZLIB,  0, "zlib",  NULL },
        { CPRES_NONE,  0, "none",  NULL },
```

So the precedence claim **holds** at 3.5.0, while the version reference had
drifted and the rendered list omitted `zlibx`. Both fixed from the C rather
than reworded.

## Deliberately unchanged — measured, not assumed

A tree-wide scan found 10 sites of this shape. Four are **not** this defect:

| site | why it stays |
|---|---|
| `transfer/generator/item_flags.rs:35,61,75` | GROUP headers inside an `impl` ("Wire flags (bits 0-15)", "bit 9 unused in upstream"). Each heads a run of constants that already carry their own `///`; converting one would bind a group header to a single constant. |
| `cli/frontend/server/tests.rs:1251` | documents a `#[test]` fn — rustdoc renders nothing, so there is no visibility to gain. |
| `daemon/.../long_form_args.rs:1` | opens with a module summary in `//`, but the file is `include!`d and therefore spliced mid-item. `//!` there is **E0753** — I tried it, the compiler refused it, and the plain `//` is correct. |

## Verification — on the pinned toolchain

`rust-toolchain.toml` pins **1.88.0**; stable here is 1.94 and has previously
produced both phantom clippy errors and a false fmt-clean, so everything below
ran at the pin:

```
rustc 1.88.0                                              (pinned)
cargo fmt --all -- --check                                clean
cargo clippy -p compress -p daemon --all-targets -D warnings   clean
RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p compress   clean
tools/ci/citation_drift_audit.py --ratchet                ratchet OK
cargo test -p compress --doc                              16 passed
cargo nextest run -p compress                             737 passed, 0 failed
```

The `cargo doc` gate matters here specifically: doc comments are the one edit
that can break a build through intra-doc links, and that class has recurred in
this repo. Comments only; no code semantics touched.
