### PR TITLE
docs: point the source-of-truth and required-check lists at 3.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Non-obvious protocol and wire behaviour is annotated with a citation to the
 upstream rsync C source, e.g. `// upstream: sender.c:477 - "sender finished"`.
 
 - **One pinned baseline.** Every citation line number is anchored to the single
-  pinned upstream tree at `target/interop/upstream-src/rsync-3.4.4/`. Do **not**
+  pinned upstream tree at `target/interop/upstream-src/rsync-3.5.0/`. Do **not**
   append a version to each citation - the baseline is recorded once, in
   `tools/ci/citation_drift_audit.py` (`VER`) and `docs/UPSTREAM_COMPARISON.md`.
   Repeating it across thousands of comments would turn a version bump into a

--- a/docs/architecture/walkthrough.md
+++ b/docs/architecture/walkthrough.md
@@ -351,7 +351,7 @@ Start with `crates/transfer/src/lib.rs` for the overview, then:
 
 ## Upstream Reference
 
-The upstream C source at `target/interop/upstream-src/rsync-3.4.4/` is the
+The upstream C source at `target/interop/upstream-src/rsync-3.5.0/` is the
 single source of truth for protocol behaviour. Key files to cross-reference:
 
 | Upstream File | Corresponds To |

--- a/docs/contributing/ONBOARDING.md
+++ b/docs/contributing/ONBOARDING.md
@@ -136,7 +136,7 @@ Explicit states with validated transitions:
 
 ## How to Add a Feature
 
-1. **Read upstream C source first.** The C code at `target/interop/upstream-src/rsync-3.4.4/` - the release `workspace.metadata.oc_rsync.upstream_version` pins - is the only source of truth for protocol behavior. Do not rely on man pages or third-party descriptions.
+1. **Read upstream C source first.** The C code at `target/interop/upstream-src/rsync-3.5.0/` - the release `workspace.metadata.oc_rsync.upstream_version` pins - is the only source of truth for protocol behavior. Do not rely on man pages or third-party descriptions.
 
 2. **Create a feature branch:**
    ```sh
@@ -179,9 +179,13 @@ All of these must pass before a PR can merge:
 | interop / interop with upstream rsync | Wire compatibility against every pinned upstream release |
 | upstream-testsuite / upstream testsuite | Upstream's own testsuite, unprivileged |
 | upstream-testsuite / upstream testsuite (root) | Upstream's own testsuite, privileged (ownership, devices) |
+| upstream-testsuite-tcp / upstream testsuite | Upstream's own testsuite over a TCP daemon, unprivileged |
+| upstream-testsuite-tcp / upstream testsuite (root) | Upstream's own testsuite over a TCP daemon, privileged |
 
 Master is protected, so every change lands through a pull request. No approving
-review is required - the checks above are the gate.
+review is required - the checks above are the gate. The branch ruleset is the
+authority for this list; [TESTING.md](TESTING.md) carries the command to
+re-derive it, because a hand-maintained copy is what drifts.
 
 ## Upstream Rsync Reference
 
@@ -191,10 +195,10 @@ The upstream C source is the authoritative reference for all protocol behavior.
 
 ```sh
 mkdir -p target/interop/upstream-src && cd target/interop/upstream-src
-curl -L https://download.samba.org/pub/rsync/src/rsync-3.4.4.tar.gz | tar xz
+curl -L https://download.samba.org/pub/rsync/src/rsync-3.5.0.tar.gz | tar xz
 ```
 
-`3.4.4` is the version `workspace.metadata.oc_rsync.upstream_version` pins, and the
+`3.5.0` is the version `workspace.metadata.oc_rsync.upstream_version` pins, and the
 one every `// upstream:` citation resolves against.
 
 Or run the interop harness, which downloads every tested version - the set lives in

--- a/docs/contributing/TESTING.md
+++ b/docs/contributing/TESTING.md
@@ -158,10 +158,24 @@ only the crates you changed.
 | interop (macOS) | macOS | Homebrew rsync smoke | Yes |
 | interop (Windows) | Windows | MSYS2 rsync smoke | No (best-effort) |
 
-Branch protection requires eight contexts: `fmt + clippy`, `nextest (stable)`,
+Branch protection requires ten contexts: `fmt + clippy`, `nextest (stable)`,
 `Windows (stable)`, `macOS (stable)`, `Linux musl (stable)`,
 `interop / interop with upstream rsync`, `upstream-testsuite / upstream testsuite`,
-and `upstream-testsuite / upstream testsuite (root)`.
+`upstream-testsuite / upstream testsuite (root)`,
+`upstream-testsuite-tcp / upstream testsuite`, and
+`upstream-testsuite-tcp / upstream testsuite (root)`.
+
+The ruleset is the authority, and this list is a copy of it, so re-derive it
+rather than trusting the copy:
+
+```sh
+gh api repos/oferchen/rsync/rulesets --jq '.[] | select(.name=="Protect master") | .id' \
+  | while read -r id; do
+      gh api "repos/oferchen/rsync/rulesets/$id" \
+        --jq '.rules[] | select(.type=="required_status_checks")
+              | .parameters.required_status_checks[].context'
+    done
+```
 
 ### Nextest configuration
 

--- a/docs/contributing/upstream-cross-references.md
+++ b/docs/contributing/upstream-cross-references.md
@@ -216,7 +216,7 @@ pub const NDX_DONE: i32 = -1;
 
 When adding new protocol features:
 
-1. Read the upstream C source first (at `target/interop/upstream-src/rsync-3.4.4/`,
+1. Read the upstream C source first (at `target/interop/upstream-src/rsync-3.5.0/`,
    the release `workspace.metadata.oc_rsync.upstream_version` pins).
 2. Add `// upstream:` on every non-obvious line that mirrors C behavior.
 3. Run `grep -rn "// upstream:" crates/<crate>/src/ | wc -l` to verify coverage

--- a/docs/protocol-compatibility.md
+++ b/docs/protocol-compatibility.md
@@ -1,9 +1,12 @@
 # Protocol Compatibility Matrix
 
 This document describes oc-rsync's wire protocol compatibility with upstream
-rsync across protocol versions 28-32 and upstream releases 2.6.9, 3.0.9,
-3.1.3, and 3.4.4. All claims are backed by automated CI tests that
-run on every pull request and nightly.
+rsync across protocol versions 28-32. The upstream releases the interop
+harness builds and exercises are listed once, in `versions=(...)` at
+`tools/ci/run_interop.sh:74`, rather than copied here - copying the list is what
+let it drift. At the time of writing that is 2.6.9, 3.0.9, 3.1.3, 3.4.4 and
+3.5.0. All claims are backed by automated CI tests that run on every pull
+request and nightly.
 
 ---
 
@@ -77,7 +80,10 @@ Batch files written by one implementation can be read by the other:
 
 The table below lists every feature tested in the comprehensive interop suite.
 Each feature is tested bidirectionally (upstream client -> oc-rsync daemon and
-oc-rsync client -> upstream daemon) against 3.0.9, 3.1.3, and 3.4.4. Rsync
+oc-rsync client -> upstream daemon) against every release in `versions=(...)`.
+The columns below record the measured results for 3.0.9, 3.1.3 and 3.4.4; 3.5.0
+is exercised by the same scenarios but has no column here yet, so read its
+status from the interop job rather than inferring it from these tables. Rsync
 3.4.4 supersedes the 3.4.1/3.4.2/3.4.3 point releases on the same protocol
 (32), so those intermediate releases are not tested separately. Rsync 2.6.9 (protocol 29) interop is
 validated via dedicated daemon push/pull cells (RP28.c/RP28.d) rather than
@@ -297,4 +303,4 @@ Interop testing is distributed across several CI workflows:
 - Interop test details: [docs/INTEROP.md](INTEROP.md)
 - Interop testing guide: [docs/interop_testing.md](interop_testing.md)
 - Interop test script: `tools/ci/run_interop.sh`
-- Upstream rsync source: `target/interop/upstream-src/rsync-3.4.4/`
+- Upstream rsync source: `target/interop/upstream-src/rsync-3.5.0/`


### PR DESCRIPTION
## What this fixes

Three doc-drift defects, each measured against its own authority rather than read.

### 1. Six sites name an upstream tree that does not exist

They tell a contributor to read the C at `target/interop/upstream-src/rsync-3.4.4/`. The pin is **3.5.0** (`Cargo.toml` `upstream_version`, and `VER` in `citation_drift_audit.py`), and only the 3.5.0 tree is fetched — the 3.4.4 directory is absent. Following those instructions produces citations the drift gate rejects.

`CONTRIBUTING.md` contradicted itself: line 164 called 3.4.4 the pinned tree, and line 196 says spelling any release other than 3.5.0 is "a hard failure".

**Deliberately unchanged:** everything under `docs/audits/` and `docs/design/`. Those state what was read at the time (`upstream-3.4.4-conformance.md` is dated in its own body); retargeting them would falsify the record instead of fixing it. Same trap as #7351 and #7307.

### 2. The required-check list was two contexts stale

`TESTING.md` said "eight contexts". The live ruleset returns **ten** — the two `upstream-testsuite-tcp` legs were registered after that sentence was written. `ONBOARDING.md`'s table was missing the same two rows.

The copy is what drifts, so both now point at the ruleset as the authority and `TESTING.md` ships the command to re-derive it. I extracted that command back out of the committed markdown and ran it; it returns exactly the ten contexts now listed:

```
fmt + clippy
nextest (stable)
Windows (stable)
macOS (stable)
Linux musl (stable)
interop / interop with upstream rsync
upstream-testsuite / upstream testsuite
upstream-testsuite / upstream testsuite (root)
upstream-testsuite-tcp / upstream testsuite
upstream-testsuite-tcp / upstream testsuite (root)
```

### 3. The compatibility matrix under-counted the tested releases

`protocol-compatibility.md` named the set as "2.6.9, 3.0.9, 3.1.3, and 3.4.4" and mentioned 3.5.0 exactly once. `versions=(3.0.9 3.1.3 3.4.4 3.5.0)` in `run_interop.sh` is the real list, and the scenario loop iterates all of it. The prose now points at that list rather than copying it.

**The per-feature tables are unchanged on purpose.** They keep their 3.0.9/3.1.3/3.4.4 columns and now say those are the measured results, with 3.5.0's status to be read from the interop job. Adding a 3.5.0 column would assert ~60 per-feature outcomes nobody has measured — an inference dressed as a measurement.

## Verification

- The command the doc ships was executed, not just written: 10 contexts, matching the list.
- `citation_drift_audit.py --ratchet`: **ratchet OK**.
- The manifest table in README was re-derived with its own awk during this pass and needed no change — all five rows, the 23-row union and the named `filter-merge-content-echo` divergence reproduce exactly.
