### PR TITLE
docs(security): count the 3.5.0 CVE coverage instead of disclaiming it

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ All crates enforce `#![deny(unsafe_code)]`. Targeted `#[allow(unsafe_code)]` is 
 - **protocol** - One isolated allow in `multiplex::helpers` for frame parsing
 - **windows-gnu-eh** - Windows GNU exception handling shims
 
-Not vulnerable to (or mitigated against) the 2024 upstream rsync CVEs (CVE-2024-12084 through CVE-2024-12088, CVE-2024-12747), and the rsync 3.4.3 batch (CVE-2026-29518, 43617, 43618, 43619, 43620, 45232) is closed - SEC-1, SEC-2, SEC-3 and SEC-MK series complete, TOCTOU path-based syscalls replaced with `*at` variants throughout. The rsync **3.5.0** batch of 33 CVEs is **partially closed and openly tracked**: it is a behavioural release, not a protocol one, so each item needs its own evidence rather than a blanket claim. See [`SECURITY.md`](./SECURITY.md) for per-CVE status, including which items are fixed and which remain under audit.
+Not vulnerable to (or mitigated against) the 2024 upstream rsync CVEs (CVE-2024-12084 through CVE-2024-12088, CVE-2024-12747), and the rsync 3.4.3 batch (CVE-2026-29518, 43617, 43618, 43619, 43620, 45232) is closed - SEC-1, SEC-2, SEC-3 and SEC-MK series complete, TOCTOU path-based syscalls replaced with `*at` variants throughout. The rsync **3.5.0** batch of 33 CVEs is **partially closed and openly tracked**: it is a behavioural release, not a protocol one, so each item needs its own evidence rather than a blanket claim. Ten of them carry a per-CVE finding today; the other twenty-two are listed by id in [`SECURITY.md`](./SECURITY.md) as untriaged, so the gap is countable rather than implied.
 
 ### Upstream rsync 3.4.3 hardening
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,35 @@ oc-rsync monitors upstream rsync CVEs to verify continued non-applicability. Rec
 
 ### Upstream rsync 3.5.0 (13 Aug 2026) - triage in progress
 
-rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in path handling and the daemon. Unlike the 3.4.2/3.4.3 batches below, this set is **not yet fully audited against oc-rsync**, and this section states that plainly rather than implying coverage that does not exist.
+rsync 3.5.0 is a major security release closing **33 CVEs**, concentrated in path handling and the daemon. That figure is upstream's own: "This release fixes 33 security issues found during a focused audit of rsync's..." (`NEWS.md:37` in the 3.5.0 tarball). Unlike the 3.4.2/3.4.3 batches below, this set is **not yet fully audited against oc-rsync**, and this section states that plainly rather than implying coverage that does not exist.
+
+**How much is audited: 10 of them.** A disclaimer that does not carry a number cannot be checked, so here is the count. Ten of the 3.5.0 CVEs have a per-CVE finding recorded in this document; the twenty-two below have **no entry yet** - they are neither claimed fixed nor claimed inapplicable:
+
+```
+CVE-2026-53785  CVE-2026-53786  CVE-2026-53788  CVE-2026-53789
+CVE-2026-53792  CVE-2026-53793  CVE-2026-53796  CVE-2026-53797
+CVE-2026-53798  CVE-2026-53799  CVE-2026-53800  CVE-2026-53801
+CVE-2026-53802  CVE-2026-53803  CVE-2026-70454  CVE-2026-70456
+CVE-2026-70457  CVE-2026-70458  CVE-2026-70459  CVE-2026-70460
+CVE-2026-70461  CVE-2026-70462
+```
+
+Re-derive the roster from the pinned tarball rather than trusting this list. Note
+the predicate: an id counts as assessed only when it has a **table row** here, not
+merely a mention - the roster above mentions all twenty-two, so a plain `grep` for
+CVE ids in this file matches them and reports nothing missing:
+
+```sh
+sed -n '1,451p' target/interop/upstream-src/rsync-3.5.0/NEWS.md \
+  | grep -o 'CVE-2026-[0-9]*' | sort -u > /tmp/batch
+grep -o '^| CVE-2026-[0-9]*' SECURITY.md | sed 's/^| //' | sort -u > /tmp/assessed
+comm -23 /tmp/batch /tmp/assessed          # ids with no per-CVE row
+```
+
+That prints 23 lines. Twenty-two are the roster above; the twenty-third,
+`CVE-2026-53794`, is a back-reference - it appears in upstream's 3.5.0 section but
+also in an older one, alongside `CVE-2026-43617` and `CVE-2026-43620`, and
+`CVE-2024-12084` is cited there only as prior art. Upstream's own sentence, not this subtraction, is the authority for **33**; the discrepancy is in how back-references are counted, not in the roster of untriaged ids.
 
 **What is established.** 3.5.0 is wire-identical to 3.4.4 (`PROTOCOL_VERSION` 32, `SUBPROTOCOL_VERSION` 0, unchanged `errcode.h`), so none of these CVEs stem from a protocol change and none require a wire-format response. They are implementation vulnerabilities in areas oc-rsync reimplements independently, which means neither "inherited" nor "not applicable" can be assumed for any of them - each needs its own evidence.
 


### PR DESCRIPTION
## What this fixes

`SECURITY.md` was honest that the rsync 3.5.0 CVE batch is "not yet fully audited against oc-rsync" — but it never said **how much** is audited. A disclaimer without a number can't be checked; a reader couldn't distinguish ten assessed from thirty.

**Measured against the pinned 3.5.0 tarball: 10 have a per-CVE table row here, 22 have none.** Those 22 are now listed by id, so the gap is an auditable ledger. README's "partially closed and openly tracked" sentence carries the same split.

## The number that did *not* change

`33 CVEs` is **correct and unchanged** — I checked it before touching it. It is upstream's own sentence, now quoted with its location:

> `NEWS.md:37`: "This release fixes 33 security issues found during a focused audit of rsync's..."

My own subtraction over the tarball lands at **32**, because three ids in upstream's 3.5.0 section (`CVE-2026-43617`, `CVE-2026-43620`, `CVE-2026-53794`) also appear in its older sections, and `CVE-2024-12084` is cited there only as prior art. The doc states that upstream's count is the authority and that the discrepancy is in how back-references are counted — not in the roster of untriaged ids. I did not "correct" a correct number on the strength of my own arithmetic.

## The shipped command, and why its predicate is load-bearing

An id counts as **assessed** only when it has a table row, not merely a mention:

```sh
sed -n '1,451p' target/interop/upstream-src/rsync-3.5.0/NEWS.md \
  | grep -o 'CVE-2026-[0-9]*' | sort -u > /tmp/batch
grep -o '^| CVE-2026-[0-9]*' SECURITY.md | sed 's/^| //' | sort -u > /tmp/assessed
comm -23 /tmp/batch /tmp/assessed          # ids with no per-CVE row
```

My **first** version grepped for any CVE id and returned **zero missing** — listing the 22 in the doc made them match its own search. Running the command is what caught that. The corrected version returns 23 lines, and the doc names the 23rd (`CVE-2026-53794`, a back-reference) rather than rounding it away.

## Verification

- Upstream's count read from `NEWS.md:37` in the pinned tree, quoted verbatim.
- Roster cross-checked two ways (raw batch minus back-refs; row-predicate) — both give the same 22 ids.
- The shipped command executed exactly as written: 23 lines, the extra one being the named back-reference.
- `CHANGELOG.md`'s "covering 33 CVEs" checked and left unchanged — it is correct.
