### PR TITLE
fix(filters): emit the FILTER2 add_rule trace where upstream emits it

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -181,6 +181,23 @@ pub(crate) struct DirMergeEntries {
 
 impl DirMergeEntries {
     fn push_rule(&mut self, rule: FilterRule) {
+        // upstream: exclude.c:259-275 add_rule() logs every parsed rule at
+        // `DEBUG_GTE(FILTER, 2)`, routing the text through `rule_text_len` and
+        // the action prefix through `rule_detail`. Every rule reaching this
+        // funnel came out of a merge file's *contents*, which upstream
+        // describes as `a file read earlier` (exclude.c:78) - the naming rule
+        // was read and closed long ago and its origin is not retained.
+        //
+        // Emitting here rather than at rule compilation is upstream's
+        // placement: `add_rule` runs with the provenance in hand, which is what
+        // decides whether the text may be shown. Compiling is downstream of the
+        // parse, where provenance has been dropped - so a trace emitted there
+        // echoed merged-file contents verbatim.
+        filters::trace_add_rule(
+            rule.action(),
+            rule.pattern(),
+            &filters::RuleSource::FileReadEarlier,
+        );
         self.rules.push(rule);
     }
 

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -81,6 +81,18 @@ impl FilterProgram {
         for entry in entries {
             match entry {
                 FilterProgramEntry::Rule(rule) => {
+                    // upstream: exclude.c:259-275 add_rule(). These entries are
+                    // the operator's own arguments, which upstream shows
+                    // verbatim "because it is the user's own and hiding it only
+                    // makes typos harder to fix" (exclude.c:90-95) - so the
+                    // source is `Argument` and `rule_text` returns it unchanged.
+                    // Merge-file contents take the redacting path in
+                    // `DirMergeEntries::push_rule`.
+                    filters::trace_add_rule(
+                        rule.action(),
+                        rule.pattern(),
+                        &filters::RuleSource::Argument,
+                    );
                     #[cfg(all(any(unix, windows), feature = "xattr"))]
                     {
                         if rule.is_xattr_only() {

--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -205,20 +205,6 @@ impl FilterSegment {
     }
 }
 
-/// Short-form action prefix used in `add_rule()` debug lines, mirroring
-/// upstream rsync's filter-rule syntax (`+`, `-`, `P`, `R`, `!`, `merge`, `dir-merge`).
-fn filter_action_prefix(action: FilterAction) -> &'static str {
-    match action {
-        FilterAction::Include => "+",
-        FilterAction::Exclude => "-",
-        FilterAction::Protect => "P",
-        FilterAction::Risk => "R",
-        FilterAction::Clear => "!",
-        FilterAction::Merge => "merge",
-        FilterAction::DirMerge => "dir-merge",
-    }
-}
-
 /// Emits a `--debug=FILTER` line for a rule that fired on `path`, naming the
 /// file, its type, and the matching pattern.
 ///
@@ -396,15 +382,13 @@ impl CompiledRule {
         let negate = rule.is_negated();
         let pattern = rule.pattern().to_owned();
 
-        // upstream: exclude.c:add_rule() logs every parsed rule at
-        // `DEBUG_GTE(FILTER, 2)` so the active rule set is observable.
-        debug_log!(
-            Filter,
-            2,
-            "add_rule({} {})",
-            filter_action_prefix(action),
-            pattern
-        );
+        // upstream: exclude.c:259-275 add_rule() logs every parsed rule at
+        // `DEBUG_GTE(FILTER, 2)`. That trace is emitted by the *parsers* -
+        // `DirMergeEntries::push_rule` for merge-file contents and
+        // `FilterProgram::compile` for the operator's own arguments - because
+        // that is where the rule's provenance is still in hand, and provenance
+        // is what decides whether the text may be shown. Emitting it here,
+        // downstream of every parse, echoed merged-file contents verbatim.
 
         let (anchored, directory_only, core_pattern) = normalise_pattern(&pattern);
 

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -58,22 +58,11 @@ impl CompiledRule {
         );
 
         // upstream: exclude.c:add_rule() logs every parsed rule at
-        // `DEBUG_GTE(FILTER, 2)` so the active rule set is observable.
-        logging::debug_log!(
-            Filter,
-            2,
-            "add_rule({} {})",
-            match action {
-                FilterAction::Include => "+",
-                FilterAction::Exclude => "-",
-                FilterAction::Protect => "P",
-                FilterAction::Risk => "R",
-                FilterAction::Clear => "!",
-                FilterAction::Merge => "merge",
-                FilterAction::DirMerge => "dir-merge",
-            },
-            pattern
-        );
+        // `DEBUG_GTE(FILTER, 2)`. That trace is emitted by the *parser*
+        // (`rule_source::trace_add_rule`), where the rule's provenance is still
+        // in hand - it is what decides whether the text may be shown. Emitting
+        // it here, downstream of the parse, echoed merged-file contents
+        // verbatim because provenance had already been dropped.
 
         let (anchored, directory_only, core_pattern) = normalise_pattern(&pattern);
 

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -152,7 +152,7 @@ pub use merge::{
     read_rules_recursive,
 };
 pub use rule::FilterRule;
-pub use rule_source::RuleSource;
+pub use rule_source::{RuleSource, trace_add_rule};
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};
 pub use wildmatch::{iwildmatch, wildmatch};
 

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use crate::FilterRule;
 use crate::RuleSource;
 use crate::clear_token::{ClearToken, classify_clear_token};
+use crate::rule_source::trace_add_rule;
 
 use super::error::MergeFileError;
 
@@ -52,7 +53,17 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
             continue;
         }
 
-        rules.push(parse_rule_line(line, source_path, line_num)?);
+        let rule = parse_rule_line(line, source_path, line_num)?;
+        let name = source_path.display().to_string();
+        trace_add_rule(
+            rule.action,
+            &rule.pattern,
+            &RuleSource::File {
+                name: &name,
+                line: line_num,
+            },
+        );
+        rules.push(rule);
     }
 
     Ok(rules)
@@ -78,24 +89,31 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
 /// literal pattern.
 pub(crate) fn parse_rules_no_prefixes(
     content: &str,
-    _source_path: &Path,
+    source_path: &Path,
     force_include: bool,
     cvs_ignore: bool,
     word_split: bool,
 ) -> Vec<FilterRule> {
     let mut rules = Vec::new();
 
+    // Every rule here comes out of a merged file's *contents*, so its text is
+    // never the operator's own and must be redacted in the FILTER2 trace.
+    let name = source_path.display().to_string();
+    let source = RuleSource::FileWordSplit { name: &name };
+
     let mut push_token = |token: &str| {
         // upstream: exclude.c:1123-1124 - when FILTRULE_CVS_IGNORE is set on
         // the template, a bare `!` becomes FILTRULE_CLEAR_LIST. Without
         // CVS_IGNORE the `!` is taken literally per the no-prefixes contract.
-        if cvs_ignore && token == "!" {
-            rules.push(FilterRule::clear());
+        let rule = if cvs_ignore && token == "!" {
+            FilterRule::clear()
         } else if force_include {
-            rules.push(FilterRule::include(token));
+            FilterRule::include(token)
         } else {
-            rules.push(FilterRule::exclude(token));
-        }
+            FilterRule::exclude(token)
+        };
+        trace_add_rule(rule.action, &rule.pattern, &source);
+        rules.push(rule);
     };
 
     if word_split {
@@ -134,8 +152,12 @@ pub(crate) fn parse_rules_word_split(
     source_path: &Path,
 ) -> Result<Vec<FilterRule>, MergeFileError> {
     let mut rules = Vec::new();
+    let name = source_path.display().to_string();
+    let source = RuleSource::FileWordSplit { name: &name };
     for token in content.split_whitespace() {
-        rules.push(parse_rule_line(token, source_path, 0)?);
+        let rule = parse_rule_line(token, source_path, 0)?;
+        trace_add_rule(rule.action, &rule.pattern, &source);
+        rules.push(rule);
     }
     Ok(rules)
 }

--- a/crates/filters/src/rule_source.rs
+++ b/crates/filters/src/rule_source.rs
@@ -27,6 +27,8 @@
 
 use std::borrow::Cow;
 
+use crate::action::FilterAction;
+
 /// Where the text of a filter rule came from.
 ///
 /// upstream: the `TEXT_FROM_FILE` predicate (`exclude.c:67-69`) plus the four
@@ -129,6 +131,45 @@ impl<'a> RuleSource<'a> {
     pub fn rule_detail<'d>(&self, detail: &'d str) -> &'d str {
         if self.is_from_file() { "" } else { detail }
     }
+}
+
+/// The action prefix upstream renders ahead of a rule's text.
+///
+/// upstream: `get_rule_prefix` (`exclude.c`), whose result `add_rule` passes to
+/// `rule_detail`. The trailing space belongs to the prefix, so a redacted rule
+/// renders as `add_rule(<rule from ...>)` with no leading gap.
+fn action_prefix(action: FilterAction) -> &'static str {
+    match action {
+        FilterAction::Include => "+ ",
+        FilterAction::Exclude => "- ",
+        FilterAction::Protect => "P ",
+        FilterAction::Risk => "R ",
+        FilterAction::Clear => "! ",
+        FilterAction::Merge => "merge ",
+        FilterAction::DirMerge => "dir-merge ",
+    }
+}
+
+/// Logs a parsed rule at `--debug=FILTER2`, redacting text that came from a
+/// file's contents.
+///
+/// upstream: `add_rule` (`exclude.c:259-275`) routes *both* halves through
+/// redactors - `rule_text_len` replaces a file-sourced pattern with
+/// `<rule from ...>`, and `rule_detail` drops the action prefix that would
+/// otherwise describe the text it no longer shows.
+///
+/// This is called from the parser rather than from rule compilation because
+/// that is where upstream calls it: `add_rule` runs with the rule's provenance
+/// in hand. Emitting downstream of the parse, where provenance has already been
+/// dropped, is what made this trace echo merged-file contents verbatim.
+pub fn trace_add_rule(action: FilterAction, pattern: &str, source: &RuleSource<'_>) {
+    logging::debug_log!(
+        Filter,
+        2,
+        "add_rule({}{})",
+        source.rule_detail(action_prefix(action)),
+        source.rule_text(pattern)
+    );
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## The defect

Under `--debug=FILTER2`, oc printed the contents of a merged filter file verbatim. A per-directory merge file is chosen by the **peer**, so the trace became a read-any-line oracle for any file the process can open:

```
$ printf ':w- ../secret\n' > src/.rsync-filter
$ oc-rsync -r -F --debug=FILTER2 src/ dest/
add_rule(- TOP-SECRET-PASSWORD-abc123)
```

## Upstream's remedy

`add_rule` (`exclude.c:259-275`) routes **both** halves through the provenance funnel — `rule_text_len` replaces a file-sourced pattern with `<rule from ...>`, and `rule_detail` drops the action prefix that would otherwise describe text it no longer shows.

oc already had that funnel: `RuleSource` in `crates/filters`, a faithful port with all four file arms, whose own tests already assert the exact target string. The live emitters simply bypassed it.

## The cause is placement, not a missing field

upstream's `add_rule` is a **parse-time** function — called with the rule *and* its provenance in hand, which is precisely what lets it decide whether the text may be shown. oc emitted the same trace from `CompiledRule::new`, a **compile-time** function downstream of the parse, where provenance has already been dropped.

Both of oc's parse paths already carry `RuleSource` as a value, so moving the trace to upstream's placement needs **no new field on `FilterRule`** and no change at its 50-odd construction sites.

`rule_source::trace_add_rule` becomes the single owner of the redaction, called from the parsers:

- `crates/filters/src/merge/parse.rs`, three sites. ⚠ `parse_rules_no_prefixes` took `_source_path` — **underscored**, so the provenance was already threaded in and deliberately discarded. That is the `:w-` word-split path the leak travelled on.
- `DirMergeEntries::push_rule` (merge-file contents → redacted) and `FilterProgram::new` (operator arguments → verbatim), for the engine's own parser, which the local `-F` path uses instead of the filters one.

Both compile-time emitters are deleted.

## Measured, end to end

Run against the upstream testsuite cell's own fixture:

| invocation | before | after |
|---|---|---|
| `-r -F --debug=FILTER2` (merge file) | `add_rule(- TOP-SECRET-PASSWORD-abc123)` | `add_rule(<rule from a file read earlier>)` |
| `--debug=FILTER2 --exclude='*.log'` (argument) | `add_rule(- *.log)` | `add_rule(- *.log)` — unchanged |

The second row is the **non-vacuity control**. upstream keeps argument text verbatim "because it is the user's own and hiding it only makes typos harder to fix" (`exclude.c:90-95`), so a fix that merely silenced the trace would fail it.

⚠ The discriminating fixture has to be the `:w-` word-split dir-merge, because it leaks through the **success** path — every whitespace token becomes its own rule and nothing fails to parse. A fixture built on an unparsable rule exercises the error path, which was already correct.

## Why the first attempt was inert

Worth recording: my initial emitter inventory found one live site (`filters/compiled/mod.rs`). Moving it to parse time and re-running the probe reproduced the leak **byte-identically** — the engine has its own parallel `CompiledRule::new` and its own dir-merge parser, and the local `-F` path never enters the filters parser at all. The tell was that the probe printed *one* line, not two.

## Verification

- `-p filters --lib` — 486/486.
- `python3 tools/ci/check_rustfmt_all.py` — exit 0 (the whole-tree gate; `cargo fmt --all` cannot see `include!`d files).
- `cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings` — clean, on the pinned 1.88.0 toolchain.
- `-p engine --lib` on this macOS host: **110 failures on pristine `origin/master`, 109 with this patch applied** (4609 → 4610 passed). This change introduces none of them and flips one green. Those 110 are a pre-existing macOS-local condition (`ELOOP` under `/var/folders`, the symlinked-`/tmp` class), unrelated to this diff.

Closes the `filter-merge-content-echo` divergence on the upstream 3.5.0 testsuite. It fails on **both** the non-root and root legs, because the leak is privilege-independent.
