### PR TITLE
fix(filters): three filter-diagnostic divergences from upstream 3.5.0's provenance funnel

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -36,11 +36,12 @@ use super::{
     LocalCopyRecordHandler, LocalCopyReport, LocalCopySummary, MergeFileRegistry, NestedDirMerge,
     ReferenceDirectory, SparseWriteState, compute_backup_path, copy_entry_to_backup,
     copy_pre_image_to_backup, create_backup_parents, delete_extraneous_entries,
-    filter_program_local_error, follow_symlink_metadata, load_dir_merge_rules_recursive,
-    map_metadata_error, record_directory_subtree, remove_source_entry_if_requested,
-    resolve_dir_merge_path, should_skip_copy, skip_matched_sparse, symlink_target_is_safe,
-    trace_make_backup_copy, trace_make_backup_device, trace_make_backup_hlink,
-    trace_make_backup_rename, trace_make_backup_symlink, write_sparse_chunk,
+    dir_merge_file_present, filter_program_local_error, follow_symlink_metadata,
+    load_dir_merge_rules_recursive, map_metadata_error, record_directory_subtree,
+    remove_source_entry_if_requested, resolve_dir_merge_path, should_skip_copy,
+    skip_matched_sparse, symlink_target_is_safe, trace_make_backup_copy, trace_make_backup_device,
+    trace_make_backup_hlink, trace_make_backup_rename, trace_make_backup_symlink,
+    write_sparse_chunk,
 };
 use crate::delta::{DeltaSignatureIndex, ProbeCounters};
 use crate::signature::SignatureBlock;

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -255,17 +255,26 @@ impl<'a> CopyContext<'a> {
         for (index, rule) in program.dir_merge_rules().iter().enumerate() {
             let candidate = resolve_dir_merge_path(source, rule.pattern());
 
-            let metadata = match fs::metadata(&candidate) {
-                Ok(metadata) => metadata,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+            // A program-level dir-merge directive is the operator's own: it is
+            // built from a `FilterRuleSpec`, which carries no provenance and so
+            // renders as `RuleSource::Argument` everywhere else on this path.
+            // (A `:` rule that reached the program out of a `--filter '. file'`
+            // merge would want redacting, but `FilterRuleSpec` cannot say so
+            // yet; the rules this scan discovers *inside* merge files take the
+            // file-sourced arm below.)
+            let present = match dir_merge_file_present(
+                &candidate,
+                rule.pattern(),
+                filters::RuleSource::Argument,
+            ) {
+                Ok(present) => present,
                 Err(error) => {
                     ephemeral_stack.pop();
                     marker_ephemeral_stack.pop();
-                    return Err(LocalCopyError::io("inspect filter file", candidate, error));
+                    return Err(error);
                 }
             };
-
-            if !metadata.is_file() {
+            if !present {
                 continue;
             }
 
@@ -456,14 +465,15 @@ impl<'a> CopyContext<'a> {
         rule: &NestedDirMerge,
     ) -> Result<Option<LoadedNestedDirMerge>, LocalCopyError> {
         let candidate = resolve_dir_merge_path(source, &rule.pattern);
-        let metadata = match fs::metadata(&candidate) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => {
-                return Err(LocalCopyError::io("inspect filter file", candidate, error));
-            }
-        };
-        if !metadata.is_file() {
+        // Every `NestedDirMerge` came out of a merge file's *contents* - the
+        // only producer is `DirMergeEntries::nested_dir_merges` - so upstream
+        // describes it as `a file read earlier` (exclude.c:78) and its text
+        // must not reach a diagnostic.
+        if !dir_merge_file_present(
+            &candidate,
+            &rule.pattern,
+            filters::RuleSource::FileReadEarlier,
+        )? {
             return Ok(None);
         }
 

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -39,6 +39,80 @@ pub(crate) fn resolve_dir_merge_path(base: &Path, pattern: &Path) -> PathBuf {
     base.join(pattern)
 }
 
+/// Reports whether `error` says the *name* was too long, rather than something
+/// about the file it names.
+///
+/// upstream decides this before the syscall, against its own fixed buffer:
+/// `parse_merge_name` refuses when `d_len + fn_len >= MAXPATHLEN` after
+/// prepending the scanned directory (exclude.c:739-744). oc composes a
+/// `PathBuf` with no ceiling of its own, so the authority on "too long" is the
+/// platform - and `MAXPATHLEN` resolves to the same `PATH_MAX` the kernel
+/// enforces (rsync.h:760-762 only supplies 1024 when `<sys/param.h>` did not),
+/// so the two rules coincide on both supported platforms.
+///
+/// This is not the errno-as-policy shape that keying a confinement fallback on
+/// a runtime errno would be: `ENAMETOOLONG` *is* the condition being reported,
+/// not a proxy for a decision made elsewhere.
+#[cfg(unix)]
+fn name_too_long(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ENAMETOOLONG)
+}
+
+/// Windows reports the same condition as `ERROR_FILENAME_EXCED_RANGE`.
+#[cfg(not(unix))]
+fn name_too_long(error: &io::Error) -> bool {
+    const ERROR_FILENAME_EXCED_RANGE: i32 = 206;
+    error.raw_os_error() == Some(ERROR_FILENAME_EXCED_RANGE)
+}
+
+/// Probes `candidate` for a per-directory merge file, reporting whether there
+/// is one to load.
+///
+/// Returns `false` for every reason upstream has to skip a per-dir merge
+/// without failing the transfer: the file is absent, it is not a regular file,
+/// or the composed `<scanned directory>/<pattern>` name overflows the
+/// platform's path limit. The last case is announced first, at `FERROR`, with
+/// `pattern` routed through the provenance funnel; the other two are silent.
+///
+/// upstream: exclude.c:739-744 `parse_merge_name` prints
+/// `merge-file name overflows: %s` and returns NULL, and the caller drops the
+/// rule (exclude.c:1577-1580) rather than aborting - the per-dir merge is
+/// parsed without `XFLG_FATAL_ERRORS` (exclude.c:912), the same reason a
+/// missing merge file is not an error either.
+///
+/// `source` is the rule's provenance. The pattern is passed, never the resolved
+/// path: the resolved path is what overflowed, but it embeds the pattern
+/// verbatim and printing it would defeat the redaction the funnel exists for.
+pub(crate) fn dir_merge_file_present(
+    candidate: &Path,
+    pattern: &Path,
+    source: filters::RuleSource<'_>,
+) -> Result<bool, LocalCopyError> {
+    let metadata = match fs::metadata(candidate) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) if name_too_long(&error) => {
+            let spelled = pattern.to_string_lossy();
+            logging::emit_info_coded(
+                logging::InfoFlag::Misc,
+                0,
+                logging::LogCode::Error,
+                filters::merge_name_overflows(&source.rule_text(&spelled)),
+            );
+            return Ok(false);
+        }
+        Err(error) => {
+            return Err(LocalCopyError::io(
+                "inspect filter file",
+                candidate.to_path_buf(),
+                error,
+            ));
+        }
+    };
+
+    Ok(metadata.is_file())
+}
+
 /// Applies the per-directory merge `options` to `rule` as defaults.
 ///
 /// Anchors the rule to the source root when configured, marks it perishable,
@@ -576,6 +650,116 @@ fn open_merge_file(path: &std::path::Path) -> io::Result<fs::File> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Builds a merge-file pattern long enough that the composed
+    /// `<scanned dir>/<pattern>` overflows the platform's path limit, while
+    /// every single component stays well inside `NAME_MAX` - so what the
+    /// platform refuses is the whole-path rule upstream applies, not a
+    /// per-component one.
+    #[cfg(unix)]
+    fn over_long_pattern() -> PathBuf {
+        let mut pattern = PathBuf::new();
+        for _ in 0..24 {
+            pattern.push("Q".repeat(200));
+        }
+        pattern
+    }
+
+    /// Drains the thread-local diagnostic buffer down to message strings.
+    #[cfg(unix)]
+    fn drained_messages() -> Vec<String> {
+        logging::drain_events()
+            .into_iter()
+            .map(|event| match event {
+                logging::DiagnosticEvent::Info { message, .. }
+                | logging::DiagnosticEvent::Debug { message, .. } => message,
+            })
+            .collect()
+    }
+
+    /// WHY: this is the leak upstream's `merge-file name overflows` exists to
+    /// avoid. A deferred `: sub/NAME` rule is read out of a `.rsync-filter`,
+    /// so echoing the name hands the peer that file's contents from a plain
+    /// `-r -F` with no verbosity asked for at all.
+    ///
+    /// upstream: exclude.c:739-744 refuses before any open and returns NULL,
+    /// which drops the rule without failing the transfer.
+    #[cfg(unix)]
+    #[test]
+    fn an_over_long_file_sourced_merge_name_is_refused_without_echoing_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pattern = over_long_pattern();
+        let candidate = resolve_dir_merge_path(dir.path(), &pattern);
+        let _ = logging::drain_events();
+
+        let present =
+            dir_merge_file_present(&candidate, &pattern, filters::RuleSource::FileReadEarlier)
+                .expect("an over-long name is skipped, not a transfer failure");
+
+        assert!(!present, "there is nothing to load");
+        assert_eq!(
+            drained_messages(),
+            vec!["merge-file name overflows: <rule from a file read earlier>".to_owned()],
+        );
+    }
+
+    /// WHY: the non-vacuity companion. A blanket-silencing bug - or one that
+    /// stopped emitting the diagnostic at all - would satisfy the test above.
+    /// Upstream keeps an argument rule's own text because it is the operator's
+    /// and hiding it only makes typos harder to fix (exclude.c:90-95).
+    #[cfg(unix)]
+    #[test]
+    fn an_over_long_argument_merge_name_is_reported_verbatim() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pattern = over_long_pattern();
+        let candidate = resolve_dir_merge_path(dir.path(), &pattern);
+        let _ = logging::drain_events();
+
+        let present = dir_merge_file_present(&candidate, &pattern, filters::RuleSource::Argument)
+            .expect("an over-long name is skipped, not a transfer failure");
+
+        assert!(!present, "there is nothing to load");
+        assert_eq!(
+            drained_messages(),
+            vec![format!("merge-file name overflows: {}", pattern.display())],
+        );
+    }
+
+    /// WHY: bounds the arm above. An absent merge file is upstream's ordinary
+    /// case - every directory the scan enters is probed - so it must stay
+    /// silent, or the diagnostic fires on every transfer.
+    #[cfg(unix)]
+    #[test]
+    fn an_absent_merge_file_is_skipped_silently() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pattern = Path::new(".rsync-filter");
+        let candidate = resolve_dir_merge_path(dir.path(), pattern);
+        let _ = logging::drain_events();
+
+        let present = dir_merge_file_present(&candidate, pattern, filters::RuleSource::Argument)
+            .expect("an absent merge file is not an error");
+
+        assert!(!present);
+        assert!(drained_messages().is_empty(), "nothing to report");
+    }
+
+    /// WHY: the positive control. Without it every assertion above would also
+    /// hold for a helper that reported `false` unconditionally.
+    #[cfg(unix)]
+    #[test]
+    fn a_present_merge_file_is_reported_as_loadable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pattern = Path::new(".rsync-filter");
+        let candidate = resolve_dir_merge_path(dir.path(), pattern);
+        fs::write(&candidate, b"- secret\n").expect("write the merge file");
+        let _ = logging::drain_events();
+
+        let present = dir_merge_file_present(&candidate, pattern, filters::RuleSource::Argument)
+            .expect("a readable merge file is not an error");
+
+        assert!(present);
+        assert!(drained_messages().is_empty(), "nothing to report");
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -198,7 +198,13 @@ impl DirMergeEntries {
             rule.pattern(),
             &filters::RuleSource::FileReadEarlier,
         );
-        self.rules.push(rule);
+        // The same provenance is RETAINED ON THE RULE, not just consumed here:
+        // the match trace (`report_filter_result`, exclude.c:1099) fires when
+        // this rule matches a path, long after this parse returns, and it needs
+        // the identical redaction. upstream keeps it as the rule's
+        // `FILTRULE_FROM_FILE` bit for exactly that reason.
+        self.rules
+            .push(rule.with_source(filters::OwnedRuleSource::FileReadEarlier));
     }
 
     fn push_exclude_if_present(&mut self, rule: ExcludeIfPresentRule) {

--- a/crates/engine/src/local_copy/dir_merge/mod.rs
+++ b/crates/engine/src/local_copy/dir_merge/mod.rs
@@ -9,8 +9,8 @@ mod parse;
 mod registry;
 
 pub(crate) use load::{
-    NestedDirMerge, apply_dir_merge_rule_defaults, filter_program_local_error,
-    load_dir_merge_rules_recursive, resolve_dir_merge_path,
+    NestedDirMerge, apply_dir_merge_rule_defaults, dir_merge_file_present,
+    filter_program_local_error, load_dir_merge_rules_recursive, resolve_dir_merge_path,
 };
 pub(crate) use parse::{FilterParseError, ParsedFilterDirective, parse_filter_directive_line};
 pub(crate) use registry::MergeFileRegistry;

--- a/crates/engine/src/local_copy/filter_program/segments.rs
+++ b/crates/engine/src/local_copy/filter_program/segments.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 
-use filters::{FilterAction, FilterRule};
+use filters::{FilterAction, FilterRule, OwnedRuleSource};
 use globset::{GlobBuilder, GlobMatcher};
 use logging::debug_log;
 
@@ -208,9 +208,20 @@ impl FilterSegment {
 /// Emits a `--debug=FILTER` line for a rule that fired on `path`, naming the
 /// file, its type, and the matching pattern.
 ///
-/// upstream: exclude.c:report_filter_result() - `[who] {action}ing {type}
+/// upstream: exclude.c:1099 report_filter_result() - `[who] {action}ing {type}
 /// {name} because of pattern {pattern}{/}`. `debug_log!` gates on the FILTER
 /// debug level internally, so the message is only formatted when enabled.
+///
+/// BOTH interpolated halves are redacted for a file-sourced rule, exactly as
+/// upstream does: the pattern through `rule_text()` and the trailing `/`
+/// through `rule_detail()`. The slash is not decoration - it reports whether
+/// the hidden rule was directory-only, which is a property OF the text being
+/// withheld, so upstream drops it "along with the text it describes"
+/// (exclude.c:127-131).
+///
+/// This trace runs at level 1 for a sender or generator (exclude.c:1093), so
+/// plain `-vv` reaches it with no `--debug` at all - which is why an unredacted
+/// pattern here echoes a peer-chosen merge file's contents to any client.
 fn report_filter_result(rule: &CompiledRule, path: &Path, is_dir: bool, who: &str) {
     let verb = match rule.action {
         FilterAction::Include => "including",
@@ -220,14 +231,40 @@ fn report_filter_result(rule: &CompiledRule, path: &Path, is_dir: bool, who: &st
         _ => return,
     };
     let kind = if is_dir { "directory" } else { "file" };
-    let slash = if rule.directory_only { "/" } else { "" };
+    let shown = match_trace_pattern(rule);
     debug_log!(
         Filter,
         1,
-        "[{who}] {verb} {kind} {} because of pattern {}{slash}",
+        "[{who}] {verb} {kind} {} because of pattern {shown}",
         path.display(),
-        rule.pattern,
     );
+}
+
+/// Renders the `{pattern}{/}` tail of the match trace, redacting BOTH halves
+/// for a file-sourced rule.
+///
+/// Split out from [`report_filter_result`] so the redaction can be asserted
+/// without capturing log output: the emitter decides *whether* to log, this
+/// decides *what the text says*.
+///
+/// upstream: exclude.c:1099 passes the two halves through separate redactors -
+/// `rule_text(ent, ent->pattern)` and `rule_detail(ent, ... ? "/" : "")`. The
+/// slash reports whether the withheld rule was directory-only, which is a
+/// property OF the hidden text, so upstream drops it too (exclude.c:127-131).
+///
+/// The trailing `/` is stripped from the pattern before the two halves are
+/// composed. Upstream's `add_rule` consumes it at parse time - it sets
+/// `FILTRULE_DIRECTORY` and stores a slash-free `ent->pattern`
+/// (exclude.c:259-275) - so the slash reaches the trace exactly once, from
+/// `rule_detail`. oc keeps the operator's raw spelling on the rule and derives
+/// `directory_only` from it, so without this strip a directory-only rule
+/// renders `sub//` where upstream renders `sub/` (measured against 3.5.0).
+fn match_trace_pattern(rule: &CompiledRule) -> String {
+    let pattern = rule.pattern.strip_suffix('/').unwrap_or(&rule.pattern);
+    let source = rule.source.as_source();
+    let shown = source.rule_text(pattern);
+    let slash = source.rule_detail(if rule.directory_only { "/" } else { "" });
+    format!("{shown}{slash}")
 }
 
 #[derive(Clone, Debug)]
@@ -372,6 +409,12 @@ struct CompiledRule {
     /// include/exclude and protect/risk chains back into the single
     /// first-match-wins pass upstream `check_filter()` runs (exclude.c:1038).
     order: usize,
+    /// Provenance of [`Self::pattern`], carried from the parse.
+    ///
+    /// upstream: `ent->rflags & FILTRULE_FROM_FILE` (`exclude.c:259-275`). The
+    /// match trace below runs long after the merge file was read and closed, so
+    /// the redaction has to travel on the rule rather than in parser scope.
+    source: OwnedRuleSource,
 }
 
 impl CompiledRule {
@@ -381,6 +424,7 @@ impl CompiledRule {
         let applies_to_receiver = rule.applies_to_receiver();
         let negate = rule.is_negated();
         let pattern = rule.pattern().to_owned();
+        let source = rule.source().clone();
 
         // upstream: exclude.c:259-275 add_rule() logs every parsed rule at
         // `DEBUG_GTE(FILTER, 2)`. That trace is emitted by the *parsers* -
@@ -448,6 +492,7 @@ impl CompiledRule {
             negate,
             pattern,
             order: 0,
+            source,
         })
     }
 
@@ -714,6 +759,39 @@ mod tests {
     fn filter_segment_is_empty() {
         let segment = FilterSegment::default();
         assert!(segment.is_empty());
+    }
+
+    /// A rule whose text came out of a merge file must not have that text
+    /// echoed by the match trace - and the trailing `/` goes with it, because
+    /// it reports a property of the withheld text.
+    ///
+    /// The trace runs at level 1 for a sender or generator (exclude.c:1093),
+    /// so plain `-vv` reaches it: an unredacted pattern here hands a
+    /// peer-chosen per-directory merge file's contents to any client.
+    #[test]
+    fn match_trace_redacts_a_merge_file_rules_text_and_its_slash() {
+        let rule = CompiledRule::new(
+            FilterRule::exclude("sec[r]et-marker-9x/".to_owned())
+                .with_source(OwnedRuleSource::FileReadEarlier),
+        )
+        .unwrap();
+
+        assert_eq!(
+            match_trace_pattern(&rule),
+            "<rule from a file read earlier>"
+        );
+    }
+
+    /// The non-vacuity companion: upstream shows an ARGUMENT rule's text
+    /// verbatim "because it is the user's own and hiding it only makes typos
+    /// harder to fix" (exclude.c:90-95), slash included. Without this row a
+    /// blanket-redaction bug would satisfy the test above.
+    #[test]
+    fn match_trace_shows_an_argument_rules_text_and_its_slash_verbatim() {
+        let rule =
+            CompiledRule::new(FilterRule::exclude("sec[r]et-marker-9x/".to_owned())).unwrap();
+
+        assert_eq!(match_trace_pattern(&rule), "sec[r]et-marker-9x/");
     }
 
     #[test]

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -115,8 +115,8 @@ pub(crate) use context::{
 #[allow(unused_imports)] // REASON: convenience re-export; not all items used in every module
 pub(crate) use dir_merge::{
     FilterParseError, MergeFileRegistry, NestedDirMerge, ParsedFilterDirective,
-    apply_dir_merge_rule_defaults, filter_program_local_error, load_dir_merge_rules_recursive,
-    parse_filter_directive_line, resolve_dir_merge_path,
+    apply_dir_merge_rule_defaults, dir_merge_file_present, filter_program_local_error,
+    load_dir_merge_rules_recursive, parse_filter_directive_line, resolve_dir_merge_path,
 };
 
 pub(crate) use executor::*;

--- a/crates/filters/src/compiled/clear.rs
+++ b/crates/filters/src/compiled/clear.rs
@@ -16,6 +16,7 @@ pub(crate) fn apply_clear_rule(rules: &mut Vec<CompiledRule>, sender: bool, rece
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rule_source::OwnedRuleSource;
     use crate::{FilterAction, FilterRule};
 
     #[test]
@@ -35,6 +36,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, false);
@@ -60,6 +62,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(false, true);
@@ -85,6 +88,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let mut compiled = CompiledRule::new(rule).unwrap();
         let still_active = compiled.clear_sides(true, true);
@@ -117,6 +121,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, false, false);
@@ -140,6 +145,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let mut rules = vec![CompiledRule::new(rule).unwrap()];
         apply_clear_rule(&mut rules, true, false);

--- a/crates/filters/src/compiled/mod.rs
+++ b/crates/filters/src/compiled/mod.rs
@@ -51,6 +51,7 @@ impl CompiledRule {
             word_split: _,
             no_prefixes: _,
             no_prefixes_include: _,
+            source,
         } = rule;
         debug_assert!(
             !xattr_only,
@@ -198,6 +199,7 @@ impl CompiledRule {
             perishable,
             negate,
             order: 0,
+            source,
         })
     }
 }
@@ -205,6 +207,7 @@ impl CompiledRule {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rule_source::OwnedRuleSource;
 
     #[test]
     fn compiled_rule_new_simple_exclude() {
@@ -223,6 +226,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Exclude);
@@ -248,6 +252,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -270,6 +275,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.perishable);
@@ -328,6 +334,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -360,6 +367,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.directory_only);
@@ -404,6 +412,7 @@ mod tests {
                 word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
+                source: OwnedRuleSource::Argument,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -437,6 +446,7 @@ mod tests {
                 word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
+                source: OwnedRuleSource::Argument,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -467,6 +477,7 @@ mod tests {
                 word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
+                source: OwnedRuleSource::Argument,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -495,6 +506,7 @@ mod tests {
                 word_split: false,
                 no_prefixes: false,
                 no_prefixes_include: false,
+                source: OwnedRuleSource::Argument,
             };
             let compiled = CompiledRule::new(rule).unwrap();
             assert!(
@@ -529,6 +541,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -565,6 +578,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -592,6 +606,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         use std::path::Path;
@@ -654,6 +669,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         })
         .unwrap()
     }
@@ -855,6 +871,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.negate);
@@ -874,6 +891,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled2 = CompiledRule::new(rule2).unwrap();
         assert!(!compiled2.negate);

--- a/crates/filters/src/compiled/rule.rs
+++ b/crates/filters/src/compiled/rule.rs
@@ -4,6 +4,7 @@ use logging::debug_log;
 
 use super::pattern::CompiledPattern;
 use crate::FilterAction;
+use crate::rule_source::OwnedRuleSource;
 
 /// A compiled filter rule with pre-built glob matchers for efficient matching.
 ///
@@ -50,6 +51,14 @@ pub(crate) struct CompiledRule {
     /// built outside `from_rules` (per-dir implied includes), which never mix
     /// the two chains against one path.
     pub(crate) order: usize,
+    /// Provenance of [`Self::pattern`], carried from the parse so the match
+    /// trace can decide whether the text may be shown.
+    ///
+    /// upstream keeps the same thing on its own rule (`ent->rflags &
+    /// FILTRULE_FROM_FILE`, `exclude.c:259-275`) precisely because
+    /// `report_filter_result` (`exclude.c:1099`) runs at MATCH time, when the
+    /// merge file that supplied the rule is long closed.
+    pub(crate) source: OwnedRuleSource,
 }
 
 impl CompiledRule {
@@ -194,6 +203,7 @@ impl CompiledRule {
 
 #[cfg(test)]
 mod tests {
+    use crate::rule_source::OwnedRuleSource;
     use std::path::Path;
 
     use crate::compiled::CompiledRule;
@@ -216,6 +226,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.bak"), false, true));
@@ -240,6 +251,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), false, true));
@@ -263,6 +275,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("node_modules"), true, true));
@@ -286,6 +299,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build"), true, true));
@@ -310,6 +324,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Protect);
@@ -333,6 +348,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Risk);
@@ -355,6 +371,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert_eq!(compiled.action, FilterAction::Include);
@@ -378,6 +395,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("build/main.o"), false, true));
@@ -407,6 +425,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -442,6 +461,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -467,6 +487,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
         assert!(compiled.matches(Path::new("file.txt"), false, true));
@@ -487,6 +508,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled_negated = CompiledRule::new(rule_negated).unwrap();
         assert!(!compiled_negated.matches(Path::new("file.txt"), false, true));
@@ -510,6 +532,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -537,6 +560,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -567,6 +591,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -604,6 +629,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -636,6 +662,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -673,6 +700,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 
@@ -709,6 +737,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         let compiled = CompiledRule::new(rule).unwrap();
 

--- a/crates/filters/src/decision.rs
+++ b/crates/filters/src/decision.rs
@@ -195,15 +195,22 @@ impl FilterSetInner {
             let allowed = matches!(rule.action, FilterAction::Include);
             decision.transfer_allowed = allowed;
 
-            // upstream: exclude.c:report_filter_result() names the matched
-            // pattern in the `--debug=FILTER` line.
+            // upstream: exclude.c:1099 report_filter_result() names the matched
+            // pattern in the `--debug=FILTER` line, but routes it through
+            // `rule_text()` first - the same redaction `add_rule` applies. This
+            // one fires at MATCH time, so the provenance has to come off the
+            // rule; the parse that supplied it is long finished. Without the
+            // redaction a peer-chosen per-directory merge file's contents are
+            // echoed at plain `-vv`, because upstream sets this trace's level
+            // to 1 for a sender or generator (`exclude.c:1093`).
+            let shown = rule.source.as_source().rule_text(&rule.pattern);
             if allowed {
                 debug_log!(
                     Filter,
                     1,
                     "including {:?} because of pattern {}",
                     path,
-                    rule.pattern
+                    shown
                 );
             } else {
                 debug_log!(
@@ -211,7 +218,7 @@ impl FilterSetInner {
                     1,
                     "excluding {:?} because of pattern {}",
                     path,
-                    rule.pattern
+                    shown
                 );
             }
         }
@@ -646,6 +653,7 @@ impl Default for FilterDecision {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rule_source::OwnedRuleSource;
 
     #[test]
     fn filter_decision_default() {
@@ -738,6 +746,7 @@ mod tests {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         };
         inner
             .include_exclude

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -148,8 +148,8 @@ pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{
-    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, parse_rules, read_rules,
-    read_rules_recursive,
+    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, merge_name_overflows, parse_rules,
+    read_rules, read_rules_recursive,
 };
 pub use rule::FilterRule;
 pub use rule_source::{OwnedRuleSource, RuleSource, trace_add_rule};

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -152,7 +152,7 @@ pub use merge::{
     read_rules_recursive,
 };
 pub use rule::FilterRule;
-pub use rule_source::{RuleSource, trace_add_rule};
+pub use rule_source::{OwnedRuleSource, RuleSource, trace_add_rule};
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};
 pub use wildmatch::{iwildmatch, wildmatch};
 

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -46,6 +46,7 @@
 
 mod depth;
 mod error;
+mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
 
@@ -54,6 +55,7 @@ mod tests;
 
 pub use depth::{MAX_MERGE_DEPTH, depth_limit_exceeded};
 pub use error::MergeFileError;
+pub use overflow::merge_name_overflows;
 pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};

--- a/crates/filters/src/merge/overflow.rs
+++ b/crates/filters/src/merge/overflow.rs
@@ -1,0 +1,75 @@
+//! Diagnostic for a merge-file name too long to compose.
+//!
+//! A per-directory merge rule names a file that is looked up again in every
+//! directory the scan enters, so the name that reaches the filesystem is
+//! `<scanned directory>/<rule pattern>`. The rule can be short enough to parse
+//! and still overflow once that prefix is prepended - which is exactly the case
+//! upstream refuses here, before any open.
+//!
+//! The refusal has to route the pattern through the provenance funnel: a
+//! deferred `:` rule is normally read out of a merge file, so echoing its text
+//! would leak that file's contents at *no* verbosity, from an operator's plain
+//! `-r -F`.
+
+/// Renders upstream's merge-name overflow diagnostic.
+///
+/// upstream: exclude.c:727 and exclude.c:741, the two `parse_merge_name`
+/// refusals:
+///
+/// ```text
+/// rprintf(FERROR, "merge-file name overflows: %s\n",
+///         rule_text(template, merge_file));
+/// ```
+///
+/// `rule` is upstream's `rule_text()` rendering of the merge directive's
+/// pattern - the rule as written for an argument, `<rule from ...>` for one
+/// that came out of a file. Pass the pattern, never the resolved path: the
+/// resolved path is what overflowed, but it embeds the pattern verbatim and
+/// would defeat the redaction.
+#[must_use]
+pub fn merge_name_overflows(rule: &str) -> String {
+    format!("merge-file name overflows: {rule}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rule_source::RuleSource;
+
+    /// WHY: the wording is what upstream's testsuite greps for
+    /// (`filter-merge-content-echo_test.py`), so it is part of the contract,
+    /// not a message we are free to reword.
+    #[test]
+    fn wording_matches_upstream() {
+        assert_eq!(
+            merge_name_overflows("sub/name"),
+            "merge-file name overflows: sub/name"
+        );
+    }
+
+    /// WHY: this is the leak the diagnostic exists to avoid - a deferred
+    /// per-dir merge whose pattern came out of a `.rsync-filter`. Without the
+    /// funnel the whole name is echoed with no verbosity requested at all.
+    #[test]
+    fn a_file_sourced_pattern_is_withheld() {
+        let rendered =
+            merge_name_overflows(&RuleSource::FileReadEarlier.rule_text("sub/DEFERRED-SECRET"));
+        assert_eq!(
+            rendered,
+            "merge-file name overflows: <rule from a file read earlier>"
+        );
+        assert!(!rendered.contains("DEFERRED-SECRET"));
+    }
+
+    /// WHY: the non-vacuity companion. A blanket-redaction bug would satisfy
+    /// the test above; upstream keeps an argument rule's own text because it is
+    /// the operator's and hiding it only makes typos harder to fix
+    /// (exclude.c:90-95).
+    #[test]
+    fn an_argument_pattern_is_shown_verbatim() {
+        assert_eq!(
+            merge_name_overflows(&RuleSource::Argument.rule_text("sub/TYPO")),
+            "merge-file name overflows: sub/TYPO"
+        );
+    }
+}

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -8,6 +8,7 @@
 //! upstream: exclude.c - filter_rule struct and FILTRULE_* flags
 
 use crate::FilterAction;
+use crate::rule_source::OwnedRuleSource;
 
 /// User-visible filter rule consisting of an action and a glob pattern.
 ///
@@ -100,6 +101,17 @@ pub struct FilterRule {
     /// upstream: exclude.c:1232-1237 - the merge-file `+` modifier sets
     /// `FILTRULE_NO_PREFIXES | FILTRULE_INCLUDE`.
     pub(crate) no_prefixes_include: bool,
+    /// Where this rule's text came from, retained so diagnostics raised after
+    /// the parse can still decide whether the text may be shown.
+    ///
+    /// upstream: the `FILTRULE_FROM_FILE` bit plus the retained `elt` location
+    /// (`exclude.c:259-275`). It is carried on the rule rather than held in the
+    /// parser because `report_filter_result` (`exclude.c:1099`) fires when a
+    /// rule MATCHES A PATH - long after the merge file that supplied it was
+    /// read and closed - and a deferred per-directory merge is parsed later
+    /// still. Rules built from an operator argument keep the default
+    /// [`OwnedRuleSource::Argument`], whose text is shown verbatim.
+    pub(crate) source: OwnedRuleSource,
 }
 
 impl FilterRule {
@@ -135,6 +147,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -170,6 +183,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -205,6 +219,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -230,6 +245,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -256,6 +272,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -285,6 +302,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -314,6 +332,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -347,6 +366,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -380,6 +400,7 @@ impl FilterRule {
             word_split: false,
             no_prefixes: false,
             no_prefixes_include: false,
+            source: OwnedRuleSource::Argument,
         }
     }
 
@@ -440,6 +461,32 @@ impl FilterRule {
     pub const fn with_perishable(mut self, perishable: bool) -> Self {
         self.perishable = perishable;
         self
+    }
+
+    /// Records where this rule's text came from.
+    ///
+    /// Call this from the parser, which is the only place that knows. Rules
+    /// left at the default [`OwnedRuleSource::Argument`] have their text shown
+    /// verbatim in diagnostics; anything sourced from a file's contents is
+    /// replaced by `<rule from ...>`.
+    ///
+    /// upstream: `add_rule` sets `FILTRULE_FROM_FILE` and retains the location
+    /// on the rule at parse time (`exclude.c:259-275`), because the diagnostics
+    /// that need it run much later - see [`FilterRule::source`].
+    #[must_use]
+    pub fn with_source(mut self, source: OwnedRuleSource) -> Self {
+        self.source = source;
+        self
+    }
+
+    /// Where this rule's text came from.
+    ///
+    /// Consumed by diagnostics raised after the parse - notably the match
+    /// trace, which fires when the rule matches a path (upstream:
+    /// `report_filter_result`, `exclude.c:1099`).
+    #[must_use]
+    pub const fn source(&self) -> &OwnedRuleSource {
+        &self.source
     }
 
     /// Marks the rule as applying exclusively to xattr names.

--- a/crates/filters/src/rule_source.rs
+++ b/crates/filters/src/rule_source.rs
@@ -133,6 +133,89 @@ impl<'a> RuleSource<'a> {
     }
 }
 
+/// An owned [`RuleSource`], retained on a rule so its provenance outlives the
+/// parse that produced it.
+///
+/// upstream keeps the same information on the rule itself - the
+/// `FILTRULE_FROM_FILE` bit plus the retained `elt` location
+/// (`exclude.c:259-275`) - and it has to live there because the redaction
+/// decision is not always made at parse time. `report_filter_result`
+/// (`exclude.c:1099`) runs when a rule MATCHES A PATH, long after the file that
+/// supplied the rule was read and closed; a deferred per-directory merge is
+/// parsed later still. [`RuleSource`] borrows its strings from the parse, so it
+/// cannot serve either case.
+///
+/// This type is storage only. Every redaction decision stays in [`RuleSource`],
+/// reached through [`Self::as_source`], so the two cannot drift apart.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum OwnedRuleSource {
+    /// See [`RuleSource::Argument`].
+    #[default]
+    Argument,
+    /// See [`RuleSource::File`].
+    File {
+        /// The merge file's name.
+        name: String,
+        /// 1-indexed physical line.
+        line: usize,
+    },
+    /// See [`RuleSource::FileWordSplit`].
+    FileWordSplit {
+        /// The merge file's name.
+        name: String,
+    },
+    /// See [`RuleSource::FileNamedAt`].
+    FileNamedAt {
+        /// Description of the location that named this file.
+        location: String,
+    },
+    /// See [`RuleSource::FileReadEarlier`].
+    FileReadEarlier,
+}
+
+impl OwnedRuleSource {
+    /// Borrows this provenance as a [`RuleSource`], which owns every redaction
+    /// rule - storage and policy each stay in exactly one place.
+    #[must_use]
+    pub fn as_source(&self) -> RuleSource<'_> {
+        match self {
+            Self::Argument => RuleSource::Argument,
+            Self::File { name, line } => RuleSource::File { name, line: *line },
+            Self::FileWordSplit { name } => RuleSource::FileWordSplit { name },
+            Self::FileNamedAt { location } => RuleSource::FileNamedAt { location },
+            Self::FileReadEarlier => RuleSource::FileReadEarlier,
+        }
+    }
+
+    /// Reports whether the text came from a file's contents.
+    ///
+    /// upstream: `TEXT_FROM_FILE` (`exclude.c:67-69`) read through the rule's
+    /// own `FILTRULE_FROM_FILE` bit rather than the parser's module state.
+    #[must_use]
+    pub fn is_from_file(&self) -> bool {
+        self.as_source().is_from_file()
+    }
+}
+
+impl From<RuleSource<'_>> for OwnedRuleSource {
+    fn from(source: RuleSource<'_>) -> Self {
+        match source {
+            RuleSource::Argument => Self::Argument,
+            RuleSource::File { name, line } => Self::File {
+                name: name.to_owned(),
+                line,
+            },
+            RuleSource::FileWordSplit { name } => Self::FileWordSplit {
+                name: name.to_owned(),
+            },
+            RuleSource::FileNamedAt { location } => Self::FileNamedAt {
+                location: location.to_owned(),
+            },
+            RuleSource::FileReadEarlier => Self::FileReadEarlier,
+        }
+    }
+}
+
 /// The action prefix upstream renders ahead of a rule's text.
 ///
 /// upstream: `get_rule_prefix` (`exclude.c`), whose result `add_rule` passes to

--- a/crates/filters/src/rule_source.rs
+++ b/crates/filters/src/rule_source.rs
@@ -233,31 +233,171 @@ fn action_prefix(action: FilterAction) -> &'static str {
     }
 }
 
-/// Logs a parsed rule at `--debug=FILTER2`, redacting text that came from a
-/// file's contents.
+/// The `--debug=FILTER` level a rule prints at, and the suffix it prints with.
 ///
-/// upstream: `add_rule` (`exclude.c:259-275`) routes *both* halves through
-/// redactors - `rule_text_len` replaces a file-sourced pattern with
-/// `<rule from ...>`, and `rule_detail` drops the action prefix that would
-/// otherwise describe the text it no longer shows.
+/// upstream: `add_rule` (`exclude.c:265-269`) gates the trace on *two* levels,
+/// not one. A rule whose last byte is a space or a tab is worth flagging on its
+/// own, so it prints from FILTER1 carrying a caution; everything else waits for
+/// FILTER2 and prints with an empty suffix. Below FILTER1 nothing prints.
+///
+/// The whitespace test reads the rule's raw text, so an empty pattern can never
+/// take the caution arm - matching upstream's leading `pat_len &&`.
+fn mention_rule_suffix(pattern: &str) -> Option<(u8, &'static str)> {
+    if logging::debug_gte(logging::DebugFlag::Filter, 1) && pattern.ends_with([' ', '\t']) {
+        return Some((1, " -- CAUTION: trailing whitespace!"));
+    }
+    if logging::debug_gte(logging::DebugFlag::Filter, 2) {
+        return Some((2, ""));
+    }
+    None
+}
+
+/// Logs a parsed rule under upstream's two-level `--debug=FILTER` gate,
+/// redacting text - and details *about* text - that came from a file's
+/// contents.
+///
+/// upstream: `add_rule` (`exclude.c:265-275`) routes all three variable halves
+/// through redactors - `rule_text_len` replaces a file-sourced pattern with
+/// `<rule from ...>`, and `rule_detail` drops both the action prefix and the
+/// trailing-whitespace caution, because each describes text the peer is no
+/// longer being shown. A caution on a hidden rule would report whether that
+/// rule ends in a space, which is exactly the kind of fact the redaction
+/// exists to withhold.
 ///
 /// This is called from the parser rather than from rule compilation because
 /// that is where upstream calls it: `add_rule` runs with the rule's provenance
 /// in hand. Emitting downstream of the parse, where provenance has already been
 /// dropped, is what made this trace echo merged-file contents verbatim.
+///
+/// Residual: upstream also prints `listp->debug_type` (`exclude.c:274`), the
+/// label naming *which* filter list the rule joined - `` for the main list,
+/// ` [daemon]`, ` [per-dir .rsync-filter]`. oc has no filter-list identity to
+/// pass here, so that field is absent rather than wrong.
 pub fn trace_add_rule(action: FilterAction, pattern: &str, source: &RuleSource<'_>) {
-    logging::debug_log!(
-        Filter,
-        2,
-        "add_rule({}{})",
-        source.rule_detail(action_prefix(action)),
-        source.rule_text(pattern)
+    let Some((level, suffix)) = mention_rule_suffix(pattern) else {
+        return;
+    };
+
+    logging::emit_debug(
+        logging::DebugFlag::Filter,
+        level,
+        format!(
+            "add_rule({}{}){}",
+            source.rule_detail(action_prefix(action)),
+            source.rule_text(pattern),
+            source.rule_detail(suffix)
+        ),
     );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Installs a `--debug=FILTER<level>` verbosity on this thread and clears
+    /// any events an earlier test left buffered, so each pin below observes
+    /// only what its own call emitted.
+    fn with_filter_debug(level: u8) {
+        logging::init(logging::VerbosityConfig::default());
+        for step in 1..=level {
+            logging::apply_debug_flag(&format!("filter{step}")).expect("filter debug flag");
+        }
+        drop(logging::drain_events());
+    }
+
+    fn drained_messages() -> Vec<String> {
+        logging::drain_events()
+            .into_iter()
+            .map(|event| match event {
+                logging::DiagnosticEvent::Info { message, .. }
+                | logging::DiagnosticEvent::Debug { message, .. } => message,
+            })
+            .collect()
+    }
+
+    /// WHY: upstream prints a rule ending in whitespace from FILTER1, one level
+    /// earlier than every other rule, because that rule almost certainly does
+    /// not do what its author meant - the space is part of the pattern
+    /// (exclude.c:265-269).
+    #[test]
+    fn an_argument_rule_ending_in_whitespace_cautions_at_filter1() {
+        with_filter_debug(1);
+        trace_add_rule(FilterAction::Exclude, "my-own-rule ", &RuleSource::Argument);
+
+        assert_eq!(
+            drained_messages(),
+            vec!["add_rule(- my-own-rule ) -- CAUTION: trailing whitespace!".to_owned()],
+            "the operator's own trailing-whitespace rule must be flagged, and shown verbatim",
+        );
+    }
+
+    /// The caution is a fact ABOUT the rule's text, so it goes through
+    /// `rule_detail` with the text itself: telling the peer that a hidden rule
+    /// ends in a space leaks exactly what the redaction withholds
+    /// (exclude.c:274). The line still prints - upstream's gate fired - but
+    /// carries neither the pattern, the action prefix, nor the caution.
+    #[test]
+    fn a_file_sourced_rule_ending_in_whitespace_is_flagged_silently() {
+        with_filter_debug(1);
+        trace_add_rule(
+            FilterAction::Exclude,
+            "trailing-ws-probe ",
+            &RuleSource::File {
+                name: ".rsync-filter",
+                line: 1,
+            },
+        );
+
+        let messages = drained_messages();
+        assert_eq!(
+            messages,
+            vec!["add_rule(<rule from .rsync-filter line 1>)".to_owned()],
+            "a file-sourced rule must not report its own trailing whitespace",
+        );
+        assert!(
+            !messages[0].contains("CAUTION") && !messages[0].contains("trailing-ws-probe"),
+            "neither the caution nor the pattern may reach the peer: {messages:?}",
+        );
+    }
+
+    /// The non-vacuity companion for the level split: without it, a gate that
+    /// simply printed everything from FILTER1 would satisfy both pins above.
+    #[test]
+    fn a_rule_without_trailing_whitespace_is_silent_at_filter1() {
+        with_filter_debug(1);
+        trace_add_rule(FilterAction::Exclude, "plain-rule", &RuleSource::Argument);
+
+        assert!(
+            drained_messages().is_empty(),
+            "FILTER1 prints only the whitespace-flagged rules",
+        );
+    }
+
+    /// ...and the companion for the other direction: FILTER2 prints every rule,
+    /// with an empty suffix rather than the caution.
+    #[test]
+    fn every_rule_prints_at_filter2_without_a_caution() {
+        with_filter_debug(2);
+        trace_add_rule(FilterAction::Exclude, "plain-rule", &RuleSource::Argument);
+
+        assert_eq!(
+            drained_messages(),
+            vec!["add_rule(- plain-rule)".to_owned()],
+        );
+    }
+
+    /// upstream guards the whitespace test with `pat_len &&` (exclude.c:265),
+    /// so an empty pattern cannot take the caution arm and reach FILTER1.
+    #[test]
+    fn an_empty_pattern_never_takes_the_caution_arm() {
+        with_filter_debug(1);
+        trace_add_rule(FilterAction::Clear, "", &RuleSource::Argument);
+
+        assert!(
+            drained_messages().is_empty(),
+            "an empty pattern has no last byte to be whitespace",
+        );
+    }
 
     #[test]
     fn argument_text_is_returned_verbatim() {


### PR DESCRIPTION
Two filter-diagnostic leaks from upstream 3.5.0's `filter-merge-content-echo`
cell, one commit each. Both route text through upstream's provenance funnel
rather than adding a second redaction rule.

## Commit 1 — the match trace echoed a merge file's contents

`-F` with a `src/.rsync-filter` containing `- secret-marker` printed:

```
[sender] excluding file secret-marker because of pattern secret-marker
```

The pattern is the merge file's own content, echoed regardless of where the
rule came from.

Upstream redacts at **match** time, not parse time. `report_filter_result`
(`exclude.c:1099`) passes both halves through `rule_text(ent, ent->pattern)`
and `rule_detail(ent, ...)`, reading provenance off the rule via
`ent->rflags & FILTRULE_FROM_FILE` plus the retained `elt`. It has to: a
deferred per-dir merge (`:` rule) is parsed long after the file that named it
was read, so the parse-time context is gone by the time a path matches.

oc already had the policy — `RuleSource::rule_text` / `rule_detail`, the funnel
#7384 built — but no way to reach it from a match. `OwnedRuleSource` is the
owned twin of the borrowed `RuleSource<'a>`: **storage only**, with
`as_source()` delegating every policy decision back to the single owner, so
there is no second copy of the redaction rule. It rides on `FilterRule`
through compilation to both match emitters.

After:

```
[sender] excluding file secret-marker because of pattern <rule from a file read earlier>
```

| source | rendering | upstream |
|---|---|---|
| merge file | `<rule from a file read earlier>`, trailing slash dropped too | `exclude.c:127-131` — the slash is a property *of* the withheld text |
| argument | verbatim, slash included | `exclude.c:90-95` — it is the operator's own, and hiding it only makes typos harder to fix |

The second row is the non-vacuity companion — and it failed on first run, on a
defect older than this change:

```
left:  "sec[r]et-marker-9x//"
right: "sec[r]et-marker-9x/"
```

oc keeps the operator's raw spelling on the rule and derives `directory_only`
from its trailing slash. Upstream's `add_rule` consumes that slash at parse
time (`exclude.c:259-275`) and stores a slash-free `ent->pattern`, so
`rule_detail` re-adds exactly one. Measured head to head with `--exclude='sub/'`:

```
upstream 3.5.0: [sender] hiding directory sub because of pattern sub/
oc (before):    [sender] excluding directory sub because of pattern sub//
oc (after):     [sender] excluding directory sub because of pattern sub/
```

(The `hiding` vs `excluding` verb and the extra `[generator]` line are task
772's separately-owned divergence, untouched here.)

## Commit 2 — an over-long merge name was echoed in full, at no verbosity

A per-dir merge rule is looked up again in every directory the scan enters, so
the name reaching the filesystem is `<scanned directory>/<rule pattern>`. A
rule short enough to parse can still overflow once that prefix is prepended —
and oc reported it by printing the whole composed path:

```
oc-rsync error: failed to inspect filter file
'.../sub/DEFERRED-SECRET-QQQ…QQQ': File name too long (63) (code 23)
```

A deferred `:` rule's pattern comes out of a `.rsync-filter`, so that line
hands the peer a file's contents from a plain `-r -F` with no verbosity asked
for at all — and fails the transfer on top.

Upstream refuses before any open, through the same funnel (`exclude.c:739-744`):

```c
rprintf(FERROR, "merge-file name overflows: %s\n", rule_text(template, fn));
return NULL;
```

`return NULL` drops the rule and the transfer continues, because a per-dir
merge is parsed without `XFLG_FATAL_ERRORS` (`exclude.c:912`) — the same reason
a missing merge file is not an error either.

`dir_merge_file_present` becomes the one owner of *is there a merge file to
load here*, covering all three of upstream's skip-without-failing reasons
(absent / not a regular file / name overflow). Both dir-merge scan sites route
onto it, which also removes the duplicated `fs::metadata` + `is_file()` pair
they each carried.

**Why the errno, not a constant of ours.** Upstream compares against its fixed
`buf[MAXPATHLEN]`, but `MAXPATHLEN` resolves to the same `PATH_MAX` the kernel
enforces (`rsync.h:760-762` supplies 1024 only when `<sys/param.h>` did not),
so the two rules coincide on both supported platforms — and oc, composing a
`PathBuf` with no ceiling of its own, has no second authority to consult. This
is not an errno standing in for a policy decision: `ENAMETOOLONG` *is* the
condition being reported.

**Provenance is passed per call site, not assumed.** The nested loop's rules
can only have come from a merge file's contents (`nested_dir_merges` is their
sole producer), so they take upstream's `a file read earlier`. Program-level
dir-merge rules are built from a `FilterRuleSpec`, which carries no provenance
and renders as `Argument` everywhere else on that path; a `:` rule that reached
the program out of a `--filter '. file'` merge would want redacting and cannot
say so yet — noted at the site rather than guessed either way.

## Commit 3 — a trailing-whitespace rule was never flagged

A filter rule whose last byte is a space or a tab almost certainly does not do
what its author meant: the whitespace is part of the pattern, so `- foo ` never
matches `foo`. Upstream prints such a rule one debug level *earlier* than every
other rule, carrying a caution, precisely so the operator sees it
(`exclude.c:265-269`):

```c
if (DEBUG_GTE(FILTER, 1) && pat_len && (pat[pat_len-1] == ' ' || pat[pat_len-1] == '\t'))
        mention_rule_suffix = " -- CAUTION: trailing whitespace!";
else
        mention_rule_suffix = DEBUG_GTE(FILTER, 2) ? "" : NULL;
if (mention_rule_suffix) { ... }
```

oc had collapsed that two-level gate to level 2 only, so `--debug=FILTER1`
printed nothing at all and the caution did not exist.

The caution is a fact *about* the rule's text, so it goes through `rule_detail`
alongside the text itself (`exclude.c:274`) — telling the peer that a hidden
rule ends in a space leaks exactly what the redaction withholds. A file-sourced
rule still takes the FILTER1 arm, but prints with neither its pattern, its
action prefix, nor the caution.

Measured against the real 3.5.0 binary, all four rows now match:

| invocation | upstream 3.5.0 | oc (after) |
|---|---|---|
| `--debug=FILTER1 --filter='- my-own-rule '` | `add_rule(- my-own-rule ) -- CAUTION: trailing whitespace!` | same |
| `--debug=FILTER1`, `- trailing-ws-probe ` in a `.rsync-filter` | `add_rule(<rule from … line 1>)` — no caution, no pattern | same |
| `--debug=FILTER1 --filter='- plain-rule'` | *(nothing)* | *(nothing)* |
| `--debug=FILTER2 --filter='- plain-rule'` | `add_rule(- plain-rule)` | same |

**Residual, noted at the site rather than guessed:** upstream also prints
`listp->debug_type` (`exclude.c:274`), the label naming *which* filter list the
rule joined — `` for the main list, ` [daemon]`, ` [per-dir .rsync-filter]`.
oc has no filter-list identity to pass here, so that field is absent rather
than wrong.

## Verification

- **End to end on a freshly built release binary**, running upstream 3.5.0's
  own cell: it now clears sections 1 through 4 and stops at section 5 (a
  separate defect — an over-long *argument* rule must still be reported at full
  length).
- **Every row above measured head to head against the real 3.5.0 binary**, not
  read off the C.
- **Every guard mutation-proven in isolation**, each killing exactly its own
  test with the others green:
  - drop the match-trace redaction → only the merge-file pin dies;
  - drop the slash strip → only the argument pin dies;
  - drop the overflow redaction → only the file-sourced overflow pin dies
    (21/22 green);
  - drop the overflow arm entirely → both overflow pins die, absent/present
    controls stay green (20/22);
  - collapse the FILTER level split downward → the two silence pins die;
  - collapse it upward (oc's old level-2-only behaviour) → both
    whitespace pins die;
  - drop the caution's `rule_detail` routing → the redaction pin dies alone.
- `cargo fmt --all` plus the whole-tree `tools/ci/check_rustfmt_all.py` (3395
  files) — which caught a diff in the `include!`d `context_impl/transfer.rs`
  that `cargo fmt --all -- --check` cannot see;
  `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
  Both on the pinned 1.88.0 toolchain.
- `cargo nextest run -p filters -p engine` green.

## Scope

The cell has four further assertion sections, each a separate defect — some
need diagnostics oc does not emit at all. It stays `fail` until those land; no
manifest row is touched here.

One adjacent defect was **measured and deliberately left out of this PR**,
because it changes which files transfer rather than what is printed: oc trims
trailing whitespace off a merge-file rule before compiling it, so
`- wsprobe ` in a `.rsync-filter` **excludes** `wsprobe` where upstream ships
it (upstream's rule is literally `wsprobe `, which matches nothing — that is
*why* upstream cautions about it). It is filed separately with its oracle
table; folding a data-selection change into a diagnostics PR would blur both.
