### PR TITLE
fix(filters): discard an over-long filter rule instead of keeping it

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/entry.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/entry.rs
@@ -4,6 +4,7 @@
 //! entry points plus the `parse_rule_directive` dispatcher that routes a
 //! trimmed line to the more specialized parsers.
 
+use std::borrow::Cow;
 use std::ffi::OsStr;
 
 use core::client::{FilterRuleKind, FilterRuleSpec};
@@ -33,15 +34,54 @@ pub(crate) fn parse_filter_directive(
     // raises "Unknown filter rule" (RERR_SYNTAX). Do not trim the leading edge.
     let rule = RuleLine::new(&text, source);
 
-    if let Some(result) = parse_short_merge_directive(rule) {
-        return result;
+    let directive = parse_short_merge_directive(rule)
+        .or_else(|| parse_long_merge_directive(rule))
+        .unwrap_or_else(|| parse_rule_directive(rule))?;
+
+    Ok(discard_over_long(directive, source))
+}
+
+/// Reports and discards a directive whose pattern reaches `MAXPATHLEN`.
+///
+/// upstream: exclude.c:1533-1538, in `parse_filter_str`'s token loop. It
+/// measures `pat_len` - the pattern *alone*, since `parse_rule_tok` has already
+/// consumed the action prefix and any modifiers (exclude.c:1456-1464) - and
+/// `continue`s, so the rule contributes nothing and parsing exits 0.
+///
+/// Consulting the CONSTRUCTED directive is how oc reads that same quantity
+/// without duplicating the prefix stripping: the pattern a directive carries is
+/// exactly what upstream measures. `Clear`, `Noop` and `CvsDefaults` carry no
+/// pattern at all, so upstream's check can never fire for them.
+///
+/// upstream's check sits above the `FILTRULE_MERGE_FILE` branch (`:1550`), and
+/// so does this one in effect: the merge file is opened later, by the caller
+/// that consumes the directive, so an over-long merge name never reaches a
+/// filesystem here either.
+fn discard_over_long(directive: FilterDirective, source: RuleSource<'_>) -> FilterDirective {
+    let pattern = match &directive {
+        FilterDirective::Rule(spec) => Cow::Borrowed(spec.pattern()),
+        FilterDirective::Merge(merge) => merge.source().to_string_lossy(),
+        FilterDirective::Clear | FilterDirective::Noop | FilterDirective::CvsDefaults => {
+            return directive;
+        }
+    };
+
+    if !filters::is_over_long(&pattern) {
+        return directive;
     }
 
-    if let Some(result) = parse_long_merge_directive(rule) {
-        return result;
-    }
+    // The rule text crosses `rule_text` (exclude.c:88-123): upstream passes a
+    // NULL template here, which falls back to the am-I-parsing-a-file state
+    // (exclude.c:67-69) - the fact oc carries explicitly on `source`.
+    logging::emit_info_coded(
+        logging::InfoFlag::Misc,
+        0,
+        logging::LogCode::Error,
+        filters::over_long_filter(&source.rule_text(&pattern)),
+    );
 
-    parse_rule_directive(rule)
+    // upstream's `continue`: the rule is dropped and parsing carries on.
+    FilterDirective::Noop
 }
 
 /// Parses a line under upstream rsync's `XFLG_OLD_PREFIXES` compatibility mode
@@ -112,7 +152,7 @@ pub(crate) fn parse_old_prefix_rule(
         FilterRuleKind::Exclude => FilterRuleSpec::exclude(pattern.to_owned()),
         _ => unreachable!("default_kind is restricted to Include/Exclude above"),
     };
-    Ok(FilterDirective::Rule(rule))
+    Ok(discard_over_long(FilterDirective::Rule(rule), source))
 }
 
 /// Dispatches a trimmed rule line (no merge prefix) to the matching parser:

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -1033,3 +1033,121 @@ fn clear_token_grid_covers_both_spellings_and_every_separator() {
     // Both contexts must be exercised for every row.
     assert!(CLEAR_TOKEN_GRID.len() >= 2 * 5);
 }
+
+/// An over-long pattern, built the way upstream's cell does
+/// (`filter-merge-content-echo_test.py`): `MAXPATHLEN + 200`, so the refusal is
+/// unambiguous and the full-length assertion has room to fail.
+fn over_long_pattern() -> String {
+    "Q".repeat(fast_io::path_limit::max_path_len() + 200)
+}
+
+/// Drains the diagnostics this thread emitted, as rendered text.
+fn drained_messages() -> Vec<String> {
+    logging::drain_events()
+        .into_iter()
+        .filter_map(|event| match event {
+            logging::DiagnosticEvent::Info { message, .. } => Some(message),
+            _ => None,
+        })
+        .collect()
+}
+
+/// WHY: upstream discards the rule and CONTINUES (`exclude.c:1533-1538`), so
+/// the directive must be a no-op rather than an error - and a pattern past
+/// `MAXPATHLEN` can still match (a long run of `*` matches everything), so
+/// keeping it would change which files transfer, not merely what is printed.
+#[test]
+fn an_over_long_argument_rule_is_discarded_and_reported() {
+    let _ = drained_messages();
+    let pattern = over_long_pattern();
+
+    let directive =
+        parse_filter_directive(OsStr::new(&format!("- {pattern}")), RuleSource::Argument)
+            .expect("an over-long rule is discarded, not a syntax error");
+
+    assert_eq!(directive, FilterDirective::Noop);
+    assert_eq!(
+        drained_messages(),
+        vec![filters::over_long_filter(&pattern)],
+        "the refusal must name the operator's own rule at full length",
+    );
+}
+
+/// The non-vacuity companion: an ordinary rule must still become a rule and
+/// must stay silent, or the guard would discard every filter ever written.
+#[test]
+fn an_ordinary_argument_rule_survives_and_is_silent() {
+    let _ = drained_messages();
+
+    let directive = parse_filter_directive(OsStr::new("- *.tmp"), RuleSource::Argument)
+        .expect("an ordinary rule parses");
+
+    match directive {
+        FilterDirective::Rule(spec) => assert_eq!(spec.pattern(), "*.tmp"),
+        other => panic!("expected a Rule directive, got {other:?}"),
+    }
+    assert!(drained_messages().is_empty());
+}
+
+/// WHY: upstream's check sits ABOVE the `FILTRULE_MERGE_FILE` branch
+/// (`exclude.c:1550`), so an over-long merge name is dropped before its file is
+/// ever named to the filesystem.
+#[test]
+fn an_over_long_merge_directive_is_discarded() {
+    let _ = drained_messages();
+    let pattern = over_long_pattern();
+
+    let directive = parse_filter_directive(
+        OsStr::new(&format!("merge {pattern}")),
+        RuleSource::Argument,
+    )
+    .expect("an over-long merge directive is discarded, not an error");
+
+    assert_eq!(directive, FilterDirective::Noop);
+    assert_eq!(
+        drained_messages(),
+        vec![filters::over_long_filter(&pattern)]
+    );
+}
+
+/// `--exclude` / `--include` reach `parse_filter_str` through the same token
+/// loop upstream - `XFLG_OLD_PREFIXES` is a flag on it, not a separate path -
+/// so the refusal governs them too.
+#[test]
+fn an_over_long_old_prefix_rule_is_discarded() {
+    let _ = drained_messages();
+    let pattern = over_long_pattern();
+
+    let directive = parse_old_prefix_rule(&pattern, FilterRuleKind::Exclude, RuleSource::Argument)
+        .expect("an over-long --exclude value is discarded, not an error");
+
+    assert_eq!(directive, FilterDirective::Noop);
+    assert_eq!(
+        drained_messages(),
+        vec![filters::over_long_filter(&pattern)]
+    );
+}
+
+/// WHY: the refusal crosses `rule_text` (`exclude.c:88-123`). A rule read out
+/// of a merge file is the peer's choice of content, so the diagnostic names the
+/// file, never the text - without this the guard would leak at no verbosity.
+#[test]
+fn an_over_long_file_sourced_rule_is_reported_without_its_text() {
+    let _ = drained_messages();
+    let pattern = over_long_pattern();
+    let source = RuleSource::File {
+        name: ".rsync-filter",
+        line: 1,
+    };
+
+    let directive = parse_filter_directive(OsStr::new(&format!("- {pattern}")), source)
+        .expect("an over-long rule is discarded, not a syntax error");
+
+    assert_eq!(directive, FilterDirective::Noop);
+    let messages = drained_messages();
+    assert_eq!(
+        messages,
+        vec!["discarding over-long filter: <rule from .rsync-filter line 1>".to_owned()],
+    );
+    assert!(!messages[0].contains('Q'));
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -143,6 +143,9 @@ pub mod owner_walk;
 pub mod page_aligned;
 /// Parallel file I/O operations using rayon.
 pub mod parallel;
+/// The platform's own `MAXPATHLEN`, for callers that must refuse an over-long
+/// path before issuing a syscall.
+pub mod path_limit;
 /// Total physical memory detection (for the buffer pool's RAM-derived cap).
 pub mod physical_memory;
 /// Source lookups anchored on the daemon's pinned module root.

--- a/crates/fast_io/src/path_limit.rs
+++ b/crates/fast_io/src/path_limit.rs
@@ -1,0 +1,80 @@
+//! The longest path this platform accepts, as upstream's `MAXPATHLEN` resolves
+//! it.
+//!
+//! Callers that need to refuse an over-long path *before* issuing a syscall
+//! need the ceiling as a value. Callers that merely react to the kernel having
+//! refused one should key on `ENAMETOOLONG` instead - that errno *is* the
+//! condition, so it needs no constant and cannot drift.
+
+/// The value upstream's `MAXPATHLEN` resolves to on this platform.
+///
+/// upstream: `rsync.h:760-762` takes `MAXPATHLEN` from `<sys/param.h>` and
+/// supplies 1024 only when that header did not define one. Every Unix oc
+/// supports *does* define it, so reading the platform's own value is what
+/// mirrors upstream - not the fallback.
+///
+/// The distinction is load-bearing, not pedantic: `PATH_MAX` is 1024 on macOS
+/// but 4096 on Linux. Hardcoding upstream's 1024 fallback would refuse, on
+/// Linux, paths that upstream itself accepts - an over-refusal, which is its
+/// own divergence rather than a conservative approximation of the right one.
+///
+/// Windows takes upstream's fallback deliberately. `libc::PATH_MAX` is 260
+/// there - the legacy `MAX_PATH` - which is *not* the operative bound for oc,
+/// because [`crate::win_path`] addresses long paths through the extended-length
+/// `\\?\` prefix. 1024 is upstream's own no-header value and does not pretend
+/// to a precision this platform does not offer.
+#[must_use]
+pub fn max_path_len() -> usize {
+    #[cfg(unix)]
+    {
+        // `PATH_MAX` is `c_int` on every supported Unix, so this widens rather
+        // than re-types: it raises neither `useless_conversion` nor
+        // `unnecessary_cast` on macOS or Linux.
+        libc::PATH_MAX as usize
+    }
+
+    #[cfg(not(unix))]
+    {
+        1024
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// WHY: the whole point of reading the platform value is that a fixed
+    /// constant is wrong somewhere. This pins that the value is the platform's
+    /// own, so a future "simplification" to a literal fails here rather than
+    /// silently over-refusing on Linux.
+    #[cfg(unix)]
+    #[test]
+    fn the_bound_is_the_platforms_own_path_max() {
+        assert_eq!(max_path_len(), libc::PATH_MAX as usize);
+    }
+
+    /// The two platforms oc builds for on Unix disagree, and that disagreement
+    /// is exactly why this is a function and not a constant.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_resolves_to_1024() {
+        assert_eq!(max_path_len(), 1024);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_resolves_to_4096() {
+        assert_eq!(max_path_len(), 4096);
+    }
+
+    /// A bound of zero would make every rule over-long; a tiny one would refuse
+    /// ordinary paths. Neither platform arm may degrade that far.
+    #[test]
+    fn the_bound_admits_an_ordinary_path() {
+        assert!(
+            max_path_len() >= 1024,
+            "an ordinary path must fit: {}",
+            max_path_len()
+        );
+    }
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -119,6 +119,8 @@ pub mod implied;
 /// Merge-file reader and parser for filter rules.
 pub mod merge;
 mod merge_open;
+/// Upstream's `discarding over-long filter` refusal and its `MAXPATHLEN` bound.
+pub mod overlong;
 mod rule;
 pub mod rule_source;
 /// Traversal clamp for peer- and file-supplied names, mirroring
@@ -151,6 +153,7 @@ pub use merge::{
     MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, merge_name_overflows, parse_rules,
     read_rules, read_rules_recursive,
 };
+pub use overlong::{is_over_long, over_long_filter};
 pub use rule::FilterRule;
 pub use rule_source::{OwnedRuleSource, RuleSource, trace_add_rule};
 pub use set::{FilterSet, FilterSetError, apple_double_exclusion_rules, cvs_exclusion_rules};

--- a/crates/filters/src/overlong.rs
+++ b/crates/filters/src/overlong.rs
@@ -1,0 +1,134 @@
+//! Refusing a filter rule whose pattern is longer than the platform accepts.
+//!
+//! upstream: `exclude.c:1533-1538`, inside `parse_filter_str`'s token loop.
+//! A rule whose pattern reaches `MAXPATHLEN` is reported and dropped:
+//!
+//! ```c
+//! if (pat_len >= MAXPATHLEN) {
+//!         rprintf(FERROR, "discarding over-long filter: %s\n",
+//!                 rule_text_len(NULL, pat, (int)pat_len));
+//!     free_continue:
+//!         free_filter(rule); continue;
+//! }
+//! ```
+//!
+//! The `continue` is the substance: the rule is discarded and parsing carries
+//! on, so an over-long rule is not a syntax error. That matters beyond the
+//! message, because a pattern longer than `MAXPATHLEN` can still *match* - a
+//! long run of `*` is over-long and matches everything - so keeping it would
+//! change which files transfer, not merely what is printed.
+//!
+//! `pat_len` is the length of the pattern alone: `parse_rule_tok` has already
+//! consumed the action prefix and any modifiers by this point
+//! (`exclude.c:1456-1464`). The check therefore sits above both the
+//! `FILTRULE_CLEAR_LIST` branch (`:1541`) and the `FILTRULE_MERGE_FILE` branch
+//! (`:1550`), governing every rule kind and running before a merge directive's
+//! file is ever opened.
+//!
+//! upstream passes `NULL` as the template here, which is not "no provenance":
+//! `TEXT_FROM_FILE(NULL)` is `rule_src_in_file || false` (`exclude.c:67-69`),
+//! so it falls back to whether the parser is reading a file's contents right
+//! now. oc carries that same fact explicitly on
+//! [`RuleSource`](crate::rule_source::RuleSource), so callers render the text
+//! through `rule_text` and pass the result here - the same shape as
+//! [`merge_name_overflows`](crate::merge_name_overflows).
+
+/// Renders upstream's over-long filter refusal for `rule`.
+///
+/// `rule` is upstream's `rule_text_len()` rendering of the pattern - the rule
+/// as written for an argument, `<rule from ...>` for one that came out of a
+/// file. The argument arm is deliberately shown at full length: truncating it
+/// would hide the very thing that made the rule too long.
+#[must_use]
+pub fn over_long_filter(rule: &str) -> String {
+    format!("discarding over-long filter: {rule}")
+}
+
+/// Reports whether `pattern` exceeds what upstream will accept.
+///
+/// upstream compares `pat_len >= MAXPATHLEN` - `>=`, not `>`, so a pattern of
+/// exactly the limit is already refused. The bound is the platform's own, via
+/// [`fast_io::path_limit::max_path_len`]; see that function for why upstream's
+/// 1024 fallback must not be hardcoded.
+#[must_use]
+pub fn is_over_long(pattern: &str) -> bool {
+    pattern.len() >= fast_io::path_limit::max_path_len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rule_source::RuleSource;
+
+    /// WHY: the wording is what upstream's testsuite greps for
+    /// (`filter-merge-content-echo_test.py`), so it is part of the contract,
+    /// not a message we are free to reword.
+    #[test]
+    fn wording_matches_upstream() {
+        assert_eq!(
+            over_long_filter("ARGLONG-QQQ"),
+            "discarding over-long filter: ARGLONG-QQQ"
+        );
+    }
+
+    /// WHY: the cell asserts `out.count('Q') > maxpath`, so the operator's own
+    /// text must survive at FULL length. A helper that truncated to keep the
+    /// line short would satisfy the message assertion and fail this one.
+    #[test]
+    fn an_argument_rule_is_shown_at_full_length() {
+        let pattern = "Q".repeat(fast_io::path_limit::max_path_len() + 200);
+        let rendered = over_long_filter(&RuleSource::Argument.rule_text(&pattern));
+
+        assert_eq!(
+            rendered.matches('Q').count(),
+            pattern.len(),
+            "the operator's own over-long rule must not be truncated",
+        );
+    }
+
+    /// The non-vacuity companion: the same over-long text out of a merge file
+    /// is withheld, so the pin above is testing the ARGUMENT arm specifically
+    /// rather than a helper that never redacts.
+    #[test]
+    fn a_file_sourced_rule_is_withheld() {
+        let pattern = "Q".repeat(fast_io::path_limit::max_path_len() + 200);
+        let source = RuleSource::File {
+            name: ".rsync-filter",
+            line: 1,
+        };
+        let rendered = over_long_filter(&source.rule_text(&pattern));
+
+        assert_eq!(
+            rendered,
+            "discarding over-long filter: <rule from .rsync-filter line 1>"
+        );
+        assert!(
+            !rendered.contains('Q'),
+            "a merge file's contents must not reach the diagnostic: {rendered}",
+        );
+    }
+
+    /// upstream's comparison is `>=`, so a pattern of exactly the limit is
+    /// already refused. Off-by-one here would leave one length upstream drops.
+    #[test]
+    fn the_bound_is_inclusive() {
+        let limit = fast_io::path_limit::max_path_len();
+
+        assert!(
+            is_over_long(&"Q".repeat(limit)),
+            "exactly the limit is over"
+        );
+        assert!(
+            !is_over_long(&"Q".repeat(limit - 1)),
+            "one under the limit is accepted",
+        );
+    }
+
+    /// The non-vacuity companion for the bound: an ordinary rule must not be
+    /// refused, or the guard would discard every filter the operator writes.
+    #[test]
+    fn an_ordinary_rule_is_not_over_long() {
+        assert!(!is_over_long("*.tmp"));
+        assert!(!is_over_long(""));
+    }
+}


### PR DESCRIPTION
Upstream discards a filter rule whose pattern reaches `MAXPATHLEN`, reports it, and carries on parsing (`exclude.c:1533-1538`):

```c
if (pat_len >= MAXPATHLEN) {
        rprintf(FERROR, "discarding over-long filter: %s\n",
                rule_text_len(NULL, pat, (int)pat_len));
    free_continue:
        free_filter(rule); continue;
}
```

oc had no such refusal at all: the rule was kept and compiled.

**This is not only a missing message.** A pattern past `MAXPATHLEN` can still *match* — a long run of `*` is over-long and matches everything — so keeping it changes which files transfer, not merely what is printed.

## Measured against the real rsync 3.5.0 binary

Fixture: `ARGLONG-` plus 1224 `Q`s (macOS `PATH_MAX` is 1024), passed as `--filter='- <pattern>'`.

| | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| exit code | 0 | 0 | 0 |
| `discarding over-long filter` | present | **absent** | present |
| `Q`s in output | 1224 | 0 | **1224** |
| rule kept? | dropped | **kept** | dropped |

## Design

**The bound is the platform's own, and that is load-bearing.** `rsync.h:760-762` supplies 1024 only when `<sys/param.h>` did not define `MAXPATHLEN`, and every Unix oc supports *does* define it: 1024 on macOS, 4096 on Linux. Hardcoding upstream's fallback would refuse, on Linux, paths upstream itself accepts — an over-refusal, which is its own divergence rather than a conservative approximation. `fast_io` owns the value because it is the crate that has `libc`; `filters` does not.

**The check consults the constructed directive, not the raw line.** `pat_len` is the pattern *alone* — `parse_rule_tok` has already consumed the action prefix and any modifiers by that point (`exclude.c:1456-1464`). Reading the pattern off the directive on the way out of the parser gives the same quantity with no duplicated stripping, and `Clear`/`Noop`/`CvsDefaults` carry no pattern at all. It still runs before any merge file is opened, matching upstream's placement above the `FILTRULE_MERGE_FILE` branch (`exclude.c:1550`).

**The message crosses `rule_text`** (`exclude.c:88-123`). upstream passes a `NULL` template, which is not "no provenance": `TEXT_FROM_FILE(NULL)` falls back to the am-I-reading-a-file state (`exclude.c:67-69`), the fact oc carries explicitly on `RuleSource`. An argument rule therefore prints at **full length** — truncating would hide the very thing that made it too long — while a rule read out of a merge file prints as `<rule from ... line N>`.

## Verification

- All three arms mutation-proven in isolation, ordinary-rule companions green throughout:
  - guard removed → all four discard pins fail (13 passed / 4 failed of 17)
  - upstream's `>=` weakened to `>` → the bound pin alone fails (16 / 1)
  - provenance funnel bypassed → the redaction pin alone fails (16 / 1)
- `filters` + `fast_io` + `cli`: 6248 run, 6248 passed.
- `cargo fmt --all -- --check` and the whole-tree `tools/ci/check_rustfmt_all.py` clean; `cargo clippy --workspace --all-targets --all-features -D warnings` clean — both on the pinned 1.88.0 toolchain.
- Upstream 3.5.0's `filter-merge-content-echo` cell advances from line 248 to line 273.

## Residual, stated rather than implied

The **engine's** per-directory merge parser (`local_copy/dir_merge`) is a separate parser with its own directive type and is not covered here, so a `.rsync-filter` line past `MAXPATHLEN` is still silently kept on that path. Measured: upstream reports it as `discarding over-long filter: <rule from ... line 1>`; oc prints nothing. Filed as its own change rather than folded in.
