### PR TITLE
fix(filters): register a `:e` self-exclude when the directive is parsed

### DIFF
--- a/crates/core/src/client/run/filters.rs
+++ b/crates/core/src/client/run/filters.rs
@@ -64,6 +64,10 @@ pub(crate) fn compile_filter_program(
                     .with_xattr_only(rule.is_xattr_only())
                     .with_negate(rule.is_negated()),
             )),
+            // The `:e` self-exclude is NOT synthesised here. `FilterProgram`
+            // owns it, so a program built by any route - this one, or a caller
+            // assembling entries directly - registers it identically
+            // (exclude.c:1558-1571).
             FilterRuleKind::DirMerge => {
                 entries.push(FilterProgramEntry::DirMerge(DirMergeRule::new(
                     rule.pattern().to_owned(),

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -323,14 +323,13 @@ impl<'a> CopyContext<'a> {
                 }
             }
 
-            if rule.options().excludes_self() {
-                let pattern = rule.pattern().to_string_lossy().into_owned();
-                if let Err(error) = segment.push_rule(FilterRule::exclude(pattern)) {
-                    ephemeral_stack.pop();
-                    marker_ephemeral_stack.pop();
-                    return Err(filter_program_local_error(&candidate, &error));
-                }
-            }
+            // The `:e` self-exclude is NOT synthesised here. upstream builds it
+            // at REGISTRATION into the enclosing list (exclude.c:1558-1571), so
+            // it exists whether or not this directory holds a file by that
+            // name; oc mirrors that at the two registration seams
+            // (core `client/run/filters.rs` for a `--filter=:e`, and
+            // `dir_merge::load` for a `:e` nested in a merge file). Adding it
+            // again on this load path would exclude the name twice.
 
             let has_segment = !segment.is_empty();
             let markers = entries.exclude_if_present;
@@ -494,12 +493,10 @@ impl<'a> CopyContext<'a> {
                 .map_err(|error| filter_program_local_error(&candidate, &error))?;
         }
 
-        if rule.options.excludes_self() {
-            let pattern = rule.pattern.to_string_lossy().into_owned();
-            segment
-                .push_rule(FilterRule::exclude(pattern))
-                .map_err(|error| filter_program_local_error(&candidate, &error))?;
-        }
+        // No self-exclude here either - see the note on the sibling load site
+        // above. This function is reached only after the named file is found,
+        // which is exactly the condition upstream does NOT place the rule
+        // behind.
 
         Ok(Some(LoadedNestedDirMerge {
             segment: (!segment.is_empty()).then_some(segment),

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -286,6 +286,26 @@ impl DirMergeEntries {
     }
 
     fn push_nested_dir_merge(&mut self, nested: NestedDirMerge) {
+        // upstream: exclude.c:1558-1571 - a `:e` directive synthesises an
+        // exclude for the merge file's own BASENAME at REGISTRATION, into the
+        // ENCLOSING list, then clears FILTRULE_EXCLUDE_SELF so it is added
+        // exactly once. `self.rules` is that enclosing list: it holds the rules
+        // of the merge file this directive was read out of. Pushing it here,
+        // ahead of the nested registration, keeps upstream's order (the exclude
+        // precedes the merge rule's own add_rule at :1590) and - crucially -
+        // makes the exclude exist whether or not a file by that name is ever
+        // found in any directory. Deferring it to the load of that file, as oc
+        // did, meant a `:e` naming an absent file excluded nothing.
+        //
+        // push_rule stamps `FileReadEarlier`, which is the provenance upstream
+        // gives it: `excl_self->rflags = rule->rflags & FILTRULE_FROM_FILE`.
+        // The bracketed literal of a `:e excl-self-[x]9` therefore stays
+        // withheld from the match trace, as it must - it came out of a file.
+        if nested.options.excludes_self() {
+            let name = nested.pattern.to_string_lossy();
+            let excluded = filters::merge_self_exclude_name(&name).to_owned();
+            self.push_rule(FilterRule::exclude(excluded));
+        }
         self.nested_dir_merges.push(nested);
     }
 

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -119,6 +119,30 @@ impl FilterProgram {
                     }
                 }
                 FilterProgramEntry::DirMerge(rule) => {
+                    // upstream: exclude.c:1558-1571 - a `:e` directive
+                    // synthesises an exclude for the merge file's own BASENAME
+                    // at REGISTRATION, into the ENCLOSING list, then clears
+                    // FILTRULE_EXCLUDE_SELF so it is added exactly once. Here
+                    // that list is `current_segment`, and pushing before the
+                    // flush below keeps the exclude AHEAD of the merge rule's
+                    // own add_rule (:1590) - filter lists are first-match-wins,
+                    // so the order is part of the behaviour.
+                    //
+                    // Doing it at registration is the substance: it makes the
+                    // exclude exist whether or not a file by that name is ever
+                    // found. oc used to synthesise it when the merge file was
+                    // LOADED, so a `:e` naming an absent file excluded nothing.
+                    if rule.options().excludes_self() {
+                        let name = rule.pattern().to_string_lossy();
+                        let excluded = filters::merge_self_exclude_name(&name).to_owned();
+                        let excluded = filters::FilterRule::exclude(excluded);
+                        filters::trace_add_rule(
+                            excluded.action(),
+                            excluded.pattern(),
+                            &filters::RuleSource::Argument,
+                        );
+                        current_segment.push_rule(excluded)?;
+                    }
                     if !current_segment.is_empty() || instructions.is_empty() {
                         instructions.push(FilterInstruction::Segment(current_segment));
                         current_segment = FilterSegment::default();

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -150,8 +150,8 @@ pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{
-    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, merge_name_overflows, parse_rules,
-    read_rules, read_rules_recursive,
+    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, merge_name_overflows,
+    merge_self_exclude_name, parse_rules, read_rules, read_rules_recursive,
 };
 pub use overlong::{is_over_long, over_long_filter};
 pub use rule::FilterRule;

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -49,6 +49,7 @@ mod error;
 mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
+mod self_exclude;
 
 #[cfg(test)]
 mod tests;
@@ -59,3 +60,4 @@ pub use overflow::merge_name_overflows;
 pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};
+pub use self_exclude::merge_self_exclude_name;

--- a/crates/filters/src/merge/self_exclude.rs
+++ b/crates/filters/src/merge/self_exclude.rs
@@ -1,0 +1,94 @@
+//! The extra exclude a `:e` / `.e` dir-merge directive synthesises for the
+//! merge file's own name.
+//!
+//! upstream: `exclude.c:1558-1571`, inside `parse_filter_str`'s
+//! `FILTRULE_MERGE_FILE` branch:
+//!
+//! ```c
+//! if (new_rflags & FILTRULE_EXCLUDE_SELF) {
+//!         excl_self = new0(filter_rule);
+//!         excl_self->rflags = rule->rflags & FILTRULE_FROM_FILE;
+//!         /* Find the beginning of the basename and add an exclude for it. */
+//!         for (name = pat + pat_len; name > pat && name[-1] != '/'; name--) {}
+//!         add_rule(listp, name, (pat + pat_len) - name, excl_self, 0);
+//!         rule->rflags &= ~FILTRULE_EXCLUDE_SELF;
+//! }
+//! ```
+//!
+//! Three properties of that block decide where a caller must put the rule, and
+//! all three are easy to lose by building it somewhere more convenient:
+//!
+//! - it runs at REGISTRATION - when the directive is parsed - so the exclude
+//!   exists whether or not a file by that name is ever found in any directory;
+//! - it goes into `listp`, the ENCLOSING list, and `FILTRULE_EXCLUDE_SELF` is
+//!   then cleared, so the rule is added exactly once rather than once per
+//!   directory that happens to contain the file;
+//! - it precedes the merge rule's own `add_rule` at `:1590`, and filter lists
+//!   are first-match-wins, so the order is part of the behaviour.
+//!
+//! The provenance is the fourth: the synthesised rule inherits only
+//! `FILTRULE_FROM_FILE` from its parent. upstream's own comment above that line
+//! records why - built by hand with no template, the rule looked
+//! argument-origin once parsing finished and the match trace echoed a merge
+//! file's contents at `-vv`. Callers therefore attach the provenance of the
+//! directive they are expanding, not of the rule they are creating.
+
+/// Returns the basename upstream excludes for a `:e` merge directive.
+///
+/// upstream scans back from the end of the pattern to the byte after the last
+/// `/` (`exclude.c:1568-1569`), so this is a byte split, not a path parse: a
+/// pattern ending in `/` yields the empty name and `..` yields `..`, both of
+/// which `Path::file_name` would instead report as absent. Mirroring the scan
+/// keeps those inputs behaving as upstream does rather than as a path API
+/// would prefer.
+#[must_use]
+pub fn merge_self_exclude_name(pattern: &str) -> &str {
+    match pattern.rfind('/') {
+        Some(slash) => &pattern[slash + 1..],
+        None => pattern,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ordinary case: a bare merge-file name is its own basename.
+    #[test]
+    fn a_bare_name_is_unchanged() {
+        assert_eq!(merge_self_exclude_name(".rsync-filter"), ".rsync-filter");
+    }
+
+    /// WHY: upstream excludes the NAME, not the path it was written with, so
+    /// `:e sub/name` hides `name` in each directory - not `sub/name`.
+    #[test]
+    fn a_qualified_name_keeps_only_the_last_segment() {
+        assert_eq!(merge_self_exclude_name("sub/name"), "name");
+        assert_eq!(merge_self_exclude_name("a/b/c/name"), "name");
+        assert_eq!(merge_self_exclude_name("/leading"), "leading");
+    }
+
+    /// WHY: the scan is over bytes, so a trailing slash leaves NOTHING after
+    /// the last one. `Path::file_name` reports `sub` here, which would exclude
+    /// a directory upstream never names.
+    #[test]
+    fn a_trailing_slash_yields_the_empty_name() {
+        assert_eq!(merge_self_exclude_name("sub/"), "");
+    }
+
+    /// The other place a path API and upstream's byte scan disagree:
+    /// `Path::file_name` returns `None` for `..`, upstream returns `..`.
+    #[test]
+    fn dot_dot_is_its_own_basename() {
+        assert_eq!(merge_self_exclude_name(".."), "..");
+        assert_eq!(merge_self_exclude_name("sub/.."), "..");
+    }
+
+    /// The glob in upstream's `filter-merge-content-echo` cell: the literal
+    /// text is what gets excluded, brackets and all, and it is that literal
+    /// which must never reach a diagnostic when it came out of a file.
+    #[test]
+    fn a_glob_name_is_carried_through_verbatim() {
+        assert_eq!(merge_self_exclude_name("excl-self-[x]9"), "excl-self-[x]9");
+    }
+}

--- a/tests/filter_dir_merge_exclude_self.rs
+++ b/tests/filter_dir_merge_exclude_self.rs
@@ -1,0 +1,154 @@
+//! The `:e` dir-merge modifier hides the merge file's own name.
+//!
+//! upstream: `exclude.c:1558-1571` synthesises the exclude at REGISTRATION -
+//! when the directive is parsed - into the ENCLOSING list, then clears
+//! `FILTRULE_EXCLUDE_SELF` so it is added exactly once. oc used to build it at
+//! LOAD time instead, once per directory that turned out to contain a file by
+//! that name, which made the rule conditional on the file existing.
+//!
+//! ## Why the fixture uses a bracket glob
+//!
+//! `:e name` excluding a file literally called `name` is not a discriminating
+//! shape: if no such file exists there is nothing to observe either way. The
+//! fixture below mirrors upstream's own `filter-merge-content-echo` cell and
+//! names the merge file `excl-self-[x]9`, a glob whose LITERAL text matches the
+//! real file `excl-self-x9`. Nothing is ever named `excl-self-[x]9`, so the
+//! merge file is never found - and the synthesised exclude still has to fire.
+//!
+//! ## What a duplicate would (not) look like
+//!
+//! Registering the exclude twice is not observable: filter lists are
+//! first-match-wins and both copies are the same exclude. So these cells pin
+//! the direction that IS observable - the exclude firing where oc used to skip
+//! it - and the file-present cell guards against the opposite regression, the
+//! load-time removal silencing a path that already worked.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// The merge-file name as written in the directive: a glob, deliberately.
+const SELF_GLOB: &str = "excl-self-[x]9";
+/// The real file the glob matches. No file is ever named `SELF_GLOB` itself.
+const MATCHED_FILE: &str = "excl-self-x9";
+
+/// Builds `<dir>/src` holding `f` plus the glob-matched file.
+fn seed_source(dir: &TestDir) -> std::io::Result<()> {
+    dir.mkdir("src")?;
+    dir.mkdir("dest")?;
+    dir.write_file("src/f", b"keep\n")?;
+    dir.write_file(&format!("src/{MATCHED_FILE}"), b"hidden\n")?;
+    Ok(())
+}
+
+/// A `--filter=':e NAME'` given on the command line must hide `NAME` even
+/// though no directory in the transfer holds a file by that name.
+///
+/// This is the arm oc got wrong: the exclude was created only when the named
+/// merge file was actually found and loaded.
+#[test]
+fn a_top_level_exclude_self_fires_without_the_merge_file() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_source(&dir).expect("fixture");
+
+    RsyncCommand::new()
+        .arg("-r")
+        .arg(format!("--filter=:e {SELF_GLOB}"))
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()))
+        .assert_success();
+
+    assert!(
+        dir.exists("dest/f"),
+        "the unrelated file must still transfer"
+    );
+    assert!(
+        !dir.exists(&format!("dest/{MATCHED_FILE}")),
+        "`:e {SELF_GLOB}` must hide {MATCHED_FILE}: upstream adds the exclude \
+         when the directive is PARSED, not when a file by that name is found"
+    );
+}
+
+/// Non-vacuity companion for the cell above: with the merge file actually
+/// present, the exclude must still fire and the file must still transfer.
+///
+/// Without this, removing the load-time push could silence a path that used to
+/// work and the first cell alone would not notice.
+#[test]
+fn a_top_level_exclude_self_still_hides_a_merge_file_that_exists() {
+    let dir = TestDir::new().expect("scratch dir");
+    dir.mkdir("src").expect("src");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/f", b"keep\n").expect("f");
+    dir.write_file("src/mergefile", b"# empty\n")
+        .expect("mergefile");
+
+    RsyncCommand::new()
+        .arg("-r")
+        .arg("--filter=:e mergefile")
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()))
+        .assert_success();
+
+    assert!(
+        dir.exists("dest/f"),
+        "the unrelated file must still transfer"
+    );
+    assert!(
+        !dir.exists("dest/mergefile"),
+        "a merge file that IS present must still be hidden by its own `:e`"
+    );
+}
+
+/// The same rule read out of a per-directory merge file: the exclude belongs to
+/// the enclosing `.rsync-filter`'s scope, and again does not wait for a file
+/// named `SELF_GLOB` to appear.
+///
+/// This is the shape upstream's `filter-merge-content-echo` cell exercises.
+#[test]
+fn a_nested_exclude_self_fires_without_the_merge_file() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_source(&dir).expect("fixture");
+    dir.write_file("src/.rsync-filter", format!(":e {SELF_GLOB}\n").as_bytes())
+        .expect("per-dir filter");
+
+    RsyncCommand::new()
+        .arg("-r")
+        .arg("-F")
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()))
+        .assert_success();
+
+    assert!(
+        dir.exists("dest/f"),
+        "the unrelated file must still transfer"
+    );
+    assert!(
+        !dir.exists(&format!("dest/{MATCHED_FILE}")),
+        "a `:e {SELF_GLOB}` nested in .rsync-filter must hide {MATCHED_FILE}"
+    );
+}
+
+/// The name upstream excludes is the BASENAME, not the path it was written
+/// with: `:e sub/NAME` hides `NAME` in each directory, never `sub/NAME`.
+///
+/// Pins the scan at `exclude.c:1568-1569` end to end rather than only in the
+/// `filters` unit test that owns it.
+#[test]
+fn a_qualified_exclude_self_hides_the_basename() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_source(&dir).expect("fixture");
+
+    RsyncCommand::new()
+        .arg("-r")
+        .arg(format!("--filter=:e sub/{SELF_GLOB}"))
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()))
+        .assert_success();
+
+    assert!(
+        !dir.exists(&format!("dest/{MATCHED_FILE}")),
+        "the exclude carries only the last path segment, so it matches \
+         {MATCHED_FILE} at the transfer root"
+    );
+}


### PR DESCRIPTION
Upstream synthesises a `:e` merge file's own exclude at **registration** — when the directive is parsed — into the **enclosing** list, then clears the flag so it is added exactly once (`exclude.c:1558-1571`):

```c
if (new_rflags & FILTRULE_EXCLUDE_SELF) {
        excl_self = new0(filter_rule);
        excl_self->rflags = rule->rflags & FILTRULE_FROM_FILE;
        /* Find the beginning of the basename and add an exclude for it. */
        for (name = pat + pat_len; name > pat && name[-1] != '/'; name--) {}
        add_rule(listp, name, (pat + pat_len) - name, excl_self, 0);
        rule->rflags &= ~FILTRULE_EXCLUDE_SELF;
}
```

oc built it at **load** time instead — once per directory that turned out to contain a file by that name — which made the rule **conditional on the merge file existing**.

## Why that is observable at all

The merge-file name is a *pattern*. Upstream's own `filter-merge-content-echo` fixture names it `excl-self-[x]9`, a glob whose literal text matches the real file `excl-self-x9` while **nothing is ever named `excl-self-[x]9`** — so the file to load is never found, and the exclude still has to fire.

Measured against the real rsync 3.5.0 binary:

| arm | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| top-level `:e`, named file absent | dest holds `f` | dest holds `f` **+ `excl-self-x9`** | dest holds `f` |
| top-level `:e`, merge file present | dest holds `f` | dest holds `f` | dest holds `f` |
| nested `:e` in `.rsync-filter` | dest holds `f` | dest holds `f` **+ `excl-self-x9`** | dest holds `f` |

Where the file exists oc was already right. Where it does not, the excluded file transferred — a data-selection divergence, not a diagnostic one.

## Design

**`FilterProgram::new` is the owner, not the CLI compiler.** The flag lives on `DirMergeRule`, so putting the rule where that type is honoured covers every route that builds a program — the CLI path and a caller assembling entries directly — and keeps `excludes_self()` meaningful instead of a field only one construction path reads. An engine test that builds a program by hand had been passing on the load-time push; it now passes for the upstream reason rather than by accident of where the rule was created.

**The nested seam is genuinely separate.** A `:e` read out of a merge file registers through `DirMergeEntries::push_nested_dir_merge` and never reaches `FilterProgram::new`. There it goes through `push_rule`, which stamps `FileReadEarlier` — exactly the provenance upstream gives the synthesised rule (`excl_self->rflags = rule->rflags & FILTRULE_FROM_FILE`), so the bracketed literal stays withheld from the match trace, as it must for text that came out of a file.

**The basename scan is a byte split, not a path parse** (`exclude.c:1568-1569`): a pattern ending in `/` yields the empty name and `..` yields `..`, both of which `Path::file_name` would instead report as absent.

**On the removed load-time pushes:** registering the exclude twice would not be observable — filter lists are first-match-wins and both copies are the same exclude — so the risk the removal had to be checked against is the *opposite* one, silencing a path that already worked. The file-present cell covers exactly that.

## Verification

- All three arms mutation-proven in isolation, each killing exactly its own cells:
  - program-level registration removed → the three top-level pins fail (1 passed / 3 failed of 4)
  - nested registration removed → the nested pin alone fails (3 / 1)
  - basename scan replaced by the whole pattern → the qualified-name pin alone fails (3 / 1)
  - baseline and restored runs both 4/4
- `filters` + `engine` + `core` + `cli`: **13148 run, 13148 passed**.
- `cargo fmt --all -- --check`, the whole-tree `tools/ci/check_rustfmt_all.py`, and `cargo clippy --workspace --all-targets --all-features -D warnings` clean — all on the **pinned 1.88.0** toolchain.
- Upstream 3.5.0's `filter-merge-content-echo` cell advances from line 273 to line 292.

## Residual, stated rather than implied

The cell's next assertion (line 292, section 7) wants the parse-error location to name `.rsync-filter line 1` rather than the directory. That is a separate defect, already filed, and is untouched here.

Two known wording divergences remain visible in the `-vv` trace and are **not** part of this change: oc says `excluding` where upstream says `hiding` for a sender-side rule, and prints the line once per role where upstream prints it once. Both belong to the generator-vs-rest verb axis tracked separately.
