### PR TITLE
fix(specials): skip a nested socket instead of failing the transfer

### DIFF
--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -359,6 +359,20 @@ pub(crate) fn copy_fifo(
         }
     }
 
+    // A socket the platform cannot create race-safely is SKIPPED with a
+    // warning, not turned into a transfer error: a socket inode is only a
+    // placeholder, so upstream keeps going and still exits 0.
+    // upstream: generator.c:2506-2521 - atomic_create()'s do_mknod_at failure
+    // arm returns 0 for S_ISSOCK with EOPNOTSUPP/ENOSYS after rprintf(FWARNING).
+    #[cfg(unix)]
+    if std::os::unix::fs::FileTypeExt::is_socket(&file_type)
+        && let Some(name) = relative
+        && ::metadata::socket_creation_unsupported(name)
+    {
+        logging::warn_log!("{}", ::metadata::format_skipped_socket_message(destination));
+        return Ok(());
+    }
+
     // actually create a FIFO, or a 0600 placeholder when --fake-super is
     // active (mirrors upstream syscall.c:do_mknod()'s am_root < 0 branch).
     #[cfg(unix)]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -322,6 +322,7 @@ pub use special::device_word;
 pub use special::{
     create_device_node, create_device_node_from_parts, create_device_node_with_fake_super,
     create_fifo, create_fifo_node_from_parts, create_fifo_with_fake_super,
+    format_skipped_socket_message, socket_creation_unsupported,
 };
 
 pub use xattr_send::{XattrRole, XattrSendOptions, XattrSyncFilters, dest_xattrs_differ};

--- a/crates/metadata/src/special.rs
+++ b/crates/metadata/src/special.rs
@@ -147,6 +147,73 @@ pub fn create_device_node_from_parts(
     }
 }
 
+/// Reports whether a socket node named `relative` cannot be created on this
+/// platform, so the caller must skip the entry rather than materialise it.
+///
+/// There is no `bindat(2)`, so a socket can only be bound through a path.
+/// Upstream therefore splits the decision on whether the entry has a parent
+/// to resolve: a top-level name lives in the receiver's own working directory
+/// (`dfd == AT_FDCWD`, nothing to subvert) and still binds through the
+/// path-based fallback, while a NESTED one is refused with `EOPNOTSUPP`
+/// rather than re-resolving a potentially unsafe parent. The test is
+/// upstream's `strrchr(pathname, '/')` on the receiver-relative name, which
+/// is why callers must pass the transfer-relative name and not the absolute
+/// destination.
+///
+/// A socket inode is only a placeholder - a live socket is not usefully
+/// transferred - so the refusal is a skip, never a transfer failure; see
+/// [`format_skipped_socket_message`].
+///
+/// Always `false` where `mknodat(2)` handles `S_IFSOCK` directly (Linux),
+/// matching the platform split the rest of this module already draws.
+// upstream: syscall.c:1369-1378 do_mknod_at() - the socket arm
+#[must_use]
+#[cfg(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+))]
+pub fn socket_creation_unsupported(relative: &Path) -> bool {
+    relative
+        .parent()
+        .is_some_and(|parent| !parent.as_os_str().is_empty())
+}
+
+/// Reports whether a socket node named `relative` cannot be created on this
+/// platform. `mknodat(2)` materialises `S_IFSOCK` here, so nothing is refused.
+// upstream: syscall.c:1362 do_mknod_at() - mknodat handles every type on Linux
+#[must_use]
+#[cfg(not(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+)))]
+pub fn socket_creation_unsupported(_relative: &Path) -> bool {
+    false
+}
+
+/// Builds the notice upstream prints for a socket it cannot create, so both
+/// the local-copy and receiver call sites share one wording.
+///
+/// `destination` is the full name, matching upstream's `full_fname()`, which
+/// wraps the path in double quotes.
+// upstream: generator.c:2510-2519 - rprintf(FWARNING, "skipping socket ...")
+#[must_use]
+pub fn format_skipped_socket_message(destination: &Path) -> String {
+    format!(
+        "skipping socket (creation unsupported here): \"{}\"",
+        destination.display()
+    )
+}
+
 /// Creates an empty 0600 regular file used as a fake-super placeholder.
 ///
 /// Upstream `do_mknod()` performs the equivalent substitution by routing the
@@ -758,6 +825,57 @@ mod tests {
             created & requested,
             created,
             "created permissions must not exceed requested"
+        );
+    }
+
+    // The nested/top-level split is upstream's own discriminator: a name with
+    // no parent binds via the path-based fallback (`dfd == AT_FDCWD`), a
+    // nested one is refused. Pinned on the platforms that HAVE the refusal,
+    // so a regression that widens or narrows it is caught rather than merely
+    // observed through a testsuite cell.
+    // upstream: syscall.c:1369-1378 do_mknod_at() - the socket arm
+    #[cfg(all(
+        unix,
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos"
+        )
+    ))]
+    #[test]
+    fn a_nested_socket_is_unsupported_and_a_top_level_one_is_not() {
+        assert!(socket_creation_unsupported(Path::new("sub/thesock")));
+        assert!(socket_creation_unsupported(Path::new("a/b/thesock")));
+        assert!(!socket_creation_unsupported(Path::new("thesock")));
+    }
+
+    // `mknodat(2)` materialises S_IFSOCK where it is available, so nothing is
+    // refused there and the caller must never skip.
+    // upstream: syscall.c:1362 do_mknod_at() - mknodat handles every type
+    #[cfg(not(all(
+        unix,
+        any(
+            target_os = "ios",
+            target_os = "macos",
+            target_os = "tvos",
+            target_os = "watchos"
+        )
+    )))]
+    #[test]
+    fn no_socket_is_unsupported_where_mknodat_creates_them() {
+        assert!(!socket_creation_unsupported(Path::new("sub/thesock")));
+        assert!(!socket_creation_unsupported(Path::new("thesock")));
+    }
+
+    // The wording is upstream's verbatim, including `full_fname()`'s quotes:
+    // the testsuite cell greps stderr, so the text is part of the contract.
+    // upstream: generator.c:2510-2519
+    #[test]
+    fn the_skipped_socket_notice_matches_upstream_wording() {
+        assert_eq!(
+            format_skipped_socket_message(Path::new("/d/sub/thesock")),
+            "skipping socket (creation unsupported here): \"/d/sub/thesock\""
         );
     }
 

--- a/crates/transfer/src/receiver/directory/special.rs
+++ b/crates/transfer/src/receiver/directory/special.rs
@@ -210,6 +210,17 @@ impl ReceiverContext {
                     continue;
                 }
 
+                // A socket the platform cannot create race-safely is SKIPPED
+                // with a warning rather than materialised through an
+                // unconfined path-based bind; the inode is only a placeholder.
+                // upstream: generator.c:2506-2521 - the S_ISSOCK EOPNOTSUPP arm
+                if entry.file_type() == FileType::Socket
+                    && metadata::socket_creation_unsupported(relative_path)
+                {
+                    logging::warn_log!("{}", metadata::format_skipped_socket_message(&node_path));
+                    continue;
+                }
+
                 // upstream: generator.c:1675 atomic_create -> do_mknod_at
                 let create_result = if is_device {
                     create_device_node_from_parts(

--- a/tests/nested_socket_skipped.rs
+++ b/tests/nested_socket_skipped.rs
@@ -1,0 +1,170 @@
+//! A nested unix socket must not fail the transfer.
+//!
+//! Upstream refuses to create a socket under a parent it would have to
+//! re-resolve, on the platforms with no `bindat(2)` - the BSDs, macOS and
+//! Solaris (`syscall.c:1369-1378`, `do_mknod_at()`'s socket arm sets
+//! `EOPNOTSUPP` whenever `dfd != AT_FDCWD`). The generator then SKIPS the
+//! entry with a warning instead of turning it into a transfer error
+//! (`generator.c:2506-2521`): a socket inode is only a placeholder, so a live
+//! socket is not usefully transferred and losing one must not cost the rest of
+//! the tree.
+//!
+//! oc instead bound the socket through an unconfined path-based `bind(2)` on
+//! the absolute destination. Two consequences, both measured against the real
+//! rsync 3.5.0 binary on macOS:
+//!
+//! * a nested socket was created where upstream deliberately refuses - the
+//!   race-safety divergence;
+//! * and where the absolute path exceeded `sun_path` (104 bytes on Apple) the
+//!   bind failed `ENAMETOOLONG` and oc exited 23, losing the whole transfer,
+//!   while upstream exited 0 with the regular files in place.
+//!
+//! ## What these cells assert, and on which platform
+//!
+//! The transfer outcome is platform-independent and is the substance: exit 0
+//! with every regular file present. The SKIP itself is only observable where
+//! the platform has the refusal, so that half is `cfg`-gated to exactly the
+//! arm the fix targets - mirroring upstream's own cell, whose comment says
+//! "On Linux the socket is created; either way the transfer exits 0".
+//!
+//! The FIFO cell is the non-vacuity companion: without it a blanket
+//! "skip every special file" regression would satisfy every other assertion
+//! here.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// Binds a unix socket at `dir/<rel>` using a short relative name, so the
+/// FIXTURE never trips `sun_path` itself - only the code under test can.
+#[cfg(unix)]
+fn bind_socket(dir: &TestDir, rel: &str) {
+    use std::os::unix::fs::FileTypeExt;
+    use std::os::unix::net::UnixListener;
+
+    let path = dir.path().join(rel);
+    let parent = path.parent().expect("socket has a parent").to_path_buf();
+    let name = path.file_name().expect("socket has a name").to_owned();
+
+    let previous = std::env::current_dir().expect("cwd");
+    std::env::set_current_dir(&parent).expect("chdir to the socket's parent");
+    let listener = UnixListener::bind(&name);
+    std::env::set_current_dir(previous).expect("restore cwd");
+
+    listener.expect("bind the fixture socket");
+    assert!(
+        std::fs::symlink_metadata(&path)
+            .expect("fixture socket metadata")
+            .file_type()
+            .is_socket(),
+        "the fixture must really be a socket, or every assertion below is vacuous"
+    );
+}
+
+#[cfg(unix)]
+fn seed(dir: &TestDir) {
+    dir.mkdir("src").expect("src");
+    dir.mkdir("src/sub").expect("src/sub");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/sub/f.txt", b"regular\n")
+        .expect("f.txt");
+    dir.write_file("src/top.txt", b"top\n").expect("top.txt");
+}
+
+#[cfg(unix)]
+fn copy_tree(dir: &TestDir) -> std::process::Output {
+    RsyncCommand::new()
+        .arg("-a")
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()))
+        .assert_success()
+}
+
+/// `-a` implies `--specials`, so a nested socket is offered for creation. The
+/// transfer must still exit 0 and land every regular file, whether the
+/// platform creates the socket or refuses it.
+#[cfg(unix)]
+#[test]
+fn a_nested_socket_does_not_fail_the_transfer() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    bind_socket(&dir, "src/sub/thesock");
+
+    copy_tree(&dir);
+
+    assert!(
+        dir.exists("dest/sub/f.txt"),
+        "a regular file was lost alongside the nested socket"
+    );
+    assert!(
+        dir.exists("dest/top.txt"),
+        "a regular file was lost alongside the nested socket"
+    );
+}
+
+/// Where the platform has no `bindat(2)` the entry is skipped, and the notice
+/// carries upstream's wording so an operator can tell a skip from a silent
+/// omission.
+#[cfg(all(
+    unix,
+    any(
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "tvos",
+        target_os = "watchos"
+    )
+))]
+#[test]
+fn a_nested_socket_is_skipped_with_upstreams_notice() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    bind_socket(&dir, "src/sub/thesock");
+
+    let output = copy_tree(&dir);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("skipping socket (creation unsupported here):"),
+        "the skip must be announced, not silent; stderr was: {stderr}"
+    );
+    assert!(
+        !dir.exists("dest/sub/thesock"),
+        "a nested socket must not be created through an unconfined path-based \
+         bind where upstream refuses it"
+    );
+}
+
+/// The non-vacuity companion: the skip is keyed on the node being a SOCKET, so
+/// a nested FIFO - which `mkfifo(2)` can create race-safely - must still be
+/// materialised. Without this cell, skipping every special file would satisfy
+/// the assertions above.
+#[cfg(unix)]
+#[test]
+fn a_nested_fifo_is_still_created() {
+    use std::os::unix::fs::FileTypeExt;
+
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    let fifo = dir.path().join("src/sub/thefifo");
+    let made = std::process::Command::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .expect("run mkfifo");
+    assert!(made.success(), "mkfifo failed for the fixture");
+    assert!(
+        std::fs::symlink_metadata(&fifo)
+            .expect("fixture fifo metadata")
+            .file_type()
+            .is_fifo(),
+        "the fixture must really be a FIFO, or this cell proves nothing"
+    );
+
+    copy_tree(&dir);
+
+    let created = std::fs::symlink_metadata(dir.path().join("dest/sub/thefifo"))
+        .expect("the nested FIFO must be created");
+    assert!(
+        created.file_type().is_fifo(),
+        "the destination entry must be a FIFO, not a placeholder"
+    );
+}

--- a/tests/nested_socket_skipped.rs
+++ b/tests/nested_socket_skipped.rs
@@ -33,6 +33,10 @@
 
 mod integration;
 
+// Every item below that names these is `cfg(unix)`, so on Windows the import
+// has no consumer and `-D warnings` rejects it. Gate it on exactly the same
+// predicate its users carry, matching tests/integration_links.rs.
+#[cfg(unix)]
 use integration::helpers::{RsyncCommand, TestDir};
 
 /// Binds a unix socket at `dir/<rel>` using a short relative name, so the


### PR DESCRIPTION
Upstream 3.5.0's `nested-socket-specials` cell was failing on macOS while its expect manifest says `pass`. This restores that row; it is not a re-baseline.

## What upstream does, in two places

There is no `bindat(2)` on the BSDs, macOS or Solaris, so a socket can only be bound through a path. Upstream splits on whether the entry has a parent to resolve (`syscall.c:1369-1378`):

```c
if (S_ISSOCK(mode)) {
        /* There is no dirfd-relative socket bind without
         * /proc/self/fd: a top-level path can bind via
         * do_mknod(), but a nested one fails safe rather than
         * re-resolve a potentially unsafe parent. */
        if (dfd == AT_FDCWD)
                ret = do_mknod(pathname, mode, dev);
        else
                errno = EOPNOTSUPP;
}
```

and the generator then **skips** that entry rather than failing the transfer (`generator.c:2506-2521`):

```c
if (S_ISSOCK(file->mode) && (e == EOPNOTSUPP || e == ENOSYS)) {
        rprintf(FWARNING, "skipping socket (creation unsupported here): %s\n",
                full_fname(create_name));
        return 0;
}
```

oc had neither half — it bound the socket through an unconfined path-based `bind(2)` on the **absolute** destination.

## Measured against the real rsync 3.5.0 binary, same host, same fixture

| fixture | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| nested socket, deep dest | skip + warn, exit 0 | `ENAMETOOLONG`, **exit 23** | skip + warn, exit 0 |
| nested socket, short dest | skip + warn, exit 0 | socket **CREATED** | skip + warn, exit 0 |

Row 1 is the availability defect: `sun_path` is 104 bytes on Apple and the testsuite scratch path is longer, so the bind failed and oc lost the **whole** transfer — regular files included — where upstream exited 0 with them in place. Row 2 is the race-safety divergence upstream deliberately closed.

## Design

`metadata::socket_creation_unsupported` is the decision, and it takes the entry's **transfer-relative** name because that is exactly what upstream tests: `strrchr(pathname, '/')` on the name after its receiver has chdir'd into the destination. It is always `false` where `mknodat(2)` handles `S_IFSOCK` (Linux), matching the platform split this module already draws.

`format_skipped_socket_message` owns the wording, so the two call sites cannot drift — the testsuite cell greps stderr, so the text is part of the contract.

Both call sites consult it: the local-copy executor (which propagated the error and exited 23) and the receiver's `create_specials` (which continued, but only after materialising a node upstream refuses).

## Verification

Mutation-proven **in isolation**, each killing exactly its own cells:

| mutation | metadata unit pins | socket integration cells | FIFO control |
|---|---|---|---|
| decision forced always-false | **1 FAIL** / 2 pass | **2 FAIL** | green |
| caller's skip block deleted | 3 pass | **2 FAIL** | green |

Baseline and restored runs are 3/3 + 3/3. The FIFO cell is the negative control: without it, a blanket "skip every special file" regression would satisfy every other assertion here.

- `metadata` + `engine` + `transfer`: **8383 run, 8383 passed**
- `cargo fmt --all -- --check`, the whole-tree `tools/ci/check_rustfmt_all.py`, and `cargo clippy --workspace --all-targets --all-features -D warnings` clean on the **pinned 1.88.0** toolchain
- `runtests.py --rsync-bin <oc> nested-socket-specials` → `PASS` (it was `FAIL` 5/5 serially before)

## Residual, stated rather than implied

A **top-level** socket whose absolute destination exceeds `sun_path` still fails. Upstream avoids that only because its receiver chdir's and binds a short relative name; oc has no per-transfer chdir. That is the same missing mechanism tracked for the daemon `--relative` operand work, and it is deliberately not papered over here.
