### PR TITLE
fix(engine): discard a merge file's over-long filter rule

### DIFF
--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::local_copy::filter_program::ExcludeIfPresentRule;
 use filters::{FilterRule, RuleSource};
+use std::borrow::Cow;
 use std::fmt;
 
 #[derive(Default)]
@@ -219,6 +220,77 @@ pub(crate) fn directive_takes_argument(token: &str) -> bool {
 /// prefix accepted four spellings upstream rejects.
 const SINGLE_LETTER_PREFIXES: &str = "SHRP";
 
+/// Parses a single line of a per-directory merge file, discarding a rule whose
+/// pattern reaches `MAXPATHLEN`.
+///
+/// See [`classify_filter_directive_line`] for the grammar; this wrapper adds
+/// upstream's over-long refusal, which sits in `parse_filter_str`'s token loop
+/// (exclude.c:1533-1538) and therefore governs every rule kind the loop can
+/// produce - including the ones a merge file yields.
+pub(crate) fn parse_filter_directive_line(
+    text: &str,
+    source: RuleSource<'_>,
+) -> Result<Option<ParsedFilterDirective>, FilterParseError> {
+    Ok(classify_filter_directive_line(text, source)?
+        .and_then(|directive| discard_over_long(directive, source)))
+}
+
+/// Reports and drops a directive whose pattern reaches `MAXPATHLEN`.
+///
+/// upstream: exclude.c:1533-1538, in `parse_filter_str`'s token loop. It
+/// measures `pat_len` - the pattern *alone*, since `parse_rule_tok` has already
+/// consumed the action prefix and any modifiers (exclude.c:1456-1464) - then
+/// `continue`s, so the rule contributes nothing and parsing exits 0. `Ok(None)`
+/// is oc's `continue`: this parser already uses it for a line that yields no
+/// rule.
+///
+/// Consulting the CONSTRUCTED directive reads that same quantity without
+/// duplicating the prefix stripping, the shape the CLI parser already uses
+/// (`crates/cli/.../filter_rules/parsing/entry.rs`). The merge name is measured
+/// as WRITTEN: `parse_merge_directive` stores the token verbatim and
+/// `resolve_dir_merge_path` resolves it later, so this is upstream's `pat_len`
+/// and not a resolved path of a different length.
+///
+/// MEASURED against rsync 3.5.0 on a `.rsync-filter` holding `- ` plus 1100
+/// `*`: upstream discards the rule and transfers all three files; oc RETAINED
+/// it, and since a long `*` run matches everything the whole transfer was
+/// silently suppressed at exit 0. The missing diagnostic was the visible half
+/// of a data divergence, not a cosmetic gap.
+///
+/// `Clear` carries no pattern, so upstream's check can never fire for it.
+/// `ExcludeIfPresent` is an oc directive with no upstream counterpart in this
+/// loop, so it is deliberately left alone rather than given a bound upstream
+/// does not impose.
+fn discard_over_long(
+    directive: ParsedFilterDirective,
+    source: RuleSource<'_>,
+) -> Option<ParsedFilterDirective> {
+    let pattern: Cow<'_, str> = match &directive {
+        ParsedFilterDirective::Rule(rule) => Cow::Borrowed(rule.pattern()),
+        ParsedFilterDirective::Merge { path, .. } => path.to_string_lossy(),
+        ParsedFilterDirective::DirMerge { pattern, .. } => pattern.to_string_lossy(),
+        ParsedFilterDirective::ExcludeIfPresent(_) | ParsedFilterDirective::Clear => {
+            return Some(directive);
+        }
+    };
+
+    if !filters::is_over_long(&pattern) {
+        return Some(directive);
+    }
+
+    // The rule text crosses `rule_text` (exclude.c:88-123): upstream passes a
+    // NULL template here, which falls back to the am-I-parsing-a-file state
+    // (exclude.c:67-69) - the fact oc carries explicitly on `source`.
+    logging::emit_info_coded(
+        logging::InfoFlag::Misc,
+        0,
+        logging::LogCode::Error,
+        filters::over_long_filter(&source.rule_text(&pattern)),
+    );
+
+    None
+}
+
 /// Parses a single line of a per-directory merge file.
 ///
 /// `source` is where this line came from, and it decides how an unparsable
@@ -232,7 +304,7 @@ const SINGLE_LETTER_PREFIXES: &str = "SHRP";
 /// directives, `exclude-if-present`, the `+`/`-` short-form rule prefixes,
 /// and the `include`/`exclude`/`show`/`hide`/`protect`/`risk` keywords with
 /// their `,modifier` suffix. Trailing whitespace is trimmed from patterns.
-pub(crate) fn parse_filter_directive_line(
+fn classify_filter_directive_line(
     text: &str,
     source: RuleSource<'_>,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {

--- a/crates/engine/src/local_copy/tests/filters_runtime.rs
+++ b/crates/engine/src/local_copy/tests/filters_runtime.rs
@@ -560,3 +560,63 @@ fn perdir_merge_delete_during_matches_upstream_no_protection() {
     assert!(dest.join("keep.txt").exists());
     assert!(dest.join("sub/keep2.txt").exists());
 }
+
+/// A merge file's over-long rule must be DISCARDED, not retained.
+///
+/// upstream: exclude.c:1533-1538 in `parse_filter_str`'s token loop -
+/// `if (pat_len >= MAXPATHLEN) { rprintf(FERROR, "discarding over-long
+/// filter: %s\n", ...); free_filter(rule); continue; }`. The `continue` is the
+/// substance: the rule contributes nothing and parsing exits 0.
+///
+/// MEASURED against the real rsync 3.5.0 binary, with a `.rsync-filter`
+/// holding `- ` plus 1100 `*` and a `-aF` local copy of two files:
+///   upstream: prints the diagnostic, dst gets `.rsync-filter a.txt b.txt`
+///   oc before: silent, dst EMPTY, exit 0
+/// A long run of `*` MATCHES EVERYTHING, so retaining the rule upstream drops
+/// suppressed the entire transfer. The missing message was the visible half of
+/// a data divergence, which is why this asserts on the RULE SET rather than on
+/// the diagnostic text.
+#[test]
+fn a_merge_files_over_long_rule_is_discarded() {
+    let temp = tempdir().expect("tempdir");
+    let filter = temp.path().join("overlong.rules");
+    let pattern = "*".repeat(fast_io::path_limit::max_path_len() + 76);
+    fs::write(&filter, format!("- {pattern}\n")).expect("write filter");
+
+    let mut visited = Vec::new();
+    let entries = load_dir_merge_rules_recursive(
+        &filter,
+        &DirMergeOptions::default(),
+        false,
+        &mut visited,
+        MergeFileOrigin::Argument,
+    )
+    .expect("an over-long rule is discarded, not a syntax error");
+
+    assert!(
+        entries.rules.is_empty(),
+        "upstream discards the rule; retaining it would exclude every file",
+    );
+}
+
+/// The non-vacuity companion: an ORDINARY rule from the same loader must
+/// survive. Without it the pin above would also pass if the loader had simply
+/// stopped producing rules at all.
+#[test]
+fn a_merge_files_ordinary_rule_is_kept() {
+    let temp = tempdir().expect("tempdir");
+    let filter = temp.path().join("ordinary.rules");
+    fs::write(&filter, b"- *.tmp\n").expect("write filter");
+
+    let mut visited = Vec::new();
+    let entries = load_dir_merge_rules_recursive(
+        &filter,
+        &DirMergeOptions::default(),
+        false,
+        &mut visited,
+        MergeFileOrigin::Argument,
+    )
+    .expect("parse filter");
+
+    assert_eq!(entries.rules.len(), 1, "an ordinary rule must be kept");
+}


### PR DESCRIPTION
## The defect

A per-directory merge file (`.rsync-filter`, `-F` / `dir-merge`) could carry a
filter rule whose pattern reaches `MAXPATHLEN`. Upstream discards such a rule;
oc kept it.

That is a **data** divergence, not a missing message. A long run of `*` is
over-long *and* matches everything, so a rule upstream drops suppressed the
entire transfer.

MEASURED against the real `rsync 3.5.0` binary. Fixture: `.rsync-filter`
holding `- ` followed by 1100 `*`, then `-aF src/ dst/` over two files.

| | diagnostic | destination |
|---|---|---|
| rsync 3.5.0 | `discarding over-long filter: <rule from …/.rsync-filter line 1>` | `.rsync-filter a.txt b.txt` |
| oc **before** | *silent* | **EMPTY**, exit 0 |
| oc **after** | same line as upstream | `.rsync-filter a.txt b.txt` |

A non-vacuity companion in the probe (`- keep-me` alongside the over-long rule)
confirms the merge file *is* read and applied, so the silent arm was not
explained by the file never being consulted.

## Upstream

`exclude.c:1533-1538`, inside `parse_filter_str`'s token loop:

```c
if (pat_len >= MAXPATHLEN) {
        rprintf(FERROR, "discarding over-long filter: %s\n",
                rule_text_len(NULL, pat, (int)pat_len));
  free_continue:
        free_filter(rule); continue;
}
```

The `continue` is the substance: the rule contributes nothing and parsing exits
0. The check sits **above** both the `FILTRULE_CLEAR_LIST` branch (`:1541`) and
the `FILTRULE_MERGE_FILE` branch (`:1550`), so it governs every rule kind that
loop can produce — including the ones a merge file yields.

PR #7673 routed the **CLI** parser onto this refusal. The engine's dir-merge
parser is a separate implementation and had no such check; this is that half.

## Shape

`parse_filter_directive_line` becomes a thin wrapper: classify the line, then
apply the refusal. That mirrors what the CLI parser already does
(`crates/cli/src/frontend/filter_rules/parsing/entry.rs`) — consult the
**constructed directive**, which carries exactly the quantity upstream
measures, instead of duplicating the prefix and modifier stripping. `Ok(None)`
is oc's `continue`: this parser already uses it for a line that yields no rule.

Two details worth calling out:

- **The merge name is measured as written.** `parse_merge_directive` stores the
  token verbatim and `resolve_dir_merge_path` resolves it later, so this is
  upstream's `pat_len` and not a resolved path of a different length.
- **`ExcludeIfPresent` is deliberately left alone.** It is an oc directive with
  no counterpart in upstream's loop, so giving it a bound upstream does not
  impose would be an invention, not a port. `Clear` carries no pattern at all.

## Verification

- Mutation-proven: disabling the guard fails
  `a_merge_files_over_long_rule_is_discarded` (1 kill, exactly its own test) and
  leaves the non-vacuity companion `a_merge_files_ordinary_rule_is_kept` green.
- The tests assert on the **rule set**, not the diagnostic text — that is what
  makes them oracles for the data divergence rather than message checks.
- End-to-end re-run against the real 3.5.0 binary: identical diagnostic and
  identical destination listing (table above).
- `cargo fmt --all -- --check`, `tools/ci/check_rustfmt_all.py` (whole-tree,
  edition 2024) and `cargo clippy --workspace --all-targets --all-features
  --no-deps -- -D warnings` all clean at the pinned toolchain (1.88.0).
