### PR TITLE
fix(daemon): deliver a refusal to the log, in upstream's words

### DIFF
--- a/crates/daemon/src/daemon/sections/auth_helpers.rs
+++ b/crates/daemon/src/daemon/sections/auth_helpers.rs
@@ -60,15 +60,56 @@ fn log_module_lock_error(
     log_message(log, &message);
 }
 
-fn log_module_refused_option(
-    log: &SharedLogSink,
-    host: &str,
-    peer_ip: IpAddr,
-    module: &str,
-    refused: &str,
-) {
-    let text = format!("refusing option '{refused}' for module '{module}' from {host} ({peer_ip})");
+/// The refusal text upstream builds once and delivers to BOTH the peer and the
+/// daemon log.
+///
+/// upstream: `options.c:1409-1423` `create_refuse_error()` fills `err_buf` with
+/// `"The server is configured to refuse --<longName>\n"`, and the post-`@RSYNCD:
+/// OK` failure branch at `clientserver.c:1254` reaches `option_error()`
+/// (`options.c:907-918`), which emits that same buffer via
+/// `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`. A daemon's `FERROR` lands in
+/// the log file, so upstream has ONE string serving as both the peer's `@ERROR`
+/// payload and the logged line.
+///
+/// This is a single owner for exactly that reason: oc previously formatted the
+/// peer's text and the log's text independently, and they drifted - the peer
+/// saw upstream's wording while the log carried an oc-invented
+/// `refusing option '...' for module '...'` line that no upstream site emits.
+pub(crate) fn refused_option_message(refused: &str) -> String {
+    format!("The server is configured to refuse {refused}")
+}
+
+/// Logs a refused option in upstream's words.
+///
+/// upstream: `options.c:915` - `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`.
+/// The logged line therefore carries the `rsync: ` prefix `option_error()` adds
+/// and nothing more: upstream names no module, host or peer here, because the
+/// connection is already identified by the line's pid stamp and by the
+/// preceding `rsync allowed access on module %s from %s (%s)`
+/// (`clientserver.c:787`), which oc emits faithfully.
+///
+/// The log CODE is deliberately left as it was. Upstream routes this at
+/// `FERROR` while oc records it at info level; both reach the daemon log file,
+/// which is the observable this mirrors, and re-coding it would change oc's
+/// message routing for a reason this change has not measured.
+fn log_module_refused_option(log: &SharedLogSink, refused: &str) {
+    let text = format!("rsync: {}", refused_option_message(refused));
     let message = rsync_info!(text).with_role(Role::Daemon);
+    log_message(log, &message);
+}
+
+/// Logs a failure to read the client's argument vector.
+///
+/// upstream: `io.c:1477-1478` - `read_args()` reports the refusal where it
+/// happens, e.g. `rprintf(FERROR, "too many daemon arguments\n")`, and a
+/// daemon's `FERROR` reaches the log file. oc sent that refusal to the peer and
+/// logged nothing at all, so an operator watching the log could not see why a
+/// connection was cut - the guard fired invisibly.
+///
+/// The text is the error's own and is emitted bare: unlike `option_error()`
+/// (`options.c:915`) upstream adds no `rsync: ` prefix at this site.
+fn log_client_args_failure(log: &SharedLogSink, error: &io::Error) {
+    let message = rsync_info!(error.to_string()).with_role(Role::Daemon);
     log_message(log, &message);
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -249,6 +249,14 @@ fn read_and_log_client_args(
     let phase1_args = match read_client_arguments(ctx.reader, negotiated_protocol) {
         Ok(args) => args,
         Err(err) => {
+            // upstream: io.c:1477-1478 - `read_args()` reports its own refusal
+            // (`too many daemon arguments`) at FERROR, which for a daemon lands
+            // in the log file. Telling only the peer leaves the operator with a
+            // connection that was cut for no recorded reason, so the log gets
+            // the same failure the peer does.
+            if let Some(log) = ctx.log_sink {
+                log_client_args_failure(log, &err);
+            }
             let error = AtError::message(format!("failed to read client arguments: {err}"));
             send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
             return Ok(None);

--- a/crates/daemon/src/daemon/sections/module_access/request.rs
+++ b/crates/daemon/src/daemon/sections/module_access/request.rs
@@ -274,10 +274,10 @@ fn handle_lock_error(ctx: &mut ModuleRequestContext<'_>, error: &io::Error) -> i
 /// Used when refused-options are detected from `OPTION` directives sent before
 /// `@RSYNCD: OK`; at this point the client still reads raw text.
 fn handle_refused_option(ctx: &mut ModuleRequestContext<'_>, refused: &str) -> io::Result<()> {
-    let error = AtError::message(format!("The server is configured to refuse {refused}"));
+    let error = AtError::message(refused_option_message(refused));
     send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
     if let Some(log) = ctx.log_sink {
-        log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);
+        log_module_refused_option(log, refused);
     }
     Ok(())
 }
@@ -318,7 +318,7 @@ fn handle_refused_option_post_handshake(
     client_args: &[String],
 ) -> io::Result<()> {
     finalize_post_ok_protocol_for_error(ctx, protocol_version, client_args)?;
-    let error = AtError::message(format!("The server is configured to refuse {refused}"));
+    let error = AtError::message(refused_option_message(refused));
     send_multiplexed_error_and_exit(
         ctx.reader.get_mut(),
         ctx.limiter,
@@ -326,7 +326,7 @@ fn handle_refused_option_post_handshake(
         RERR_UNSUPPORTED_EXIT_CODE,
     )?;
     if let Some(log) = ctx.log_sink {
-        log_module_refused_option(log, ctx.host_display(), ctx.peer_ip, ctx.request, refused);
+        log_module_refused_option(log, refused);
     }
     Ok(())
 }

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -215,6 +215,8 @@ include!("tests/chunks/run_daemon_loads_modules_from_config_file.rs");
 include!("tests/chunks/run_daemon_loads_modules_from_inline_config_flag.rs");
 include!("tests/chunks/run_daemon_lists_modules_with_motd_lines.rs");
 include!("tests/chunks/run_daemon_lists_modules_with_module_timeout.rs");
+include!("tests/chunks/run_daemon_logs_a_refused_option_in_upstream_words.rs");
+include!("tests/chunks/run_daemon_logs_an_oversized_client_argv.rs");
 include!("tests/chunks/run_daemon_omits_unlisted_modules_from_listing.rs");
 include!("tests/chunks/run_daemon_panic_isolation_keeps_daemon_alive.rs");
 include!("tests/chunks/run_daemon_post_ok_refused_option_uses_multiplexed_error.rs");

--- a/crates/daemon/src/tests/chunks/run_daemon_logs_a_refused_option_in_upstream_words.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_logs_a_refused_option_in_upstream_words.rs
@@ -1,0 +1,99 @@
+/// A refused option must reach the daemon log, in the words upstream uses.
+///
+/// upstream: `options.c:1409-1423` builds the refusal into `err_buf` once, and
+/// `option_error()` (`options.c:907-918`) emits that same buffer via
+/// `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`. A daemon's `FERROR` lands in
+/// the log file, so the peer's `@ERROR` payload and the logged line are the
+/// same string. Asserting both sides here is what pins them to one owner:
+/// oc previously formatted them independently and they drifted, the log
+/// carrying an oc-invented `refusing option '...' for module '...'` that no
+/// upstream site emits.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: in-process daemon intermittently fails to respond; the refusal path is platform-independent and covered on Linux/macOS"
+)]
+fn run_daemon_logs_a_refused_option_in_upstream_words() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let temp = tempdir().expect("log dir");
+    let log_path = temp.path().join("rsyncd.log");
+
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[docs]\npath = {module_path}\nrefuse options = compress\n",
+    )
+    .expect("write config");
+
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--config"),
+            file.path().as_os_str().to_os_string(),
+            OsString::from("--log-file"),
+            log_path.as_os_str().to_os_string(),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, legacy_daemon_greeting());
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream
+        .write_all(b"@RSYNCD: OPTION --compress\n")
+        .expect("send refused option");
+    stream.flush().expect("flush refused option");
+
+    stream.write_all(b"docs\n").expect("send module request");
+    stream.flush().expect("flush module request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("refusal message");
+    assert_eq!(
+        line.trim_end(),
+        "@ERROR: The server is configured to refuse --compress",
+    );
+
+    drop(reader);
+    if let Some(result) = finish_daemon(handle) {
+        assert!(result.is_ok());
+    }
+
+    let log_contents = fs::read_to_string(&log_path).expect("read log file");
+    // upstream: options.c:915 - `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`.
+    // The `rsync: ` prefix is `option_error()`'s; nothing else is added,
+    // because the connection is already identified by the pid stamp and the
+    // preceding `rsync allowed access on module ...` line.
+    assert!(
+        log_contents
+            .lines()
+            .any(|entry| entry.ends_with("rsync: The server is configured to refuse --compress")),
+        "the log must carry upstream's refusal verbatim: {log_contents:?}"
+    );
+    // The peer and the log must not drift apart again: upstream has one
+    // `err_buf`, so any wording the log invents for itself is a divergence.
+    assert!(
+        !log_contents.contains("refusing option"),
+        "the log must not invent wording upstream never emits: {log_contents:?}"
+    );
+}

--- a/crates/daemon/src/tests/chunks/run_daemon_logs_an_oversized_client_argv.rs
+++ b/crates/daemon/src/tests/chunks/run_daemon_logs_an_oversized_client_argv.rs
@@ -1,0 +1,96 @@
+/// The daemon-argument ceiling must be recorded, not only sent to the peer.
+///
+/// upstream: `io.c:1476-1479` - `read_args()` cuts the peer off at
+/// `MAX_DAEMON_ARGS` with `rprintf(FERROR, "too many daemon arguments\n")`, and
+/// a daemon's `FERROR` reaches the log file. oc answered the peer and logged
+/// nothing, so the guard fired invisibly: an operator saw a connection cut with
+/// no recorded reason.
+///
+/// The client sends exactly the number of arguments that trips the ceiling, so
+/// the daemon consumes every byte written here and neither side is left
+/// blocking on the other.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: in-process daemon intermittently fails to respond; the argument ceiling is platform-independent and covered on Linux/macOS"
+)]
+fn run_daemon_logs_an_oversized_client_argv() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (port, held_listener) = allocate_test_port();
+
+    let temp = tempdir().expect("log dir");
+    let log_path = temp.path().join("rsyncd.log");
+
+    let module_path = std::env::temp_dir()
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let config = DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--log-file"),
+            log_path.as_os_str().to_os_string(),
+            OsString::from("--module"),
+            OsString::from(format!("docs={module_path}")),
+            OsString::from("--once"),
+        ])
+        .build();
+
+    let (mut stream, handle) = start_daemon(config, port, held_listener);
+    let mut reader = BufReader::new(stream.try_clone().expect("clone stream"));
+
+    let mut line = String::new();
+    reader.read_line(&mut line).expect("greeting");
+    assert_eq!(line, legacy_daemon_greeting());
+
+    stream
+        .write_all(b"@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4\n")
+        .expect("send handshake response");
+    stream.flush().expect("flush handshake response");
+
+    stream.write_all(b"docs\n").expect("send module request");
+    stream.flush().expect("flush module request");
+
+    line.clear();
+    reader.read_line(&mut line).expect("module acknowledgement");
+    assert_eq!(line, "@RSYNCD: OK\n");
+
+    // upstream: io.c:1476 - the ceiling is checked before an argument is
+    // appended, so the refusal fires once the vector already holds
+    // `MAX_DAEMON_ARGS - 1` entries. Sending exactly that many leaves no
+    // unconsumed bytes in flight.
+    let overflow = protocol::secluded_args::MAX_DAEMON_ARGS - 1;
+    let mut argv = Vec::with_capacity(overflow * 3);
+    for _ in 0..overflow {
+        argv.extend_from_slice(b"-v\0");
+    }
+    stream.write_all(&argv).expect("send oversized argv");
+    stream.flush().expect("flush oversized argv");
+
+    line.clear();
+    reader.read_line(&mut line).expect("argument refusal");
+    assert!(
+        line.contains("too many daemon arguments"),
+        "the peer must be told upstream's reason: {line:?}"
+    );
+
+    drop(reader);
+    if let Some(result) = finish_daemon(handle) {
+        assert!(result.is_ok());
+    }
+
+    let log_contents = fs::read_to_string(&log_path).expect("read log file");
+    // upstream: io.c:1477-1478 emits the refusal bare - unlike `option_error()`
+    // (`options.c:915`) this site adds no `rsync: ` prefix.
+    assert!(
+        log_contents
+            .lines()
+            .any(|entry| entry.ends_with("too many daemon arguments")),
+        "the log must record why the connection was cut: {log_contents:?}"
+    );
+}

--- a/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.nonroot.tcp.txt
@@ -22,7 +22,7 @@ copy-dest-source-symlink pass
 daemon pass
 daemon-access pass
 daemon-access-ip pass
-daemon-argv-limit fail
+daemon-argv-limit pass
 daemon-auth pass
 daemon-auth-digest-floor pass
 daemon-auth-group skip
@@ -70,7 +70,7 @@ daemon-path-rsync-var pass
 daemon-proxy-protocol fail
 daemon-refuse pass
 daemon-refuse-compress pass
-daemon-refuse-compress-threads-alias fail
+daemon-refuse-compress-threads-alias pass
 daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass

--- a/tools/ci/upstream-3.5.0-expect.root.tcp.txt
+++ b/tools/ci/upstream-3.5.0-expect.root.tcp.txt
@@ -22,7 +22,7 @@ copy-dest-source-symlink pass
 daemon pass
 daemon-access pass
 daemon-access-ip pass
-daemon-argv-limit fail
+daemon-argv-limit pass
 daemon-auth pass
 daemon-auth-digest-floor pass
 daemon-auth-group pass
@@ -70,7 +70,7 @@ daemon-path-rsync-var pass
 daemon-proxy-protocol fail
 daemon-refuse pass
 daemon-refuse-compress pass
-daemon-refuse-compress-threads-alias fail
+daemon-refuse-compress-threads-alias pass
 daemon-refuse-delete-alias pass
 daemon-scan-cwd-desync pass
 daemon-scan-dir-escape pass


### PR DESCRIPTION
Two daemon refusals never reached the log correctly. Both are faithful ports of named upstream sites, and they are the log half of the `daemon-refuse-compress-threads-alias` and `daemon-argv-limit` testsuite cells, whose assertions are log greps.

## 1. The refused-option text had two owners and they drifted

Upstream builds it once and delivers it to both destinations:

- `options.c:1409-1423` — `create_refuse_error()` fills `err_buf` with `"The server is configured to refuse --<longName>"`.
- `options.c:907-918` — `option_error()` emits that same buffer via `rprintf(FERROR, RSYNC_NAME ": %s", err_buf)`. A daemon's `FERROR` lands in the log file.

So upstream has ONE string serving as both the peer's `@ERROR` payload and the logged line. oc formatted them independently: the peer saw upstream's wording while the log carried an oc-invented

```
refusing option '--compress-threads' for module 'mod' from localhost (127.0.0.1)
```

that no upstream site emits. `refused_option_message()` is now the single owner, consumed by both `@ERROR` sites in `request.rs` and by the log, which writes

```
rsync: The server is configured to refuse --compress-threads
```

and nothing more. The dropped `module` / `host` / `peer_ip` operands are deliberate: upstream names none of them here, because the connection is already identified by the line's pid stamp and by the preceding `rsync allowed access on module %s from %s (%s)` (`clientserver.c:787`), which oc already emits faithfully.

The log *code* is left as it was. Upstream routes this at `FERROR` while oc records it at info level; both reach the daemon log file, which is the observable this mirrors, and re-coding it would change oc's message routing for a reason this change has not measured.

## 2. The daemon-argument ceiling fired invisibly

`read_args()` reports its own refusal where it happens — `io.c:1477-1478`, `rprintf(FERROR, "too many daemon arguments\n")` — and a daemon's `FERROR` reaches the log. oc sent that refusal to the peer and logged nothing at all, so an operator watching the log saw a connection cut with no recorded reason.

The refusal now reaches the log too, emitted bare: unlike `option_error()` this site adds no `rsync: ` prefix.

## Verification

Both are pinned end to end against a real daemon and its real log file, and mutation-proven in isolation:

| mutation | result |
|---|---|
| restore the oc-invented `refusing option '...'` wording | only `run_daemon_logs_a_refused_option_in_upstream_words` reddens |
| drop the `log_client_args_failure` call | only `run_daemon_logs_an_oversized_client_argv` reddens |

`run_daemon_records_log_file_entries` stays green under both as the negative control. The refusal test also asserts the log does **not** contain `refusing option`, so the two owners cannot silently drift apart again.

The argv test sends exactly `MAX_DAEMON_ARGS - 1` arguments — the count that trips upstream's before-append check — so the daemon consumes every byte written and neither side is left blocking on the other.

`cargo fmt` + whole-tree rustfmt gate clean, workspace `clippy --all-targets --all-features` clean, `-p daemon` 1821/1821, all at the pinned 1.88.0 toolchain.
