### PR TITLE
fix(daemon): open operator path parameters verbatim and log the banner before readiness

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -142,7 +142,7 @@ fn apply_global_directive(
                 ));
             }
 
-            let resolved = resolve_config_relative_path(path, trimmed);
+            let resolved = daemon_parameter_path(trimmed);
             store_global_directive(&mut state.pid_file, resolved, canonical, line_number);
         }
         "reverselookup" => {
@@ -594,7 +594,7 @@ fn apply_global_directive(
         // lost - measured against rsync 3.5.0, which writes three of them here.
         "logfile" => {
             if !value.is_empty() {
-                let resolved = log_file_path(value);
+                let resolved = daemon_parameter_path(value);
                 state.module_defaults.log_file = Some(resolved.clone());
                 store_global_directive(&mut state.log_file, resolved, canonical, line_number);
             }

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -594,7 +594,7 @@ fn apply_global_directive(
         // lost - measured against rsync 3.5.0, which writes three of them here.
         "logfile" => {
             if !value.is_empty() {
-                let resolved = resolve_config_relative_path(canonical, value);
+                let resolved = log_file_path(value);
                 state.module_defaults.log_file = Some(resolved.clone());
                 store_global_directive(&mut state.log_file, resolved, canonical, line_number);
             }

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -259,7 +259,7 @@ fn apply_module_directive(
                     "'log file' directive must not be empty",
                 ));
             }
-            builder.set_log_file(log_file_path(value));
+            builder.set_log_file(daemon_parameter_path(value));
         }
         "dontcompress" => {
             let patterns = if value.is_empty() {

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -259,8 +259,7 @@ fn apply_module_directive(
                     "'log file' directive must not be empty",
                 ));
             }
-            let resolved = resolve_config_relative_path(canonical, value);
-            builder.set_log_file(resolved);
+            builder.set_log_file(log_file_path(value));
         }
         "dontcompress" => {
             let patterns = if value.is_empty() {

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -402,20 +402,24 @@ fn continuation_offset(line: &str) -> Option<usize> {
     trimmed.ends_with('\\').then(|| trimmed.len() - 1)
 }
 
-/// Resolves an operator-supplied `log file` value.
+/// Resolves an operator-supplied daemon path parameter.
 ///
-/// upstream: log.c:216-218 log_init() takes `logfile_name` from
-/// `lp_log_file(module_id)` - the raw config string, since loadparm.c stores
-/// parameter values verbatim - and log.c:169 logfile_open() hands that string
-/// straight to `open_no_attacker_symlinks()`. A relative value is therefore
-/// resolved against the daemon's working directory, never against the config
-/// file's directory.
+/// loadparm.c stores every parameter value verbatim, and each consumer opens
+/// that string as given, so a relative value is resolved against the daemon's
+/// working directory - never against the config file's directory:
 ///
-/// The two `log file` sites share this function because they must agree: the
-/// module value and the global value are read through the same
-/// `lp_log_file()` accessor upstream, so a rule applied to one and not the
-/// other would open two different files for one config line.
-fn log_file_path(value: &str) -> PathBuf {
+/// - `log file`: log.c:216-218 `log_init()` takes `logfile_name` from
+///   `lp_log_file(module_id)`, and log.c:169 `logfile_open()` hands it straight
+///   to `open_no_attacker_symlinks()`.
+/// - `pid file`: clientserver.c:1584 `create_pid_file()` opens
+///   `lp_pid_file()`'s value directly.
+///
+/// The three sites share this function because they must agree. `log file`'s
+/// module and global halves are read through one `lp_log_file()` accessor, so
+/// a rule applied to one and not the other would open two different files for
+/// one config line; `pid file` obeys the same storage rule, and rebasing it
+/// creates a pid file the operator cannot find.
+fn daemon_parameter_path(value: &str) -> PathBuf {
     PathBuf::from(value)
 }
 

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -402,6 +402,23 @@ fn continuation_offset(line: &str) -> Option<usize> {
     trimmed.ends_with('\\').then(|| trimmed.len() - 1)
 }
 
+/// Resolves an operator-supplied `log file` value.
+///
+/// upstream: log.c:216-218 log_init() takes `logfile_name` from
+/// `lp_log_file(module_id)` - the raw config string, since loadparm.c stores
+/// parameter values verbatim - and log.c:169 logfile_open() hands that string
+/// straight to `open_no_attacker_symlinks()`. A relative value is therefore
+/// resolved against the daemon's working directory, never against the config
+/// file's directory.
+///
+/// The two `log file` sites share this function because they must agree: the
+/// module value and the global value are read through the same
+/// `lp_log_file()` accessor upstream, so a rule applied to one and not the
+/// other would open two different files for one config line.
+fn log_file_path(value: &str) -> PathBuf {
+    PathBuf::from(value)
+}
+
 fn resolve_config_relative_path(config_path: &Path, value: &str) -> PathBuf {
     let candidate = Path::new(value);
     if candidate.is_absolute() {

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -2907,8 +2907,16 @@ mod config_parsing_tests {
         );
     }
 
+    /// A relative `log file` is kept verbatim, so the daemon opens it against
+    /// its own working directory.
+    ///
+    /// upstream: log.c:216-218 log_init() assigns `lp_log_file(module_id)` -
+    /// loadparm.c's stored string - to `logfile_name`, and log.c:169
+    /// logfile_open() opens that string unchanged. Rebasing it on the config
+    /// file's directory prefixes a path that is already relative to the
+    /// daemon's cwd, and the resulting open fails with ENOENT.
     #[test]
-    fn parse_module_log_file_relative() {
+    fn parse_module_log_file_relative_is_kept_verbatim() {
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
@@ -2919,10 +2927,37 @@ mod config_parsing_tests {
         );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).unwrap();
-        let log_file = result.modules[0].log_file.as_ref().expect("log_file set");
-        let config_dir = file.path().canonicalize().unwrap();
-        let expected = config_dir.parent().unwrap().join("rsync-mod.log");
-        assert_eq!(*log_file, expected);
+        assert_eq!(
+            result.modules[0].log_file,
+            Some(PathBuf::from("rsync-mod.log"))
+        );
+    }
+
+    /// The global `log file` half takes the same rule as the module half.
+    ///
+    /// upstream reads both through one accessor (`lp_log_file`), so the
+    /// daemon-wide log opened at startup and the per-module log opened after
+    /// `log_init(1)` must name the same file for the same config line.
+    #[test]
+    fn parse_global_log_file_relative_is_kept_verbatim() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "log file = rsyncd.log\n\n[mod]\npath = {}\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.log_file.as_ref().map(|(path, _)| path.as_path()),
+            Some(Path::new("rsyncd.log"))
+        );
+        assert_eq!(
+            result.modules[0].log_file,
+            Some(PathBuf::from("rsyncd.log"))
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -248,6 +248,24 @@ mod config_parsing_tests {
         assert!(path.ends_with("rsync.pid"));
     }
 
+    /// A relative `pid file` is kept verbatim, so the daemon writes it against
+    /// its own working directory.
+    ///
+    /// upstream: clientserver.c:1584 `create_pid_file()` opens the string
+    /// `lp_pid_file()` returns, with no config-directory rebase. Prefixing the
+    /// config file's directory puts the pid file where nothing looks for it:
+    /// the 3.5.0 `daemon-standalone-detach` cell waits on the pid file it named
+    /// and times out.
+    #[test]
+    fn parse_global_pid_file_relative_is_kept_verbatim() {
+        let file = write_config("pid file = rsyncd.pid\n");
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(
+            result.pid_file.as_ref().map(|(path, _)| path.as_path()),
+            Some(Path::new("rsyncd.pid"))
+        );
+    }
+
     #[test]
     fn parse_global_reverse_lookup_true() {
         let file = write_config("reverse lookup = yes\n");

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -295,6 +295,28 @@ fn serve_connections(
     #[cfg(not(unix))]
     let _ = detach;
 
+    // Announce the daemon BEFORE any readiness signal an observer can act on.
+    //
+    // upstream: clientserver.c:1770 logs "rsyncd version %s starting, listening
+    // on port %d" and only then calls start_accept_loop() (:1776), which is
+    // where socket.c binds AND listens. So upstream guarantees the banner is in
+    // the log before the port can complete a handshake.
+    //
+    // oc binds earlier than upstream on purpose (see become_daemon above: a bind
+    // failure must reach the launching terminal's stderr rather than a detached
+    // child's log), so by this point the socket is already listening and that
+    // guarantee cannot be expressed as "log before listen". The observable
+    // readiness signal is the pid file - it is what an operator, an init system
+    // and upstream's own `daemon-standalone-detach` cell wait on - so the banner
+    // is emitted before it is written. That inverts upstream's line order
+    // (pid file at :1759/:1705, banner at :1770) and is the deliberate cost of
+    // the earlier bind; the property upstream actually provides is preserved.
+    if let Some(log) = log_sink.as_ref() {
+        let text = format!("rsyncd version {version} starting, listening on port {port}");
+        let message = rsync_info!(text).with_role(Role::Daemon);
+        log_message(log, &message);
+    }
+
     // Write the PID file after binding so the file only appears once the port
     // is ready to accept connections - matching upstream main.c write_pid_file().
     let pid_guard = if let Some(path) = pid_file {
@@ -355,12 +377,6 @@ fn serve_connections(
     };
     if let Err(error) = notifier.ready(Some(&ready_status)) {
         log_sd_notify_failure(log_sink.as_ref(), "service readiness", &error);
-    }
-
-    if let Some(log) = log_sink.as_ref() {
-        let text = format!("rsyncd version {version} starting, listening on port {port}");
-        let message = rsync_info!(text).with_role(Role::Daemon);
-        log_message(log, &message);
     }
 
     let mut state = AcceptLoopState {

--- a/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_loads_pid_file_from_config.rs
@@ -1,3 +1,11 @@
+/// A relative `pid file` reaches the runtime verbatim.
+///
+/// upstream: clientserver.c:1584 `create_pid_file()` opens the string
+/// `lp_pid_file()` returns - loadparm.c stores parameter values as written -
+/// so a relative value names a path under the daemon's working directory.
+/// This test previously asserted the config file's directory as the prefix,
+/// which is where oc used to put it; that is the behaviour being removed, not
+/// a contract to preserve.
 #[test]
 fn runtime_options_loads_pid_file_from_config() {
     let dir = tempdir().expect("config dir");
@@ -14,6 +22,5 @@ fn runtime_options_loads_pid_file_from_config() {
     ])
     .expect("parse config with pid file");
 
-    let expected = dir.path().join("daemon.pid");
-    assert_eq!(options.pid_file(), Some(expected.as_path()));
+    assert_eq!(options.pid_file(), Some(Path::new("daemon.pid")));
 }


### PR DESCRIPTION
Three commits, all daemon startup, all converging on `daemon-standalone-detach`
- which is `pass` in both TCP manifests and is what makes master red.

**⚠ Correction to my earlier message on this PR.** I claimed the `pid file`
fix closes the detach cell in CI. That is refuted by the CI log: the failure
there reports an existing-but-truncated log with the pid file *present*, so
the paths were already correct on that leg. Both defects are real; only the
third commit moves the CI row. The measured table is below.

### 1-2. `log file` and `pid file` are opened verbatim

`loadparm.c` stores every daemon parameter value as written and does no path
rebasing, so a relative value resolves against the daemon's **working
directory**, never the config file's directory:

- **`log file`** - `log.c:216-218` `log_init()` takes `logfile_name` from
  `lp_log_file(module_id)`; `log.c:169` `logfile_open()` hands it straight to
  `open_no_attacker_symlinks()`. Three sites in oc (module value, global
  module-default, global startup value) read one config line through one
  `lp_log_file()` accessor upstream, so rebasing one and not the others would
  open two different files for a single directive.
- **`pid file`** - `clientserver.c:1584` `create_pid_file()` opens the value
  `lp_pid_file()` returns, directly.

oc prefixed the config file's directory, so a relative value with a directory
component landed in a doubled path that `create_dir_all` obligingly created -
silently, because the write then succeeded. upstream's own `runtests.py`
defaults to `scratchbase=./testtmp`, so on that default the detach cell's pid
file lands somewhere the harness never looks.

The shared helper is `daemon_parameter_path`, named for loadparm's storage
rule rather than as a `log file` special case.
`resolve_config_relative_path` stays for `include` / `motd file` and the other
directives upstream really does resolve differently.

### 3. The banner is logged before the pid file appears

Upstream logs `rsyncd version %s starting, listening on port %d`
(`clientserver.c:1770`) and only then calls `start_accept_loop()` (`:1776`),
which is where `socket.c` binds *and* listens - so reaching the port implies
the banner is already in the log.

oc binds earlier on purpose (a bind failure must reach the launching
terminal's stderr, not a detached child's log), so the socket is already
listening by the time the daemon detaches and that guarantee cannot be
restated as "log before listen". oc emitted the banner after the pid file,
after the chroot and after the privilege drop - behind every readiness signal
an observer acts on. It now precedes the pid file, which is the signal
operators, init systems and the cell all wait on. That inverts upstream's line
order and is the deliberate cost of the earlier bind; the property upstream
actually provides is preserved.

### Measured

Linux, upstream 3.5.0 suite, `daemon-standalone-detach` only:

| tree | scratchbase | result |
|---|---|---|
| master `cdb2d2416` | absolute (CI's shape) | 3 passed / 7 failed of 10 |
| + `pid file` verbatim | absolute | 8 passed / 17 failed of 25 |
| + banner ordering | absolute | **25 passed / 0 failed of 25** |
| + banner ordering | relative (`runtests.py` default) | **10 passed / 0 failed of 10** |

The recurrence guard is that cell: a required context on both TCP legs, which
reproduced the ordering defect at 17/25.

Each parser arm is mutation-proven in isolation, restoring
`resolve_config_relative_path` at one site at a time:

| mutation | result |
|---|---|
| global `log file` rebased | 27 passed / 1 failed - only `parse_global_log_file_relative_is_kept_verbatim` |
| module `log file` rebased | 27 passed / 1 failed - only `parse_module_log_file_relative_is_kept_verbatim` |
| `pid file` rebased | 41 passed / 2 failed - exactly the two pid-file tests, all four log-file tests green |

`runtime_options_loads_pid_file_from_config` asserted the config file's
directory as the prefix, so it encoded the behaviour being removed. It is
re-pinned against the upstream value with the citation, not preserved.

`cargo fmt --all -- --check` clean; `tools/ci/check_rustfmt_all.py` clean over
3401 files; `-p daemon` clippy `--all-targets --all-features -D warnings`
clean.

### Not fixed here

`logfile_open()`'s failure path is non-fatal upstream (`log.c:175-182`): it
falls back to syslog, prints `Ignoring "log file" setting.` and keeps serving,
where oc exits `RERR_MESSAGEIO` from five startup call sites. Separate
divergence, deliberately out of scope.
