### PR TITLE
fix(daemon): report a refused name-converter token instead of swallowing it

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/streams.rs
@@ -347,11 +347,25 @@ fn execute_transfer(
     // matching upstream rsync's socket I/O model.
     let result = run_daemon_transfer(config, handshake, read_stream, write_stream);
 
-    // upstream: log.c:290-305 - FLOG-classified diagnostics emitted while the
-    // transfer ran belong in the daemon log only; they never travel to the
-    // client. Consume them from the thread-local queue by log code.
+    // Diagnostics emitted while the transfer ran go to the daemon log.
+    //
+    // upstream: log.c:310-327 `else if (am_daemon || logfile_name)` calls
+    // `logit()` for EVERY code that reaches it, not for `FLOG` alone - `FLOG`
+    // is merely the code that `return`s afterwards instead of also reaching
+    // the stream switch. So a daemon that raises `FERROR` mid-session logs it
+    // too, and a drain that took only `FLOG` would discard it: the message
+    // would exist, be correct, and never be delivered.
+    //
+    // This runs after `run_daemon_transfer` returns, so anything the receiver
+    // pipeline already framed to the peer through `drain_events_for_peer` is
+    // gone from the buffer by now and cannot be logged twice. That ordering
+    // also states the residual honestly: upstream's `rwrite()` reaches
+    // `logit()` and then the `am_server` frame, feeding BOTH sinks, whereas a
+    // drain removes - so on the receiver role an `FERROR` reaches the peer
+    // instead of the log. Widening here can only add deliveries, never move
+    // one.
     if let Some(log) = ctx.log_sink {
-        for event in logging::drain_events_coded(logging::LogCode::Log) {
+        for event in logging::drain_events_for_daemon_log() {
             let (logging::DiagnosticEvent::Info { message, .. }
             | logging::DiagnosticEvent::Debug { message, .. }) = event;
             log_message(log, &rsync_info!(message).with_role(Role::Daemon));

--- a/crates/daemon/src/daemon/sections/name_converter.rs
+++ b/crates/daemon/src/daemon/sections/name_converter.rs
@@ -136,6 +136,18 @@ impl NameConverter {
         // make the converter answer twice while this reads once, leaving the
         // surplus answer buffered for the *next* lookup to consume.
         if !is_safe_token(arg) {
+            // Upstream reports the refusal before returning, so the operator
+            // learns that a peer-supplied name was rejected rather than merely
+            // unknown. Emitting at the guard - not at a caller - keeps the one
+            // site that decides also the one site that speaks.
+            // upstream: clientserver.c:1317-1319 `rprintf(FERROR, "invalid
+            // name-converter token: %s\n", *name_p)` then `return False`.
+            logging::emit_info_coded(
+                logging::InfoFlag::Misc,
+                0,
+                logging::LogCode::Error,
+                format!("invalid name-converter token: {arg}"),
+            );
             return ConverterOutcome::Refused;
         }
         let request = format!("{cmd} {arg}\n");
@@ -573,6 +585,50 @@ mod name_converter_tests {
         // is actually capable of moving.
         assert_eq!(answered(nc.name_to_uid("alice")), Some(1001));
         assert_eq!(requests_seen(&log), 1, "a safe name reaches the converter");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_refused_token_is_reported_not_merely_unresolved() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let (mut nc, log) = spawn_counting_converter(&dir.path().join("seen"));
+
+        // Refusing silently is a defect of its own: an operator reading the
+        // daemon log sees a name that "has no id", indistinguishable from an
+        // ordinary unknown user, when in fact a peer sent a control byte.
+        // upstream reports it before returning False
+        // (clientserver.c:1317-1319 `rprintf(FERROR, "invalid name-converter
+        // token: %s\n", *name_p)`).
+        let _ = logging::drain_events_for_daemon_log();
+        assert!(matches!(
+            nc.name_to_uid("bad\nname"),
+            ConverterOutcome::Refused
+        ));
+        assert_eq!(requests_seen(&log), 0, "nothing may reach the converter");
+
+        let reported: Vec<String> = logging::drain_events_for_daemon_log()
+            .into_iter()
+            .map(|event| {
+                let (logging::DiagnosticEvent::Info { message, .. }
+                | logging::DiagnosticEvent::Debug { message, .. }) = event;
+                message
+            })
+            .collect();
+        assert!(
+            reported
+                .iter()
+                .any(|line| line == "invalid name-converter token: bad\nname"),
+            "the refusal must be reported verbatim: {reported:?}"
+        );
+
+        // Non-vacuity: an accepted name reaches the converter and reports
+        // nothing, so the assertion above cannot pass on an emitter that
+        // fires for every lookup.
+        assert_eq!(answered(nc.name_to_uid("alice")), Some(1001));
+        assert!(
+            logging::drain_events_for_daemon_log().is_empty(),
+            "an accepted name must not be reported"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -103,9 +103,9 @@ pub use sequence::{Sequence, Stamped};
 pub use stream::{BadLogCode, MessageStream, Msgs2Stderr, StreamContext, message_stream};
 pub use thread_local::{
     DiagnosticEvent, apply_debug_flag, apply_info_flag, debug_gte, drain_events,
-    drain_events_coded, drain_events_for_peer, drain_stamped_events_for_client, emit_debug,
-    emit_debug_coded, emit_info, emit_info_coded, emit_warning, finfo_suppressed, info_gte, init,
-    set_quiet,
+    drain_events_coded, drain_events_for_daemon_log, drain_events_for_peer,
+    drain_stamped_events_for_client, emit_debug, emit_debug_coded, emit_info, emit_info_coded,
+    emit_warning, finfo_suppressed, info_gte, init, set_quiet,
 };
 pub use verify_failure::{VerifyFailure, verification_failure};
 

--- a/crates/logging/src/thread_local.rs
+++ b/crates/logging/src/thread_local.rs
@@ -320,6 +320,26 @@ pub fn drain_events_for_peer() -> Vec<DiagnosticEvent> {
     })
 }
 
+/// Drain the events a daemon must write to its log file, leaving the rest.
+///
+/// Upstream does not pick codes here: once a message reaches
+/// `rwrite()`'s `else if (am_daemon || logfile_name)` block it is handed to
+/// `logit()` whatever its code, and only the priority differs - `LOG_INFO`
+/// for `FINFO`/`FLOG`, `LOG_WARNING` for everything else
+/// (upstream: log.c:310-327). `FLOG` is not special-cased *into* the log; it
+/// is special-cased *out of* the stream switch that follows
+/// (upstream: log.c:329-331).
+///
+/// So this takes everything except [`LogCode::None`], upstream's `FNONE`,
+/// which `rwrite()` is never handed at all (upstream: rsync.h:276 "never
+/// sent"). Draining a narrower set would silently discard a daemon-side
+/// `FERROR`: the message would be produced, be correct, and never reach the
+/// operator.
+/// upstream: log.c:310-327 rwrite() `else if (am_daemon || logfile_name)`
+pub fn drain_events_for_daemon_log() -> Vec<DiagnosticEvent> {
+    drain_events_where(|code| code != LogCode::None)
+}
+
 /// Apply an info flag token to the current thread's configuration.
 ///
 /// Parses tokens like `"copy2"` or `"del"` and updates the corresponding
@@ -448,6 +468,54 @@ mod tests {
             &events[0],
             DiagnosticEvent::Info { code: LogCode::Log, message, .. } if message == "building file list"
         ));
+    }
+
+    /// A daemon logs every code it is handed, not just `FLOG`.
+    ///
+    /// The narrow reading - "the daemon log takes `FLOG`" - is what
+    /// `rwrite()`'s trailing `if (code == FLOG) return;` looks like from the
+    /// stream switch. Read from the top, `logit()` has already run for every
+    /// code that reached the `am_daemon` branch (upstream: log.c:310-327), so
+    /// a drain keyed on `FLOG` alone discards a daemon-side `FERROR`: the
+    /// message is produced, is correct, and never reaches the operator.
+    #[test]
+    fn the_daemon_log_takes_every_code_it_is_handed_not_only_flog() {
+        init(VerbosityConfig::default());
+        drain_events();
+
+        for code in [
+            LogCode::Log,
+            LogCode::Error,
+            LogCode::Warning,
+            LogCode::ErrorXfer,
+            LogCode::Info,
+        ] {
+            emit_info_coded(InfoFlag::Misc, 0, code, format!("{code:?}"));
+        }
+        // `FNONE` is the one code `rwrite()` is never handed
+        // (upstream: rsync.h:276 "never sent").
+        emit_info_coded(InfoFlag::Misc, 0, LogCode::None, "unsent".to_owned());
+
+        let logged: Vec<LogCode> = drain_events_for_daemon_log()
+            .iter()
+            .map(DiagnosticEvent::code)
+            .collect();
+        assert_eq!(
+            logged,
+            vec![
+                LogCode::Log,
+                LogCode::Error,
+                LogCode::Warning,
+                LogCode::ErrorXfer,
+                LogCode::Info,
+            ]
+        );
+
+        // The excluded code is left in the buffer rather than dropped, so a
+        // later drain still owns it - and this is what proves the filter is
+        // doing something at all.
+        let left: Vec<LogCode> = drain_events().iter().map(DiagnosticEvent::code).collect();
+        assert_eq!(left, vec![LogCode::None]);
     }
 
     #[test]


### PR DESCRIPTION
Closes the `daemon-namecvt-newline-token` cell of the upstream 3.5.0 testsuite, and the deeper defect found while closing it.

## The cell

`daemon-namecvt-newline-token_test.py` asserts two things:

1. a peer-supplied name carrying a control byte never reaches the name converter, and
2. the daemon **reports** `invalid name-converter token` — in the client bytes or in the daemon log.

oc already satisfies (1). `is_safe_token` is byte-for-byte upstream's `namecvt_safe_token` (`clientserver.c:1362`, rejecting `ch < ' ' || ch == 0x7f`), and it runs before anything is written to the converter pipe, so the stream desync CVE-2026-53788 describes is structurally impossible here. oc failed (2): it returned `ConverterOutcome::Refused` silently.

## Why the obvious one-line fix would have shipped inert

Emitting the diagnostic at the guard is correct and insufficient. The post-transfer drain in `execute_transfer` read `drain_events_coded(LogCode::Log)`, so an `FERROR` raised mid-session was produced, was correct, and was **discarded before any sink saw it**. With only part one applied the cell still fails.

That narrow filter is itself the divergence. Upstream does not pick codes for the daemon log:

```c
} else if (am_daemon || logfile_name) {          /* log.c:310 */
        ...
        logit(priority, buf);                    /* every code that reaches here */
        ...
}
if (code == FLOG)                                /* log.c:329-331 */
        return;
```

`FLOG` is not special-cased *into* the log — it is special-cased *out of* the stream switch that follows.

## Shape

`drain_events_for_daemon_log()` states that rule once, in `crates/logging` beside the existing `drain_events_for_peer()`, so the routing policy lives with its siblings instead of as a predicate in the daemon. It takes every code except `FNONE`, which `rwrite()` is never handed at all (`rsync.h:276` "never sent").

## Verification

**Mutation-proven in isolation.** Dropping the emission fails only `a_refused_token_is_reported_not_merely_unresolved` (19 passed / 1 failed). Narrowing the drain back to `FLOG` fails *both* that test and `the_daemon_log_takes_every_code_it_is_handed_not_only_flog` (`left: [Log]`, `right: [Log, Error, Warning, ErrorXfer, Info]`) — the coupling made visible, and the reason part one could not ship alone.

Each test carries its own non-vacuity control: an accepted name reaches the converter and reports nothing, and the excluded `FNONE` event is shown still sitting in the buffer for a later drain rather than dropped.

**Blast radius measured, not assumed.** The widened drain runs after `run_daemon_transfer` returns, so anything the receiver pipeline already framed to the peer through `drain_events_for_peer` is gone from the buffer and cannot be logged twice. That ordering also states the residual honestly — upstream's `rwrite()` reaches `logit()` and *then* the `am_server` frame, feeding both sinks, whereas a drain removes — so on the receiver role an `FERROR` reaches the peer instead of the log. Widening here can only add deliveries, never move one. It is written into the comment rather than left for the next reader.

`cargo fmt --all -- --check`, `clippy --workspace --all-targets --all-features -D warnings`, and `nextest -p logging -p daemon` (2171/2171) all clean on the pinned 1.88.0 toolchain.
