### PR TITLE
fix(batch): refuse an unusable --read-batch path at RERR_FILEIO, in upstream's words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ version = "0.6.4"
 dependencies = [
  "fast_io",
  "filetime",
+ "logging",
  "metadata",
  "protocol",
  "tempfile",

--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 protocol = { path = "../protocol" }
 metadata = { path = "../metadata" }
 fast_io = { path = "../fast_io" }
+logging = { path = "../logging" }
 filetime = { workspace = true }
 
 [dev-dependencies]

--- a/crates/batch/src/error.rs
+++ b/crates/batch/src/error.rs
@@ -30,6 +30,19 @@ pub enum BatchError {
     /// `RERR_SYNTAX`.
     #[error("{0}")]
     FlagMismatch(String),
+    /// The `--read-batch` file could not be opened, or the path resolved to a
+    /// non-regular file.
+    ///
+    /// Kept apart from [`BatchError::Io`] because upstream gives these two
+    /// failures their own exit code and their own bare wording: both
+    /// `batch.c:267-271` (open failure) and `batch.c:273-281` (the `!S_ISREG`
+    /// refusal) print a lone `Batch file %s ...` line and then
+    /// `exit_cleanup(RERR_FILEIO)`. Folding them into the generic I/O arm
+    /// re-labels them as a replay failure and reports exit 1.
+    ///
+    /// upstream: batch.c:267-281
+    #[error("{0}")]
+    BatchFileUnusable(String),
 }
 
 #[cfg(test)]

--- a/crates/batch/src/reader/mod.rs
+++ b/crates/batch/src/reader/mod.rs
@@ -135,10 +135,17 @@ impl BatchReader {
             // `open_no_attacker_symlinks()`. The path is operator-supplied and
             // may transit attacker-writable parents, so a planted symlink would
             // feed the replay a batch stream the operator never named.
+            // upstream: batch.c:268-271 - `rsyserr(FERROR, errno, "Batch file %s
+            // open error", full_fname(batch_name))` then
+            // `exit_cleanup(RERR_FILEIO)`. `full_fname` double-quotes the name
+            // and `rsyserr` appends `strerror(errno) (errno)`, so the rendered
+            // line is reproduced rather than paraphrased: an operator (and the
+            // upstream testsuite) matches on this text.
             let file = crate::operator_file::open_read(path).map_err(|e| {
-                BatchError::Io(io::Error::new(
-                    e.kind(),
-                    format!("Failed to open batch file '{}': {}", path.display(), e),
+                BatchError::BatchFileUnusable(format!(
+                    "Batch file \"{}\" open error: {}",
+                    path.display(),
+                    logging::upstream_errno_text(&e)
                 ))
             })?;
             Self::reject_non_regular(&file, path)?;
@@ -163,9 +170,9 @@ impl BatchReader {
     /// upstream: batch.c:275-281
     fn reject_non_regular(file: &File, path: &Path) -> BatchResult<()> {
         match file.metadata() {
-            Ok(meta) if !meta.file_type().is_file() => Err(BatchError::Io(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("Batch file \"{}\" is not a regular file", path.display()),
+            Ok(meta) if !meta.file_type().is_file() => Err(BatchError::BatchFileUnusable(format!(
+                "Batch file \"{}\" is not a regular file",
+                path.display()
             ))),
             _ => Ok(()),
         }

--- a/crates/batch/src/reader/tests.rs
+++ b/crates/batch/src/reader/tests.rs
@@ -65,6 +65,69 @@ mod reader_creation_tests {
         );
     }
 
+    /// Both batch-file refusals must carry the variant that maps to
+    /// `RERR_FILEIO`, not the generic I/O variant.
+    ///
+    /// upstream: batch.c:271,280 - the failed open and the `!S_ISREG` refusal
+    /// both `exit_cleanup(RERR_FILEIO)`. oc renders the exit code from the
+    /// error variant, so a refusal filed as `BatchError::Io` reports exit 1
+    /// under a "batch replay failed" prefix - naming a phase that never ran.
+    #[test]
+    #[cfg(unix)]
+    fn a_refused_batch_path_is_filed_as_unusable_not_generic_io() {
+        let dev = BatchConfig::new(BatchMode::Read, "/dev/null".to_owned(), 30);
+        let missing = BatchConfig::new(
+            BatchMode::Read,
+            "/nonexistent/path/batch.file".to_owned(),
+            30,
+        );
+
+        for config in [dev, missing] {
+            let Err(err) = BatchReader::new(config) else {
+                panic!("an unusable batch path was accepted");
+            };
+            assert!(
+                matches!(err, BatchError::BatchFileUnusable(_)),
+                "expected BatchFileUnusable, got: {err}"
+            );
+        }
+    }
+
+    /// A failed open reports upstream's line verbatim.
+    ///
+    /// `full_fname` double-quotes the name and `rsyserr` appends
+    /// `strerror(errno) (errno)`, so the rendered text is
+    /// `Batch file "PATH" open error: REASON (N)`. The upstream testsuite cell
+    /// `batch-file-symlink` matches on the `open error` substring when the
+    /// device node cannot be opened at all (a `nodev` mount), and an operator
+    /// reads the errno - paraphrasing loses both.
+    ///
+    /// upstream: batch.c:268-271
+    #[test]
+    #[cfg(unix)]
+    fn a_failed_open_reports_upstreams_wording_and_errno() {
+        let config = BatchConfig::new(
+            BatchMode::Read,
+            "/nonexistent/path/batch.file".to_owned(),
+            30,
+        );
+
+        let Err(err) = BatchReader::new(config) else {
+            panic!("a missing batch file was accepted");
+        };
+
+        let text = err.to_string();
+        assert!(
+            text.starts_with("Batch file \"/nonexistent/path/batch.file\" open error: "),
+            "expected upstream's bare wording, got: {text}"
+        );
+        // rsyserr's parenthesised errno, not io::Error's " (os error N)".
+        assert!(
+            text.ends_with(" (2)"),
+            "expected the rsyserr ENOENT suffix, got: {text}"
+        );
+    }
+
     #[test]
     fn create_with_nonexistent_file() {
         let config = BatchConfig::new(

--- a/crates/core/src/client/run/batch.rs
+++ b/crates/core/src/client/run/batch.rs
@@ -415,6 +415,15 @@ fn replay_batch(
             {
                 ClientError::new(2, rsync_error!(2, "{}", io_err).with_role(Role::Client))
             }
+            // upstream: batch.c:271,280 - a batch file that cannot be opened, or
+            // that resolves to a non-regular node, aborts with
+            // `exit_cleanup(RERR_FILEIO)` (exit 11) and prints the bare
+            // `Batch file ...` line. The generic arm below would report exit 1
+            // under a "batch replay failed" prefix, which names the wrong phase:
+            // nothing was replayed, the input was refused.
+            engine::batch::BatchError::BatchFileUnusable(ref msg) => {
+                ClientError::new(11, rsync_error!(11, "{}", msg).with_role(Role::Client))
+            }
             other => {
                 let msg = format!("batch replay failed: {other}");
                 ClientError::new(1, rsync_error!(1, "{}", msg).with_role(Role::Client))

--- a/crates/logging/src/errno_text.rs
+++ b/crates/logging/src/errno_text.rs
@@ -1,0 +1,32 @@
+//! Rendering an `io::Error` the way upstream's `rsyserr()` does.
+
+use std::io;
+
+/// Renders an error the way upstream's `rsyserr` does: `strerror(errno)`
+/// followed by the numeric errno in parentheses.
+///
+/// `io::Error`'s own `Display` appends `" (os error N)"`, so the suffix is
+/// stripped and re-emitted in upstream's shape. A non-OS error renders
+/// verbatim, with no parenthesised number to invent.
+///
+/// upstream: `rsync-3.5.0/log.c` `rsyserr()` - `"%s: %s (%d)"`.
+pub fn upstream_errno_text(error: &io::Error) -> String {
+    let display = error.to_string();
+    // A tagged failure is an `io::Error::new(kind, payload)`, i.e. the `Custom`
+    // variant, whose `raw_os_error()` is `None` even though the payload wraps a
+    // real OS error. Recover the errno from the source chain so tagging an
+    // error does not silently drop the number from its own message.
+    let errno = error.raw_os_error().or_else(|| {
+        std::error::Error::source(error.get_ref()?)?
+            .downcast_ref::<io::Error>()?
+            .raw_os_error()
+    });
+    match errno {
+        Some(errno) => {
+            let suffix = format!(" (os error {errno})");
+            let text = display.strip_suffix(&suffix).unwrap_or(&display);
+            format!("{text} ({errno})")
+        }
+        None => display,
+    }
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -75,6 +75,7 @@
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 mod config;
+mod errno_text;
 /// Upstream-compatible error and warning formatting.
 pub mod error_format;
 mod levels;
@@ -93,6 +94,7 @@ mod tracing_bridge;
 mod tracing_macros;
 
 pub use config::VerbosityConfig;
+pub use errno_text::upstream_errno_text;
 pub use error_format::{
     file_basename, format_rsync_error, format_rsync_warning, strip_repo_prefix,
 };

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -307,7 +307,7 @@ impl PipelinedReceiver {
             None => (None, dest),
         };
         let name = full_fname_path(named, self.daemon_paths());
-        let reason = upstream_errno_text(error);
+        let reason = logging::upstream_errno_text(error);
         match op {
             // upstream: rsync-3.5.0/receiver.c:452-453
             Some(crate::temp_guard::CommitOp::Mkstemp) | None => {
@@ -778,35 +778,6 @@ pub(crate) fn keep_backup_failed_line(name: &str, error: &io::Error, reason: &st
             backup.display()
         ),
         None => format!("rsync: [receiver] keep_backup failed: {name}: {reason}"),
-    }
-}
-
-/// Renders an error the way upstream's `rsyserr` does: `strerror(errno)`
-/// followed by the numeric errno in parentheses.
-///
-/// `io::Error`'s own `Display` appends `" (os error N)"`, so the suffix is
-/// stripped and re-emitted in upstream's shape. A non-OS error renders
-/// verbatim, with no parenthesised number to invent.
-///
-/// upstream: `rsync-3.5.0/log.c` `rsyserr()` - `"%s: %s (%d)"`.
-pub(crate) fn upstream_errno_text(error: &io::Error) -> String {
-    let display = error.to_string();
-    // A tagged failure is an `io::Error::new(kind, payload)`, i.e. the `Custom`
-    // variant, whose `raw_os_error()` is `None` even though the payload wraps a
-    // real OS error. Recover the errno from the source chain so tagging an
-    // error does not silently drop the number from its own message.
-    let errno = error.raw_os_error().or_else(|| {
-        std::error::Error::source(error.get_ref()?)?
-            .downcast_ref::<io::Error>()?
-            .raw_os_error()
-    });
-    match errno {
-        Some(errno) => {
-            let suffix = format!(" (os error {errno})");
-            let text = display.strip_suffix(&suffix).unwrap_or(&display);
-            format!("{text} ({errno})")
-        }
-        None => display,
     }
 }
 

--- a/crates/transfer/src/receiver/directory/obstacle.rs
+++ b/crates/transfer/src/receiver/directory/obstacle.rs
@@ -56,7 +56,6 @@ use std::io;
 use std::path::Path;
 
 #[cfg(any(unix, windows))]
-use crate::pipeline::receiver::upstream_errno_text;
 #[cfg(any(unix, windows))]
 use crate::receiver::ReceiverContext;
 
@@ -378,7 +377,7 @@ impl ReceiverContext {
                 &format!(
                     "rsync: [receiver] delete_file: rmdir({}) failed: {}\n",
                     relative_path.display(),
-                    upstream_errno_text(&error)
+                    logging::upstream_errno_text(&error)
                 ),
             );
         }
@@ -408,7 +407,7 @@ impl ReceiverContext {
             &format!(
                 "rsync: [receiver] delete_file: unlink({}) failed: {}\n",
                 relative_path.display(),
-                upstream_errno_text(&error)
+                logging::upstream_errno_text(&error)
             ),
         );
         self.report_make_way_failure(writer, relative_path, make_way_for, error)
@@ -478,7 +477,7 @@ impl ReceiverContext {
             crate::pipeline::receiver::keep_backup_failed_line(
                 &relative_path.display().to_string(),
                 &error,
-                &upstream_errno_text(&error),
+                &logging::upstream_errno_text(&error),
             )
         );
         let _ = self.emit_error_line(writer, &line);


### PR DESCRIPTION
fix(batch): refuse an unusable --read-batch path at RERR_FILEIO, in upstream's words

Measured on the Linux root leg of the upstream 3.5.0 testsuite (aarch64,
`/tmp` mounted `nodev`), where `batch-file-symlink` fails. The cell plants a
char device at the `--read-batch` path. On that mount neither implementation
can open it, so both fall to the cell's second predicate - `'open error' in
stderr and returncode != 0` - and the divergence becomes visible:

    upstream  rc=11  rsync: [Receiver] Batch file "…/read_batch_dev" open
                     error: Permission denied (13)
    oc        rc=1   oc-rsync error: batch replay failed: I/O error: Failed
                     to open batch file '…'

Two divergences from batch.c:267-281, both real and both invisible on a
filesystem that permits device nodes:

1. Exit code. Upstream aborts `exit_cleanup(RERR_FILEIO)` for BOTH the failed
   open (batch.c:271) and the `!S_ISREG` refusal (batch.c:280). oc's
   catch-all mapped every batch error to 1 under a `batch replay failed:`
   prefix, which names the wrong phase - nothing was replayed, the input was
   refused. The `!S_ISREG` arm was wrong here too, just unobservable: the
   cell's primary predicate reads the message, not the code.

2. Wording. Upstream prints a bare `Batch file %s open error` through
   `rsyserr`, so `full_fname` double-quotes the name and the errno is
   appended as `strerror (errno)`.

`BatchError::BatchFileUnusable` carries both refusals, following the
`FlagMismatch` precedent already in the enum: a bare `#[error("{0}")]`
rendered verbatim, with its own exit code at the one dispatch site. The
`!S_ISREG` text already matched upstream and is unchanged.

`upstream_errno_text` - the `rsyserr` renderer that strips io::Error's
" (os error N)" and re-emits upstream's " (N)" - was `pub(crate)` in
crates/transfer. It moves to crates/logging, which owns diagnostic rendering
and is a leaf crate both `transfer` and `batch` can depend on, so there is
one copy rather than two. The six transfer call sites are unchanged in
behaviour.

Two tests, pinning independent axes: the variant (which decides the exit
code) and the rendered text (which the testsuite cell matches on). Filing
both refusals as `BatchError::Io` instead kills the variant test in 0.00s
with `expected BatchFileUnusable, got: I/O error: Batch file "…" open error:
No such file or directory (2)`, while the wording test stays green - the
separation is what makes each test discriminating rather than incidental.

batch 120/120; fmt and clippy clean on the pinned 1.88.0 toolchain across
batch, logging, transfer and core.
