### PR TITLE
fix(daemon): an empty `hosts allow` value means "no list", not a config error

### DIFF
--- a/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
+++ b/crates/daemon/src/daemon/sections/config_helpers/host_pattern.rs
@@ -533,9 +533,28 @@ fn allow_proxy_protocol_peer(list: &[HostPattern], addr: IpAddr) -> bool {
 
 /// Parses a host allow/deny list from a config directive value.
 ///
-/// Splits the value by commas and whitespace, parses each token as a
-/// `HostPattern`, and returns the list. Returns an error if any token
-/// is invalid or the list is empty.
+/// Splits the value by commas and whitespace and parses each token as a
+/// [`HostPattern`]. An invalid token is an error; an *empty* value is not.
+///
+/// upstream: access.c:275-278 - `allow_access()` normalises an empty list
+/// string to `NULL` (`if (allow_list && !*allow_list) allow_list = NULL;`)
+/// before it decides anything, so `hosts allow =` is legal config meaning
+/// "no list", indistinguishable from the directive being absent.
+/// `allow_proxy_protocol_peer` (access.c:302-303) reads its own list through
+/// the same `!list || !*list` guard, where it means "trust nobody".
+///
+/// The empty list is what carries that meaning here, because both oc
+/// consumers already key on emptiness rather than on an `Option`:
+/// `ModuleDefinition::permits` skips the allow short-circuit when
+/// `hosts_allow` is empty, and the proxy-peer check matches nothing against
+/// an empty pattern set. Refusing the value instead aborted the daemon at
+/// startup, where upstream serves.
+///
+/// upstream: params.c:62 - "Leading and trailing whitespace is stripped
+/// from" the value before it is stored, so a whitespace-only value is the
+/// empty string on both implementations; oc's parser trims identically
+/// (`config_parsing/parser.rs`), which is what makes this equivalence exact
+/// rather than approximate.
 fn parse_host_list(
     value: &str,
     config_path: &Path,
@@ -558,14 +577,6 @@ fn parse_host_list(
             )
         })?;
         patterns.push(pattern);
-    }
-
-    if patterns.is_empty() {
-        return Err(config_parse_error(
-            config_path,
-            line,
-            format!("{directive} directive must specify at least one pattern"),
-        ));
     }
 
     Ok(patterns)

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -505,14 +505,9 @@ fn apply_global_directive(
         "proxyprotocolhosts" => {
             // upstream: access.c:300-306 `allow_proxy_protocol_peer()` reads
             // the list with `if (!list || !*list) return 0;`, so an empty
-            // value is legal config that trusts nobody. `parse_host_list`
-            // rejects an empty list for `hosts allow`/`hosts deny`, where
-            // emptiness really is a mistake; here it is upstream's default.
-            let patterns = if value.trim().is_empty() {
-                Vec::new()
-            } else {
-                parse_host_list(value, path, line_number, "proxy protocol hosts")?
-            };
+            // value is legal config that trusts nobody - which the empty
+            // pattern set expresses, since nothing matches against it.
+            let patterns = parse_host_list(value, path, line_number, "proxy protocol hosts")?;
 
             store_global_directive(
                 &mut state.proxy_protocol_hosts,

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -364,6 +364,8 @@ include!("tests/chunks/runtime_options_parse_bwlimit_unlimited.rs");
 include!("tests/chunks/runtime_options_parse_bwlimit_rejects_suffix_and_burst.rs");
 include!("tests/chunks/runtime_options_module_bwlimit_directive_is_unknown.rs");
 include!("tests/chunks/runtime_options_parse_hostname_patterns.rs");
+include!("tests/chunks/runtime_options_accept_an_empty_hosts_directive.rs");
+include!("tests/chunks/runtime_options_empty_module_hosts_allow_overrides_the_global.rs");
 include!("tests/chunks/runtime_options_parse_hosts_allow_and_deny.rs");
 include!("tests/chunks/runtime_options_parse_lock_file_argument.rs");
 include!("tests/chunks/runtime_options_parse_log_file_argument.rs");

--- a/crates/daemon/src/tests/chunks/runtime_options_accept_an_empty_hosts_directive.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_accept_an_empty_hosts_directive.rs
@@ -1,0 +1,38 @@
+/// An empty `hosts allow` / `hosts deny` value is legal config, not a parse
+/// error, and it means "no list".
+///
+/// upstream: access.c:275-278 - `allow_access()` normalises an empty list
+/// string to `NULL` before deciding anything, so the directive with no value
+/// behaves exactly as if it were absent. Refusing it aborted the daemon at
+/// startup where upstream serves: measured against real rsync 3.5.0, a config
+/// carrying `hosts allow =` starts and listens, while oc exited 1 with
+/// "hosts allow directive must specify at least one pattern".
+#[test]
+fn runtime_options_accept_an_empty_hosts_directive() {
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "[docs]\npath = /srv/docs\nhosts allow =\nhosts deny =\n",
+    )
+    .expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect("an empty hosts directive is legal config");
+
+    let modules = options.modules();
+    assert_eq!(modules.len(), 1);
+
+    let module = &modules[0];
+    assert!(module.hosts_allow.is_empty());
+    assert!(module.hosts_deny.is_empty());
+
+    // The empty list is what carries upstream's "no restriction"; assert the
+    // decision, not just the representation.
+    assert!(module.permits(
+        IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7)),
+        PeerHost::new(None, true)
+    ));
+}

--- a/crates/daemon/src/tests/chunks/runtime_options_empty_module_hosts_allow_overrides_the_global.rs
+++ b/crates/daemon/src/tests/chunks/runtime_options_empty_module_hosts_allow_overrides_the_global.rs
@@ -1,0 +1,47 @@
+/// A module's empty `hosts allow` overrides a restrictive global default,
+/// because upstream reads the module's own (empty) string and normalises it to
+/// "no list" rather than falling back to the global one.
+///
+/// upstream: loadparm.c - `hosts allow` is a `P_LOCAL` string whose global
+/// value seeds every module's default; access.c:275-278 then turns whatever
+/// that module ends up holding into `NULL` when it is empty. So the empty
+/// value has to reach the module as a *set* value, not as "unset" - mapping it
+/// to absent would re-inherit the global list and deny the peer.
+///
+/// The `closed` module is the control: it names no directive, so it must still
+/// inherit the global list and refuse. Without it this test would also pass if
+/// the global default were simply never applied.
+#[test]
+fn runtime_options_empty_module_hosts_allow_overrides_the_global() {
+    let mut file = NamedTempFile::new().expect("config file");
+    writeln!(
+        file,
+        "hosts allow = 10.0.0.0/8\n\n[open]\npath = /srv/open\nhosts allow =\n\n[closed]\npath = /srv/closed\n",
+    )
+    .expect("write config");
+
+    let options = RuntimeOptions::parse(&[
+        OsString::from("--config"),
+        file.path().as_os_str().to_os_string(),
+    ])
+    .expect("parse a global hosts allow with an empty module override");
+
+    let modules = options.modules();
+    assert_eq!(modules.len(), 2);
+
+    let unlisted = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+
+    let open = &modules[0];
+    assert_eq!(open.name, "open");
+    assert!(open.hosts_allow.is_empty());
+    assert!(open.permits(unlisted, PeerHost::new(None, true)));
+
+    let closed = &modules[1];
+    assert_eq!(closed.name, "closed");
+    assert_eq!(closed.hosts_allow.len(), 1);
+    assert!(!closed.permits(unlisted, PeerHost::new(None, true)));
+    assert!(closed.permits(
+        IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)),
+        PeerHost::new(None, true)
+    ));
+}


### PR DESCRIPTION
Measured against the real rsync 3.5.0 binary on Linux. A config carrying a
bare `hosts allow =` starts and serves on upstream; oc refused it at startup:

    UP: STAYED UP (config accepted)
    OC: EXIT 1 :: oc-rsync error: failed to parse config '...':
                  hosts allow directive must specify at least one pattern (line 1)

upstream `access.c:275-278` normalises the value before deciding anything:

    if (allow_list && !*allow_list)
            allow_list = NULL;
    if (deny_list && !*deny_list)
            deny_list = NULL;

so the empty string is legal config meaning "no list" - indistinguishable
from the directive being absent. There is no parse-time validation: `hosts
allow` is a plain `P_LOCAL` string, and emptiness is resolved at the
decision site.

The empty list is what carries that meaning here, because both oc consumers
already key on emptiness rather than on an `Option`:
`ModuleDefinition::permits` skips the allow short-circuit when `hosts_allow`
is empty, and the proxy-peer check matches nothing against an empty pattern
set. So the refusal in `parse_host_list` was the single wrong thing, and it
was wrong for all five callers.

The whitespace-only case needs no separate arm: upstream strips leading and
trailing whitespace from a parameter value (`params.c:62`) exactly as oc's
parser does, so a whitespace-only value is the empty string on both
implementations. That equivalence is exact, not approximate.

`proxy protocol hosts` already special-cased the empty value with a comment
asserting that emptiness "really is a mistake" for `hosts allow`/`hosts
deny`. That claim is the inverse of `access.c:275-278`; the special case is
now redundant and both directives share one parser.

Two tests on independent axes: the parse (an empty value is accepted and
yields no restriction) and the OVERRIDE (a module's empty value beats a
restrictive global default). The second carries its own control - a sibling
module naming no directive must still inherit the global list and refuse -
without which the test would also pass if the default were never applied at
all. Restoring the refusal fails both and leaves the non-empty-list test
green.

MEASURED on the Linux nonroot TCP daemon leg: `daemon-proxy-protocol` no
longer reports `rsyncd exited before listening on port 19873 (status=1)` -
the daemon starts and logs `listening on port 19873`. The cell still fails,
now at the handshake after the PROXY header is consumed, which is a separate
defect; the leg total is unchanged at 112 passed / 10 failed / 33 skipped
and no manifest row is flipped.

daemon 1821/1821; fmt and clippy clean on the pinned 1.88.0 toolchain.
