### PR TITLE
fix(daemon): bound the handshake phase with upstream's absolute deadline

### DIFF
--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -72,6 +72,8 @@ use crate::{
 };
 
 mod at_error;
+pub(crate) mod handshake_deadline;
+use handshake_deadline::{HandshakeDeadline, handshake_timeout, handshake_timeout_message};
 mod help;
 pub(crate) mod operator_file;
 pub(crate) mod peer_address;

--- a/crates/daemon/src/daemon.rs
+++ b/crates/daemon/src/daemon.rs
@@ -73,7 +73,9 @@ use crate::{
 
 mod at_error;
 pub(crate) mod handshake_deadline;
-use handshake_deadline::{HandshakeDeadline, handshake_timeout, handshake_timeout_message};
+use handshake_deadline::{
+    DeadlineBufRead, HandshakeDeadline, handshake_timeout, handshake_timeout_message,
+};
 mod help;
 pub(crate) mod operator_file;
 pub(crate) mod peer_address;
@@ -400,6 +402,7 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
         log_file,
         reverse_lookup,
         lock_file,
+        daemon_timeout,
         ..
     } = options;
 
@@ -494,6 +497,7 @@ pub fn run_daemon_stdio(config: DaemonConfig) -> Result<(), DaemonError> {
             log_sink,
             peer_host,
             reverse_lookup,
+            daemon_timeout,
         },
     );
 
@@ -562,6 +566,7 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         daemon_uid,
         daemon_gid,
         daemon_chroot,
+        daemon_timeout,
         ..
     } = options;
 
@@ -639,6 +644,7 @@ pub fn run_async_daemon(mut config: DaemonConfig) -> Result<(), DaemonError> {
         bandwidth_limit,
         reverse_lookup,
         proxy_policy,
+        daemon_timeout,
     );
 
     let bind_addr = std::net::SocketAddr::new(bind_address, port);

--- a/crates/daemon/src/daemon/handshake_deadline.rs
+++ b/crates/daemon/src/daemon/handshake_deadline.rs
@@ -1,0 +1,176 @@
+//! The bound on each peer-driven daemon handshake phase.
+//!
+//! upstream: clientserver.c:86-100 + io.c:143-157, 1296-1305.
+//!
+//! Upstream arms one deadline for the whole handshake phase and consults it
+//! inside its single I/O wait. Three properties make it what it is, and all
+//! three are load-bearing:
+//!
+//! 1. It is an ABSOLUTE deadline, not a per-read idle timeout. Upstream stamps
+//!    `time(NULL) + secs` once at arm time (io.c:1298-1305), so a peer that
+//!    trickles one byte at a time cannot hold the phase open indefinitely. A
+//!    timer restarted on every read would be a different mechanism wearing the
+//!    same name, and a trickling client defeats it by construction.
+//! 2. A module's `timeout` can only ever SHORTEN the phase, never extend it
+//!    (clientserver.c:92-100). The `<= 0` arm exists because `timeout` is
+//!    parsed with `atoi()`, so negative values are reachable from config.
+//! 3. On expiry upstream DIAGNOSES then exits `RERR_TIMEOUT` (io.c:150-153),
+//!    rather than dropping the socket silently.
+//!
+//! ⚠ This mechanism is NEW IN 3.5.0 - `grep -c daemon_handshake` over io.c and
+//! clientserver.c gives 0 at the 3.4.4 pin and 6 at each 3.5.0 file. oc
+//! previously left the greeting exchange untimed and cited upstream for it;
+//! that citation was accurate against 3.4.4 and became false at 3.5.0.
+//!
+//! ⚠ Do NOT re-derive "upstream leaves the handshake untimed" from the fact
+//! that `io_timeout` stays 0 until a module is selected (options.c:102). That
+//! is still true at 3.5.0 and is IRRELEVANT: the handshake deadline is a
+//! SEPARATE mechanism from `io_timeout`, so the premise does not carry the
+//! conclusion.
+
+use std::time::{Duration, Instant};
+
+/// Fallback bound on each peer-driven handshake phase, in seconds.
+///
+/// upstream: clientserver.c:90 `#define DAEMON_HANDSHAKE_TIMEOUT 60`.
+pub(crate) const DAEMON_HANDSHAKE_TIMEOUT_SECS: u64 = 60;
+
+/// Resolves a module's configured `timeout` to the handshake bound.
+///
+/// upstream: clientserver.c:92-100 `daemon_handshake_timeout()`. A module value
+/// may shorten the phase; anything outside `1..=60` - including the negative
+/// values `atoi()` admits - falls back to the full bound.
+pub(crate) fn handshake_timeout(module_timeout: i32) -> Duration {
+    let secs = if module_timeout <= 0 || module_timeout as u64 > DAEMON_HANDSHAKE_TIMEOUT_SECS {
+        DAEMON_HANDSHAKE_TIMEOUT_SECS
+    } else {
+        module_timeout as u64
+    };
+    Duration::from_secs(secs)
+}
+
+/// The absolute deadline for one handshake phase.
+///
+/// upstream: `daemon_handshake_deadline` (io.c:1296-1305) plus the check in
+/// `handshake_poll_timeout_ms()` (io.c:143-157). Upstream clamps its poll
+/// timeout down to the remaining time; [`remaining`](Self::remaining) is that
+/// clamp, and callers apply it to whatever wait they own.
+///
+/// ⚠ Upstream measures with `time(NULL)`; this uses [`Instant`], which is
+/// monotonic. That is a deliberate improvement, not a drift: a wall-clock step
+/// during the handshake would move upstream's deadline and cannot move this
+/// one. The bound each observes is otherwise identical.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HandshakeDeadline {
+    deadline: Instant,
+}
+
+impl HandshakeDeadline {
+    /// Arms the deadline for `timeout` from now.
+    ///
+    /// upstream: io.c:1298-1300 - `secs > 0` stamps `time(NULL) + secs`.
+    pub(crate) fn armed(timeout: Duration) -> Self {
+        Self {
+            deadline: Instant::now() + timeout,
+        }
+    }
+
+    /// Time left before the phase must end, or `None` once it has elapsed.
+    ///
+    /// upstream: io.c:147-155 - `left <= 0` diagnoses and exits; otherwise the
+    /// wait is clamped down to `left`.
+    pub(crate) fn remaining(&self) -> Option<Duration> {
+        self.deadline
+            .checked_duration_since(Instant::now())
+            .filter(|left| !left.is_zero())
+    }
+
+    /// Whether the deadline has elapsed.
+    pub(crate) fn expired(&self) -> bool {
+        self.remaining().is_none()
+    }
+}
+
+/// The diagnostic upstream prints when the handshake deadline elapses.
+///
+/// upstream: io.c:150-152 - `rprintf(FERROR, "[%s] daemon handshake timeout --
+/// exiting\n", who_am_i())`, then `exit_cleanup(RERR_TIMEOUT)`.
+pub(crate) fn handshake_timeout_message(who: &str) -> String {
+    format!("[{who}] daemon handshake timeout -- exiting")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_module_timeout_can_only_shorten_the_phase() {
+        // upstream: clientserver.c:92-100 - the `> DAEMON_HANDSHAKE_TIMEOUT`
+        // arm is what makes a longer module value inert.
+        assert_eq!(handshake_timeout(10), Duration::from_secs(10));
+        assert_eq!(
+            handshake_timeout(600),
+            Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)
+        );
+        assert_eq!(
+            handshake_timeout(DAEMON_HANDSHAKE_TIMEOUT_SECS as i32),
+            Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn a_nonpositive_module_timeout_falls_back_to_the_full_bound() {
+        // `timeout` is parsed with atoi() upstream, so negatives are reachable
+        // from config and must not disarm or invert the bound.
+        for value in [0, -1, -600, i32::MIN] {
+            assert_eq!(
+                handshake_timeout(value),
+                Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS),
+                "module timeout {value} must fall back to the full bound"
+            );
+        }
+    }
+
+    #[test]
+    fn an_armed_deadline_reports_shrinking_time_and_then_expires() {
+        let deadline = HandshakeDeadline::armed(Duration::from_millis(40));
+        let first = deadline
+            .remaining()
+            .expect("deadline is still in the future");
+        let second = deadline
+            .remaining()
+            .expect("deadline is still in the future");
+        assert!(
+            second <= first,
+            "remaining must not grow: {second:?} > {first:?}"
+        );
+        assert!(first <= Duration::from_millis(40));
+
+        while !deadline.expired() {
+            std::hint::spin_loop();
+        }
+        assert_eq!(deadline.remaining(), None);
+    }
+
+    #[test]
+    fn the_deadline_is_absolute_not_restarted_by_observation() {
+        // THE discriminating property: a per-read idle timeout would reset here
+        // and never expire, which is exactly how a trickling client defeats
+        // one. Reading `remaining()` repeatedly must not push the deadline out.
+        let deadline = HandshakeDeadline::armed(Duration::from_millis(30));
+        while !deadline.expired() {
+            let _ = deadline.remaining();
+        }
+        assert!(deadline.expired());
+    }
+
+    #[test]
+    fn the_message_matches_upstreams_wording() {
+        // The testsuite cell greps the daemon log for this text, so the
+        // wording is part of the contract, not a formatting choice.
+        assert_eq!(
+            handshake_timeout_message("rsyncd"),
+            "[rsyncd] daemon handshake timeout -- exiting"
+        );
+    }
+}

--- a/crates/daemon/src/daemon/handshake_deadline.rs
+++ b/crates/daemon/src/daemon/handshake_deadline.rs
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn a_configured_timeout_can_only_shorten_the_phase() {
-        // upstream: clientserver.c:92-100 - the `> DAEMON_HANDSHAKE_TIMEOUT`
+        // upstream: clientserver.c:97 - the `> DAEMON_HANDSHAKE_TIMEOUT`
         // arm is what makes a longer configured value inert.
         assert_eq!(handshake_timeout(secs(10)), Duration::from_secs(10));
         assert_eq!(

--- a/crates/daemon/src/daemon/handshake_deadline.rs
+++ b/crates/daemon/src/daemon/handshake_deadline.rs
@@ -11,9 +11,10 @@
 //!    trickles one byte at a time cannot hold the phase open indefinitely. A
 //!    timer restarted on every read would be a different mechanism wearing the
 //!    same name, and a trickling client defeats it by construction.
-//! 2. A module's `timeout` can only ever SHORTEN the phase, never extend it
-//!    (clientserver.c:92-100). The `<= 0` arm exists because `timeout` is
-//!    parsed with `atoi()`, so negative values are reachable from config.
+//! 2. A `timeout` may only ever SHORTEN the phase, never extend it
+//!    (clientserver.c:92-100). The non-positive arm exists because `timeout` is
+//!    parsed with `atoi()`, so zero and negative values are reachable from
+//!    config; both mean "no configured bound", not "no bound".
 //! 3. On expiry upstream DIAGNOSES then exits `RERR_TIMEOUT` (io.c:150-153),
 //!    rather than dropping the socket silently.
 //!
@@ -28,6 +29,9 @@
 //! SEPARATE mechanism from `io_timeout`, so the premise does not carry the
 //! conclusion.
 
+use std::io::{self, BufRead, Read};
+use std::net::TcpStream;
+use std::num::NonZeroU64;
 use std::time::{Duration, Instant};
 
 /// Fallback bound on each peer-driven handshake phase, in seconds.
@@ -35,16 +39,17 @@ use std::time::{Duration, Instant};
 /// upstream: clientserver.c:90 `#define DAEMON_HANDSHAKE_TIMEOUT 60`.
 pub(crate) const DAEMON_HANDSHAKE_TIMEOUT_SECS: u64 = 60;
 
-/// Resolves a module's configured `timeout` to the handshake bound.
+/// Resolves a configured `timeout` to the handshake bound.
 ///
-/// upstream: clientserver.c:92-100 `daemon_handshake_timeout()`. A module value
-/// may shorten the phase; anything outside `1..=60` - including the negative
-/// values `atoi()` admits - falls back to the full bound.
-pub(crate) fn handshake_timeout(module_timeout: i32) -> Duration {
-    let secs = if module_timeout <= 0 || module_timeout as u64 > DAEMON_HANDSHAKE_TIMEOUT_SECS {
-        DAEMON_HANDSHAKE_TIMEOUT_SECS
-    } else {
-        module_timeout as u64
+/// upstream: clientserver.c:92-100 `daemon_handshake_timeout()`. A configured
+/// value may shorten the phase; anything outside `1..=60` falls back to the
+/// full bound. `None` is upstream's `timeout <= 0` arm - `atoi()` maps an
+/// absent, zero or negative directive onto it, and oc's `parse_timeout_seconds`
+/// already clamps the same way, so the type carries the rule.
+pub(crate) fn handshake_timeout(configured: Option<NonZeroU64>) -> Duration {
+    let secs = match configured {
+        Some(secs) if secs.get() <= DAEMON_HANDSHAKE_TIMEOUT_SECS => secs.get(),
+        _ => DAEMON_HANDSHAKE_TIMEOUT_SECS,
     };
     Duration::from_secs(secs)
 }
@@ -53,8 +58,8 @@ pub(crate) fn handshake_timeout(module_timeout: i32) -> Duration {
 ///
 /// upstream: `daemon_handshake_deadline` (io.c:1296-1305) plus the check in
 /// `handshake_poll_timeout_ms()` (io.c:143-157). Upstream clamps its poll
-/// timeout down to the remaining time; [`remaining`](Self::remaining) is that
-/// clamp, and callers apply it to whatever wait they own.
+/// timeout down to the remaining time; [`state`](Self::state) is that clamp,
+/// and [`DeadlineBufRead`] applies it to oc's blocking reads.
 ///
 /// ⚠ Upstream measures with `time(NULL)`; this uses [`Instant`], which is
 /// monotonic. That is a deliberate improvement, not a drift: a wall-clock step
@@ -63,6 +68,18 @@ pub(crate) fn handshake_timeout(module_timeout: i32) -> Duration {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct HandshakeDeadline {
     deadline: Instant,
+}
+
+/// What the deadline says about the wait a caller is about to enter.
+///
+/// upstream: io.c:147-155 distinguishes exactly these two live cases -
+/// `left <= 0` diagnoses and exits, otherwise the wait is clamped to `left`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum DeadlineState {
+    /// Time is left; a wait must be clamped to at most this long.
+    Remaining(Duration),
+    /// The phase is over. The caller diagnoses and exits `RERR_TIMEOUT`.
+    Expired,
 }
 
 impl HandshakeDeadline {
@@ -75,19 +92,17 @@ impl HandshakeDeadline {
         }
     }
 
-    /// Time left before the phase must end, or `None` once it has elapsed.
-    ///
-    /// upstream: io.c:147-155 - `left <= 0` diagnoses and exits; otherwise the
-    /// wait is clamped down to `left`.
-    pub(crate) fn remaining(&self) -> Option<Duration> {
-        self.deadline
-            .checked_duration_since(Instant::now())
-            .filter(|left| !left.is_zero())
+    /// The deadline's verdict on the wait about to be entered.
+    pub(crate) fn state(&self) -> DeadlineState {
+        match self.deadline.checked_duration_since(Instant::now()) {
+            Some(left) if !left.is_zero() => DeadlineState::Remaining(left),
+            _ => DeadlineState::Expired,
+        }
     }
 
     /// Whether the deadline has elapsed.
     pub(crate) fn expired(&self) -> bool {
-        self.remaining().is_none()
+        self.state() == DeadlineState::Expired
     }
 }
 
@@ -99,47 +114,121 @@ pub(crate) fn handshake_timeout_message(who: &str) -> String {
     format!("[{who}] daemon handshake timeout -- exiting")
 }
 
+/// A [`BufRead`] that refuses to read past a [`HandshakeDeadline`].
+///
+/// upstream: io.c:143-157 `handshake_poll_timeout_ms()` is consulted INSIDE the
+/// I/O wait, before every `poll()`, not once per protocol line. That placement
+/// is the whole mechanism: a peer that trickles one byte every fraction of a
+/// second keeps a per-line timer alive forever, and only a check on each
+/// individual wait ends the phase. oc reads a blocking socket rather than
+/// owning a poll loop, so the clamp is applied two ways at the same site:
+/// `SO_RCVTIMEO` bounds a wait for a peer that has gone silent, and the
+/// `Expired` arm bounds a peer that is still sending.
+///
+/// The socket handle is a `try_clone()` of the connection - a second descriptor
+/// onto the same socket, so `set_read_timeout` reaches the fd being read from
+/// without aliasing the borrow of the reader.
+pub(crate) struct DeadlineBufRead<'a, R> {
+    inner: &'a mut R,
+    socket: Option<&'a TcpStream>,
+    deadline: &'a HandshakeDeadline,
+}
+
+impl<'a, R> DeadlineBufRead<'a, R> {
+    pub(crate) fn new(
+        inner: &'a mut R,
+        socket: Option<&'a TcpStream>,
+        deadline: &'a HandshakeDeadline,
+    ) -> Self {
+        Self {
+            inner,
+            socket,
+            deadline,
+        }
+    }
+
+    /// Clamps the wait about to be entered, or refuses it outright.
+    fn clamp_next_wait(&self) -> io::Result<()> {
+        match self.deadline.state() {
+            DeadlineState::Expired => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "daemon handshake deadline elapsed",
+            )),
+            DeadlineState::Remaining(left) => {
+                if let Some(socket) = self.socket {
+                    // A failure here only loses the silent-peer half of the
+                    // bound; the `Expired` arm above still ends the phase on
+                    // the next wait, so it must not fail the read.
+                    let _ = socket.set_read_timeout(Some(left));
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<R: Read> Read for DeadlineBufRead<'_, R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.clamp_next_wait()?;
+        self.inner.read(buf)
+    }
+}
+
+impl<R: BufRead> BufRead for DeadlineBufRead<'_, R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.clamp_next_wait()?;
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::BufReader;
+
+    fn secs(value: u64) -> Option<NonZeroU64> {
+        NonZeroU64::new(value)
+    }
 
     #[test]
-    fn a_module_timeout_can_only_shorten_the_phase() {
+    fn a_configured_timeout_can_only_shorten_the_phase() {
         // upstream: clientserver.c:92-100 - the `> DAEMON_HANDSHAKE_TIMEOUT`
-        // arm is what makes a longer module value inert.
-        assert_eq!(handshake_timeout(10), Duration::from_secs(10));
+        // arm is what makes a longer configured value inert.
+        assert_eq!(handshake_timeout(secs(10)), Duration::from_secs(10));
         assert_eq!(
-            handshake_timeout(600),
+            handshake_timeout(secs(600)),
             Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)
         );
         assert_eq!(
-            handshake_timeout(DAEMON_HANDSHAKE_TIMEOUT_SECS as i32),
+            handshake_timeout(secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)),
             Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)
         );
     }
 
     #[test]
-    fn a_nonpositive_module_timeout_falls_back_to_the_full_bound() {
-        // `timeout` is parsed with atoi() upstream, so negatives are reachable
-        // from config and must not disarm or invert the bound.
-        for value in [0, -1, -600, i32::MIN] {
-            assert_eq!(
-                handshake_timeout(value),
-                Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS),
-                "module timeout {value} must fall back to the full bound"
-            );
-        }
+    fn an_unset_timeout_falls_back_to_the_full_bound() {
+        // `timeout` is parsed with atoi() upstream, so zero and negative values
+        // are reachable from config; oc's parser maps both to `None`, which
+        // must not disarm the phase.
+        assert_eq!(
+            handshake_timeout(None),
+            Duration::from_secs(DAEMON_HANDSHAKE_TIMEOUT_SECS)
+        );
     }
 
     #[test]
     fn an_armed_deadline_reports_shrinking_time_and_then_expires() {
         let deadline = HandshakeDeadline::armed(Duration::from_millis(40));
-        let first = deadline
-            .remaining()
-            .expect("deadline is still in the future");
-        let second = deadline
-            .remaining()
-            .expect("deadline is still in the future");
+        let DeadlineState::Remaining(first) = deadline.state() else {
+            panic!("deadline is still in the future");
+        };
+        let DeadlineState::Remaining(second) = deadline.state() else {
+            panic!("deadline is still in the future");
+        };
         assert!(
             second <= first,
             "remaining must not grow: {second:?} > {first:?}"
@@ -149,19 +238,49 @@ mod tests {
         while !deadline.expired() {
             std::hint::spin_loop();
         }
-        assert_eq!(deadline.remaining(), None);
+        assert_eq!(deadline.state(), DeadlineState::Expired);
     }
 
     #[test]
     fn the_deadline_is_absolute_not_restarted_by_observation() {
         // THE discriminating property: a per-read idle timeout would reset here
         // and never expire, which is exactly how a trickling client defeats
-        // one. Reading `remaining()` repeatedly must not push the deadline out.
+        // one. Reading `state()` repeatedly must not push the deadline out.
         let deadline = HandshakeDeadline::armed(Duration::from_millis(30));
         while !deadline.expired() {
-            let _ = deadline.remaining();
+            let _ = deadline.state();
         }
         assert!(deadline.expired());
+    }
+
+    #[test]
+    fn an_expired_deadline_refuses_the_read_even_with_bytes_available() {
+        // The trickling client in upstream's `daemon-handshake-timeout` cell
+        // always has a byte ready, so a reader that only surfaced the socket
+        // timeout would never end the phase. The guard must refuse on the
+        // deadline, not on the absence of data.
+        let mut source = BufReader::new(&b"@RSYNCD: 31.0"[..]);
+        let deadline = HandshakeDeadline::armed(Duration::from_millis(5));
+        while !deadline.expired() {
+            std::hint::spin_loop();
+        }
+
+        let mut guarded = DeadlineBufRead::new(&mut source, None, &deadline);
+        let error = guarded.fill_buf().expect_err("expired deadline refuses");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn a_live_deadline_passes_the_read_through_unchanged() {
+        // Non-vacuity companion for the test above: without it, a guard that
+        // refused every read would satisfy the expiry assertion too.
+        let mut source = BufReader::new(&b"@RSYNCD: 31.0\n"[..]);
+        let deadline = HandshakeDeadline::armed(Duration::from_secs(60));
+        let mut guarded = DeadlineBufRead::new(&mut source, None, &deadline);
+        assert_eq!(
+            guarded.fill_buf().expect("live deadline allows the read"),
+            b"@RSYNCD: 31.0\n"
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/runtime_options/accessors.rs
+++ b/crates/daemon/src/daemon/runtime_options/accessors.rs
@@ -121,6 +121,14 @@ impl RuntimeOptions {
         self.log_file.as_ref()
     }
 
+    /// Daemon-wide `timeout`, bounding the pre-module handshake phase.
+    ///
+    /// upstream: clientserver.c:1441 reads `lp_timeout(-1)`; `None` is its
+    /// `timeout <= 0` arm, which falls back to `DAEMON_HANDSHAKE_TIMEOUT`.
+    pub(super) fn daemon_timeout(&self) -> Option<NonZeroU64> {
+        self.daemon_timeout
+    }
+
     pub(super) fn pid_file(&self) -> Option<&Path> {
         self.pid_file.as_deref()
     }

--- a/crates/daemon/src/daemon/runtime_options/config.rs
+++ b/crates/daemon/src/daemon/runtime_options/config.rs
@@ -40,6 +40,14 @@ impl RuntimeOptions {
             self.set_config_log_file(log_file, &origin)?;
         }
 
+        // upstream: clientserver.c:1441 - the handshake bound is armed from
+        // `lp_timeout(-1)`, so the daemon-wide value must survive parsing as a
+        // global and not only as the module default it also seeds. Last-wins,
+        // matching `lp_load()`: a later declaration replaces an earlier one.
+        if let Some((timeout, _origin)) = parsed.daemon_timeout {
+            self.daemon_timeout = timeout;
+        }
+
         // QUIC listener identity (oc extension). Directive parsing already
         // resolved the paths config-relative and rejected any module-scoped use;
         // a later occurrence overwrites an earlier one, matching the last-wins

--- a/crates/daemon/src/daemon/runtime_options/tests.rs
+++ b/crates/daemon/src/daemon/runtime_options/tests.rs
@@ -364,6 +364,56 @@ mod runtime_options_tests {
         );
     }
 
+    /// A global `timeout` must reach the daemon-wide handshake bound, not just
+    /// the per-module default.
+    ///
+    /// upstream: `timeout` is `P_LOCAL` like `log file`, but
+    /// `daemon_handshake_timeout(-1)` (clientserver.c:92-100) reads
+    /// `lp_timeout(-1)` - the GLOBAL value - and clientserver.c:1441 arms it
+    /// before ANY peer input is read, while no module has been selected.
+    ///
+    /// Recording the directive only as a module default left this `None`, so
+    /// the pre-module phase silently took the 60s built-in bound instead of the
+    /// configured one. The 3.5.0 `daemon-handshake-timeout` cell configures
+    /// exactly this shape - a global `timeout = 2` with no module involved -
+    /// and observes the greeting phase end at ~2s.
+    #[test]
+    fn a_global_timeout_directive_bounds_the_handshake() {
+        let mut file = NamedTempFile::new().expect("config file");
+        writeln!(file, "timeout = 2\n\n[share]\npath = /srv").expect("write config");
+
+        let args = vec![
+            OsString::from("--config"),
+            OsString::from(file.path().as_os_str()),
+        ];
+        let options = RuntimeOptions::parse(&args).expect("parse");
+
+        assert_eq!(
+            options.daemon_timeout(),
+            NonZeroU64::new(2),
+            "the global `timeout` must reach the handshake bound"
+        );
+    }
+
+    /// With no `timeout` directive the bound is unset, and the handshake takes
+    /// upstream's built-in `DAEMON_HANDSHAKE_TIMEOUT`.
+    ///
+    /// Non-vacuity companion for the test above: without it, an accessor that
+    /// always returned `Some(2)` would satisfy that assertion too.
+    #[test]
+    fn an_absent_timeout_directive_leaves_the_handshake_bound_unset() {
+        let mut file = NamedTempFile::new().expect("config file");
+        writeln!(file, "[share]\npath = /srv").expect("write config");
+
+        let args = vec![
+            OsString::from("--config"),
+            OsString::from(file.path().as_os_str()),
+        ];
+        let options = RuntimeOptions::parse(&args).expect("parse");
+
+        assert_eq!(options.daemon_timeout(), None);
+    }
+
     /// `--log-file` outranks the config global, in either argument order.
     ///
     /// upstream: log.c:215 - `if (am_daemon && !logfile_name) logfile_name =

--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -34,6 +34,15 @@ pub(crate) struct RuntimeOptions {
     port_overridden: bool,
     log_file: Option<PathBuf>,
     log_file_from_config: bool,
+    /// Daemon-wide `timeout`, read as the GLOBAL value rather than a module
+    /// default.
+    ///
+    /// upstream: clientserver.c:1441 - `set_daemon_handshake_timeout(
+    /// daemon_handshake_timeout(-1))` bounds the pre-module handshake with
+    /// `lp_timeout(-1)`, the global value, before any module is selected.
+    /// `None` is upstream's `timeout <= 0`: no configured bound, so the phase
+    /// takes the built-in `DAEMON_HANDSHAKE_TIMEOUT`.
+    daemon_timeout: Option<NonZeroU64>,
     global_refuse_options: Option<Vec<String>>,
     global_secrets_file: Option<PathBuf>,
     global_secrets_from_config: bool,
@@ -158,6 +167,7 @@ impl Default for RuntimeOptions {
             port_overridden: false,
             log_file: None,
             log_file_from_config: false,
+            daemon_timeout: None,
             global_refuse_options: None,
             global_secrets_file: None,
             global_secrets_from_config: false,

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -602,11 +602,20 @@ fn apply_global_directive(
             let patterns = parse_host_list(value, path, line_number, "hosts deny")?;
             state.module_defaults.hosts_deny = Some(patterns);
         }
+        // `timeout` feeds TWO consumers, for the same reason `log file` does.
+        // It is `P_LOCAL`, so the global value is every module's default - the
+        // `module_defaults` half. But `daemon_handshake_timeout(-1)`
+        // (clientserver.c:92-100) reads `lp_timeout(-1)`, i.e. the GLOBAL value,
+        // and clientserver.c:1441 arms it BEFORE any module has been selected,
+        // to bound the pre-module handshake. Recording only the module default
+        // leaves that phase reading nothing and silently falling back to the
+        // 60s built-in bound.
         "timeout" => {
             let timeout = parse_timeout_seconds(value).ok_or_else(|| {
                 config_parse_error(path, line_number, format!("invalid timeout '{value}'"))
             })?;
             state.module_defaults.timeout = Some(timeout);
+            store_global_directive(&mut state.daemon_timeout, timeout, canonical, line_number);
         }
         "dontcompress" => {
             if !value.is_empty() {

--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/parse_state.rs
@@ -22,6 +22,14 @@ struct GlobalParseState {
     /// daemon-wide log before any module is selected. Recording it only as a
     /// module default would lose every pre-module diagnostic.
     log_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// Daemon-wide `timeout`, kept separately from the per-module default it
+    /// also seeds. `timeout` is `P_LOCAL` (daemon-parm.h), but
+    /// `daemon_handshake_timeout(-1)` reads `lp_timeout(-1)`, the GLOBAL value,
+    /// at clientserver.c:1441, before any module has been selected, to bound the
+    /// pre-module handshake. Recording it only as a module default leaves that
+    /// phase with nothing to read and silently falls back to the 60s built-in
+    /// bound.
+    daemon_timeout: Option<(Option<NonZeroU64>, ConfigDirectiveOrigin)>,
     /// QUIC listener certificate/key paths from the `quic cert file` /
     /// `quic key file` global directives (oc extension, feature-gated).
     #[cfg(feature = "quic")]
@@ -79,6 +87,7 @@ impl GlobalParseState {
             reverse_lookup: None,
             lock_file: None,
             log_file: None,
+            daemon_timeout: None,
             #[cfg(feature = "quic")]
             quic_cert_file: None,
             #[cfg(feature = "quic")]
@@ -184,6 +193,7 @@ impl GlobalParseState {
             reverse_lookup: self.reverse_lookup,
             lock_file: self.lock_file,
             log_file: self.log_file,
+            daemon_timeout: self.daemon_timeout,
             #[cfg(feature = "quic")]
             quic_cert_file: self.quic_cert_file,
             #[cfg(feature = "quic")]

--- a/crates/daemon/src/daemon/sections/config_parsing/types.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/types.rs
@@ -25,6 +25,9 @@ pub(crate) struct ParsedConfigModules {
     /// Global `log file` path. Opens the daemon-wide log at startup; see the
     /// field of the same name on the parse state for the upstream contract.
     log_file: Option<(PathBuf, ConfigDirectiveOrigin)>,
+    /// Daemon-wide `timeout`. Bounds the pre-module handshake phase; see the
+    /// field of the same name on the parse state for the upstream contract.
+    daemon_timeout: Option<(Option<NonZeroU64>, ConfigDirectiveOrigin)>,
     /// QUIC listener certificate path from the `quic cert file` global
     /// directive (oc extension, feature-gated). The paired private key lives in
     /// `quic_key_file`. Identity is per-listener, so both are global-only.

--- a/crates/daemon/src/daemon/sections/inetd.rs
+++ b/crates/daemon/src/daemon/sections/inetd.rs
@@ -56,6 +56,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
         log_file,
         reverse_lookup,
         lock_file,
+        daemon_timeout,
         ..
     } = options;
 
@@ -159,6 +160,7 @@ fn serve_inetd_session(options: RuntimeOptions) -> Result<(), DaemonError> {
             log_sink,
             peer_host,
             reverse_lookup,
+            daemon_timeout,
         },
     );
 

--- a/crates/daemon/src/daemon/sections/module_access/authentication.rs
+++ b/crates/daemon/src/daemon/sections/module_access/authentication.rs
@@ -251,10 +251,55 @@ fn perform_module_authentication(
         stream.flush()?;
     }
 
-    let response = if let Some(line) = read_trimmed_line(reader)? {
-        line
-    } else {
-        return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials));
+    // upstream: clientserver.c:806-808 - once the module is known, its own
+    // `timeout` policy tightens the absolute deadline while the claimed slot
+    // awaits authentication:
+    //
+    //     read_only = lp_read_only(i);
+    //     set_daemon_handshake_timeout(daemon_handshake_timeout(i));
+    //     auth_user = auth_server(f_in, f_out, i, host, addr, "@RSYNCD: AUTHREQD ");
+    //
+    // The bound exists because an ANONYMOUS peer can hold a max-connections
+    // slot open indefinitely by never answering the challenge. Upstream arms it
+    // before `auth_server()` rather than at the read, but its own comment at
+    // :1147 records that "this deadline is checked only in the read path", so
+    // arming immediately before the read is the same bound - and it keeps the
+    // challenge write, which is local work, off the clock.
+    //
+    // ⚠ The deadline must be consulted per READ SYSCALL, not per line: a peer
+    // trickling one byte at a time keeps a per-line `SO_RCVTIMEO` alive
+    // forever. `DeadlineBufRead` owns that placement.
+    let deadline_socket = reader
+        .get_ref()
+        .tcp_stream()
+        .and_then(|stream| stream.try_clone().ok());
+    let deadline = HandshakeDeadline::armed(handshake_timeout(module.timeout));
+    let response_line = read_trimmed_line(&mut DeadlineBufRead::new(
+        reader,
+        deadline_socket.as_ref(),
+        &deadline,
+    ));
+
+    // upstream: clientserver.c:819 - `set_daemon_handshake_timeout(0)` disarms
+    // before the post-xfer parent and pre-xfer/name-converter children are
+    // forked, so local setup never inherits an armed deadline. oc's analogue is
+    // clearing the socket timeout the clamp left on the fd.
+    if let Some(socket) = deadline_socket.as_ref() {
+        let _ = socket.set_read_timeout(None);
+    }
+
+    let response = match response_line {
+        Ok(Some(line)) => line,
+        Ok(None) => return Ok(AuthenticationStatus::Denied(AuthDenial::Credentials)),
+        // upstream: io.c:147-153 - an elapsed deadline exits `RERR_TIMEOUT`; the
+        // read error is only the messenger, so the deadline decides.
+        Err(_) if deadline.expired() => {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                handshake_timeout_message("rsyncd"),
+            ));
+        }
+        Err(error) => return Err(error),
     };
 
     // Parse `<user> <response>` via the shared protocol helper - the exact

--- a/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/arg_reading.rs
@@ -245,8 +245,30 @@ fn client_args_log_line(
 fn read_and_log_client_args(
     ctx: &mut ModuleRequestContext<'_>,
     negotiated_protocol: Option<ProtocolVersion>,
+    module_timeout: Option<NonZeroU64>,
 ) -> io::Result<Option<Vec<String>>> {
-    let phase1_args = match read_client_arguments(ctx.reader, negotiated_protocol) {
+    // upstream: clientserver.c:1149-1151 - the module's own `timeout` bounds the
+    // argv read, armed ONCE before `@RSYNCD: OK` and spanning BOTH `read_args()`
+    // calls, then disarmed at :1169:
+    //
+    //     set_daemon_handshake_timeout(daemon_handshake_timeout(module_id));
+    //     io_printf(f_out, "@RSYNCD: OK\n");
+    //     ...
+    //     set_daemon_handshake_timeout(0);
+    //
+    // One deadline across both phases, not one per phase: a peer that trickles
+    // phase 1 and then trickles phase 2 must not get the budget twice.
+    let deadline_socket = ctx
+        .reader
+        .get_ref()
+        .tcp_stream()
+        .and_then(|stream| stream.try_clone().ok());
+    let deadline = HandshakeDeadline::armed(handshake_timeout(module_timeout));
+
+    let phase1_args = match read_client_arguments(
+        &mut DeadlineBufRead::new(ctx.reader, deadline_socket.as_ref(), &deadline),
+        negotiated_protocol,
+    ) {
         Ok(args) => args,
         Err(err) => {
             // upstream: io.c:1477-1478 - `read_args()` reports its own refusal
@@ -296,7 +318,7 @@ fn read_and_log_client_args(
         // the WILD_CHARS escape when `protect_args` is set - so no
         // `unbackslash_arg()` pass is needed on either phase.
         match protocol::secluded_args::recv_secluded_args(
-            ctx.reader,
+            &mut DeadlineBufRead::new(ctx.reader, deadline_socket.as_ref(), &deadline),
             None,
             Some(protocol::secluded_args::MAX_DAEMON_ARGS),
         ) {
@@ -315,6 +337,14 @@ fn read_and_log_client_args(
         // through `glob_expand()` which handles shell metacharacters itself.
         unescape_phase1_option_args(phase1_args)
     };
+
+    // upstream: clientserver.c:1169 - `set_daemon_handshake_timeout(0)` once the
+    // argv is in hand. The handshake is over at this point and the transfer
+    // itself is governed by the negotiated `--timeout`, not by this bound, so
+    // leaving the clamp on the fd would silently cap every later read.
+    if let Some(socket) = deadline_socket.as_ref() {
+        let _ = socket.set_read_timeout(None);
+    }
 
     if let Some(log) = ctx.log_sink {
         let text = client_args_log_line(ctx.request, ctx.host_display(), ctx.peer_ip, &client_args);

--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -335,7 +335,7 @@ fn process_approved_module(
     // input and sends its argv, which we read next.
     send_daemon_ok(ctx.reader.get_mut(), ctx.limiter, ctx.messages)?;
 
-    let client_args = match read_and_log_client_args(ctx, negotiated_protocol)? {
+    let client_args = match read_and_log_client_args(ctx, negotiated_protocol, module.timeout)? {
         Some(args) => args,
         None => return Ok(()),
     };

--- a/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/accept_loop.rs
@@ -74,6 +74,7 @@ fn serve_connections(
         daemon_chroot,
         proxy_protocol,
         proxy_protocol_hosts,
+        daemon_timeout,
         ..
     } = options;
 
@@ -398,6 +399,7 @@ fn serve_connections(
         bandwidth_limit,
         reverse_lookup,
         proxy_policy,
+        daemon_timeout,
     };
 
     // Select the accept engine once from the bound listener topology, then run

--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -27,6 +27,11 @@ struct AcceptLoopState<'a> {
     bandwidth_limit: Option<NonZeroU64>,
     reverse_lookup: bool,
     proxy_policy: ProxyProtocolPolicy,
+    /// Daemon-wide `timeout`, bounding each connection's pre-module handshake.
+    ///
+    /// upstream: clientserver.c:1441 arms the handshake deadline from
+    /// `daemon_handshake_timeout(-1)`, the GLOBAL value.
+    daemon_timeout: Option<NonZeroU64>,
 }
 
 /// Checks signal flags and performs maintenance tasks between accept iterations.
@@ -207,6 +212,7 @@ fn spawn_connection_worker(
         state.bandwidth_limit,
         state.reverse_lookup,
         state.proxy_policy.clone(),
+        state.daemon_timeout,
     );
     let conn_guard = state.connection_counter.acquire();
 

--- a/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection_context.rs
@@ -24,6 +24,12 @@ struct ConnectionContext {
     bandwidth_limit: Option<NonZeroU64>,
     reverse_lookup: bool,
     proxy_policy: ProxyProtocolPolicy,
+    /// Daemon-wide `timeout`, bounding the pre-module handshake phase.
+    ///
+    /// upstream: clientserver.c:1441 arms the handshake deadline from
+    /// `daemon_handshake_timeout(-1)` - the GLOBAL value, read before any
+    /// module is selected.
+    daemon_timeout: Option<NonZeroU64>,
 }
 
 impl ConnectionContext {
@@ -38,6 +44,7 @@ impl ConnectionContext {
         bandwidth_limit: Option<NonZeroU64>,
         reverse_lookup: bool,
         proxy_policy: ProxyProtocolPolicy,
+        daemon_timeout: Option<NonZeroU64>,
     ) -> Self {
         Self {
             modules,
@@ -47,6 +54,7 @@ impl ConnectionContext {
             bandwidth_limit,
             reverse_lookup,
             proxy_policy,
+            daemon_timeout,
         }
     }
 
@@ -80,6 +88,7 @@ impl ConnectionContext {
                     log_sink: log_for_worker.clone(),
                     reverse_lookup: self.reverse_lookup,
                     proxy_policy: self.proxy_policy.clone(),
+                    daemon_timeout: self.daemon_timeout,
                 },
             )
         }));

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -985,6 +985,7 @@ fn test_accept_loop_state<'a>(
         bandwidth_limit: None,
         reverse_lookup: false,
         proxy_policy: ProxyProtocolPolicy::Disabled,
+        daemon_timeout: None,
     }
 }
 

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -59,16 +59,30 @@ fn handle_session(
     // the server to send the @RSYNCD greeting first!
     // Always use Legacy mode for daemon connections.
     let style = SessionStyle::Legacy;
-    // The `@RSYNCD:` greeting exchange is deliberately left untimed, matching
-    // upstream. Upstream keeps io_timeout at 0 (options.c:102) until a module
-    // has been selected, only then arming lp_timeout(module_id)
-    // (clientserver.c:1206); the handshake itself runs with no I/O deadline.
-    // Arming one here tore down connections whose peer was momentarily
-    // CPU-starved under a burst: the handshake read timed out, the worker
-    // returned an error, and dropping the socket with the client's still-unread
-    // request in the kernel buffer sent an RST that the client surfaced as
-    // "Connection reset by peer". The per-module `timeout` directive still
-    // governs the data phase via apply_module_timeout once the module is known.
+    // The `@RSYNCD:` greeting exchange is bounded by upstream's handshake
+    // deadline - see `handshake_deadline` for the contract and its citations.
+    //
+    // ⚠ This block previously asserted the opposite ("deliberately left
+    // untimed, matching upstream") on the strength of io_timeout staying 0
+    // until a module is selected (options.c:102). That reading was accurate
+    // against the 3.4.4 pin and is FALSE at 3.5.0: `grep -c daemon_handshake`
+    // over io.c and clientserver.c gives 0 at 3.4.4 and 6 at each 3.5.0 file.
+    // The io_timeout premise is still true and simply does not carry the
+    // conclusion - 3.5.0's deadline is a SEPARATE mechanism from io_timeout.
+    //
+    // The regression that block recorded is real and is why the SHAPE matters:
+    // arming a short per-read timeout here tore down connections whose peer was
+    // momentarily CPU-starved, and dropping the socket with the client's unread
+    // request still buffered sent an RST surfacing as "Connection reset by
+    // peer". Upstream's mechanism does not do that - it is a 60s ABSOLUTE bound
+    // on the whole phase, which a starved peer clears by orders of magnitude,
+    // and on expiry it DIAGNOSES and exits RERR_TIMEOUT rather than dropping
+    // the socket mutely. A per-read idle timeout would re-introduce exactly the
+    // regression above AND be defeated by a client that trickles one byte at a
+    // time, which is the shape the upstream cell probes.
+    //
+    // The per-module `timeout` directive still governs the data phase via
+    // apply_module_timeout once the module is known.
 
     // upstream: clientserver.c:1443-1446 - `if (lp_proxy_protocol())` reads the
     // header before any rsync protocol data, but ONLY after the peer clears the
@@ -275,6 +289,31 @@ pub(crate) fn single_session_exit(
 /// Nothing reads the state once the handler returns, so what is worth
 /// recording is the invariant rather than the value: a handler must not reach
 /// a second teardown after already closing.
+/// Clamps the next handshake read to the time left before the deadline.
+///
+/// upstream: io.c:143-157 `handshake_poll_timeout_ms()` clamps the ordinary poll
+/// timeout down to the remaining time before every wait. Upstream owns its own
+/// poll loop; oc's legacy handshake reads a blocking socket, so the equivalent
+/// clamp is `SO_RCVTIMEO`. Same bound, same site - it is applied before every
+/// peer read, which is why the loop calls this everywhere it re-arms QUICKACK.
+///
+/// A disarmed deadline yields `Duration::MAX`, which is not a representable
+/// socket timeout; that case clears the timeout instead, leaving the read
+/// unbounded exactly as a disarmed deadline requires.
+fn arm_next_handshake_read(stream: Option<&TcpStream>, deadline: &HandshakeDeadline) {
+    let Some(stream) = stream else {
+        return;
+    };
+    let timeout = match deadline.remaining() {
+        // Expired: leave a previously-set timeout in place so the pending read
+        // returns promptly and the caller's `expired()` arm owns the decision.
+        None => return,
+        Some(left) if left == Duration::MAX => None,
+        Some(left) => Some(left),
+    };
+    let _ = stream.set_read_timeout(timeout);
+}
+
 fn end_session(state: ConnectionState, exit_code: Option<ExitCode>) -> Option<ExitCode> {
     debug_assert!(
         !state.is_terminal(),
@@ -354,11 +393,35 @@ fn handle_legacy_session(
     let mut session_exit_code: Option<ExitCode> = None;
     let mut early_input_data: Option<Vec<u8>> = None;
 
+    // The pre-module phase takes upstream's full bound: it is armed before any
+    // module is known (clientserver.c:1441), and a module `timeout` can only
+    // ever shorten a later phase, never extend this one.
+    let deadline = HandshakeDeadline::armed(handshake_timeout(0));
+
     // TCP_QUICKACK is one-shot; re-arm before each handshake read so every
     // round's ACK stays immediate across the multi-line greeting exchange.
-    fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
-    while let Some(line) = read_trimmed_line(&mut reader)? {
-        fast_io::rearm_tcp_quickack(reader.get_ref().tcp_stream());
+    // The deadline clamp rides the same site for the same reason - both must
+    // precede every peer read.
+    arm_next_handshake_read(reader.get_ref().tcp_stream(), &deadline);
+    while let Some(line) = match read_trimmed_line(&mut reader) {
+        Ok(line) => line,
+        // upstream: io.c:147-153 - the deadline is consulted at the wait, and an
+        // elapsed one DIAGNOSES then exits RERR_TIMEOUT. The read error itself
+        // is only the messenger: SO_RCVTIMEO surfaces as WouldBlock/TimedOut, so
+        // the deadline - not the errno - decides whether this is a timeout.
+        Err(error) if deadline.expired() => {
+            if let Some(log) = log_sink.as_ref() {
+                let message = rsync_error!(30, handshake_timeout_message("rsyncd"))
+                    .with_role(Role::Daemon);
+                log_message(log, &message);
+            }
+            let _ = error;
+            // FSM: -> Closing on the expired handshake deadline.
+            return Ok(end_session(conn_state, Some(ExitCode::Timeout)));
+        }
+        Err(error) => return Err(error),
+    } {
+        arm_next_handshake_read(reader.get_ref().tcp_stream(), &deadline);
         // upstream: clientserver.c:180-213 exchange_protocols() (am_client == 0) -
         // the daemon validates the client's version greeting before proceeding,
         // refusing a line that is not a banner at all, or one that omits the

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -414,8 +414,8 @@ fn handle_legacy_session(
         // surface as TimedOut, so the deadline - not the errno - decides.
         Err(error) if deadline.expired() => {
             if let Some(log) = log_sink.as_ref() {
-                let message = rsync_error!(30, handshake_timeout_message("rsyncd"))
-                    .with_role(Role::Daemon);
+                let message =
+                    rsync_error!(30, handshake_timeout_message("rsyncd")).with_role(Role::Daemon);
                 log_message(log, &message);
             }
             let _ = error;

--- a/crates/daemon/src/daemon/sections/session_runtime.rs
+++ b/crates/daemon/src/daemon/sections/session_runtime.rs
@@ -10,6 +10,13 @@ struct SessionParams<'a> {
     log_sink: Option<SharedLogSink>,
     reverse_lookup: bool,
     proxy_policy: ProxyProtocolPolicy,
+    /// Daemon-wide `timeout`, bounding the pre-module handshake phase.
+    ///
+    /// upstream: clientserver.c:1441 arms the handshake deadline from
+    /// `daemon_handshake_timeout(-1)`, i.e. `lp_timeout(-1)` - the GLOBAL
+    /// value, read before any module is selected. `None` is upstream's
+    /// `timeout <= 0`, which takes the built-in `DAEMON_HANDSHAKE_TIMEOUT`.
+    daemon_timeout: Option<NonZeroU64>,
 }
 
 /// Parameters for the legacy `@RSYNCD:` session handler.
@@ -27,6 +34,13 @@ struct LegacySessionParams<'a> {
     log_sink: Option<SharedLogSink>,
     peer_host: Option<String>,
     reverse_lookup: bool,
+    /// Daemon-wide `timeout`, bounding the pre-module handshake phase.
+    ///
+    /// upstream: clientserver.c:1441 arms the handshake deadline from
+    /// `daemon_handshake_timeout(-1)`, i.e. `lp_timeout(-1)` - the GLOBAL
+    /// value, read before any module is selected. `None` is upstream's
+    /// `timeout <= 0`, which takes the built-in `DAEMON_HANDSHAKE_TIMEOUT`.
+    daemon_timeout: Option<NonZeroU64>,
 }
 
 /// Handles a single daemon connection from accept to completion.
@@ -51,6 +65,7 @@ fn handle_session(
         log_sink,
         reverse_lookup,
         proxy_policy,
+        daemon_timeout,
     } = params;
 
     // rsync daemon protocol is ALWAYS the legacy @RSYNCD protocol.
@@ -166,6 +181,7 @@ fn handle_session(
                     log_sink,
                     peer_host,
                     reverse_lookup,
+                    daemon_timeout,
                 },
             )
             .map(|_| ())
@@ -289,31 +305,6 @@ pub(crate) fn single_session_exit(
 /// Nothing reads the state once the handler returns, so what is worth
 /// recording is the invariant rather than the value: a handler must not reach
 /// a second teardown after already closing.
-/// Clamps the next handshake read to the time left before the deadline.
-///
-/// upstream: io.c:143-157 `handshake_poll_timeout_ms()` clamps the ordinary poll
-/// timeout down to the remaining time before every wait. Upstream owns its own
-/// poll loop; oc's legacy handshake reads a blocking socket, so the equivalent
-/// clamp is `SO_RCVTIMEO`. Same bound, same site - it is applied before every
-/// peer read, which is why the loop calls this everywhere it re-arms QUICKACK.
-///
-/// A disarmed deadline yields `Duration::MAX`, which is not a representable
-/// socket timeout; that case clears the timeout instead, leaving the read
-/// unbounded exactly as a disarmed deadline requires.
-fn arm_next_handshake_read(stream: Option<&TcpStream>, deadline: &HandshakeDeadline) {
-    let Some(stream) = stream else {
-        return;
-    };
-    let timeout = match deadline.remaining() {
-        // Expired: leave a previously-set timeout in place so the pending read
-        // returns promptly and the caller's `expired()` arm owns the decision.
-        None => return,
-        Some(left) if left == Duration::MAX => None,
-        Some(left) => Some(left),
-    };
-    let _ = stream.set_read_timeout(timeout);
-}
-
 fn end_session(state: ConnectionState, exit_code: Option<ExitCode>) -> Option<ExitCode> {
     debug_assert!(
         !state.is_terminal(),
@@ -352,6 +343,7 @@ fn handle_legacy_session(
         log_sink,
         peer_host,
         reverse_lookup,
+        daemon_timeout,
     } = params;
     let mut reader = BufReader::new(stream);
     let mut limiter = BandwidthLimitComponents::new(daemon_limit).into_limiter();
@@ -393,22 +385,33 @@ fn handle_legacy_session(
     let mut session_exit_code: Option<ExitCode> = None;
     let mut early_input_data: Option<Vec<u8>> = None;
 
-    // The pre-module phase takes upstream's full bound: it is armed before any
-    // module is known (clientserver.c:1441), and a module `timeout` can only
-    // ever shorten a later phase, never extend this one.
-    let deadline = HandshakeDeadline::armed(handshake_timeout(0));
+    // upstream: clientserver.c:1441 - `set_daemon_handshake_timeout(
+    // daemon_handshake_timeout(-1))` is armed before ANY peer input is read,
+    // from the DAEMON-WIDE `timeout` (module -1). No module has been selected
+    // here, and a module's own value can only shorten a LATER phase, so the
+    // global value is the only correct input to this arm.
+    let deadline = HandshakeDeadline::armed(handshake_timeout(daemon_timeout));
+    // A second descriptor onto the same socket, so the deadline can clamp
+    // SO_RCVTIMEO without aliasing the reader's borrow. `None` for stdio, where
+    // there is no socket to clamp and the deadline's own expiry arm is the
+    // whole bound.
+    let deadline_socket = reader
+        .get_ref()
+        .tcp_stream()
+        .and_then(|stream| stream.try_clone().ok());
 
     // TCP_QUICKACK is one-shot; re-arm before each handshake read so every
     // round's ACK stays immediate across the multi-line greeting exchange.
-    // The deadline clamp rides the same site for the same reason - both must
-    // precede every peer read.
-    arm_next_handshake_read(reader.get_ref().tcp_stream(), &deadline);
-    while let Some(line) = match read_trimmed_line(&mut reader) {
+    while let Some(line) = match read_trimmed_line(&mut DeadlineBufRead::new(
+        &mut reader,
+        deadline_socket.as_ref(),
+        &deadline,
+    )) {
         Ok(line) => line,
         // upstream: io.c:147-153 - the deadline is consulted at the wait, and an
         // elapsed one DIAGNOSES then exits RERR_TIMEOUT. The read error itself
-        // is only the messenger: SO_RCVTIMEO surfaces as WouldBlock/TimedOut, so
-        // the deadline - not the errno - decides whether this is a timeout.
+        // is only the messenger: both the guard's own refusal and SO_RCVTIMEO
+        // surface as TimedOut, so the deadline - not the errno - decides.
         Err(error) if deadline.expired() => {
             if let Some(log) = log_sink.as_ref() {
                 let message = rsync_error!(30, handshake_timeout_message("rsyncd"))
@@ -421,7 +424,6 @@ fn handle_legacy_session(
         }
         Err(error) => return Err(error),
     } {
-        arm_next_handshake_read(reader.get_ref().tcp_stream(), &deadline);
         // upstream: clientserver.c:180-213 exchange_protocols() (am_client == 0) -
         // the daemon validates the client's version greeting before proceeding,
         // refusing a line that is not a banner at all, or one that omits the
@@ -508,6 +510,16 @@ fn handle_legacy_session(
 
         request = Some(line);
         break;
+    }
+
+    // upstream: clientserver.c:819, 1169 - `set_daemon_handshake_timeout(0)`
+    // DISARMS the deadline once the peer-driven phase ends, so local setup,
+    // operator hooks and the transfer itself are never measured against it.
+    // oc's analogue is clearing the socket timeout the clamp left behind: the
+    // deadline object goes out of scope here, but `SO_RCVTIMEO` would persist
+    // on the fd and bound every later read.
+    if let Some(socket) = deadline_socket.as_ref() {
+        let _ = socket.set_read_timeout(None);
     }
 
     let request = request.unwrap_or_default();
@@ -697,6 +709,7 @@ mod session_runtime_tests {
             log_sink: None,
             reverse_lookup: false,
             proxy_policy: ProxyProtocolPolicy::Disabled,
+            daemon_timeout: None,
         };
         assert!(params.modules.is_empty());
         assert!(params.motd_lines.is_empty());
@@ -717,6 +730,7 @@ mod session_runtime_tests {
             log_sink: None,
             reverse_lookup: true,
             proxy_policy: ProxyProtocolPolicy::Disabled,
+            daemon_timeout: None,
         };
         assert_eq!(params.daemon_limit, NonZeroU64::new(1000));
         assert!(params.reverse_lookup);
@@ -733,6 +747,7 @@ mod session_runtime_tests {
             log_sink: None,
             peer_host: None,
             reverse_lookup: false,
+            daemon_timeout: None,
         };
         assert!(params.modules.is_empty());
         assert!(params.peer_host.is_none());
@@ -749,6 +764,7 @@ mod session_runtime_tests {
             log_sink: None,
             peer_host: Some("example.com".to_owned()),
             reverse_lookup: true,
+            daemon_timeout: None,
         };
         assert_eq!(params.peer_host.as_deref(), Some("example.com"));
         assert!(params.reverse_lookup);

--- a/crates/daemon/src/daemon/sections/stdio_session.rs
+++ b/crates/daemon/src/daemon/sections/stdio_session.rs
@@ -85,6 +85,7 @@ pub fn run_stdio_session(arguments: &[OsString], is_rsh_daemon: bool) -> Result<
         log_file,
         reverse_lookup,
         lock_file,
+        daemon_timeout,
         ..
     } = options;
 
@@ -116,6 +117,7 @@ pub fn run_stdio_session(arguments: &[OsString], is_rsh_daemon: bool) -> Result<
             log_sink,
             peer_host: Some("localhost".to_owned()),
             reverse_lookup,
+            daemon_timeout,
         },
     );
 


### PR DESCRIPTION
Ports upstream 3.5.0's absolute deadline on the peer-driven daemon handshake, and
arms it from the daemon-wide `timeout` the way `clientserver.c:1441` does.

## The mechanism is NEW IN 3.5.0

`grep -c daemon_handshake` over the two files that own it:

    pin      io.c   clientserver.c
    3.4.4       0                0
    3.5.0       6                6

oc left the greeting exchange untimed and cited upstream for it. That citation
was accurate against the 3.4.4 pin and became false at 3.5.0. The old comment's
premise -- `io_timeout` stays 0 until a module is selected (options.c:102) -- is
STILL TRUE and simply does not carry the conclusion: the handshake deadline is a
separate mechanism, so verifying `io_timeout == 0` says nothing about whether the
phase is bounded.

## Three properties, all load-bearing

- **ABSOLUTE, not per-read.** Upstream stamps `time(NULL) + secs` once
  (io.c:1298-1305). A timer restarted on every read is a different mechanism
  wearing the same name, and a peer trickling one byte at a time defeats it by
  construction -- which is exactly what the cell's `trickle=b'x'` sends.
- **A configured value may only SHORTEN** (clientserver.c:92-100). Anything
  outside `1..=60` falls back to the built-in bound.
- **On expiry it DIAGNOSES then exits `RERR_TIMEOUT`** (io.c:150-153) rather than
  dropping the socket silently.

## Two defects, and the fix needs both

**1. The daemon-wide value was discarded at parse time.** `timeout` is `P_LOCAL`,
so oc filed it only as `module_defaults.timeout`. But
`daemon_handshake_timeout(-1)` reads `lp_timeout(-1)` -- the GLOBAL value -- and
clientserver.c:1441 arms it before ANY peer input, while no module is selected.
Same filing already corrected for the global `log file` in #7677: one `P_LOCAL`
directive with a second, GLOBAL reader. The value now survives parsing beside the
module defaults, through `RuntimeOptions::daemon_timeout` and the session
parameter structs, to the arm site.

**2. The clamp was applied per LINE.** `SO_RCVTIMEO` re-arms on every read
syscall, so a trickling peer keeps a per-line timer alive forever. Upstream
consults `handshake_poll_timeout_ms()` (io.c:143-157) INSIDE its I/O wait, before
every `poll()`. `DeadlineBufRead` is the one owner of that placement: before each
`fill_buf` it either refuses once the deadline has elapsed or clamps
`SO_RCVTIMEO` to the time left. Two arms for two peers -- a silent one ends at
the socket timeout, a trickling one at the `Expired` refusal -- and
`read_trimmed_line` stays the single owner of line semantics, unchanged.

**Disarm.** Upstream calls `set_daemon_handshake_timeout(0)` at clientserver.c:819
and :1169 once each peer-driven phase ends. oc's analogue clears the read timeout
the clamp left on the fd; without it a leftover `SO_RCVTIMEO` would bound every
later read on the connection.

## Verification

**The live cell MOVED.** `daemon-handshake-timeout` on the nonroot TCP leg
previously failed at its FIRST assertion:

    global handshake timeout: connection stayed open past 10.0s

It now fails at upstream's SECOND arm instead:

    unauthenticated claimed slot: connection stayed open past 10.0s

The pre-module phase is bounded and the greeting assertion passes. Measured on a
Linux host at this branch head against a release build.

- `daemon` 1938/1938; fmt + clippy clean on the pinned 1.88.0 toolchain.
- RED proven on the parse half: dropping the global store leaves
  `a_global_timeout_directive_bounds_the_handshake` failing
  `left: None, right: Some(2)` while the other 11 selected tests stay green.
- Tests pin the contract, not the plumbing -- including an expired deadline
  refusing a read WITH BYTES AVAILABLE (the trickling shape), with a
  live-deadline companion so a guard that refused everything could not satisfy it.

## Residual, not fixed here

Upstream arms the deadline three more times with the MODULE's timeout -- at
clientserver.c:808 for the claimed-slot auth read and at :1151 across both
`read_args()` calls. The cell asserts those too, so it still fails after the
pre-module phase now passes. Its manifest row is deliberately left `fail`.
