### PR TITLE
fix(ci): let the whole-tree rustfmt gate see untracked sources

### DIFF
--- a/tools/ci/check_rustfmt_all.py
+++ b/tools/ci/check_rustfmt_all.py
@@ -68,14 +68,22 @@ def workspace_edition(root: Path) -> str:
     return edition
 
 
-def tracked_rust_sources(root: Path) -> list[str]:
-    """Every `.rs` path git tracks, relative to the repository root.
+def rust_sources(root: Path) -> list[str]:
+    """Every `.rs` path in the working tree, relative to the repository root.
+
+    `--cached --others --exclude-standard` enumerates tracked files AND
+    untracked-but-not-ignored ones. Tracked-only was a hole: a brand-new `.rs`
+    file is invisible to this gate until it is `git add`ed, so a developer can
+    run the gate clean locally and still fail CI - which checks out a tree
+    where that file IS tracked. The file COUNT is the only tell, and nobody
+    compares it across machines. Matches the idiom the placeholder scanner
+    already uses.
 
     Paths stay relative and rustfmt runs with `cwd=root`: the absolute forms
     total roughly 400 KB of argv, which approaches the platform limit on macOS.
     """
     out = subprocess.run(
-        ["git", "ls-files", "-z", "--", "*.rs"],
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", "*.rs"],
         cwd=root,
         check=True,
         capture_output=True,
@@ -102,10 +110,10 @@ def main() -> int:
         return 1
     print(f"rustfmt edition {edition} (from [workspace.package] in Cargo.toml)")
 
-    targets = tracked_rust_sources(root)
+    targets = rust_sources(root)
     if not targets:
         print(
-            "no tracked .rs files found - the enumerator matched nothing",
+            "no .rs files found - the enumerator matched nothing",
             file=sys.stderr,
         )
         return 1
@@ -132,12 +140,12 @@ def main() -> int:
                 "that is only\nvalid at its include! site does not parse "
                 "standalone; this gate does not skip\nsuch files. Either give "
                 "the fragment a form that parses on its own, or make it\na real "
-                f"module. {len(targets)} tracked .rs file(s) were submitted.",
+                f"module. {len(targets)} .rs file(s) were submitted.",
                 file=sys.stderr,
             )
         elif not args.write:
             print(
-                f"\n{len(targets)} tracked .rs file(s) checked. Diffs in a file "
+                f"\n{len(targets)} .rs file(s) checked. Diffs in a file "
                 "that no `mod`\ndeclaration reaches are invisible to `cargo fmt "
                 "--all -- --check`.\n"
                 "Fix with: python3 tools/ci/check_rustfmt_all.py --write",
@@ -146,7 +154,7 @@ def main() -> int:
         return result.returncode
 
     verb = "reformatted" if args.write else "checked"
-    print(f"{verb} {len(targets)} tracked .rs file(s) at edition {edition}")
+    print(f"{verb} {len(targets)} .rs file(s) at edition {edition}")
     return 0
 
 

--- a/tools/tests/test_check_rustfmt_all.py
+++ b/tools/tests/test_check_rustfmt_all.py
@@ -1,0 +1,91 @@
+"""Unit tests for the whole-tree rustfmt gate's file enumeration.
+
+The gate exists because `cargo fmt --all -- --check` cannot see a file that no
+`mod` declaration reaches. Enumerating only *tracked* files reopened a second
+hole of the same shape: a brand-new `.rs` file is invisible until it is
+`git add`ed, so the gate reports clean locally and CI - which checks out a tree
+where that file IS tracked - fails on it. These tests pin both halves.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.ci.check_rustfmt_all import rust_sources
+
+
+class RustSourcesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self._tempdir.name)
+        self._git("init", "--quiet")
+        # `git ls-files` needs an identity only for commits, but keeping the
+        # repo self-contained stops a developer's global config from steering
+        # the fixture.
+        self._git("config", "user.email", "gate@example.invalid")
+        self._git("config", "user.name", "gate")
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _git(self, *args: str) -> None:
+        subprocess.run(["git", *args], cwd=self.root, check=True, capture_output=True)
+
+    def _write(self, name: str, body: str = "fn probe() {}\n") -> None:
+        path = self.root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body)
+
+    def test_tracked_sources_are_enumerated(self) -> None:
+        self._write("src/tracked.rs")
+        self._git("add", "src/tracked.rs")
+
+        self.assertEqual(rust_sources(self.root), ["src/tracked.rs"])
+
+    def test_untracked_sources_are_enumerated(self) -> None:
+        """The hole this gate had: an un-added file was invisible to it.
+
+        Without `--others` the gate reports clean on a tree whose newest file
+        is misformatted, and CI - where the file is tracked - then fails.
+        """
+        self._write("src/untracked.rs")
+
+        self.assertEqual(rust_sources(self.root), ["src/untracked.rs"])
+
+    def test_ignored_sources_are_excluded(self) -> None:
+        """`--exclude-standard` keeps build output out of the argv.
+
+        Without it, every `.rs` under `target/` would be submitted to rustfmt.
+        """
+        (self.root / ".gitignore").write_text("target/\n")
+        self._write("target/generated.rs")
+        self._write("src/kept.rs")
+
+        self.assertEqual(rust_sources(self.root), ["src/kept.rs"])
+
+    def test_non_rust_files_are_excluded(self) -> None:
+        """The `*.rs` pathspec, isolated from the tracked/untracked axis."""
+        self._write("src/kept.rs")
+        (self.root / "notes.txt").write_text("not rust\n")
+        (self.root / "build.rs.bak").write_text("not rust either\n")
+        self._git("add", "-A")
+
+        self.assertEqual(rust_sources(self.root), ["src/kept.rs"])
+
+    def test_paths_are_relative_and_sorted(self) -> None:
+        """Relative paths keep the argv under the platform limit on macOS."""
+        for name in ("src/b.rs", "src/a.rs", "z.rs"):
+            self._write(name)
+        self._git("add", "-A")
+
+        found = rust_sources(self.root)
+
+        self.assertEqual(found, ["src/a.rs", "src/b.rs", "z.rs"])
+        self.assertTrue(all(not Path(name).is_absolute() for name in found))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix(ci): let the whole-tree rustfmt gate see untracked sources

`tools/ci/check_rustfmt_all.py` enumerated with `git ls-files -z -- '*.rs'`,
which lists TRACKED files only. A brand-new `.rs` file is therefore invisible
to the gate until it is `git add`ed - so the gate reports clean locally, and
CI, which checks out a tree where that file IS tracked, fails on it.

That is not hypothetical: it cost a full CI cycle on #7689. The only signal
the two runs differed was the file count, 3407 locally against 3408 in CI,
and nothing compares that number across machines.

Measured A/B with one misformatted untracked file present:

    before   exit 0   "checked 3407 tracked .rs file(s)"   <- reports clean
    after    exit 1   diff reported

`--cached --others --exclude-standard` is the idiom the placeholder scanner
already uses in this repo, so this aligns the two enumerators rather than
inventing a third policy. `--exclude-standard` keeps `target/` out of the
argv; without it every generated `.rs` would be submitted to rustfmt.

The gate had no tests at all, so the fix would have shipped with nothing to
stop the hole reopening. Five are added, and the mutation sweep discriminates:
reverting to the tracked-only enumeration kills exactly the two that depend on
the new flags (`test_untracked_sources_are_enumerated`,
`test_ignored_sources_are_excluded`) while the other three stay green as
negative controls - tracked enumeration, the `*.rs` pathspec, and sort order
are all orthogonal to this change, and their fixtures are `git add`ed so they
fail for one reason only.

Verified with `bash tools/ci/run_tools_tests.sh`, CI's own runner rather than
a hand-rolled equivalent: 86 tests, exit 0.
