### PR TITLE
fix(daemon): refuse a wire-supplied --max-alloc=0 instead of ignoring it

### DIFF
--- a/crates/cli/src/frontend/execution/options/size.rs
+++ b/crates/cli/src/frontend/execution/options/size.rs
@@ -102,19 +102,9 @@ pub(crate) fn parse_size_limit_argument(value: &OsStr, flag: &str) -> Result<u64
     }
 }
 
-/// Sanity ceiling for `--max-alloc`.
-///
-/// Limits the parsed value to at most one quarter of `u64::MAX` so the cap
-/// can be safely converted to `usize` and added to outstanding-byte counters
-/// without risking arithmetic overflow on 64-bit platforms. Upstream imposes
-/// no upper bound; this guard is oc-specific overflow protection.
-pub(crate) const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
-
-/// Lower bound for a non-zero `--max-alloc`, mirroring upstream's
-/// `parse_size_arg(arg, 'B', "max-alloc", 1024*1024, -1, True)` min value.
-///
-/// upstream: options.c:2067 `parse_size_arg()` call in `parse_arguments()`.
-const MAX_ALLOC_MIN: u64 = 1024 * 1024;
+// The `--max-alloc` value rules and their constants live in
+// `protocol::max_alloc`, because the daemon's client-argv parser applies the
+// same rules to a peer-forwarded value; see `validate_max_alloc` there.
 
 /// Upper bound for `--block-size` at protocol >= 30.
 ///
@@ -122,12 +112,6 @@ const MAX_ALLOC_MIN: u64 = 1024 * 1024;
 /// enforced by options.c:1692-1695 `parse_size_arg(arg, 'b', "block-size", 0,
 /// max_blength, False)`.
 const MAX_BLOCK_SIZE: u64 = 1 << 17;
-
-/// Error text for `--max-alloc=0`, byte-for-byte upstream's message.
-///
-/// upstream: `options.c:parse_arguments()` - `snprintf(err_buf, sizeof err_buf,
-/// "max-alloc must be greater than zero\n")` (options.c:2071).
-pub(crate) const MAX_ALLOC_ZERO_REJECTED: &str = "max-alloc must be greater than zero";
 
 /// Parses the `--max-alloc` argument as a byte ceiling.
 ///
@@ -140,8 +124,8 @@ pub(crate) const MAX_ALLOC_ZERO_REJECTED: &str = "max-alloc must be greater than
 ///   (CVE-2026-53794) because the value also arrives from a peer.
 /// - A non-zero value below 1 MiB is rejected ("too small").
 /// - Empty, negative, and non-numeric input is rejected.
-/// - Values above [`MAX_ALLOC_CEILING`] are rejected for overflow safety
-///   (an oc-specific guard; upstream has no upper bound).
+/// - Values above `protocol::max_alloc::MAX_ALLOC_CEILING` are rejected for
+///   overflow safety (an oc-specific guard; upstream has no upper bound).
 ///
 /// # Errors
 ///
@@ -158,36 +142,13 @@ pub(crate) fn parse_max_alloc_argument(value: &OsStr) -> Result<u64, Message> {
 
     let limit = parse_size_limit_argument(value, "--max-alloc")?;
 
-    // upstream: options.c:2069-2072 - `if (size == 0) { snprintf(err_buf, ...
-    // "max-alloc must be greater than zero\n"); goto cleanup; }`. The value can
-    // reach a daemon from the wire, so accepting zero would let a peer disable
-    // the my_alloc() ceiling (CVE-2026-53794).
-    if limit == 0 {
-        return Err(rsync_error!(1, MAX_ALLOC_ZERO_REJECTED.to_owned()).with_role(Role::Client));
-    }
-
-    // upstream: options.c:2067,1250-1259 - parse_size_arg rejects a value below
-    // the 1 MiB minimum with "is too small (min: 1.00M or 0 for unlimited)".
-    // do_big_num renders the constant 1 MiB minimum as "1.00M"; 3.5.0 left the
-    // "or 0 for unlimited" clause in place even though zero is now refused by
-    // the caller, so the text is mirrored verbatim.
-    if limit < MAX_ALLOC_MIN {
-        return Err(rsync_error!(
-            1,
-            format!("--max-alloc={display} is too small (min: 1.00M or 0 for unlimited)")
-        )
-        .with_role(Role::Client));
-    }
-
-    if limit > MAX_ALLOC_CEILING {
-        return Err(rsync_error!(
-            1,
-            format!("invalid --max-alloc '{display}': size exceeds the supported range")
-        )
-        .with_role(Role::Client));
-    }
-
-    Ok(limit)
+    // The zero / too-small / too-large rules are NOT restated here: the daemon
+    // applies the identical block to a peer-forwarded `--max-alloc`, and
+    // upstream runs one `parse_arguments()` body on both ends
+    // (options.c:2065-2074). This call site only adapts the shared owner's text
+    // into the client-role `Message` shape.
+    ::protocol::max_alloc::validate_max_alloc(limit, display)
+        .map_err(|text| rsync_error!(1, text).with_role(Role::Client))
 }
 
 /// Parses the `--block-size` argument into an optional override.
@@ -266,6 +227,9 @@ fn parse_size_spec(text: &str) -> Result<u64, SizeParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The rule's owner; these tests assert against ITS constants, so a change
+    // there cannot leave a stale copy asserting the old bound here.
+    use ::protocol::max_alloc::{MAX_ALLOC_CEILING, ZERO_REJECTED as MAX_ALLOC_ZERO_REJECTED};
     use std::ffi::OsString;
 
     fn os(s: &str) -> OsString {

--- a/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/long_form_args.rs
@@ -390,6 +390,28 @@ fn apply_long_form_args(
                             rejection.get_or_insert(ClientArgRejection::InvalidValue(message));
                         }
                     }
+                // upstream: options.c:2065-2074 - `server_options()` forwards
+                // `--max-alloc` (options.c:3029-3030) and the daemon runs the
+                // SAME `parse_arguments()` block the client does, so a peer
+                // value is both applied and refused there. The daemon decodes
+                // the client argv here rather than through the `--server` argv
+                // parser, so it needs its own arm; both call the one shared
+                // rule in `protocol::max_alloc`.
+                //
+                // Without this arm the option fell off the end of the chain and
+                // was SILENTLY IGNORED, which is exactly the shape 3.5.0's zero
+                // refusal exists to close: an older client that predates the
+                // check still forwards `--max-alloc=0` on the wire.
+                } else if let Some(val) = arg.strip_prefix("--max-alloc=") {
+                    match parse_max_alloc_limit(val) {
+                        // upstream: util2.c:75 - the rewritten `max_alloc`
+                        // global is what my_alloc() consults, so applying it is
+                        // the whole point of parsing it.
+                        Ok(limit) => ::protocol::set_max_alloc(limit),
+                        Err(message) => {
+                            rejection.get_or_insert(ClientArgRejection::InvalidValue(message));
+                        }
+                    }
                 // upstream: options.c - server_options() forwards `--modify-window=NUM`.
                 // The daemon receiver's quick-check honours it via same_time() so
                 // files within the window are not needlessly re-transferred.
@@ -661,6 +683,35 @@ fn parse_transfer_size_limit(opt_name: &str, value: &str) -> Result<u64, String>
             Err(size_arg_error(opt_name, value, "too large"))
         }
     }
+}
+
+/// Parses a peer-forwarded `--max-alloc` value into a byte ceiling.
+///
+/// upstream: `options.c:2066-2074` - `parse_size_arg(max_alloc_arg, 'B',
+/// "max-alloc", 1024*1024, -1, True)` followed by the zero refusal. The value
+/// RULES live in `protocol::max_alloc` because the client's own CLI applies
+/// exactly the same ones; only the front-end parse is restated here, since this
+/// parser reads raw wire strings rather than an `OsStr` argv.
+fn parse_max_alloc_limit(value: &str) -> Result<usize, String> {
+    // upstream: options.c:1172-1175 - the digit scan leaves the cursor on the
+    // terminator and `strtod("")` gives 0, so an empty value is exactly `=0`.
+    // For `--max-alloc` that resolves to the zero refusal rather than a parse
+    // error, which is what upstream reports for a forwarded `--max-alloc=`.
+    let text = if value.is_empty() { "0" } else { value };
+
+    // upstream: options.c:2067 passes def_suf 'B'.
+    let bytes = match ::core::bandwidth::parse_size_arg(text, b'B') {
+        Ok(parsed) => u64::try_from(parsed.bytes).unwrap_or(u64::MAX),
+        Err(::core::bandwidth::SizeArgError::Invalid) => {
+            return Err(size_arg_error("max-alloc", value, "invalid"));
+        }
+        Err(::core::bandwidth::SizeArgError::TooLarge) => {
+            return Err(size_arg_error("max-alloc", value, "too large"));
+        }
+    };
+
+    let limit = ::protocol::max_alloc::validate_max_alloc(bytes, value)?;
+    usize::try_from(limit).map_err(|_| size_arg_error("max-alloc", value, "too large"))
 }
 
 /// Renders upstream's size-argument failure text.

--- a/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/tests.rs
@@ -612,3 +612,89 @@ mod daemon_partial_dir_sanitize_tests {
         );
     }
 }
+
+/// A peer-forwarded `--max-alloc` must be parsed and refused exactly as
+/// upstream's own `parse_arguments()` does when the daemon runs it.
+///
+/// upstream: `options.c:2065-2074`. The daemon executes the same block as the
+/// client, so a client that predates 3.5.0's zero refusal - and therefore still
+/// forwards `--max-alloc=0` on the wire - is refused by the SERVER rather than
+/// silently disabling the server's own `my_alloc()` ceiling.
+#[cfg(test)]
+mod daemon_max_alloc_arg_tests {
+    use super::{ClientArgRejection, ServerConfig, ServerRole, apply_long_form_args};
+    use std::ffi::OsString;
+
+    fn rejection(client_args: &[&str]) -> Option<ClientArgRejection> {
+        let mut config = ServerConfig::from_flag_string_and_args(
+            ServerRole::Receiver,
+            "-logDtpre.iLsfxCIvu".to_owned(),
+            vec![OsString::from(".")],
+        )
+        .expect("server flag string parses");
+        let owned: Vec<String> = client_args.iter().map(|a| (*a).to_owned()).collect();
+        apply_long_form_args(&owned, &mut config)
+    }
+
+    fn invalid_value_text(client_args: &[&str]) -> String {
+        match rejection(client_args) {
+            Some(ClientArgRejection::InvalidValue(text)) => text,
+            other => {
+                panic!("expected an InvalidValue rejection for {client_args:?}, got {other:?}")
+            }
+        }
+    }
+
+    /// The attack shape: every spelling of zero must be refused with upstream's
+    /// own wording, because the value arrives from a peer.
+    #[test]
+    fn a_wire_supplied_zero_is_refused() {
+        for value in ["--max-alloc=0", "--max-alloc=0B", "--max-alloc=0.0M"] {
+            assert_eq!(
+                invalid_value_text(&[value]),
+                "max-alloc must be greater than zero",
+                "{value} must be refused with upstream's text",
+            );
+        }
+    }
+
+    /// upstream: options.c:1172-1175 - an empty value parses as 0, so it lands
+    /// on the SAME refusal rather than a distinct parse error.
+    #[test]
+    fn an_empty_value_takes_the_zero_refusal() {
+        assert_eq!(
+            invalid_value_text(&["--max-alloc="]),
+            "max-alloc must be greater than zero",
+        );
+    }
+
+    /// upstream: options.c:2067 - the 1 MiB minimum is enforced on the daemon
+    /// side too, so a too-small forwarded value cannot shrink the ceiling below
+    /// what upstream permits.
+    #[test]
+    fn a_value_below_one_mib_is_refused() {
+        assert_eq!(
+            invalid_value_text(&["--max-alloc=512K"]),
+            "--max-alloc=512K is too small (min: 1.00M or 0 for unlimited)",
+        );
+    }
+
+    /// Non-vacuity, two ways. A legitimate value is ACCEPTED and APPLIED, so
+    /// the arm is not simply refusing every `--max-alloc` it sees; and an argv
+    /// without the option is accepted too, so the refusals above are
+    /// attributable to the value rather than to the harness.
+    #[test]
+    fn a_legitimate_value_is_accepted_and_applied() {
+        let restore = ::protocol::effective_max_alloc();
+        assert_eq!(rejection(&["--max-alloc=64M"]), None);
+        assert_eq!(
+            ::protocol::effective_max_alloc(),
+            64 * 1024 * 1024,
+            "upstream: util2.c:75 - parsing the value is pointless unless it \
+             rewrites the ceiling my_alloc() consults",
+        );
+        ::protocol::set_max_alloc(restore);
+
+        assert_eq!(rejection(&["--delete"]), None);
+    }
+}

--- a/crates/protocol/src/max_alloc.rs
+++ b/crates/protocol/src/max_alloc.rs
@@ -30,6 +30,71 @@ pub const DEFAULT_MAX_ALLOC: usize = 1024 * 1024 * 1024;
 /// [`set_max_alloc`] runs during option processing.
 static MAX_ALLOC: AtomicUsize = AtomicUsize::new(DEFAULT_MAX_ALLOC);
 
+/// Smallest `--max-alloc` upstream's `parse_size_arg` accepts.
+///
+/// upstream: `options.c:2067` passes `min_value = 1024*1024` to
+/// `parse_size_arg(max_alloc_arg, 'B', "max-alloc", 1024*1024, -1, True)`.
+pub const MIN_MAX_ALLOC: u64 = 1024 * 1024;
+
+/// Largest `--max-alloc` oc accepts.
+///
+/// An oc-specific overflow guard with no upstream counterpart: upstream stores
+/// the value in a `size_t` and imposes no ceiling, while oc must keep the value
+/// multipliable inside `u64` at the decode sites that scale it.
+pub const MAX_ALLOC_CEILING: u64 = u64::MAX / 4;
+
+/// Error text for `--max-alloc=0`, byte-for-byte upstream's message.
+///
+/// upstream: `options.c:2071` - `snprintf(err_buf, sizeof err_buf,
+/// "max-alloc must be greater than zero\n")`.
+pub const ZERO_REJECTED: &str = "max-alloc must be greater than zero";
+
+/// Applies upstream's three `--max-alloc` value rules to an already-parsed
+/// byte count, returning the message upstream emits on each rejection.
+///
+/// This is the ONE owner of the rules. Both decode paths reach a peer-supplied
+/// `--max-alloc`: the client's own CLI, and the `--server` / daemon argv
+/// parsers that read what a peer forwarded. Upstream runs the identical block
+/// in `parse_arguments()` regardless of which end is executing it
+/// (`options.c:2065-2074`), so the rules must not be restated per caller -
+/// a caller that omits the zero check hands a peer the ability to disable the
+/// `my_alloc()` ceiling (CVE-2026-53794).
+///
+/// `display` is the operator's spelling of the value, used only to render the
+/// two size diagnostics the way upstream's `parse_size_arg` does.
+///
+/// # Errors
+///
+/// Returns upstream's diagnostic text when the value is zero, below
+/// [`MIN_MAX_ALLOC`], or above [`MAX_ALLOC_CEILING`].
+pub fn validate_max_alloc(limit: u64, display: &str) -> Result<u64, String> {
+    // upstream: options.c:2069-2072 - `if (size == 0) { ... "max-alloc must be
+    // greater than zero\n"); goto cleanup; }`. Zero used to mean SIZE_MAX,
+    // which disabled the guard outright; 3.5.0 removed that escape hatch
+    // because the value also arrives from a peer.
+    if limit == 0 {
+        return Err(ZERO_REJECTED.to_owned());
+    }
+
+    // upstream: options.c:2067 + :1250-1259 - parse_size_arg rejects a value
+    // below the 1 MiB minimum. do_big_num renders the constant as "1.00M";
+    // 3.5.0 left the "or 0 for unlimited" clause in place even though zero is
+    // now refused by the caller, so the text is mirrored verbatim.
+    if limit < MIN_MAX_ALLOC {
+        return Err(format!(
+            "--max-alloc={display} is too small (min: 1.00M or 0 for unlimited)"
+        ));
+    }
+
+    if limit > MAX_ALLOC_CEILING {
+        return Err(format!(
+            "invalid --max-alloc '{display}': size exceeds the supported range"
+        ));
+    }
+
+    Ok(limit)
+}
+
 /// Sets the process-wide `--max-alloc` ceiling in bytes.
 ///
 /// Called once during option processing by whichever side owns the receive


### PR DESCRIPTION
oc's daemon had **no `--max-alloc` arm at all**. The option fell off the end of
the long-form chain and was **silently ignored** — neither applied nor refused.

Upstream's daemon runs the *same* `parse_arguments()` block the client does, so
a peer-forwarded value is parsed, applied, and — since 3.5.0 — refused when it
is zero (`options.c:2065-2074`). An older client that predates that refusal
still forwards `--max-alloc=0` on the wire, and oc served it.

## How it surfaced

Master's nightly **`Upstream Testsuite 3.5.0 (root, tcp)`** went red on exactly
one cell:

```
daemon-max-alloc-zero: expected skip, got fail
  ----- daemon-max-alloc-zero log follows
  daemon accepted a wire-supplied --max-alloc=0
```

That leg sets `legacy_oracles: 'on'`, which builds `old_versions/rsync_3.2.7` —
the older client the cell drives. So the cell stopped skipping and started
**asserting**. The workflow's own comment predicted the row would move; what it
found was a real gap, not just a manifest delta.

## One owner for the rules, two front ends

`protocol::max_alloc::validate_max_alloc` now owns the three value rules (zero /
below 1 MiB / above oc's overflow ceiling) and their diagnostics. Upstream runs
**one** `parse_arguments()` body regardless of which end executes it, so
restating the rules per caller is precisely how one of them ends up missing the
zero check. `protocol::max_alloc` already owned the ceiling
(`set_max_alloc`/`effective_max_alloc`), and both callers already depend on it.

The two callers keep their own **front ends**, because their inputs differ:

| caller | input | rejection shape |
|---|---|---|
| CLI | `OsStr` argv value | client-role `Message` |
| daemon | raw wire string, `parse_size_arg(text, b'B')` (upstream's def_suf at `options.c:2067`) | `ClientArgRejection::InvalidValue` → `@ERROR` |

An empty forwarded value maps to `"0"` before validation: upstream's digit scan
leaves the cursor on the terminator and `strtod("")` gives 0
(`options.c:1172-1175`), so `--max-alloc=` takes the **zero** refusal rather
than a parse error. Same per-option placement as the existing
`--max-size`/`--min-size` arm — deliberately not folded into the shared string
parser.

## Applying the value is half the arm

A legitimate forwarded value now calls `set_max_alloc`, the global `my_alloc()`
consults (`util2.c:75`). Parsing a value the daemon then discards would leave
the ceiling at its default while reporting success — the same silence in a
different shape.

## Verification

- **Four daemon tests, all mutation-lethal.** With the arm's prefix changed so
  nothing matches it — the exact pre-fix state — all four fail: three because
  the refusal disappears, the fourth because `effective_max_alloc()` no longer
  moves. Restored: 4/4.
- **Non-vacuity from both directions.** `--max-alloc=64M` is accepted *and
  observed in the ceiling*; an argv without the option is accepted. So the
  refusals are attributable to the value, not to the harness.
- **The CLI refactor is behaviour-neutral by measurement.** Its 77 existing
  max-alloc assertions — including the byte-for-byte upstream texts for zero,
  too-small and the ceiling — pass unchanged against the shared owner, and now
  import that owner's constants so a change there cannot leave a stale copy
  asserting an old bound.
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets
  --all-features --no-deps -- -D warnings` clean; protocol + daemon + cli
  **11731/11731**, 11 skipped.
- ⚠ The cli integration cells report a cascade of ~0.02s failures unless
  `-p bin --bin oc-rsync` is built first. The binary is load-bearing for that
  suite; the first run's "failures" were that cascade, not a regression.

## Follow-up, filed not fixed

`tools/ci/upstream-3.5.0-expect.root.tcp.txt` is shared by two legs that run
with **different** `LEGACY_ORACLES` settings — `ci.yml`'s PR caller (default
`off`, where the cell SKIPS) and the nightly badge workflow (`on`, where it
RUNS). One manifest cannot describe both oracle configurations, so that leg
needs its own manifest generated from an executed run. This PR makes the cell
*pass* rather than fail; the manifest axis is a separate, CI-structural change.
