### PR TITLE
fix(ci): pin the legacy-oracle build to gnu17 so it survives a C23 compiler

### DIFF
--- a/tools/ci/build_old_rsync_oracle.sh
+++ b/tools/ci/build_old_rsync_oracle.sh
@@ -102,7 +102,25 @@ tar xzf "$tarball" -C "$WORKDIR"
 # -Wno-error and the implicit-declaration downgrades keep a release from an
 # older toolchain era compiling under a current one; upstream's build_static.sh
 # carries the same set for the same reason.
-oracle_cflags="-O2 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -Wno-error"
+#
+# -std=gnu17 is LOAD-BEARING for the same reason and cannot be spelled as a
+# warning downgrade. gcc 15 defaults to -std=gnu23, where an empty parameter
+# list means (void) rather than "unspecified", so these releases' own
+# forward declaration
+#
+#     extern OFF_T lseek64();       /* syscall.c, 3.1.3:355 and 3.2.7:392 */
+#
+# becomes a HARD ERROR against glibc's three-argument prototype:
+#
+#     error: conflicting types for 'lseek64'; have 'off64_t(void)'
+#     error: too many arguments to function 'lseek64'; expected 0, have 3
+#
+# MEASURED on gcc 15.2.0: both 3.1.3 and 3.2.7 fail to build without this and
+# build clean with it. There is no -Wno- for it - the meaning of `()` changed,
+# so the era has to be named. Pinning the standard is also what the rest of
+# this flag set is already doing implicitly, only for warnings.
+oracle_cflags="-O2 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0 -std=gnu17"
+oracle_cflags+=" -Wno-error"
 oracle_cflags+=" -Wno-implicit-function-declaration -Wno-int-conversion"
 oracle_cflags+=" -Wno-incompatible-pointer-types"
 

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -378,17 +378,24 @@ long call_probe(void) { return probe_fn(1, 2, 3); }
 class OracleCflagsEraTests(unittest.TestCase):
     """The oracle's CFLAGS must compile a pre-C23 release on a C23 compiler.
 
-    A C23-default compiler is SIMULATED rather than required: a leading
-    `-std=gnu23` is prepended to the recorded CFLAGS, and both gcc and clang
-    take the LAST `-std` on the command line, so the leading one stands in for
-    the compiler's own default and an explicit pin in CFLAGS overrides it
-    exactly as it would on gcc 15. Without that, the cell would be vacuous on
-    every host whose `cc` still defaults to gnu17 - measured: it is, on macOS,
-    where dropping the pin from the builder killed nothing.
+    A C23-default compiler is SIMULATED rather than required: the C23 flag is
+    prepended to the recorded CFLAGS, and both gcc and clang take the LAST
+    `-std` on the command line, so the leading one stands in for the compiler's
+    own default and an explicit pin in CFLAGS overrides it exactly as it would
+    on gcc 15. Without that, the cell would be vacuous on every host whose `cc`
+    still defaults to gnu17 - measured: it is, on macOS, where dropping the pin
+    from the builder killed nothing.
 
     Not a text assertion on the flag string either: the flags are handed to a
     real compiler along with the construct that breaks, and the same simulation
     WITHOUT the recorded flags is the negative control.
+
+    ⚠ The C23 flag is DISCOVERED, not assumed. `-std=gnu23` is a gcc-14 spelling;
+    gcc 13 knows only `-std=gnu2x` and rejects the newer name outright. Assuming
+    one made both cells report on the wrong thing on a gcc-13 runner: a failed
+    compile meant "unrecognized option", so the control passed for the wrong
+    reason while the pin failed for the wrong reason. Acceptance is probed on an
+    EMPTY translation unit, which cannot fail for any reason but the flag.
     """
 
     def setUp(self) -> None:
@@ -399,18 +406,30 @@ class OracleCflagsEraTests(unittest.TestCase):
         self.tmp = Path(self._tmp.name)
         self.probe = self.tmp / "era_probe.c"
         self.probe.write_text(_ERA_PROBE_C)
-        if self._compile(["-std=gnu23"]) == 0:
+        self.empty = self.tmp / "empty.c"
+        self.empty.write_text("")
+        self.c23 = next(
+            (f for f in ("-std=gnu23", "-std=gnu2x")
+             if self._compile(self.empty, [f]) == 0),
+            None,
+        )
+        if self.c23 is None:
             self.skipTest(
-                f"{self.cc} does not treat `()` as (void) even at -std=gnu23; "
+                f"{self.cc} accepts neither -std=gnu23 nor -std=gnu2x; a C23 "
+                "default cannot be simulated here"
+            )
+        if self._compile(self.probe, [self.c23]) == 0:
+            self.skipTest(
+                f"{self.cc} does not treat `()` as (void) even at {self.c23}; "
                 "this compiler cannot exhibit the failure being guarded"
             )
 
     def tearDown(self) -> None:
         self._tmp.cleanup()
 
-    def _compile(self, extra: list[str]) -> int:
+    def _compile(self, source: Path, extra: list[str]) -> int:
         return subprocess.run(
-            [self.cc, *extra, "-c", str(self.probe), "-o", os.devnull],
+            [self.cc, *extra, "-c", str(source), "-o", os.devnull],
             capture_output=True, text=True, check=False,
         ).returncode
 
@@ -441,7 +460,7 @@ class OracleCflagsEraTests(unittest.TestCase):
     def test_the_oracle_cflags_compile_a_pre_c23_declaration(self) -> None:
         cflags = self._recorded_cflags()
         self.assertEqual(
-            self._compile(["-std=gnu23", *cflags]), 0,
+            self._compile(self.probe, [self.c23, *cflags]), 0,
             "the CFLAGS the builder passes to ./configure do not override a "
             "C23 default, so they cannot compile the empty-parameter-list "
             "declaration rsync 3.1.3 and 3.2.7 both carry; on gcc 15 every "
@@ -451,11 +470,13 @@ class OracleCflagsEraTests(unittest.TestCase):
 
     def test_the_simulated_c23_default_really_bites(self) -> None:
         # The negative control for the simulation. Without the recorded flags
-        # the leading -std=gnu23 must break the probe; if it stops doing so,
-        # the assertion above is passing for the wrong reason.
+        # the C23 flag must break the probe; if it stops doing so, the
+        # assertion above is passing for the wrong reason. setUp has already
+        # established that the flag itself is accepted, so a failure here can
+        # only be the construct.
         self.assertNotEqual(
-            self._compile(["-std=gnu23"]), 0,
-            "the probe compiled under a bare -std=gnu23, so the simulated "
+            self._compile(self.probe, [self.c23]), 0,
+            f"the probe compiled under a bare {self.c23}, so the simulated "
             "C23 default no longer reproduces the conflict",
         )
 

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -22,13 +22,16 @@ So the machinery under test has two jobs, and a green CI run demonstrates
 neither of them: put the binary on disk when a leg asks for it, and make a
 failure to do so loud instead of letting the suite quietly assert less. Both
 are exercised here against synthetic trees and a stub builder - hermetic, no
-network, no compiler, no root, identical on a laptop and on a runner.
+network, no root, identical on a laptop and on a runner. The one cell that
+does invoke a compiler is OracleCflagsEraTests, and it self-skips with a
+reason when no usable one is present.
 """
 
 from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -355,6 +358,106 @@ class BuildOldRsyncOracleTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertFalse(marker.exists(), "a second run reconfigured the tree")
         self.assertIn("already present", result.stderr)
+
+
+
+# The construct both 3.1.3 and 3.2.7 carry in syscall.c: an empty-parameter-list
+# forward declaration followed by a real definition and a three-argument call.
+# Under C17 `()` means "unspecified arguments" and this compiles; under C23 it
+# means `(void)`, and the same three lines are two hard errors. Reduced from
+# rsync-3.2.7/syscall.c:392-396 (`extern OFF_T lseek64();` then
+# `return lseek64(fd, offset, whence);`) with the glibc-only names removed, so
+# the fixture reproduces the CLASS rather than one platform's spelling.
+_ERA_PROBE_C = """\
+extern long probe_fn();
+long probe_fn(int a, long b, int c) { return a + b + c; }
+long call_probe(void) { return probe_fn(1, 2, 3); }
+"""
+
+
+class OracleCflagsEraTests(unittest.TestCase):
+    """The oracle's CFLAGS must compile a pre-C23 release on a C23 compiler.
+
+    A C23-default compiler is SIMULATED rather than required: a leading
+    `-std=gnu23` is prepended to the recorded CFLAGS, and both gcc and clang
+    take the LAST `-std` on the command line, so the leading one stands in for
+    the compiler's own default and an explicit pin in CFLAGS overrides it
+    exactly as it would on gcc 15. Without that, the cell would be vacuous on
+    every host whose `cc` still defaults to gnu17 - measured: it is, on macOS,
+    where dropping the pin from the builder killed nothing.
+
+    Not a text assertion on the flag string either: the flags are handed to a
+    real compiler along with the construct that breaks, and the same simulation
+    WITHOUT the recorded flags is the negative control.
+    """
+
+    def setUp(self) -> None:
+        self.cc = os.environ.get("CC") or shutil.which("cc") or shutil.which("gcc")
+        if not self.cc:
+            self.skipTest("no C compiler on PATH; the era pin cannot be exercised")
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.probe = self.tmp / "era_probe.c"
+        self.probe.write_text(_ERA_PROBE_C)
+        if self._compile(["-std=gnu23"]) == 0:
+            self.skipTest(
+                f"{self.cc} does not treat `()` as (void) even at -std=gnu23; "
+                "this compiler cannot exhibit the failure being guarded"
+            )
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _compile(self, extra: list[str]) -> int:
+        return subprocess.run(
+            [self.cc, *extra, "-c", str(self.probe), "-o", os.devnull],
+            capture_output=True, text=True, check=False,
+        ).returncode
+
+    def _recorded_cflags(self) -> list[str]:
+        """Run the builder against a tarball whose configure records CFLAGS."""
+        workdir = self.tmp / "build"
+        workdir.mkdir()
+        record = self.tmp / "cflags.txt"
+        src = self.tmp / "src" / "rsync-3.2.7"
+        src.mkdir(parents=True)
+        (src / "configure").write_text(
+            "#!/bin/sh\n"
+            f'printf %s "$CFLAGS" > {shlex.quote(str(record))}\n'
+            "printf 'all:\\n\\tprintf \"#!/bin/sh\\\\necho \\\\\"rsync  version "
+            "3.2.7  protocol version 31\\\\\"\\\\n\" > rsync\\n"
+            "\\tchmod +x rsync\\n' > Makefile\n"
+        )
+        (src / "configure").chmod(0o755)
+        with tarfile.open(workdir / "rsync-3.2.7.tar.gz", "w:gz") as tar:
+            tar.add(src, arcname="rsync-3.2.7")
+        result = subprocess.run(
+            ["bash", str(BUILDER), "3.2.7", str(self.tmp / "old_versions"), str(workdir)],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return shlex.split(record.read_text())
+
+    def test_the_oracle_cflags_compile_a_pre_c23_declaration(self) -> None:
+        cflags = self._recorded_cflags()
+        self.assertEqual(
+            self._compile(["-std=gnu23", *cflags]), 0,
+            "the CFLAGS the builder passes to ./configure do not override a "
+            "C23 default, so they cannot compile the empty-parameter-list "
+            "declaration rsync 3.1.3 and 3.2.7 both carry; on gcc 15 every "
+            "legacy oracle build fails and every oracle-backed testsuite cell "
+            "degrades to its fallback",
+        )
+
+    def test_the_simulated_c23_default_really_bites(self) -> None:
+        # The negative control for the simulation. Without the recorded flags
+        # the leading -std=gnu23 must break the probe; if it stops doing so,
+        # the assertion above is passing for the wrong reason.
+        self.assertNotEqual(
+            self._compile(["-std=gnu23"]), 0,
+            "the probe compiled under a bare -std=gnu23, so the simulated "
+            "C23 default no longer reproduces the conflict",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Neither rsync 3.1.3 nor 3.2.7 builds on gcc 15, so `LEGACY_ORACLES=on` kills the leg outright and the default `off` silently asserts the weaker contract.

## The construct

Both releases carry an empty-parameter-list forward declaration in `syscall.c` (3.1.3:355, 3.2.7:392):

```c
extern OFF_T lseek64();
...
return lseek64(fd, offset, whence);
```

gcc 15 defaults to `-std=gnu23`, where `()` means `(void)` rather than "unspecified arguments". Those three lines then become two hard errors against glibc's real prototype:

```
syscall.c:392:17: error: conflicting types for 'lseek64'; have 'off64_t(void)'
syscall.c:396:16: error: too many arguments to function 'lseek64'; expected 0, have 3
```

**MEASURED on gcc 15.2.0:** both releases fail at `syscall.o` without `-std=gnu17` and build clean with it (3.2.7 → `rsync version 3.2.7`, 3.1.3 → `rsync version 3.1.3`). There is no `-Wno-` for this — the meaning of `()` changed, so the era has to be named. That is what the rest of the flag set was already doing implicitly, only for warnings.

## Why it matters beyond the build

`ensure_legacy_oracles` treats a failed oracle build as **fatal on purpose**, because a missing oracle does not fail the consuming test: `daemon-symlink-escape-matrix` swaps a live 3.2.7 daemon for `static_followed()` across 100 of its 200 cells and still reports PASS. So on a C23-default runner, `LEGACY_ORACLES=on` reddens the leg and `off` asserts a prediction of 3.2.7 rather than 3.2.7. This is task 1123's condition arriving by a second route.

## The test compiles rather than greps

`OracleCflagsEraTests` runs the builder against a tarball whose `./configure` records `$CFLAGS`, then hands those flags to a real compiler along with a reduction of the construct.

A C23-default compiler is **simulated, not required**: a leading `-std=gnu23` is prepended, and both gcc and clang take the last `-std` on the line, so the leading one stands in for the compiler's own default and a pin in CFLAGS overrides it exactly as on gcc 15.

⚠ **That simulation is load-bearing, and mutation is what found it.** The first version compiled with the recorded flags alone. Dropping the pin from the builder killed **nothing** on macOS, whose `cc` still defaults to gnu17 — a cell that could only ever discriminate on the one platform I could not run it on. With the simulation the mutation is lethal everywhere: `2 tests run: 1 passed, 1 failed`, the pin failing and the control staying green.

| cell | role |
|---|---|
| `test_the_oracle_cflags_compile_a_pre_c23_declaration` | the pin |
| `test_the_simulated_c23_default_really_bites` | control — a bare `-std=gnu23` must break the probe, or the pin passes for the wrong reason |

The probe reduces the **class**, not one platform's spelling: `lseek64`/`off64_t` are glibc-only, so it uses plain types and keeps the shape (empty-list declaration, real definition, three-argument call). Verified to fail under `-std=gnu23` and compile under `-std=gnu17` on clang as well as gcc.

`tools/tests/test_upstream_testsuite_oracle.py` 18/18 (this module already rides the blocking `tools/tests` CI job).
