### PR TITLE
fix(flist): normalise the --relative operand name, carry name_type apart

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -109,10 +109,17 @@ impl GeneratorContext {
             } else {
                 non_relative_walk_base(base_path)
             };
+            // upstream: flist.c:2589-2657 - `name_type` is a SEPARATE local
+            // from `fbuf`. It is decided from the operand as typed and then
+            // survives the normalisation that strips the marker out of the
+            // transmitted name, which is why the follow at flist.c:2697 still
+            // fires for a `--relative` operand whose name is now marker-free.
+            // Read it from the raw operand for exactly that reason.
+            let operand_is_dotdir = operand_has_dotdir_marker(base_path);
             // upstream: flist.c:2254-2272 - pre-stat each top-level source and
             // apply missing_args handling. Separates "source never existed" from
             // "source vanished during recursive walk".
-            if !self.try_walk_source_entry(&base, &path)? {
+            if !self.try_walk_source_entry(&base, &path, operand_is_dotdir)? {
                 continue;
             }
             // upstream: flist.c:2368-2369 - the first operand whose relative
@@ -415,7 +422,13 @@ impl GeneratorContext {
             // upstream: options.c:2307-2308 - `if (files_from) { ... if
             // (xfer_dirs < 0) xfer_dirs = 1; }`. A --files-from run always
             // transfers directories, so the flist.c:2723 skip is inert here.
-            if !self.try_walk_source_entry_dedup(&entry.base, &entry.path, Some(&scoped), true)? {
+            if !self.try_walk_source_entry_dedup(
+                &entry.base,
+                &entry.path,
+                Some(&scoped),
+                true,
+                operand_has_dotdir_marker(&entry.path),
+            )? {
                 continue;
             }
 
@@ -566,6 +579,42 @@ pub(super) fn operand_has_dotdir_marker(path: &Path) -> bool {
     bytes == b"." || bytes.ends_with(b"/") || bytes.ends_with(b"/.")
 }
 
+/// Normalises a `--relative` operand into the name that rides the wire.
+///
+/// Upstream runs the operand through
+/// `clean_fname(fn, CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR)` and
+/// then strips the trailing `/` that flag deliberately left in place, keeping
+/// only the fact that it was there in `name_type`
+/// (`SLASH_ENDING_NAME` / `DOTDIR_NAME`). The marker is therefore never part of
+/// the transmitted name: `-R src/d/` and `-R src/d/.` both send `src/d`.
+///
+/// Leaving the marker in the name is not cosmetic. `src/d/` sorts AFTER its own
+/// child `src/d/f.txt` under `f_name_cmp`, so the receiver's generator walks the
+/// list in an order the sender never intended and the NDX echo desynchronises
+/// ("sender echoed NDX 4 but expected 2", exit 12). The `/.` spelling produces
+/// `src/d/./f.txt` names that only survive because the destination filesystem
+/// happens to collapse them.
+///
+/// `Path::components()` performs exactly the cleaning upstream's flags select:
+/// interior `.` components and redundant separators are dropped, a trailing `/`
+/// or `/.` disappears, and `..` is preserved verbatim (upstream rejects `..` in
+/// the active part of a relative path at `flist.c:2658-2668`).
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/flist.c:2642` - `len = clean_fname(fn, CFN_KEEP_TRAILING_SLASH
+///   | CFN_DROP_TRAILING_DOT_DIR);`
+/// - `rsync-3.5.0/flist.c:2651-2657` - `else if (fn[len-1] == '/') { fn[--len] =
+///   '\0'; ... name_type = SLASH_ENDING_NAME; }`
+fn clean_relative_name(path: &Path) -> PathBuf {
+    let cleaned: PathBuf = path.components().collect();
+    if cleaned.as_os_str().is_empty() {
+        path.to_path_buf()
+    } else {
+        cleaned
+    }
+}
+
 /// Splits a source path for `--relative` mode into (base, full path).
 ///
 /// Mirrors upstream rsync's `--relative` handling in `flist.c:2316-2350`:
@@ -592,16 +641,14 @@ fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
         } else {
             PathBuf::from(head)
         };
-        // upstream: flist.c:2670-2673 - an empty remainder is forced to "."
-        // with `name_type = DOTDIR_NAME`. Joining "." rather than reusing
-        // `base` keeps the DOTDIR marker on the walked path, and that marker is
-        // what drives the follow decision at flist.c:2697
-        // (`copy_dirlinks || name_type != NORMAL_NAME`). Dropping it makes
-        // `<dir>/./` lstat a symlinked operand and send it under its basename.
+        // upstream: flist.c:2670-2673 - an empty remainder is forced to `.`,
+        // which after the `chdir(dir)` IS the base directory. The DOTDIR
+        // marker that made it so does not travel in the name; it travels in
+        // `name_type`, which the caller reads off the raw operand.
         let full = if rest.is_empty() {
-            base.join(".")
+            base.clone()
         } else {
-            base.join(rest)
+            clean_relative_name(&base.join(rest))
         };
         return (base, full);
     }
@@ -614,7 +661,7 @@ fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
     } else {
         PathBuf::from(".")
     };
-    (base, path.to_path_buf())
+    (base, clean_relative_name(path))
 }
 
 /// Returns true when a positional operand carries a bare leading `./` anchor
@@ -693,6 +740,76 @@ fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
 
 #[cfg(test)]
 pub(super) use protocol::flist::apply_permutation_in_place;
+
+#[cfg(test)]
+mod relative_operand_name_tests {
+    use super::{operand_has_dotdir_marker, relative_walk_base};
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    /// upstream: flist.c:2642-2657 - the `--relative` transmitted name is
+    /// `clean_fname(fn, CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR)`
+    /// with the trailing `/` then stripped. The marker never travels in the
+    /// name; it travels in `name_type`.
+    ///
+    /// A name that keeps its marker (`src/d/`) sorts AFTER its own child
+    /// `src/d/f.txt` under `f_name_cmp`, which desynchronises the NDX stream
+    /// ("sender echoed NDX 4 but expected 2", exit 12). The `/.` spelling
+    /// leaks `src/d/./f.txt` names instead.
+    ///
+    /// ⚠ Compared as raw `OsStr` bytes, never as `Path`/`PathBuf`. `PathBuf`'s
+    /// `PartialEq` compares `components()`, under which `"src/d/"`,
+    /// `"src/d/."` and `"src/d"` are all EQUAL - the exact distinction this
+    /// test exists to make. A `PathBuf` comparison here passes even with the
+    /// normalisation deleted.
+    #[test]
+    fn relative_operand_name_drops_the_marker_upstream_normalises_away() {
+        // (operand, expected base, expected transmitted path)
+        let cases: [(&str, &str, &str); 8] = [
+            ("src/d", ".", "src/d"),
+            ("src/d/", ".", "src/d"),
+            ("src/d/.", ".", "src/d"),
+            ("/abs/d/", "/", "/abs/d"),
+            ("/abs/d/.", "/", "/abs/d"),
+            // A `/./` anchor splits first (flist.c:2623); the remainder is then
+            // normalised the same way.
+            ("src/./d/", "src", "src/d"),
+            ("src/./d/.", "src", "src/d"),
+            // An empty remainder is upstream's `fn = "."` after `chdir(dir)`,
+            // which IS the base directory (flist.c:2670-2673).
+            ("src/./", "src", "src"),
+        ];
+
+        for (operand, want_base, want_path) in cases {
+            let (base, path) = relative_walk_base(Path::new(operand));
+            assert_eq!(
+                (base.as_os_str(), path.as_os_str()),
+                (OsStr::new(want_base), OsStr::new(want_path)),
+                "relative_walk_base({operand:?})"
+            );
+        }
+    }
+
+    /// The marker survives the normalisation as a separate fact, read off the
+    /// operand as typed. This is upstream's `name_type != NORMAL_NAME`, the
+    /// second disjunct of the `link_stat` follow at flist.c:2697 - without it
+    /// the normalisation above would silently disarm the follow.
+    #[test]
+    fn the_marker_survives_the_normalisation_as_name_type() {
+        for yes in ["src/d/", "src/d/.", "src/./", "src/./d/", ".", "/"] {
+            assert!(
+                operand_has_dotdir_marker(Path::new(yes)),
+                "{yes:?} must count as name_type != NORMAL_NAME"
+            );
+        }
+        for no in ["src/d", "/abs/d", "src/./d", "d"] {
+            assert!(
+                !operand_has_dotdir_marker(Path::new(no)),
+                "{no:?} must count as NORMAL_NAME"
+            );
+        }
+    }
+}
 
 #[cfg(test)]
 mod implied_dot_tests {

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -598,7 +598,30 @@ pub(super) fn operand_has_dotdir_marker(path: &Path) -> bool {
 /// `Path::components()` performs exactly the cleaning upstream's flags select:
 /// interior `.` components and redundant separators are dropped, a trailing `/`
 /// or `/.` disappears, and `..` is preserved verbatim (upstream rejects `..` in
-/// the active part of a relative path at `flist.c:2658-2668`).
+/// the active part of a relative path at `flist.c:2658-2668`). It is also the
+/// only spelling that parses a Windows path PREFIX (`C:\`, `\\?\`, UNC)
+/// correctly; a hand-rolled byte scan for separators would corrupt those.
+///
+/// # Separators on Windows
+///
+/// `components().collect()` re-joins with the PLATFORM separator, so on Windows
+/// this returns `src\d` for `src/d/`. That is correct at this layer, and it is
+/// not a new condition: every recursive child name is built with
+/// `PathBuf::push`/`join`, which has appended `\` on Windows since long before
+/// this function existed (`src/d` + `f.txt` = `src/d\f.txt`). Nothing
+/// downstream reads the local separator - all three consumers normalise:
+///
+/// - the wire encoder: `FileListWriter::write_entry()` takes
+///   `FileEntry::name_bytes()` (`protocol/src/flist/write/mod.rs:470`), which
+///   is `wire_path::path_bytes_to_wire()` and folds `\` to `/`;
+/// - the sort that the NDX stream depends on: `sort.rs` and `name_cmp.rs`
+///   compare `name_bytes()` / `path_bytes_to_wire(dirname())`, so ordering is
+///   decided on `/`-separated bytes;
+/// - filter matching: `filters/src/compiled/pattern.rs:path_match_bytes()`
+///   folds `\` to `/` before `wildmatch()`.
+///
+/// The unit test therefore asserts the WIRE bytes, not the local `OsStr`: that
+/// is the invariant with meaning, and it holds identically on both platforms.
 ///
 /// # Upstream Reference
 ///
@@ -744,8 +767,21 @@ pub(super) use protocol::flist::apply_permutation_in_place;
 #[cfg(test)]
 mod relative_operand_name_tests {
     use super::{operand_has_dotdir_marker, relative_walk_base};
-    use std::ffi::OsStr;
-    use std::path::Path;
+    use protocol::flist::FileEntry;
+    use std::path::{Path, PathBuf};
+
+    /// The bytes `path` would contribute to a transmitted file-list name.
+    ///
+    /// Routed through the production encoder rather than a reimplementation:
+    /// `FileEntry::name_bytes()` is what `FileListWriter::write_entry()` calls
+    /// (`protocol/src/flist/write/mod.rs:470`), and it applies
+    /// `wire_path::path_bytes_to_wire()`. Asserting here rather than on the
+    /// local `OsStr` makes the expectation platform-independent AND pins the
+    /// byte that actually leaves the process.
+    fn wire_name(path: &Path) -> String {
+        let entry = FileEntry::new_file(PathBuf::from(path), 0, 0o644);
+        String::from_utf8_lossy(&entry.name_bytes()).into_owned()
+    }
 
     /// upstream: flist.c:2642-2657 - the `--relative` transmitted name is
     /// `clean_fname(fn, CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR)`
@@ -757,11 +793,21 @@ mod relative_operand_name_tests {
     /// ("sender echoed NDX 4 but expected 2", exit 12). The `/.` spelling
     /// leaks `src/d/./f.txt` names instead.
     ///
-    /// ⚠ Compared as raw `OsStr` bytes, never as `Path`/`PathBuf`. `PathBuf`'s
+    /// ⚠ Compared as wire BYTES, never as `Path`/`PathBuf`. `PathBuf`'s
     /// `PartialEq` compares `components()`, under which `"src/d/"`,
     /// `"src/d/."` and `"src/d"` are all EQUAL - the exact distinction this
     /// test exists to make. A `PathBuf` comparison here passes even with the
     /// normalisation deleted.
+    ///
+    /// ⚠ And compared as WIRE bytes, not local `OsStr` bytes. `clean_fname`'s
+    /// stand-in here is `Path::components().collect()`, which re-joins with the
+    /// PLATFORM separator - so on Windows the local `PathBuf` is `src\d` where
+    /// on Unix it is `src/d`. That difference is correct and invisible past this
+    /// layer (see `clean_relative_name`'s note on the three normalisation
+    /// boundaries); an `OsStr` expectation would be a platform-conditional
+    /// literal asserting the wrong thing. `wire_name()` asserts the byte the
+    /// peer actually reads, identically on both platforms, and still
+    /// discriminates: `src/d/` encodes as `b"src/d/"`, not `b"src/d"`.
     #[test]
     fn relative_operand_name_drops_the_marker_upstream_normalises_away() {
         // (operand, expected base, expected transmitted path)
@@ -783,9 +829,9 @@ mod relative_operand_name_tests {
         for (operand, want_base, want_path) in cases {
             let (base, path) = relative_walk_base(Path::new(operand));
             assert_eq!(
-                (base.as_os_str(), path.as_os_str()),
-                (OsStr::new(want_base), OsStr::new(want_path)),
-                "relative_walk_base({operand:?})"
+                (wire_name(&base), wire_name(&path)),
+                (want_base.to_owned(), want_path.to_owned()),
+                "relative_walk_base({operand:?}); local paths were ({base:?}, {path:?})"
             );
         }
     }

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -167,6 +167,11 @@ impl GeneratorContext {
     /// (upstream `link_stat ... failed`, exit 23), while a missing recursive
     /// child is "vanished during walk" (upstream `file has vanished`, exit 24).
     ///
+    /// `is_dotdir` is upstream's `name_type != NORMAL_NAME` for this operand.
+    /// It is a caller-supplied fact rather than something re-derived from
+    /// `path`, because `--relative` strips the marker out of the transmitted
+    /// name (`flist.c:2651-2657`) while keeping its effect on the follow.
+    ///
     /// # Upstream Reference
     ///
     /// - `flist.c:2254-2272` - `link_stat` + `missing_args` handling per source
@@ -174,6 +179,7 @@ impl GeneratorContext {
         &mut self,
         base: &Path,
         path: &Path,
+        is_dotdir: bool,
     ) -> io::Result<bool> {
         // upstream: options.c:2314-2320 - `xfer_dirs` resolves to `-d`, or `-r`
         // (`else if (recurse) xfer_dirs = 1`), or `list_only` when neither was
@@ -181,7 +187,7 @@ impl GeneratorContext {
         // why `build_file_list_with_base` passes `true` instead of this.
         let xfer_dirs =
             self.config.flags.recursive || self.config.flags.dirs || self.config.flags.list_only;
-        self.try_walk_source_entry_dedup(base, path, None, xfer_dirs)
+        self.try_walk_source_entry_dedup(base, path, None, xfer_dirs, is_dotdir)
     }
 
     /// Upstream's `xfer_dirs` gate on a top-level directory argument.
@@ -258,6 +264,7 @@ impl GeneratorContext {
         path: &Path,
         emitted_dirs: Option<&HashSet<PathBuf>>,
         xfer_dirs: bool,
+        is_dotdir: bool,
     ) -> io::Result<bool> {
         // Record the transfer root so per-directory merge files re-anchor their
         // leading-`/` rules to the merge file's own directory (upstream
@@ -272,7 +279,7 @@ impl GeneratorContext {
         // upstream: flist.c:2425 - link_stat() once, then pass &st to
         // send_file_name(). Reuse the metadata to avoid a redundant stat
         // inside walk_path_with_metadata.
-        match self.resolve_symlink_metadata(path, base) {
+        match self.resolve_symlink_metadata(path, base, is_dotdir) {
             Ok(metadata) => {
                 // upstream: flist.c:2723-2726 - a directory argument is dropped
                 // before any implied parent is emitted when `xfer_dirs` is off.
@@ -907,6 +914,12 @@ impl GeneratorContext {
     /// stat re-walks the module's ancestors as the dropped uid and `EACCES`es
     /// on an unsearchable one.
     ///
+    /// `is_dotdir` is upstream's `name_type != NORMAL_NAME` for this operand,
+    /// supplied by the caller. It cannot be re-derived from `path` here: the
+    /// `--relative` operand split already normalised the marker out of the name
+    /// (`flist.c:2651-2657`), which is precisely the step that keeps `name_type`
+    /// and `fbuf` separate upstream.
+    ///
     /// # Upstream Reference
     ///
     /// - `flist.c:217-244` - `readlink_stat()`
@@ -916,15 +929,15 @@ impl GeneratorContext {
         &self,
         path: &Path,
         base: &Path,
+        is_dotdir: bool,
     ) -> io::Result<std::fs::Metadata> {
         // upstream: flist.c:readlink_stat() operates on paths without the
         // DOTDIR marker. On Linux, lstat("path/") follows symlinks because the
         // kernel resolves the trailing slash, making a symlink appear as its
         // target directory - so the marker must be stripped before the stat to
-        // get a decision that is the same on every platform. Capture whether it
-        // was there FIRST: the marker is not noise to discard, it is upstream's
-        // `name_type`, and the follow decision below depends on it.
-        let is_dotdir = super::operand_has_dotdir_marker(path);
+        // get a decision that is the same on every platform. The marker itself
+        // is not noise to discard: it is upstream's `name_type`, and the follow
+        // decision below depends on the `is_dotdir` the caller passed in.
         let normalized: PathBuf;
         let path = {
             let bytes = path.as_os_str().as_encoded_bytes();

--- a/crates/transfer/tests/uts_relative_slash_ending_operand_name.rs
+++ b/crates/transfer/tests/uts_relative_slash_ending_operand_name.rs
@@ -1,0 +1,252 @@
+//! A `--relative` operand's DOTDIR marker must not ride along in its NAME.
+//!
+//! Upstream keeps two things apart that are easy to fuse. The transmitted name
+//! is `clean_fname(fn, CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR)`
+//! with the trailing `/` then stripped (`flist.c:2642-2657`); the fact that a
+//! marker was there survives only in `name_type`, which is what makes
+//! `link_stat()` follow a symlinked operand at `flist.c:2697`. So `-R src/d`,
+//! `-R src/d/` and `-R src/d/.` all put the SAME names on the wire, and
+//! `-R sym/` differs from `-R sym` only in that the symlink is followed.
+//!
+//! Leaving the marker in the name is not cosmetic: `src/d/` sorts AFTER its own
+//! child `src/d/f.txt` under `f_name_cmp`, so the receiver's generator sees an
+//! order the sender never intended and the NDX echo desynchronises. Measured on
+//! oc-rsync before this pin: `oc-rsync -aR src/d/ h:dst/` died with
+//! "sender echoed NDX 4 but expected 2 - protocol violation (code 12)" and left
+//! `f.txt` untransferred. The `/.` spelling emitted `src/d/./f.txt` names that
+//! only landed correctly because the destination filesystem collapses them.
+//!
+//! ⚠ These cells use ABSOLUTE operands, so the `--relative` base is `/` and
+//! `strip_prefix` against it re-slices through `Components`, which absorbs a
+//! trailing `/` on its own. The trailing-slash spelling is therefore NOT
+//! discriminating here - it is pinned byte-exactly by
+//! `generator::file_list::relative_operand_name_tests` instead. What these cells
+//! do pin is the `/.` spelling, which `Components` does not absorb, plus the
+//! follow decision in both directions.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/flist.c:2642` - `len = clean_fname(fn,
+//!   CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR);`
+//! - `rsync-3.5.0/flist.c:2651-2657` - `else if (fn[len-1] == '/') {
+//!   fn[--len] = '\0'; ... name_type = SLASH_ENDING_NAME; }`
+//! - `rsync-3.5.0/flist.c:2697` - `link_stat(fbuf, &st, copy_dirlinks ||
+//!   name_type != NORMAL_NAME)` - the marker's surviving effect.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileType;
+use transfer::{
+    GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
+};
+
+fn generator_config(operand: &Path) -> ServerConfig {
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        "-rR.iLsfxCIvu".to_owned(),
+        vec![operand.to_path_buf().into_os_string()],
+    )
+    .expect("server config");
+    config.connection.client_mode = true;
+    assert!(config.flags.relative, "-R must parse as --relative");
+    assert!(
+        !config.flags.copy_dirlinks,
+        "the follow must come from the operand marker, not from -k"
+    );
+    assert!(!config.flags.copy_links, "-L would follow every symlink");
+    config
+}
+
+fn test_handshake() -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: true,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+fn test_pipeline() -> TransferPipeline {
+    let mut pipeline = TransferPipeline::new(ServerRole::Generator);
+    pipeline
+        .advance_to(TransferPhase::FilterExchange)
+        .expect("advance to FilterExchange");
+    pipeline
+        .advance_to(TransferPhase::FileListTransfer)
+        .expect("advance to FileListTransfer");
+    pipeline
+}
+
+/// `<scratch>/realdir/{f.txt,sub/g.txt}` plus `<scratch>/symdir -> realdir`.
+fn build_source_tree(scratch: &TempDir) {
+    let realdir = scratch.path().join("realdir");
+    fs::create_dir_all(realdir.join("sub")).expect("mkdir realdir/sub");
+    fs::write(realdir.join("f.txt"), b"payload").expect("write realdir/f.txt");
+    fs::write(realdir.join("sub/g.txt"), b"deeper").expect("write realdir/sub/g.txt");
+    symlink("realdir", scratch.path().join("symdir")).expect("plant symdir -> realdir");
+}
+
+/// Builds the flist for `operand` and returns the transmitted names that live
+/// under `scratch`, in wire order, paired with their file types.
+///
+/// Names above the scratch directory are the operand's implied parents
+/// (`flist.c:1937 send_implied_dirs()`); they are identical for every shape
+/// under test and would only bury the rows that differ.
+fn scoped_flist(scratch: &TempDir, operand: &Path) -> Vec<(String, FileType)> {
+    let config = generator_config(operand);
+    let mut ctx = GeneratorContext::new(&test_handshake(), config, test_pipeline());
+    ctx.build_file_list(&[operand.to_path_buf()])
+        .expect("build_file_list");
+
+    // The receiver strips the leading `/` (flist.c:3071), so the sender's names
+    // are the absolute path minus its root.
+    let root = scratch
+        .path()
+        .to_str()
+        .expect("scratch path is utf-8")
+        .trim_start_matches('/')
+        .to_owned();
+    let prefix = format!("{root}/");
+    ctx.file_list()
+        .iter()
+        .filter_map(|e| {
+            e.name()
+                .strip_prefix(&prefix)
+                .map(|rest| (rest.to_owned(), e.file_type()))
+        })
+        .collect()
+}
+
+fn names_of(rows: &[(String, FileType)]) -> Vec<&str> {
+    rows.iter().map(|(n, _)| n.as_str()).collect()
+}
+
+/// The three spellings of a real directory operand are indistinguishable on the
+/// wire, and none of them may carry a marker in a name.
+#[test]
+fn relative_directory_operand_sends_the_same_names_for_every_spelling() {
+    let expected = [
+        "realdir",
+        "realdir/f.txt",
+        "realdir/sub",
+        "realdir/sub/g.txt",
+    ];
+
+    let mut report = Vec::new();
+    let mut failed = false;
+    for suffix in ["", "/", "/."] {
+        let scratch = TempDir::new().expect("tempdir");
+        build_source_tree(&scratch);
+        let operand = PathBuf::from(format!("{}/realdir{suffix}", scratch.path().display()));
+
+        let rows = scoped_flist(&scratch, &operand);
+        let got = names_of(&rows);
+        let row_ok = got == expected;
+        failed |= !row_ok;
+        report.push(format!(
+            "  realdir{suffix:<2} [{}] left: {got:?}\n              right: {expected:?}",
+            if row_ok { "pass" } else { "FAIL" },
+        ));
+    }
+
+    assert!(
+        !failed,
+        "`-R <dir>`, `-R <dir>/` and `-R <dir>/.` must transmit identical \
+         names: upstream normalises the operand at flist.c:2642-2657 and keeps \
+         the marker in `name_type`, never in the name:\n{}",
+        report.join("\n"),
+    );
+}
+
+/// No transmitted name may contain a `/` run, an interior `.` component, or a
+/// trailing separator - the shapes `clean_fname()` exists to remove.
+#[test]
+fn relative_operand_names_are_clean_fname_normalised() {
+    let mut report = Vec::new();
+    let mut failed = false;
+    for base in ["realdir", "symdir"] {
+        for suffix in ["", "/", "/."] {
+            let scratch = TempDir::new().expect("tempdir");
+            build_source_tree(&scratch);
+            let operand = PathBuf::from(format!("{}/{base}{suffix}", scratch.path().display()));
+
+            let rows = scoped_flist(&scratch, &operand);
+            let dirty: Vec<&str> = names_of(&rows)
+                .into_iter()
+                .filter(|n| {
+                    n.contains("//") || n.contains("/./") || n.ends_with('/') || n.ends_with("/.")
+                })
+                .collect();
+            failed |= !dirty.is_empty();
+            report.push(format!(
+                "  {base}{suffix:<2} [{}] unnormalised: {dirty:?} (all: {:?})",
+                if dirty.is_empty() { "pass" } else { "FAIL" },
+                names_of(&rows),
+            ));
+        }
+    }
+
+    assert!(
+        !failed,
+        "a `--relative` operand's DOTDIR marker must be normalised out of every \
+         transmitted name (upstream flist.c:2642-2657); a name that keeps it \
+         sorts against its own children and desynchronises the NDX \
+         stream:\n{}",
+        report.join("\n"),
+    );
+}
+
+/// The marker still decides FOLLOW vs LSTAT. `symdir` stays a symlink;
+/// `symdir/` and `symdir/.` become the directory whose contents they name,
+/// under the operand's own name rather than `realdir`.
+#[test]
+fn relative_symlink_operand_follows_only_with_the_marker() {
+    // (suffix, is the operand expected to be sent as a symlink)
+    let cases: [(&str, bool); 3] = [("", true), ("/", false), ("/.", false)];
+
+    let mut report = Vec::new();
+    let mut failed = false;
+    for (suffix, want_symlink) in cases {
+        let scratch = TempDir::new().expect("tempdir");
+        build_source_tree(&scratch);
+        let operand = PathBuf::from(format!("{}/symdir{suffix}", scratch.path().display()));
+
+        let rows = scoped_flist(&scratch, &operand);
+        let got = names_of(&rows);
+        let expected: Vec<&str> = if want_symlink {
+            vec!["symdir"]
+        } else {
+            vec!["symdir", "symdir/f.txt", "symdir/sub", "symdir/sub/g.txt"]
+        };
+        let sent_as_symlink = rows
+            .iter()
+            .any(|(n, ty)| n == "symdir" && *ty == FileType::Symlink);
+
+        let row_ok = got == expected && sent_as_symlink == want_symlink;
+        failed |= !row_ok;
+        report.push(format!(
+            "  symdir{suffix:<2} [{}] symlink={sent_as_symlink} (want {want_symlink})\n \
+             left: {got:?}\n            right: {expected:?}",
+            if row_ok { "pass" } else { "FAIL" },
+        ));
+    }
+
+    assert!(
+        !failed,
+        "the DOTDIR/SLASH_ENDING marker, and only it, decides whether a \
+         `--relative` symlink operand is followed (upstream flist.c:2697); the \
+         followed contents still ride under the operand's own name:\n{}",
+        report.join("\n"),
+    );
+}


### PR DESCRIPTION
## The filed diagnosis was wrong; the conclusion was in the right neighbourhood

The task on file read: *the sender drops the DOTDIR marker, so a trailing-slash
operand naming a symlink-to-directory (`sym-to-dir/`) is `lstat`'d as a symlink
instead of being followed as a directory.*

**That does not reproduce on master.** The DOTDIR follow is already wired, and
deliberately so - `file_list/walk.rs:resolve_symlink_metadata` carries upstream's
second `follow_dirlinks` disjunct (`flist.c:2697`, `copy_dirlinks || name_type !=
NORMAL_NAME`) with an ownership gate on the DOTDIR half. Measured across 24
local-copy cells (three operand shapes x eight option sets), oc matched rsync
3.5.0 exactly.

What the operand-shape sweep *did* surface, once it was run over the wire instead
of through the local-copy engine, is a different defect at a nearby site: **the
`--relative` operand split never applies upstream's `clean_fname()`
normalisation, so the DOTDIR marker rides along inside the transmitted name.**
That is a hard failure, and it is not symlink-specific.

```
$ oc-rsync -aR -e <rsh> src/d/ h:dst/
oc-rsync error: server error: sender echoed NDX 4 but expected 2 - protocol violation (code 12)
oc-rsync error: transfer failed: multiplexed frame truncated: expected 4 bytes but received 0 (code 12)
```

## Upstream

Upstream keeps two things apart that oc had fused. `flist.c:2640-2657`:

```c
len = clean_fname(fn, CFN_KEEP_TRAILING_SLASH | CFN_DROP_TRAILING_DOT_DIR);
if (len == 1) {
        if (fn[0] == '/') { fn = "/."; len = 2; name_type = DOTDIR_NAME; }
        else if (fn[0] == '.') name_type = DOTDIR_NAME;
} else if (fn[len-1] == '/') {
        fn[--len] = '\0';
        if (len == 1 && *fn == '.') name_type = DOTDIR_NAME;
        else name_type = SLASH_ENDING_NAME;
}
```

`CFN_KEEP_TRAILING_SLASH` keeps the marker only long enough for the very next
line to *read* it and then delete it. The name that goes on the wire is
marker-free; the marker survives as `name_type`, a separate local, and its one
surviving job is the follow at `flist.c:2697`:

```c
if (link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME) != 0
```

So `-R src/d`, `-R src/d/` and `-R src/d/.` transmit *identical* names, and
`-R sym/` differs from `-R sym` only in that the symlink is followed. Confirmed
against the 3.5.0 binary, not read off the source (table below).

`clean_fname()` itself is `util1.c:1037-1112`; `CFN_DROP_TRAILING_DOT_DIR` is the
`if (f[1] == '\0' && flags & CFN_DROP_TRAILING_DOT_DIR) break;` arm, which is why
`src/d/.` cleans to `src/d/` and then falls into the same trailing-slash strip.

## What oc did instead

`relative_walk_base()` returned the operand verbatim as the walked path, and
`resolve_symlink_metadata()` re-derived the marker *from that path*. The marker
therefore had to stay in the name for the follow to keep working - the two were
one variable. Consequences, both measured:

* `-R src/d/` put `src/d/` in the file list. `f_name_cmp` sorts `src/d/` **after**
  its own child `src/d/f.txt`, so the sorted list is `["src", "src/d/f.txt",
  "src/d", ...]`, the receiver's generator walks an order the sender never
  intended, and the NDX echo desynchronises. Exit 12, `f.txt` never transferred.
  Push *and* pull.
* `-R src/d/.` put `src/d/.`, `src/d/./f.txt`, `src/d/./sub` on the wire. Those
  land in the right place only because the destination filesystem collapses
  `/./`; the wire bytes still diverge from upstream's.

Instrumented proof that the name, not the follow, is the lever
(`--debug=flist2`, operand `src/d/`, oc before the fix):

```
file list entries: ["src", "src/d/f.txt", "src/d/", "src/d/sub", "src/d/sub/g.txt"]
```

versus rsync 3.5.0 on the same fixture:

```
cd+++++++++ src/  cd+++++++++ src/d/  <f+++++++++ src/d/f.txt  ...
```

The symlink was already being followed in the broken cells - `src/sym-to-dir/`
arrived as a real directory containing `sub/`. Only `f.txt` was missing, and it
went missing to the NDX desync, not to an `lstat`.

## The fix

Split the two variables the way upstream does.

* `clean_relative_name()` (new, `file_list/mod.rs`) applies upstream's cleaning to
  the `--relative` transmitted name. `Path::components()` performs exactly the set
  of removals those two `clean_fname` flags select: interior `.` components and
  redundant separators go, a trailing `/` or `/.` goes, `..` is preserved
  verbatim (upstream rejects `..` in the active part separately, `flist.c:2659`).
* `name_type` is now read off the operand *as typed*
  (`operand_has_dotdir_marker(base_path)`) and threaded to
  `resolve_symlink_metadata()` as an explicit `is_dotdir` argument, instead of
  being re-derived from a path that no longer carries it. Two call sites; the
  `--files-from` one passes `operand_has_dotdir_marker(&entry.path)`, which is
  bit-for-bit what that path computed before.
* The `/./`-anchor branch's empty remainder now returns the base directly rather
  than `base.join(".")`. `strip_prefix` already yielded an empty relative for
  both, so the transmitted name is unchanged; the join only existed to smuggle
  the marker through, and the marker now travels on its own.

No divergence from upstream is introduced. Nothing here touches the
`--relative`-root pivot: a trailing `/.` still does **not** pivot the root
(`-R src/d/.` lands at `dst/src/d/`, as upstream and as the earlier
DOTDIR/pivot-split work established). The follow decision and the pivot remain
separate decisions, and this change moves neither.

## Measured operand-shape table

Fixture: `src/d/f.txt`, `src/d/sub/g.txt`, `src/sym-to-dir -> d`. Destination
listing after `rsync -a <opts> src/<operand> dst/`. `rc` is the exit code.

### Local copy - oc matched upstream before AND after (negative control on the whole change)

| operand | opts | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|---|
| `sym-to-dir` | | `sym-to-dir -> d` | same | same |
| `sym-to-dir/` | | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir/.` | | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir` | `-L` | `sym-to-dir/ +contents` | same | same |
| `sym-to-dir/` | `-L` | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir/.` | `-L` | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir` | `--copy-dirlinks` | `sym-to-dir/ +contents` | same | same |
| `sym-to-dir/` | `--copy-dirlinks` | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir/.` | `--copy-dirlinks` | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir` | `--no-inc-recursive` | `sym-to-dir -> d` | same | same |
| `sym-to-dir/` | `--no-inc-recursive` | `f.txt sub/ sub/g.txt` | same | same |
| `sym-to-dir/.` | `--no-inc-recursive` | `f.txt sub/ sub/g.txt` | same | same |

24/24 cells (the `--relative` rows below included) identical to upstream on the
local-copy engine, before and after. **This is the row that refutes the filed
diagnosis.**

### Over the wire, `--relative` - where the defect actually lives

Push (`src/<operand>` -> `h:dst/`); pull is symmetric and was measured too.

| operand | opts | upstream 3.5.0 | oc BEFORE | oc AFTER |
|---|---|---|---|---|
| `d` | `-R` | rc=0 `src/d/ src/d/f.txt src/d/sub/ src/d/sub/g.txt` | same | same |
| `d/` | `-R` | rc=0 same as above | **rc=12** `src/d/ src/d/sub/` (no `f.txt`) | matches |
| `d/.` | `-R` | rc=0 same as above | rc=0 but wire names `src/d/.`, `src/d/./f.txt` | matches |
| `sym-to-dir` | `-R` | rc=0 `src/sym-to-dir -> d` | same | same |
| `sym-to-dir/` | `-R` | rc=0 `src/sym-to-dir/ +contents` | **rc=12** `src/sym-to-dir/ src/sym-to-dir/sub/` | matches |
| `sym-to-dir/.` | `-R` | rc=0 `src/sym-to-dir/ +contents` | rc=0, wire names carry `/./` | matches |
| all six | `-R --no-inc-recursive` | as above | same failures | matches |
| all six | `-R -L` | as above | same failures | matches |
| all six | `-R --copy-dirlinks` | as above | same failures | matches |

After the fix, every sweep was re-run against a freshly built binary and diffed
against the 3.5.0 binary's output line for line:

```
RELATIVE local: IDENTICAL to upstream (24 cells)
RELATIVE push:  IDENTICAL to upstream (24 cells)
RELATIVE pull:  IDENTICAL to upstream (24 cells)
ALL-SHAPES local: IDENTICAL to upstream (24 cells)
SYMLINK-SHAPES over-the-wire push: IDENTICAL (15 cells)
SYMLINK-SHAPES over-the-wire pull: IDENTICAL (15 cells)
```

126 cells, zero differences.

Note the shape of the "before" column: the failure is **not** symlink-specific.
`d/` - a plain directory - fails identically. That alone falsifies the
"symlink is lstat'd" diagnosis.

## Mutation proof

Mutation: `clean_relative_name()` reduced to the identity `path.to_path_buf()`,
which is exactly the pre-fix behaviour. Everything else left in place.

Killed, `crates/transfer/tests/uts_relative_slash_ending_operand_name.rs`:

```
realdir/. [FAIL] left:  ["realdir", "realdir/./f.txt", "realdir/./sub", "realdir/./sub/g.txt"]
                right: ["realdir", "realdir/f.txt", "realdir/sub", "realdir/sub/g.txt"]

symdir/.  [FAIL] unnormalised: ["symdir/./f.txt", "symdir/./sub", "symdir/./sub/g.txt"]
```

Killed, `relative_operand_name_drops_the_marker_upstream_normalises_away`
(unit test on `relative_walk_base`, which is where the trailing-slash spelling is
observable - the integration harness uses absolute operands, and `strip_prefix`
against the `/` base silently absorbs a trailing slash there, so that layer
alone would have been a false pass on the `/` shape):

```
assertion `left == right` failed: relative_walk_base("src/d/")
  left: (".", "src/d/")
 right: (".", "src/d")
```

⚠ That unit test was itself vacuous on its first run, and the mutation is what
exposed it. It compared `PathBuf` to `PathBuf`, and `PathBuf`'s `PartialEq`
compares `components()` - under which `"src/d/"`, `"src/d/."` and `"src/d"` are
all **equal**, which is exactly the distinction the test exists to draw. It
passed under the mutation. It now compares `as_os_str()` bytes, and the comment
above it says why, so the next edit does not quietly reintroduce the hole.

Negative controls green under the mutation - the pin discriminates rather than
just failing:

```
realdir   [pass] left: ["realdir", "realdir/f.txt", "realdir/sub", "realdir/sub/g.txt"]
symdir    [pass] symlink=true (want true)   left: ["symdir"]
symdir/   [pass] symlink=false (want false) left: ["symdir", "symdir/f.txt", ...]
```

The bare `symdir` row is the load-bearing one: a fix that normalised the marker
away *without* threading `name_type` separately would turn `symdir/` into a
symlink entry and redden that row's sibling, and a fix that broke the follow
would redden `symdir/`. Both directions are pinned.

Restored: all new tests pass, `python3 tools/ci/check_rustfmt_all.py` exits 0
(3409 files, edition 2024), `cargo clippy --locked --workspace --all-targets
--all-features --no-deps -- -D warnings` exits 0, and the full workspace
`cargo nextest run` is green. All on the pinned 1.88.0 toolchain.

## Found but NOT fixed here

`--files-from` mishandles the `/.` spelling, and it is a *different* site
(`generator/filters.rs:split_files_from_entry`, the "trailing-anchor form"
branch, which treats `d/.` as a `/./` anchor and promotes `d` to the walk base).
Upstream does not: `strstr(fbuf, "/./")` does not match `d/.`, so the entry
cleans to `d` with `SLASH_ENDING_NAME` and its contents land under `d`. Measured,
`--files-from` with one entry, `-a`, over the wire:

| entry | upstream 3.5.0 | oc (unchanged by this PR) |
|---|---|---|
| `d/` | `dst/d dst/d/f.txt dst/d/sub` | same |
| `d/.` | `dst/d dst/d/f.txt dst/d/sub` | **`dst/f.txt dst/sub`** - contents flattened to the transfer root |
| `sym-to-dir/` | `dst/sym-to-dir +contents` | same |
| `sym-to-dir/.` | `dst/sym-to-dir +contents` | **`dst/sym-to-dir` only** - contents lost |

Left out deliberately: it is a separate operand channel with its own parser and
its own test surface, and folding it in would blur the mutation proof above.

## Unverified

* The daemon leg was not measured directly. The rsh harness exercises both the
  sender and the receiver roles in both directions over the real protocol, and
  the repo's daemon tests run in the workspace suite, but no `rsync://` cell for
  these operand shapes was run by hand.
* Non-Unix behaviour of `clean_relative_name` is reasoned from
  `Path::components()` semantics, not measured; the new integration tests are
  `#![cfg(unix)]` (they need `symlink`), while the unit tests are not.

---

## Follow-up: the `Windows IOCP` red, and what the trace showed

CI went red on exactly one check with my own new unit test:

```
assertion `left == right` failed: relative_walk_base("src/d")
  left:  (".", "src\\d")
 right:  (".", "src/d")
```

`clean_relative_name` is `path.components().collect::<PathBuf>()`, and
`components()` re-joins with the PLATFORM separator, so the local `PathBuf`
is `src\d` on Windows. The question that mattered is whether that `\` reaches
a transmitted name. **It does not.** Traced, not assumed:

| step | what it does with `\` |
|---|---|
| `FileEntry::new_file(name, ..)` → `new_with_type` (`protocol/src/flist/entry/constructors.rs:18-45`) | stores the `PathBuf` verbatim; `extract_dirname` uses `Path::parent()`, which is separator-aware on Windows |
| `FileListWriter::write_entry()` (`protocol/src/flist/write/mod.rs:470`) | `let raw_name = entry.name_bytes();` — the only path from a `FileEntry` name to the wire |
| `FileEntry::name_bytes()` (`protocol/src/flist/entry/accessors.rs:153-155`) | `wire_path::path_bytes_to_wire(&self.name)` — folds every `\` to `/` on non-Unix |
| the sort the NDX stream depends on (`protocol/src/flist/sort.rs:46,90-91,234-246,360-369`) | compares `name_bytes()`, i.e. `/`-separated bytes |
| `f_name_cmp` (`protocol/src/flist/name_cmp.rs:61-62,89-90,106-107`) | `path_bytes_to_wire()` on both name and dirname |
| filter matching (`filters/src/compiled/pattern.rs:66-73` `path_match_bytes`) | folds `\` to `/` before `wildmatch()` |
| sender-side `entry.name()` consumers (`generator/file_list/inc_recurse.rs:90,301`) | `Path::new(name).parent()` (separator-aware) and a compare against `"."` (no separator) |

So this is **(a)** — a test defect, not a wire defect.

It is also worth stating plainly that a `\` inside `FileEntry.name` is **not
something this PR introduces**. Every recursive child name is built with
`PathBuf::push`/`join`, which has appended `\` on Windows since long before
`clean_relative_name` existed: `src/d` + `f.txt` is `src/d\f.txt`, a mixed-
separator name, and `wire_path` has a dedicated
`windows_mixed_separators_are_normalized` test for exactly that. Two existing
sender tests already `.replace('\\', "/")` when reading `e.name()` /
`e.path()` (`generator/tests.rs:4673,6805`) for the same reason. This PR only
changes the separators of the operand's own prefix, which flows through the
same three boundaries.

### The fix, and why it is not a patched assertion

The obvious repair — a `#[cfg(windows)]` expectation of `"src\\d"` — would
hardcode an implementation detail of `components()` and assert nothing anyone
cares about. Instead the test now asserts the **wire bytes**, through the
production encoder rather than a reimplementation:

```rust
fn wire_name(path: &Path) -> String {
    let entry = FileEntry::new_file(PathBuf::from(path), 0, 0o644);
    String::from_utf8_lossy(&entry.name_bytes()).into_owned()
}
```

`name_bytes()` is precisely what `write_entry()` calls. The expectation is now
platform-independent *and* strictly stronger:

- it pins the byte the peer actually reads, so it is the Windows regression pin
  as well — if `path_bytes_to_wire` were ever dropped from the write path, this
  test reddens on Windows;
- it still discriminates byte-exactly, because the encoder is not a normaliser
  for markers: `src/d/` encodes as `b"src/d/"`, `src/d/.` as `b"src/d/."`,
  neither equal to `b"src/d"`.

`clean_relative_name` gains a `# Separators on Windows` section recording the
three boundaries above, so the next reader does not have to re-derive this.

### Deliberately NOT done

I considered replacing `components().collect()` with a byte-level port of
upstream's `clean_fname` that preserves the input separator. Rejected:
`components()` is the only spelling that parses a Windows path PREFIX (`C:\`,
`\\?\`, UNC `\\server\share`) correctly, and a hand-rolled separator scan would
corrupt those. I have no Windows host to measure on, so hand-rolling Windows
path parsing blind to fix a cosmetic local-path difference would trade a
non-problem for a real regression risk. Noted in the doc comment.

### Mutation re-proof (after the change)

The identity mutation of `clean_relative_name` still kills the test, now via
the wire bytes:

```
assertion `left == right` failed: relative_walk_base("src/d/"); local paths were (".", "src/d/")
  left:  (".", "src/d/")
 right:  (".", "src/d")
```

Gates re-run on the pinned 1.88.0 toolchain: `check_rustfmt_all.py` exit 0,
clippy `--workspace --all-targets --all-features --no-deps -D warnings` exit 0,
full-workspace nextest green apart from the pre-existing macOS-only
`xtask ... backdated_tree_populates_and_backdates_the_root` (BSD `touch`
rejects `@epoch`; fails identically on stashed clean master).
