### PR TITLE
fix(filters): stop trimming whitespace off filter-file rules

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -241,15 +241,12 @@ fn parse_merge_contents(
     // filter at :1806, so comments and blank lines advance the count.
     for (index, line) in contents.lines().enumerate() {
         let line_number = index + 1;
-        // upstream: exclude.c:1514 parse_filter_file - a line is skipped only
-        // when it is empty or (line parsing) begins with `;`/`#`. Whitespace is
-        // never stripped, so leading whitespace and whitespace-only lines fall
-        // through to the rule parser and error, while trailing whitespace stays
-        // part of the pattern verbatim (exclude.c:1313, strlen length).
-        if line.is_empty() {
-            continue;
-        }
-        if options.allows_comments() && (line.starts_with('#') || line.starts_with(';')) {
+        // upstream: exclude.c:1806 parse_filter_file. `filter_file_line_is_rule`
+        // is the single owner of that test: whitespace is never stripped, so
+        // leading whitespace and whitespace-only lines fall through to the rule
+        // parser and error, while trailing whitespace stays part of the pattern
+        // verbatim (exclude.c:1465, strlen length).
+        if !filters::filter_file_line_is_rule(line, options.allows_comments()) {
             continue;
         }
 

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -258,9 +258,12 @@ pub(crate) fn read_filter_patterns_from_standard_input(
     })
 }
 
-/// Splits a reader into filter pattern records, skipping blank lines and `#`/`;`
-/// comments. Records split on newline, or on NUL when `eol_nulls` is set
-/// (`--from0`), in which case embedded newlines are literal pattern bytes.
+/// Splits a reader into filter pattern records, skipping EMPTY records and
+/// those whose FIRST BYTE is `#`/`;` - the test
+/// [`filters::filter_file_line_is_rule`] owns. Nothing is trimmed, so a
+/// whitespace-only record and an indented `#` are patterns. Records split on
+/// newline, or on NUL when `eol_nulls` is set (`--from0`), in which case
+/// embedded newlines are literal pattern bytes.
 pub(super) fn read_filter_patterns<R: BufRead>(
     reader: &mut R,
     eol_nulls: bool,
@@ -289,9 +292,17 @@ pub(super) fn read_filter_patterns<R: BufRead>(
             buffer.pop();
         }
 
+        // upstream: exclude.c:1806. `filters::filter_file_line_is_rule` is the
+        // single owner of that test; it looks at the FIRST BYTE and does not
+        // trim. `--*clude-from` files are always line-parsed, never word-split.
+        //
+        // MEASURED against rsync 3.5.0 over a source holding files named
+        // `   ` (three spaces) and `  #a`: with an `--exclude-from` file whose
+        // only line is `   `, upstream excludes the file named `   ` and oc
+        // transferred it; with `  #a`, upstream excludes `  #a` and oc
+        // transferred it. Both at exit 0 - silent data selection divergence.
         let line = String::from_utf8_lossy(&buffer);
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+        if !filters::filter_file_line_is_rule(&line, true) {
             continue;
         }
 
@@ -389,11 +400,26 @@ mod tests {
     }
 
     #[test]
-    fn read_filter_patterns_handles_whitespace_only_lines() {
+    fn read_filter_patterns_keeps_whitespace_only_lines() {
+        // upstream: exclude.c:1806 tests `*line`, the first BYTE, so a
+        // whitespace-only record is not empty and becomes a literal pattern.
+        // MEASURED against rsync 3.5.0: an `--exclude-from` file holding only
+        // `   ` excludes a file literally named `   `.
         let input = b"pattern1\n   \n\t\npattern2\n";
         let mut reader = Cursor::new(input.to_vec());
         let result = read_filter_patterns(&mut reader, false).expect("read");
-        assert_eq!(result, vec!["pattern1", "pattern2"]);
+        assert_eq!(result, vec!["pattern1", "   ", "\t", "pattern2"]);
+    }
+
+    #[test]
+    fn read_filter_patterns_keeps_an_indented_comment_marker() {
+        // upstream: exclude.c:1806 - only a `;`/`#` in COLUMN ZERO is a
+        // comment. MEASURED against rsync 3.5.0: an `--exclude-from` file
+        // holding only `  #a` excludes a file literally named `  #a`.
+        let input = b"  #a\n  ;b\n";
+        let mut reader = Cursor::new(input.to_vec());
+        let result = read_filter_patterns(&mut reader, false).expect("read");
+        assert_eq!(result, vec!["  #a", "  ;b"]);
     }
 
     #[test]

--- a/crates/cli/src/frontend/tests/load.rs
+++ b/crates/cli/src/frontend/tests/load.rs
@@ -15,8 +15,15 @@ fn load_filter_file_patterns_skips_comments_and_trims_crlf() {
     assert_eq!(patterns, vec![" include ".to_owned(), "pattern".to_owned()]);
 }
 
+/// A `;` comment must start in COLUMN ZERO; an indented one is a pattern.
+///
+/// upstream: exclude.c:1806 - `if (*line && (word_split || (*line != ';' &&
+/// *line != '#')))` tests the FIRST BYTE of the line, with no trimming first.
+/// MEASURED against rsync 3.5.0: an `--exclude-from` file holding only `  #a`
+/// excludes a file literally named `  #a`; oc used to transfer it, because the
+/// reader trimmed before testing.
 #[test]
-fn load_filter_file_patterns_skip_semicolon_comments() {
+fn load_filter_file_patterns_skip_only_column_zero_semicolon_comments() {
     use tempfile::tempdir;
 
     let tmp = tempdir().expect("tempdir");
@@ -26,7 +33,10 @@ fn load_filter_file_patterns_skip_semicolon_comments() {
     let patterns =
         load_filter_file_patterns(path.as_path()).expect("load filter patterns succeeds");
 
-    assert_eq!(patterns, vec!["keep".to_owned()]);
+    assert_eq!(
+        patterns,
+        vec!["  ; spaced comment".to_owned(), "keep".to_owned()]
+    );
 }
 
 #[test]

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -586,15 +586,18 @@ pub(crate) fn load_dir_merge_rules_recursive(
             // physical line, so blanks and comments still advance it.
             for (index, line) in contents.lines().enumerate() {
                 let line_number = index + 1;
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                if allow_comments && trimmed.starts_with('#') {
+                // upstream: exclude.c:1806. `filters::filter_file_line_is_rule`
+                // is the single owner of that test - it does NOT trim, so
+                // trailing whitespace stays part of the pattern
+                // (exclude.c:1465, `len = strlen(s)`) and a leading-whitespace
+                // or whitespace-only line is a fatal `Unknown filter rule`
+                // (exclude.c:1363). This reader used to trim both ends, which
+                // changed which files transferred at exit 0.
+                if !filters::filter_file_line_is_rule(line, allow_comments) {
                     continue;
                 }
 
-                if trimmed == "!" || trimmed == "clear" {
+                if line == "!" || line == "clear" {
                     if options.list_clear_allowed() {
                         entries.rules.clear();
                         entries.exclude_if_present.clear();
@@ -602,14 +605,14 @@ pub(crate) fn load_dir_merge_rules_recursive(
                         continue;
                     }
                     return Err(map_error(FilterParseError::new(format!(
-                        "list-clearing '{trimmed}' is not permitted in this filter file"
+                        "list-clearing '{line}' is not permitted in this filter file"
                     ))));
                 }
 
                 if let Some(kind) = enforce_kind {
                     let rule = match kind {
-                        DirMergeEnforcedKind::Include => FilterRule::include(trimmed.to_owned()),
-                        DirMergeEnforcedKind::Exclude => FilterRule::exclude(trimmed.to_owned()),
+                        DirMergeEnforcedKind::Include => FilterRule::include(line.to_owned()),
+                        DirMergeEnforcedKind::Exclude => FilterRule::exclude(line.to_owned()),
                     };
                     entries.push_rule(apply_dir_merge_rule_defaults(
                         rule,
@@ -620,13 +623,13 @@ pub(crate) fn load_dir_merge_rules_recursive(
                 }
 
                 match parse_filter_directive_line(
-                    trimmed,
+                    line,
                     origin.rule_source(&src_name, Some(line_number)),
                 ) {
                     Ok(Some(ParsedFilterDirective::Rule(rule))) => {
                         if dir_merge_side_conflict(&rule, options) {
                             return Err(map_error(FilterParseError::new(format!(
-                                "specified-side merge file contains specified-side filter: {trimmed}"
+                                "specified-side merge file contains specified-side filter: {line}"
                             ))));
                         }
                         entries.push_rule(apply_dir_merge_rule_defaults(

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -299,47 +299,59 @@ fn discard_over_long(
 /// upstream's decision has two arms, and picking one here would collapse
 /// them - see the `Err` arm at the bottom of this function.
 ///
-/// Returns `Ok(None)` for blank or comment-only lines. Recognises list-clear
-/// (`!`/`clear`), short-form merges (`.`/`:`), `merge`/`dir-merge`/`per-dir`
-/// directives, `exclude-if-present`, the `+`/`-` short-form rule prefixes,
-/// and the `include`/`exclude`/`show`/`hide`/`protect`/`risk` keywords with
-/// their `,modifier` suffix. Trailing whitespace is trimmed from patterns.
+/// Returns `Ok(None)` only for an EMPTY line. Blank-and-comment filtering is
+/// the file reader's job, not this parser's - upstream puts it in
+/// `parse_filter_file` (exclude.c:1806) and `parse_rule_tok` has no comment
+/// concept at all. Recognises list-clear (`!`/`clear`), short-form merges
+/// (`.`/`:`), `merge`/`dir-merge`/`per-dir` directives, `exclude-if-present`,
+/// the `+`/`-` short-form rule prefixes, and the
+/// `include`/`exclude`/`show`/`hide`/`protect`/`risk` keywords with their
+/// `,modifier` suffix.
+///
+/// Whitespace is NEVER trimmed. Exactly one separator is consumed after the
+/// rule character or keyword (exclude.c:1444-1445) and the pattern is then
+/// taken verbatim (`len = strlen(s)`, exclude.c:1465), so a trailing space is
+/// pattern text and a leading-whitespace line is an unknown rule.
 fn classify_filter_directive_line(
     text: &str,
     source: RuleSource<'_>,
 ) -> Result<Option<ParsedFilterDirective>, FilterParseError> {
-    if text.is_empty() || text.starts_with('#') {
+    // upstream: exclude.c:1806 - `if (*line && (word_split || (*line != ';' &&
+    // *line != '#')))`. A line is dropped only when it is EMPTY or when its
+    // FIRST byte is `;`/`#`. Whitespace is never stripped: `parse_rule_tok`
+    // skips leading whitespace only under FILTRULE_WORD_SPLIT (exclude.c:1249-
+    // 1253) and takes the pattern length as `strlen(s)` otherwise
+    // (exclude.c:1465), so trailing whitespace is part of the pattern.
+    //
+    // Trimming here changed WHICH FILES TRANSFER. MEASURED against rsync 3.5.0
+    // with a `.rsync-filter` holding `- a ` over a source containing `a` and
+    // `a ` (trailing space): upstream excludes `a ` and copies `a`; oc excluded
+    // `a` and copied `a `. A whitespace-only line and a leading-whitespace rule
+    // are fatal `Unknown filter rule` syntax errors upstream; oc accepted both.
+    if text.is_empty() {
         return Ok(None);
     }
 
-    let trimmed = text.trim_start();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-
-    let trimmed = trimmed.trim_end();
-
-    if trimmed == "!" || trimmed == CLEAR_KEYWORD {
+    if text == "!" || text == CLEAR_KEYWORD {
         return Ok(Some(ParsedFilterDirective::Clear));
     }
 
-    if let Some(directive) = parse_short_merge_directive_line(trimmed)? {
+    if let Some(directive) = parse_short_merge_directive_line(text)? {
         return Ok(Some(directive));
     }
 
-    if let Some(directive) = parse_merge_directive(trimmed)? {
+    if let Some(directive) = parse_merge_directive(text)? {
         return Ok(Some(directive));
     }
 
-    if let Some(directive) = parse_dir_merge_directive(trimmed)? {
+    if let Some(directive) = parse_dir_merge_directive(text)? {
         return Ok(Some(directive));
     }
 
-    if trimmed.len() >= EXCLUDE_IF_PRESENT_PREFIX.len()
-        && trimmed[..EXCLUDE_IF_PRESENT_PREFIX.len()]
-            .eq_ignore_ascii_case(EXCLUDE_IF_PRESENT_PREFIX)
+    if text.len() >= EXCLUDE_IF_PRESENT_PREFIX.len()
+        && text[..EXCLUDE_IF_PRESENT_PREFIX.len()].eq_ignore_ascii_case(EXCLUDE_IF_PRESENT_PREFIX)
     {
-        let mut remainder = trimmed[EXCLUDE_IF_PRESENT_PREFIX.len()..]
+        let mut remainder = text[EXCLUDE_IF_PRESENT_PREFIX.len()..]
             .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
         if let Some(rest) = remainder.strip_prefix('=') {
             remainder = rest.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
@@ -357,33 +369,42 @@ fn classify_filter_directive_line(
         )));
     }
 
-    if let Some(remainder) = trimmed.strip_prefix('+') {
+    if let Some(remainder) = text.strip_prefix('+') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, false)?;
-        let pattern = remainder.trim_start();
+        let modifiers = parse_rule_modifiers(modifier_text, text, false)?;
+        // `split_short_rule_modifiers` already consumed the ONE separator that
+        // ends the modifier run (upstream exclude.c:1444-1445 `if (*s) s++`),
+        // and the pattern is then taken verbatim (`len = strlen(s)`, :1465).
+        // Trimming here made `+  a` match `a` where upstream matches ` a`.
+        let pattern = remainder;
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '+' requires a pattern"));
         }
         let rule = FilterRule::include(pattern.to_owned());
-        let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
+        let rule = apply_rule_modifiers(rule, modifiers, text)?;
         return Ok(Some(ParsedFilterDirective::Rule(rule)));
     }
 
-    if let Some(remainder) = trimmed.strip_prefix('-') {
+    if let Some(remainder) = text.strip_prefix('-') {
         let (modifier_text, remainder) = split_short_rule_modifiers(remainder);
-        let modifiers = parse_rule_modifiers(modifier_text, trimmed, false)?;
-        let pattern = remainder.trim_start();
+        let modifiers = parse_rule_modifiers(modifier_text, text, false)?;
+        // See the `+` arm above: the single separator is already consumed, so
+        // any further whitespace is pattern text (upstream exclude.c:1465).
+        let pattern = remainder;
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter rule '-' requires a pattern"));
         }
         let rule = FilterRule::exclude(pattern.to_owned());
-        let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
+        let rule = apply_rule_modifiers(rule, modifiers, text)?;
         return Ok(Some(ParsedFilterDirective::Rule(rule)));
     }
 
-    let mut parts = trimmed.splitn(2, char::is_whitespace);
+    let mut parts = text.splitn(2, char::is_whitespace);
     let keyword = parts.next().unwrap_or("");
-    let remainder = parts.next().unwrap_or("").trim_start();
+    // `splitn` already consumed the single separator between the keyword and
+    // the pattern (upstream exclude.c:1444-1445), so the remainder is the
+    // pattern verbatim: `exclude  a` matches ` a`, not `a` (exclude.c:1465).
+    let remainder = parts.next().unwrap_or("");
     let (keyword, keyword_modifiers) = split_keyword_modifiers(keyword);
 
     let handle_keyword = |pattern: &str,
@@ -393,9 +414,9 @@ fn classify_filter_directive_line(
         if pattern.is_empty() {
             return Err(FilterParseError::new("filter directive missing pattern"));
         }
-        let modifiers = parse_rule_modifiers(keyword_modifiers, trimmed, prefix_specifies_side)?;
+        let modifiers = parse_rule_modifiers(keyword_modifiers, text, prefix_specifies_side)?;
         let rule = builder(pattern.to_owned());
-        let rule = apply_rule_modifiers(rule, modifiers, trimmed)?;
+        let rule = apply_rule_modifiers(rule, modifiers, text)?;
         Ok(Some(ParsedFilterDirective::Rule(rule)))
     };
 
@@ -465,7 +486,7 @@ fn classify_filter_directive_line(
     // supplies it.
     Err(FilterParseError::new(format!(
         "Unknown filter rule: {}",
-        source.rule_text(trimmed)
+        source.rule_text(text)
     )))
 }
 
@@ -735,16 +756,31 @@ mod tests {
     }
 
     #[test]
-    fn parse_filter_directive_line_comment() {
-        let result =
-            parse_filter_directive_line("# this is a comment", RuleSource::Argument).unwrap();
-        assert!(result.is_none());
+    fn parse_filter_directive_line_comment_is_the_readers_decision() {
+        // upstream: exclude.c:1806 - `;`/`#` are comments only in the FILE
+        // READER (`parse_filter_file`), never in the rule parser. MEASURED
+        // against rsync 3.5.0: `--filter='# a comment'` exits 1 with
+        // `Unknown filter rule: # a comment`. `load.rs` owns the skip.
+        let error = parse_filter_directive_line("# this is a comment", RuleSource::Argument)
+            .expect_err("a comment is not a rule the parser recognises");
+        assert!(
+            error.to_string().contains("Unknown filter rule"),
+            "unexpected diagnostic: {error}"
+        );
     }
 
     #[test]
-    fn parse_filter_directive_line_whitespace() {
-        let result = parse_filter_directive_line("   ", RuleSource::Argument).unwrap();
-        assert!(result.is_none());
+    fn parse_filter_directive_line_whitespace_is_a_syntax_error() {
+        // upstream: exclude.c:1249-1253 skips leading whitespace only under
+        // FILTRULE_WORD_SPLIT, so a whitespace-only line reaches the prefix
+        // switch's `default:` arm and dies at exclude.c:1363. MEASURED against
+        // rsync 3.5.0: a `.rsync-filter` whose first line is `   ` exits 1.
+        let error = parse_filter_directive_line("   ", RuleSource::Argument)
+            .expect_err("whitespace is not a rule");
+        assert!(
+            error.to_string().contains("Unknown filter rule"),
+            "unexpected diagnostic: {error}"
+        );
     }
 
     #[test]

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -150,8 +150,8 @@ pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{
-    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, merge_name_overflows,
-    merge_self_exclude_name, parse_rules, read_rules, read_rules_recursive,
+    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, filter_file_line_is_rule,
+    merge_name_overflows, merge_self_exclude_name, parse_rules, read_rules, read_rules_recursive,
 };
 pub use overlong::{is_over_long, over_long_filter};
 pub use rule::FilterRule;

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -50,6 +50,7 @@ mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
 mod self_exclude;
+mod skip;
 
 #[cfg(test)]
 mod tests;
@@ -61,3 +62,4 @@ pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};
 pub use self_exclude::merge_self_exclude_name;
+pub use skip::filter_file_line_is_rule;

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -44,12 +44,10 @@ pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>,
     for (line_num, line) in content.lines().enumerate() {
         let line_num = line_num + 1; // 1-indexed for error messages
 
-        // upstream: exclude.c:1514 parse_filter_file - a line is skipped only
-        // when it is empty or (line parsing) begins with `;`/`#`. Whitespace is
-        // never stripped, so a whitespace-only line and a leading-whitespace
-        // rule both fall through to parse_rule_tok and raise "Unknown filter
-        // rule" (RERR_SYNTAX). Trailing whitespace stays part of the pattern.
-        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+        // upstream: exclude.c:1806 parse_filter_file. `filter_file_line_is_rule`
+        // is the single owner of that test; see `merge::skip` for why it must
+        // not trim first.
+        if !crate::filter_file_line_is_rule(line, true) {
             continue;
         }
 
@@ -124,11 +122,11 @@ pub(crate) fn parse_rules_no_prefixes(
         }
     } else {
         for line in content.lines() {
-            // upstream: exclude.c:1514 parse_filter_file - skip only empty and
-            // (line parsing) `;`/`#` comment lines; the surviving line becomes a
-            // literal pattern verbatim (FILTRULE_NO_PREFIXES takes strlen with no
-            // trimming, exclude.c:1313), so leading/trailing whitespace is kept.
-            if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            // upstream: exclude.c:1806 parse_filter_file, via the single owner
+            // `filter_file_line_is_rule`. The surviving line becomes a literal
+            // pattern verbatim (FILTRULE_NO_PREFIXES takes strlen with no
+            // trimming, exclude.c:1465), so leading/trailing whitespace is kept.
+            if !crate::filter_file_line_is_rule(line, true) {
                 continue;
             }
             push_token(line);

--- a/crates/filters/src/merge/skip.rs
+++ b/crates/filters/src/merge/skip.rs
@@ -1,0 +1,87 @@
+//! The one owner of "does this filter-file record carry a rule?".
+//!
+//! Every reader that turns a filter FILE into rules has to answer this, and
+//! upstream answers it in exactly one place - the tail of `parse_filter_file`'s
+//! read loop (`exclude.c:1806`):
+//!
+//! ```c
+//! /* Skip an empty token and (when line parsing) comments. */
+//! if (*line && (word_split || (*line != ';' && *line != '#')))
+//!     parse_filter_str(listp, line, template, xflags);
+//! ```
+//!
+//! Two properties of that line are load-bearing and were repeatedly lost when
+//! each reader spelled the test for itself:
+//!
+//! 1. It tests `*line` and `line[0]` - the FIRST BYTE - with no trimming. A
+//!    whitespace-only record is not empty, and `  # x` is not a comment.
+//! 2. `word_split ||` short-circuits, so in a `w`/`C` merge file `#` and `;`
+//!    are ordinary pattern bytes.
+//!
+//! Both matter to file selection, not to formatting: whatever survives this
+//! test becomes a pattern matched literally against names. oc had four readers
+//! spelling it four ways, and two of them trimmed, which changed which files
+//! transferred at exit 0. Routing them all through one predicate is what stops
+//! the next reader from drifting again.
+
+/// Reports whether a filter-file record should be handed to the rule parser.
+///
+/// `comments_recognised` is upstream's `!word_split`: a line-parsed filter file
+/// treats a leading `;`/`#` as a comment, and a word-split one (`:w`, `:C`,
+/// `merge,w`) does not.
+///
+/// The record must already have had its delimiter removed - upstream's reader
+/// stops before the `\n`/`\r`/NUL - and is otherwise passed verbatim.
+#[must_use]
+pub fn filter_file_line_is_rule(line: &str, comments_recognised: bool) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    if comments_recognised && (line.starts_with('#') || line.starts_with(';')) {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::filter_file_line_is_rule;
+
+    #[test]
+    fn an_empty_record_carries_no_rule() {
+        assert!(!filter_file_line_is_rule("", true));
+        assert!(!filter_file_line_is_rule("", false));
+    }
+
+    #[test]
+    fn a_whitespace_only_record_is_a_rule() {
+        // upstream tests `*line`, so `   ` is not empty and reaches the parser
+        // (where it then fails as `Unknown filter rule`). MEASURED against
+        // rsync 3.5.0: a `.rsync-filter` whose first line is `   ` exits 1.
+        assert!(filter_file_line_is_rule("   ", true));
+        assert!(filter_file_line_is_rule("\t", true));
+    }
+
+    #[test]
+    fn a_comment_marker_counts_only_in_column_zero() {
+        assert!(!filter_file_line_is_rule("# x", true));
+        assert!(!filter_file_line_is_rule("; x", true));
+        // MEASURED against rsync 3.5.0: an `--exclude-from` file holding only
+        // `  #a` excludes a file literally named `  #a`.
+        assert!(filter_file_line_is_rule("  # x", true));
+        assert!(filter_file_line_is_rule("  ; x", true));
+    }
+
+    #[test]
+    fn word_split_files_have_no_comments() {
+        // upstream: `word_split ||` short-circuits the comment test entirely.
+        assert!(filter_file_line_is_rule("# x", false));
+        assert!(filter_file_line_is_rule("; x", false));
+    }
+
+    #[test]
+    fn an_ordinary_rule_is_a_rule() {
+        assert!(filter_file_line_is_rule("- *.log", true));
+        assert!(filter_file_line_is_rule("- a ", true));
+    }
+}

--- a/tests/filter_rule_whitespace_is_pattern_text.rs
+++ b/tests/filter_rule_whitespace_is_pattern_text.rs
@@ -1,0 +1,358 @@
+//! A filter rule's whitespace is pattern text, not decoration.
+//!
+//! upstream reads a merge file byte for byte and skips a line only when it is
+//! EMPTY or when its FIRST byte is `;`/`#` (`exclude.c:1806`):
+//!
+//! ```c
+//! if (*line && (word_split || (*line != ';' && *line != '#')))
+//!     parse_filter_str(listp, line, template, xflags);
+//! ```
+//!
+//! `parse_rule_tok` then skips leading whitespace only under
+//! `FILTRULE_WORD_SPLIT` (`exclude.c:1249-1253`) and takes the pattern length
+//! as `len = strlen((char*)s)` (`exclude.c:1465`). So trailing whitespace is
+//! part of the pattern, exactly ONE separator is consumed after the rule
+//! character (`exclude.c:1444-1445`, `if (*s) s++`), and a leading-whitespace
+//! or whitespace-only line reaches the prefix switch's `default:` arm and dies
+//! at `exclude.c:1363` with `Unknown filter rule`.
+//!
+//! TWO oc readers trimmed. The engine dir-merge parser trimmed both ends of
+//! every line, and the CLI `--exclude-from`/`--include-from` reader trimmed
+//! before testing for a blank or a comment. Because a filter pattern is
+//! matched literally, both changed WHICH FILES TRANSFER at exit 0 - silent
+//! data selection divergence, not cosmetics. The third reader, the CLI
+//! `--filter='merge FILE'` loop (`crates/cli/.../filter_rules/merge.rs`),
+//! already mirrored upstream, which is what made this a one-of-three lag
+//! rather than a uniform choice.
+//!
+//! MEASURED against rsync 3.5.0 with a source holding `a` and `a ` (trailing
+//! space) and a `.rsync-filter` of `- a `: upstream excludes `a ` and copies
+//! `a`; oc excluded `a` and copied `a `. Every cell below is asserted against
+//! that measured upstream behaviour.
+//!
+//! These assert on the DESTINATION TREE rather than on a parsed pattern
+//! string, because the destination tree is the property that matters.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// The plain name.
+const PLAIN: &str = "a";
+/// The same name with one trailing space. Legal on every supported filesystem.
+const TRAILING: &str = "a ";
+/// An unrelated file, the negative control: no cell here may exclude it.
+const OTHER: &str = "b";
+
+/// Seeds `<dir>/src` with `a`, `a ` and `b`, plus a `.rsync-filter` holding
+/// `body`, and creates an empty `<dir>/dest`.
+fn seed(dir: &TestDir, body: &str) {
+    dir.mkdir("src").expect("src");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/a", b"plain\n").expect("a");
+    dir.write_file("src/a ", b"trailing\n").expect("a-space");
+    dir.write_file("src/b", b"other\n").expect("b");
+    dir.write_file("src/.rsync-filter", body.as_bytes())
+        .expect("filter");
+}
+
+/// Runs `oc-rsync -r -F src/ dest/` inside `dir`.
+fn transfer(dir: &TestDir) -> RsyncCommand {
+    let mut command = RsyncCommand::new();
+    command
+        .arg("-r")
+        .arg("-F")
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()));
+    command
+}
+
+/// `- a ` excludes the file whose name ENDS IN A SPACE, and leaves `a` alone.
+///
+/// This is the headline cell. Trimming inverted it: oc excluded `a` and copied
+/// `a `, the exact opposite of upstream, at exit 0.
+#[test]
+fn a_trailing_space_belongs_to_the_pattern() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "- a \n");
+
+    transfer(&dir).assert_success();
+
+    assert!(
+        dir.exists(&format!("dest/{PLAIN}")),
+        "`- a ` must NOT exclude `{PLAIN}`: the pattern is `a ` with the \
+         trailing space, and upstream matches it literally (exclude.c:1465)"
+    );
+    assert!(
+        !dir.exists(&format!("dest/{TRAILING}")),
+        "`- a ` must exclude `{TRAILING}`: upstream takes the pattern length \
+         as strlen, so the trailing space is pattern text (exclude.c:1465)"
+    );
+    assert!(
+        dir.exists(&format!("dest/{OTHER}")),
+        "the unrelated file must still transfer"
+    );
+}
+
+/// Two trailing spaces make a pattern that matches NOTHING in the fixture.
+///
+/// The negative control for the cell above: it proves the rule is matched
+/// literally rather than merely "one trailing space is special".
+#[test]
+fn two_trailing_spaces_match_no_file_here() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "- a  \n");
+
+    transfer(&dir).assert_success();
+
+    for name in [PLAIN, TRAILING, OTHER] {
+        assert!(
+            dir.exists(&format!("dest/{name}")),
+            "`- a  ` names the pattern `a  `, which matches nothing here, so \
+             `{name}` must transfer"
+        );
+    }
+}
+
+/// Only ONE separator is consumed after the rule character, so `-  a` is a
+/// rule for the pattern ` a`, not `a`.
+///
+/// upstream: `exclude.c:1444-1445` - the modifier loop stops at the first
+/// ` `/`_` and `if (*s) s++` consumes exactly that one byte.
+#[test]
+fn only_one_separator_follows_the_rule_character() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "-  a\n");
+
+    transfer(&dir).assert_success();
+
+    assert!(
+        dir.exists(&format!("dest/{PLAIN}")),
+        "`-  a` names the pattern ` a` (leading space), so `{PLAIN}` must \
+         transfer: upstream consumes exactly one separator (exclude.c:1444)"
+    );
+    assert!(
+        dir.exists(&format!("dest/{TRAILING}")),
+        "`-  a` must not touch `{TRAILING}` either"
+    );
+}
+
+/// The long-keyword form takes its pattern verbatim too.
+#[test]
+fn a_keyword_rule_keeps_its_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "exclude a \n");
+
+    transfer(&dir).assert_success();
+
+    assert!(
+        dir.exists(&format!("dest/{PLAIN}")),
+        "`exclude a ` names the pattern `a `, not `a`"
+    );
+    assert!(
+        !dir.exists(&format!("dest/{TRAILING}")),
+        "`exclude a ` must exclude `{TRAILING}`"
+    );
+}
+
+/// A whitespace-only line is a fatal syntax error, not a blank line.
+///
+/// upstream: `exclude.c:1806` skips only an EMPTY line, so `   ` reaches
+/// `parse_rule_tok`, takes the prefix switch's `default:` arm and dies at
+/// `exclude.c:1363`. MEASURED against rsync 3.5.0: exit 1, nothing transfers.
+#[test]
+fn a_whitespace_only_line_is_a_syntax_error() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "   \n- b\n");
+
+    let output = transfer(&dir).assert_failure();
+
+    assert!(
+        !dir.exists(&format!("dest/{PLAIN}")),
+        "a rejected filter file must abort the transfer, not partly apply it"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown filter rule"),
+        "expected upstream's `Unknown filter rule` refusal, got: {stderr}"
+    );
+}
+
+/// A rule indented by whitespace is a fatal syntax error, not an indented rule.
+#[test]
+fn a_leading_whitespace_rule_is_a_syntax_error() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "  - a\n");
+
+    let output = transfer(&dir).assert_failure();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown filter rule"),
+        "expected upstream's `Unknown filter rule` refusal, got: {stderr}"
+    );
+}
+
+/// A `#` comment must start at column ZERO. An indented one is a rule, and an
+/// unparsable one at that.
+///
+/// upstream: `exclude.c:1806` tests `*line`, the FIRST byte, so `  # x` is
+/// never a comment.
+#[test]
+fn a_comment_marker_must_be_the_first_byte() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "  # x\n- b\n");
+
+    let output = transfer(&dir).assert_failure();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown filter rule"),
+        "expected upstream's `Unknown filter rule` refusal, got: {stderr}"
+    );
+}
+
+/// `;` at column zero IS a comment, exactly like `#`.
+///
+/// upstream: `exclude.c:1806` skips a line whose first byte is `;` OR `#`. oc
+/// tested only `#`, so a `;` comment was parsed as a rule and exited 1.
+#[test]
+fn a_semicolon_at_column_zero_is_a_comment() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "; a comment\n- b\n");
+
+    transfer(&dir).assert_success();
+
+    assert!(
+        dir.exists(&format!("dest/{PLAIN}")),
+        "`; ...` is a comment, so only the `- b` rule applies"
+    );
+    assert!(
+        !dir.exists(&format!("dest/{OTHER}")),
+        "the `- b` rule after the `;` comment must still be honoured"
+    );
+}
+
+/// A file literally named `   ` (three spaces).
+const SPACES: &str = "   ";
+/// A file literally named `  #a` - an indented comment marker.
+const INDENTED_HASH: &str = "  #a";
+
+/// Seeds `<dir>/src` with the two exotic names plus `keep`, and writes an
+/// `--exclude-from` file holding `body`.
+fn seed_exclude_from(dir: &TestDir, body: &str) {
+    dir.mkdir("src").expect("src");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/keep", b"keep\n").expect("keep");
+    dir.write_file(&format!("src/{SPACES}"), b"spaces\n")
+        .expect("spaces");
+    dir.write_file(&format!("src/{INDENTED_HASH}"), b"hash\n")
+        .expect("hash");
+    dir.write_file("filt", body.as_bytes()).expect("filt");
+}
+
+/// Runs `oc-rsync -r --exclude-from=filt src/ dest/` inside `dir`.
+fn transfer_exclude_from(dir: &TestDir) -> RsyncCommand {
+    let mut command = RsyncCommand::new();
+    command
+        .arg("-r")
+        .arg(format!(
+            "--exclude-from={}",
+            dir.path().join("filt").display()
+        ))
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()));
+    command
+}
+
+/// A whitespace-only `--exclude-from` line is a PATTERN, not a blank line.
+///
+/// upstream: `exclude.c:1806` tests `*line`, the first byte, so `   ` is not
+/// empty. MEASURED against rsync 3.5.0: it excludes the file named `   `.
+#[test]
+fn a_whitespace_only_exclude_from_line_is_a_pattern() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_exclude_from(&dir, "   \n");
+
+    transfer_exclude_from(&dir).assert_success();
+
+    assert!(
+        !dir.exists(&format!("dest/{SPACES}")),
+        "an `--exclude-from` line of three spaces is the pattern `   `, which \
+         must exclude the file of that name (exclude.c:1806)"
+    );
+    assert!(dir.exists("dest/keep"), "`keep` must still transfer");
+    assert!(
+        dir.exists(&format!("dest/{INDENTED_HASH}")),
+        "`{INDENTED_HASH}` must still transfer"
+    );
+}
+
+/// An INDENTED `#` in an `--exclude-from` file is a pattern, not a comment.
+///
+/// upstream: `exclude.c:1806` - only a `;`/`#` in column zero is a comment.
+#[test]
+fn an_indented_hash_in_an_exclude_from_file_is_a_pattern() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_exclude_from(&dir, "  #a\n");
+
+    transfer_exclude_from(&dir).assert_success();
+
+    assert!(
+        !dir.exists(&format!("dest/{INDENTED_HASH}")),
+        "`  #a` is indented, so it is the pattern `  #a` and must exclude the \
+         file of that name (exclude.c:1806)"
+    );
+    assert!(dir.exists("dest/keep"), "`keep` must still transfer");
+    assert!(
+        dir.exists(&format!("dest/{SPACES}")),
+        "`{SPACES}` must still transfer"
+    );
+}
+
+/// The `--exclude-from` control: a `#` in COLUMN ZERO really is a comment, so
+/// the fix must not turn every comment into a pattern.
+#[test]
+fn a_column_zero_hash_in_an_exclude_from_file_is_still_a_comment() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed_exclude_from(&dir, "#a\n;b\nkeep\n");
+
+    transfer_exclude_from(&dir).assert_success();
+
+    assert!(
+        !dir.exists("dest/keep"),
+        "the `keep` rule after the two comments must be honoured"
+    );
+    for name in [SPACES, INDENTED_HASH] {
+        assert!(
+            dir.exists(&format!("dest/{name}")),
+            "`#a`/`;b` in column zero are comments, so `{name}` must transfer"
+        );
+    }
+}
+
+/// The unchanged baseline: a rule with no stray whitespace behaves as before.
+///
+/// This is the control that must stay green under the mutation that reverts
+/// the fix - a test that fails both ways would prove nothing about the cells
+/// above.
+#[test]
+fn a_plain_rule_is_unaffected() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir, "- a\n");
+
+    transfer(&dir).assert_success();
+
+    assert!(
+        !dir.exists(&format!("dest/{PLAIN}")),
+        "`- a` must exclude `{PLAIN}`"
+    );
+    assert!(
+        dir.exists(&format!("dest/{TRAILING}")),
+        "`- a` must not exclude `{TRAILING}`"
+    );
+    assert!(
+        dir.exists(&format!("dest/{OTHER}")),
+        "`- a` must not exclude `{OTHER}`"
+    );
+}


### PR DESCRIPTION
## What

oc trimmed whitespace off filter-file rules. Upstream does not. A filter
pattern is matched literally, so trimming changes **which files transfer** -
this is silent data selection divergence at exit 0, not cosmetics.

## Upstream behaviour (read first, then measured)

`parse_filter_file`'s read loop skips a record only when it is EMPTY or when
its **first byte** is `;`/`#` (`exclude.c:1806`):

```c
/* Skip an empty token and (when line parsing) comments. */
if (*line && (word_split || (*line != ';' && *line != '#')))
        parse_filter_str(listp, line, template, xflags);
```

Nothing is trimmed before or after that test:

- `parse_rule_tok` skips leading whitespace **only** under
  `FILTRULE_WORD_SPLIT` (`exclude.c:1249-1253`).
- Exactly **one** separator is consumed after the rule character or keyword:
  `if (*s) s++` (`exclude.c:1444-1445`).
- The pattern length is then `len = strlen((char*)s)` (`exclude.c:1465`), so
  everything to end of record - trailing whitespace included - is the pattern.
- A record that survives the skip but starts with whitespace reaches the prefix
  switch's `default:` arm and dies at `exclude.c:1363`
  (`filter_rule_err("Unknown filter rule")`, `RERR_SYNTAX`).

This is identical for a CLI `--filter` rule, `--filter='merge FILE'`, a
dir-merge (`:`), and `--exclude-from`; the only variation is `word_split`,
which turns the comment half of the test off.

## Sites enumerated before editing

oc has **four** readers that turn a filter file into rules. Two trimmed:

| reader | trimmed? |
|---|---|
| `crates/filters/src/merge/parse.rs::parse_rules` | no - already correct |
| `crates/cli/.../filter_rules/merge.rs::parse_merge_contents` (`--filter='merge FILE'`) | no - already correct |
| `crates/engine/.../dir_merge/load.rs` + `parse/line.rs` (dir-merge, `-F`, `:`) | **yes**, both ends of the line, plus again after the rule character |
| `crates/cli/.../filter_rules/sources.rs::read_filter_patterns` (`--exclude-from`/`--include-from`) | **yes**, before the blank/comment test |

Two readers already mirroring upstream is what makes this per-reader drift
rather than a considered project-wide choice - and it is the recurring defect
class here (fix one, leave the other).

## Measured oracle

Binaries: upstream `rsync 3.5.0` (`target/interop/upstream-src/rsync-3.5.0/rsync`,
`protocol version 32`) and `oc-rsync` built from this branch, both run as
`-r ... src/ dst/` on macOS/APFS. Cells report the destination listing.

### Dir-merge (`-F`, `.rsync-filter`)

Source holds `a`, `a ` (trailing space), ` a` (leading space), `b`.

| `.rsync-filter` | upstream | oc BEFORE | oc AFTER |
|---|---|---|---|
| `- a` | 0 `[ a, a , b]` | 0 `[ a, a , b]` | 0 `[ a, a , b]` |
| `- a ` (trailing sp) | 0 `[ a, a, b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[ a, a, b]` |
| `- a  ` (2 trailing sp) | 0 `[ a, a, a , b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[ a, a, a , b]` |
| `-  a` (2 separator sp) | 0 `[a, a , b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[a, a , b]` |
| `- a\t` (trailing tab) | 0 `[ a, a, a , b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[ a, a, a , b]` |
| `exclude a ` | 0 `[ a, a, b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[ a, a, b]` |
| `exclude  a` | 0 `[a, a , b]` | 0 `[ a, a , b]` **DIVERGE** | 0 `[a, a , b]` |
| `+ b `, `- *` | 0 `[]` | 0 `[b]` **DIVERGE** | 0 `[]` |
| `   ` then `- b` | **1** `[]` | 0 `[ a, a, a ]` **DIVERGE** | **1** `[]` |
| `  - a` | **1** `[]` | 0 `[ a, a , b]` **DIVERGE** | **1** `[]` |
| `; c` then `- b` | 0 `[ a, a, a ]` | **1** `[]` **DIVERGE** | 0 `[ a, a, a ]` |
| `  # x` then `- b` | **1** `[]` | 0 `[ a, a, a ]` **DIVERGE** | **1** `[]` |
| `- b` then `!  ` | **1** `[]` | 0 `[ a, a, a , b]` **DIVERGE** | **1** `[]` |
| `- a #c` | 0 `[ a, a, a , b]` | 0 `[ a, a, a , b]` | 0 `[ a, a, a , b]` |

12 of 14 cells diverged before; 14 of 14 match after.

### `--exclude-from`

Source holds `keep`, `   ` (three spaces), `  #a`. The exotic names are what
make this cell discriminating - with ordinary names both implementations
produce the same tree and the divergence is invisible.

| exclude-from file | upstream | oc BEFORE | oc AFTER |
|---|---|---|---|
| `   ` | 0 `[  #a, keep]` | 0 `[   ,   #a, keep]` **DIVERGE** | 0 `[  #a, keep]` |
| `  #a` | 0 `[   , keep]` | 0 `[   ,   #a, keep]` **DIVERGE** | 0 `[   , keep]` |

### Readers that were already correct (regression check, after the change)

`--filter='merge filt'`, `--filter='. filt'`, and a bare CLI `--filter='- a '`
were measured across the same six shapes and match upstream both before and
after. `:-` / `:+` (`FILTRULE_NO_PREFIXES`) dir-merge was measured across five
shapes and matches upstream after the change.

## The fix

The skip test now has **one owner**: `filters::filter_file_line_is_rule`, in a
new `crates/filters/src/merge/skip.rs`, carrying the upstream citation and the
two properties that were repeatedly lost (first-byte test, `word_split ||`
short-circuit). All four readers call it - including the two that were already
correct, so a future drift has nowhere to hide. `filters` was already a shared
dependency of `cli` and `engine` and already exports small predicates of this
shape (`is_over_long`), so no new abstraction was introduced.

The engine dir-merge parser additionally stopped trimming after the rule
character and after the keyword, matching the CLI parser's existing
`consume_rule_separator` contract.

## Mutation proof

Test: `tests/filter_rule_whitespace_is_pattern_text.rs`, 12 cells, all
asserting on **which files reached the destination**, not on an internal
string.

**Mutation 1** - revert the engine dir-merge change
(`git checkout -- crates/engine/src/local_copy/dir_merge/{load.rs,parse/line.rs}`),
keep the test:

```
Summary  9 tests run: 1 passed, 8 failed
```

(the file had 9 cells at that point). The one that stayed green is the negative
control `a_plain_rule_is_unaffected`. Headline failure:

```
thread 'a_trailing_space_belongs_to_the_pattern' panicked at
tests/filter_rule_whitespace_is_pattern_text.rs:78:5:
`- a ` must NOT exclude `a`: the pattern is `a ` with the trailing space,
and upstream matches it literally (exclude.c:1465)
```

**Mutation 2** - revert only the CLI reader change
(`git checkout -- crates/cli/src/frontend/filter_rules/sources.rs`), keep
everything else:

```
Summary  12 tests run: 10 passed, 2 failed
  FAIL  a_whitespace_only_exclude_from_line_is_a_pattern
  FAIL  an_indented_hash_in_an_exclude_from_file_is_a_pattern
```

Exactly the two cells that site owns. The sibling dir-merge cells and the
column-zero-comment control (`a_column_zero_hash_in_an_exclude_from_file_is_still_a_comment`)
stayed green, so neither mutation is killed by an unrelated assertion.

Restored, both runs return `12 tests run: 12 passed`.

## Full workspace run

`cargo nextest run --workspace --no-fail-fast` on the pinned 1.88.0 toolchain:

```
Summary [ 387.560s] 32802 tests run: 32798 passed (6 slow, 2 leaky), 4 failed, 148 skipped
```

All four failures were run down rather than waved off:

| failure | verdict |
|---|---|
| `engine ... execute_with_sparse_enabled_creates_holes` | **pre-existing** - fails identically on unmodified `origin/master` (900b5c445) |
| `cli ... transfer_request_with_sparse_preserves_holes` | **pre-existing** - same |
| `xtask ... backdated_tree_populates_and_backdates_the_root` | **pre-existing** - same |
| `bin::delete_during_stream_error_1895 delete_during_survives_sender_stream_truncation` | **load flake** - passes on `origin/master`; on this branch it failed at 20s and 50s while three other agents' full-workspace nextest runs shared the host, and passes 3/3 in isolation (12.9s / 12.2s / 12.1s). The test contains no filter, merge, or exclude reference, so it has no path to this change. |

The baseline was measured by checking out `900b5c445` detached, rebuilding, and
running the same four test filters: `4 tests run: 1 passed, 3 failed`.

`python3 tools/ci/check_rustfmt_all.py` exits 0 (3411 files) and
`cargo clippy --locked --workspace --all-targets --all-features --no-deps -- -D warnings`
is clean.

## Tests changed rather than added

Three existing tests encoded the pre-fix behaviour and were rewritten against
the measured upstream behaviour, not deleted:

- `engine ... parse_filter_directive_line_comment` -> now asserts the parser
  refuses `# this is a comment` (measured: upstream `--filter='# a comment'`
  exits 1 with `Unknown filter rule`). Comment skipping is the file reader's
  job, which is where upstream puts it.
- `engine ... parse_filter_directive_line_whitespace` -> now asserts `   ` is a
  syntax error.
- `cli ... load_filter_file_patterns_skip_semicolon_comments` -> renamed to
  `..._skip_only_column_zero_semicolon_comments`; `  ; spaced comment` is now
  expected to survive as a pattern.

## NOT verified

Stated plainly rather than implied:

- **Only macOS/APFS.** Every measurement above was taken on darwin arm64. Linux
  and Windows were not exercised; filenames with trailing spaces are illegal on
  Windows, so those cells cannot run there at all.
- **Local transfers only.** No daemon, SSH, or wire-protocol leg was measured.
  The dir-merge rules do travel over the wire, and that path is untested here.
- **`oc BEFORE` for the `:-`/`:+` (`NO_PREFIXES`) dir-merge sub-table was not
  captured** - only post-fix parity was measured. The pre-fix divergence there
  is inferred from the code path (it shared the trimmed line), not measured.
- **The `:w` word-split cells were non-discriminating.** Both implementations
  exited 1 on my fixture for an unrelated reason, so word-split behaviour is
  effectively unmeasured. `filter_file_line_is_rule` takes the
  `comments_recognised` flag for it, and the engine's word-split arm now passes
  `#` tokens through (upstream-correct per `exclude.c:1806`'s `word_split ||`),
  but that is source-only, not measured end to end.
- **Remaining known divergences, deliberately left alone** (each wants its own
  change, none is a whitespace trim):
  - A merge FILENAME still has trailing whitespace trimmed
    (`parse_merge_directive`); both oc parsers agree with each other but not
    necessarily with upstream. Unmeasured.
  - `exclude\ta` is accepted by oc; upstream's modifier loop breaks only on
    ` `/`_`, so a tab should be an invalid modifier. Unmeasured.
  - `exclude-if-present` is an oc-only directive with no upstream counterpart
    and still trims its marker name.
