### PR TITLE
fix(daemon): name --relative sender operands from the module root

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -83,6 +83,20 @@ impl GeneratorContext {
         self.source_bases.reserve(FLIST_START);
 
         let relative_paths = self.config.flags.relative;
+        // upstream: clientserver.c:1059 - `change_dir(module_chdir, CD_NORMAL)`
+        // puts a daemon server's `curr_dir` at the module root before a single
+        // positional is read, and `glob_expand_module()` (util1.c:881) plus
+        // `sanitize_path(NULL, argv[i], "", 0, ..)` (options.c:2405) hand the
+        // sender module-RELATIVE positionals. oc-rsync never `chdir()`s and
+        // resolves each positional to an absolute on-disk path instead, so the
+        // module root is the base `--relative` must name against. Without it the
+        // walk base is `/` and the daemon's real filesystem prefix goes out on
+        // the wire as the transmitted name.
+        let daemon_module_root = self
+            .config
+            .connection
+            .served_module_root()
+            .map(Path::to_path_buf);
         // upstream: flist.c:send_implied_dirs() - every parent directory of a
         // --relative source must be present in the file list so the receiver
         // can find it via flist_find_name() (generator.c:1313). We track
@@ -105,7 +119,7 @@ impl GeneratorContext {
             // upstream: flist.c:2316 - --relative additionally honours the
             // `/./` anchor and emits implied parent directories.
             let (base, path) = if relative_paths {
-                relative_walk_base(base_path)
+                relative_walk_base(base_path, daemon_module_root.as_deref())
             } else {
                 non_relative_walk_base(base_path)
             };
@@ -580,7 +594,29 @@ pub(super) fn operand_has_dotdir_marker(path: &Path) -> bool {
 ///
 /// The returned `base` is what `walk_path` strips from each child path to
 /// compute its wire-side relative name.
-fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
+///
+/// # The daemon module root
+///
+/// `module_root` is upstream's `module_dir`, present only in a daemon server
+/// process that has selected a module. Upstream's sender never sees an
+/// absolute operand there: `glob_expand_module()` (`util1.c:881`) strips the
+/// `MODULE/` prefix the client sent and `sanitize_path(NULL, argv[i], "", 0,
+/// SP_KEEP_DOT_DIRS)` (`options.c:2405`) re-roots whatever is left at the
+/// module, so the positional reaching `flist.c:2610` is already
+/// module-relative and the `curr_dir` it is named against is the module root
+/// the server `chdir()`ed into (`clientserver.c:1059`).
+///
+/// oc-rsync resolves each positional to an absolute on-disk path instead of
+/// `chdir()`ing, so the module root has to be re-supplied here. Without it the
+/// no-anchor branch below falls to `base = "/"`, the transmitted name becomes
+/// the daemon's own filesystem path, and every `--relative` daemon pull either
+/// materialises that path at the client or is refused by the receiver's
+/// `rejecting unrequested file-list name` check (`flist.c:1144-1145`).
+///
+/// The anchor branch needs no such treatment: a `/./` operand already carries
+/// its own base, which is upstream's `dir` half and the directory upstream
+/// `change_pathname()`s into (`flist.c:2678`).
+fn relative_walk_base(path: &Path, module_root: Option<&Path>) -> (PathBuf, PathBuf) {
     // upstream: flist.c:2623 - `if ((p = strstr(fbuf, "/./")) != NULL)`
     if let Some(anchor) = find_dot_dir_anchor(path) {
         let path_str = path.as_os_str().to_string_lossy();
@@ -604,6 +640,15 @@ fn relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
             base.join(rest)
         };
         return (base, full);
+    }
+
+    // upstream: clientserver.c:1059 - a daemon server serves from the module
+    // root, so that root is the `curr_dir` the operand is named against and the
+    // transmitted name is the module-relative tail, never the server's path.
+    if let Some(root) = module_root {
+        if path.starts_with(root) {
+            return (root.to_path_buf(), path.to_path_buf());
+        }
     }
 
     // upstream: flist.c:2329 - no "/./" anchor: the entire path is the

--- a/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
+++ b/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
@@ -1,0 +1,293 @@
+//! A daemon `--relative` pull must transmit MODULE-relative names.
+//!
+//! Upstream's daemon sender never sees an absolute operand. `read_args()`
+//! routes every post-`.` positional through `glob_expand_module()`, which
+//! strips the `MODULE/` prefix the client sent, and `parse_arguments()` then
+//! re-roots whatever is left at the module with `sanitize_path(NULL, argv[i],
+//! "", 0, SP_KEEP_DOT_DIRS)`. By the time `send_file_list()` splits the
+//! positional, `curr_dir` is the module root the server `chdir()`ed into and
+//! the transmitted name is the module-relative tail.
+//!
+//! oc-rsync never `chdir()`s: the daemon resolves each positional to an
+//! absolute on-disk path and the sender walks that. Under `--relative` the
+//! whole path is the transmitted name, so without re-supplying the module root
+//! as the walk base the daemon's own filesystem prefix goes out on the wire.
+//! Measured against rsync 3.5.0 serving the same fixture, every one of sixteen
+//! operand shapes diverged: the receiver either refused the file list
+//! (`rejecting unrequested file-list name`, flist.c:1144) or materialised the
+//! server's absolute path under the destination.
+//!
+//! Ground truth for the two pinned shapes, captured from rsync 3.5.0 serving
+//! module `mod` rooted at a tree of `top.txt`, `a/c.txt`, `a/b/file.txt`:
+//!
+//! ```text
+//! rsync -R -r rsync://host/mod/a/b/file.txt dst/  ->  a, a/b, a/b/file.txt
+//! rsync -R -r rsync://host/mod/            dst/  ->  a, a/b, a/b/file.txt, a/c.txt, top.txt
+//! ```
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/clientserver.c:1059` - `change_dir(module_chdir, CD_NORMAL)`
+//! - `rsync-3.5.0/util1.c:881` - `glob_expand_module()` strips `MODULE/`
+//! - `rsync-3.5.0/options.c:2405` - `sanitize_path(NULL, argv[i], "", 0, ..)`
+//! - `rsync-3.5.0/flist.c:2610-2660` - the per-positional `dir`/`fn` split
+//! - `rsync-3.5.0/flist.c:1144` - `rejecting unrequested file-list name`
+
+#![cfg(unix)]
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use tempfile::{TempDir, tempdir};
+
+const MODULE: &str = "relmod";
+
+fn write_daemon_config(
+    config_path: &Path,
+    pid_path: &Path,
+    log_path: &Path,
+    module_root: &Path,
+) -> io::Result<()> {
+    let body = format!(
+        "pid file = {pid}\n\
+         log file = {log}\n\
+         use chroot = false\n\
+         max connections = 4\n\
+         \n\
+         [{MODULE}]\n\
+         path = {root}\n\
+         comment = relative daemon pull names\n\
+         read only = true\n\
+         list = true\n",
+        pid = pid_path.display(),
+        log = log_path.display(),
+        root = module_root.display(),
+    );
+    fs::write(config_path, body)
+}
+
+/// Kills the daemon child on drop so a panicking cell never leaks the listener.
+struct DaemonGuard {
+    child: Child,
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_oc_daemon(oc_bin: &Path, config_path: &Path) -> io::Result<(DaemonGuard, u16)> {
+    let (child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(oc_bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    Ok((DaemonGuard { child }, port))
+}
+
+/// The module tree every cell serves:
+///
+/// ```text
+/// <module>/top.txt
+/// <module>/a/c.txt
+/// <module>/a/b/file.txt
+/// ```
+struct Fixture {
+    _tmp: TempDir,
+    config: PathBuf,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Option<Self> {
+        let tmp = tempdir().ok()?;
+        // macOS resolves `/tmp -> /private/tmp`; canonicalise so the ambient
+        // prefix is not what the tree assertion measures.
+        let root = fs::canonicalize(tmp.path()).ok()?;
+        let module_root = root.join("module");
+        fs::create_dir_all(module_root.join("a/b")).ok()?;
+        fs::write(module_root.join("top.txt"), b"top\n").ok()?;
+        fs::write(module_root.join("a/c.txt"), b"c\n").ok()?;
+        fs::write(module_root.join("a/b/file.txt"), b"f\n").ok()?;
+        let config = root.join("rsyncd.conf");
+        write_daemon_config(
+            &config,
+            &root.join("rsyncd.pid"),
+            &root.join("rsyncd.log"),
+            &module_root,
+        )
+        .ok()?;
+        Some(Self {
+            config,
+            root,
+            _tmp: tmp,
+        })
+    }
+}
+
+/// Everything a cell needs to judge a pull: exit status, stderr, and the
+/// destination tree as `/`-joined relative paths in sorted order.
+struct Pulled {
+    status: std::process::ExitStatus,
+    stderr: String,
+    tree: Vec<String>,
+}
+
+/// Pulls `rsync://127.0.0.1:<port>/relmod/<tail>` into a fresh destination,
+/// passing `extra` ahead of the source (`-R` for the pinned cells, nothing for
+/// the negative control).
+fn pull(tail: &str, extra: &[&str]) -> Option<Pulled> {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(fixture) = Fixture::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return None;
+    };
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &fixture.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return None;
+        }
+    };
+
+    let dest = fixture.root.join("dest");
+    fs::create_dir_all(&dest).expect("create destination");
+
+    let src_url = OsString::from(format!("rsync://127.0.0.1:{port}/{MODULE}/{tail}"));
+    let mut dest_arg = dest.clone().into_os_string();
+    dest_arg.push("/");
+    let mut args: Vec<&OsStr> = vec![OsStr::new("-r")];
+    args.extend(extra.iter().map(OsStr::new));
+    args.push(&src_url);
+    args.push(&dest_arg);
+
+    let output = Command::new(&oc_bin)
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn oc-rsync client (daemon pull)");
+
+    Some(Pulled {
+        status: output.status,
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        tree: collect_tree(&dest, &dest),
+    })
+}
+
+/// Relative `/`-joined names of everything under `dir`, sorted.
+fn collect_tree(root: &Path, dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .into_owned();
+        let is_dir = fs::symlink_metadata(&path).is_ok_and(|m| m.file_type().is_dir());
+        out.push(rel);
+        if is_dir {
+            out.extend(collect_tree(root, &path));
+        }
+    }
+    out.sort();
+    out
+}
+
+/// A `--relative` pull of a sub-path names it from the module root.
+///
+/// Before the walk base was re-anchored, the sender transmitted the daemon's
+/// absolute path, and the receiver's `rejecting unrequested file-list name`
+/// check (flist.c:1144) refused the whole list - so this cell fails on the
+/// status line, promptly, rather than hanging.
+#[test]
+fn relative_pull_of_a_subpath_names_it_from_the_module_root() {
+    let Some(pulled) = pull("a/b/file.txt", &["-R"]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "`-R` pull of `{MODULE}/a/b/file.txt` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["a".to_owned(), "a/b".to_owned(), "a/b/file.txt".to_owned(),],
+        "upstream's daemon sender names the positional against `curr_dir`, \
+         which `clientserver.c:1059` put at the module root, so `-R` transmits \
+         `a/b/file.txt`; any component of the server's own path in this tree \
+         means the walk base was `/` instead of the module root",
+    );
+}
+
+/// The whole-module operand takes the same base.
+///
+/// This shape TRANSFERS either way, so only the tree can see the defect: with
+/// the walk base at `/` the client materialises the daemon's absolute path
+/// under the destination instead of the module contents.
+#[test]
+fn relative_pull_of_the_module_root_names_its_contents_from_the_module_root() {
+    let Some(pulled) = pull("", &["-R"]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "`-R` pull of `{MODULE}/` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec![
+            "a".to_owned(),
+            "a/b".to_owned(),
+            "a/b/file.txt".to_owned(),
+            "a/c.txt".to_owned(),
+            "top.txt".to_owned(),
+        ],
+        "the module root operand resolves to the module root itself, so the \
+         relative names are the module's own contents; a `private`/`tmp`/... \
+         prefix here is the server's filesystem path on the wire",
+    );
+}
+
+/// Negative control: the non-`--relative` path is a different upstream branch
+/// (`flist.c:2610-2620` splits on the LAST `/`) and must be unaffected. It is
+/// green before and after the re-anchoring, so a red pin beside a green
+/// control proves the change is scoped to `--relative`.
+#[test]
+fn a_non_relative_pull_of_the_same_subpath_is_unchanged() {
+    let Some(pulled) = pull("a/b/file.txt", &[]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/a/b/file.txt` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["file.txt".to_owned()],
+        "without `--relative` upstream sends the basename only",
+    );
+}


### PR DESCRIPTION
On a `--relative` pull from a daemon module, the transmitted file-list names were
built from the absolute server-side path instead of the module root. Four operand
shapes materialised the daemon's absolute filesystem layout at the client
(`private/var/.../srv/module/top.txt`); the rest were refused outright with
`rejecting unrequested file-list name`.

## Upstream

Upstream never lets its daemon sender see an absolute operand. The module prefix is
stripped and the remainder re-rooted at the module before `send_file_list()` runs:

- `clientserver.c:1059-1060` - `change_dir(module_chdir, CD_NORMAL)`, the
  unconditional per-connection chdir, so `curr_dir` is the module root.
- `io.c:1497` / `util1.c:881-914` - `read_args()` routes post-`.` args through
  `glob_expand_module()`, which strips the `MODULE/` prefix.
- `flist.c:2610-2662` - the per-positional `dir`/`fn` split then runs against that
  already-module-relative name.

oc never `chdir()`s, so the module root has to be supplied explicitly at each
consumer. `relative_walk_base()` had no such parameter and fell back to making the
whole absolute path the transmitted name.

## Change

`relative_walk_base()` takes the served module root and uses it as the walk base for
the no-anchor case; `build_file_list()` supplies it from
`ConnectionConfig::served_module_root()` (upstream's `am_daemon ? module_dir : ...`).
The `/./` anchor branch is untouched and still runs first, mirroring upstream's
per-positional split.

`relative_walk_base` has exactly one call site. `daemon_module_root` has one
non-test producer and six consumers; the other five already read the pair
correctly - only the sender-side flist base was wrong. `--files-from` uses its own
explicit base and is untouched.

## Oracle

Real rsync 3.5.0 daemon vs oc daemon, upstream client both sides. Module
`mod` = `{top.txt, a/c.txt, a/b/file.txt, sym -> a}`; client
`rsync -R -r rsync://127.0.0.1:P/<shape> dst/`.

| # | shape | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|---|
| 1 | `mod/a/b/file.txt` | `a a/b a/b/file.txt` | rc4 rejecting ... `private` | match |
| 2 | `mod/./a/b/file.txt` | same | rc4 leak | match |
| 3 | `mod/a/./b/file.txt` | `b b/file.txt` | rc4 leak | still diverges (below) |
| 4 | `mod/a/b/` | `a a/b a/b/file.txt` | rc4 leak | match |
| 5 | `mod/a/b` | same | rc4 leak | match |
| 6 | `mod/` | full module | rc0, absolute tree materialised | match |
| 7 | `mod` | full module | rc0, absolute tree | match |
| 8 | `mod/.` | full module | rc0, absolute tree | match |
| 9 | `mod//a/b/file.txt` | `a a/b a/b/file.txt` | rc4 leak | match |
| 10 | `mod/a/../a/c.txt` | rc4 `...: a/c.txt` | rc4 `...: private` | byte-identical |
| 11 | `mod/../mod/a/c.txt` | rc23 `link_stat "mod/a/c.txt" (in mod)` | rc23 absolute path | byte-identical |
| 12 | `mod/sym/c.txt` | `sym sym/c.txt` | rc4 leak | match |
| 13 | `mod/sym/` | `sym sym/b sym/b/file.txt sym/c.txt` | rc4 leak | match |
| 14 | `mod/a/.` | `a a/b a/b/file.txt a/c.txt` | rc4 leak | match |
| 15 | `mod/./` | full module | rc0, absolute tree | match |
| 16 | `mod/top.txt` | `top.txt` | rc4 leak | match |

Before 0/16, after 15/16. A control sweep without `-R` was already 15/16 before and
is unchanged after, which localises the defect to `--relative` exactly.

## Non-inertness

Shape 11's error text becomes `link_stat "mod/a/c.txt" (in mod) failed` - byte-identical
to upstream - because `GeneratorContext::curr_dir` is fed from the same walk base. That
is a second independent observable of the same branch.

Mutating the branch to `if false && path.starts_with(root)` and rebuilding:

- `relative_pull_of_a_subpath_names_it_from_the_module_root` FAILS
  (`rejecting unrequested file-list name: private (code 23)`)
- `relative_pull_of_the_module_root_names_its_contents_from_the_module_root` FAILS
  (`left: ["private", "private/var", ...]` vs `right: ["a", "a/b", ...]`)
- `a_non_relative_pull_of_the_same_subpath_is_unchanged` stays green - the negative
  control, exercising the untouched `non_relative_walk_base`.

No mutation hangs; the binary finishes in 8.49s.

## Verification

- `python3 tools/ci/check_rustfmt_all.py` clean (3409 files)
- `cargo clippy --locked --workspace --all-targets --all-features --no-deps` exit 0
- `cargo nextest run --locked --workspace --all-features --no-fail-fast` - 33139 tests,
  4 failures, all pre-existing and environmental (proved by re-running each with the
  change reverted; three fail identically on the clean tree, the fourth is the same
  APFS sparse-holes class that flips run to run)
- No expect-manifest touched. No `daemon*_test.py` cell in the 3.5.0 testsuite uses
  `-R`, and `run_interop.sh`'s only `-R` daemon cell pushes, so neither gate exercises
  this path.

## Deliberately out of scope

Shape 3 (`mod/a/./b/file.txt`) is a separate defect at a separate site. Upstream keeps
`.` components under `--relative` (`util1.c:1141`, `drop_dot_dirs = !relative_paths ||
!(flags & SP_KEEP_DOT_DIRS)`, reached via `options.c:2405` which passes
`SP_KEEP_DOT_DIRS`), so the `/./` pivot survives to `flist.c:2622`. oc's
`collapse_module_relative` calls the drop-dot-dirs variant unconditionally. Fixing it
means threading `relative_paths` through `resolve_sender_sources`/`resolve_receiver_dest`
and changing a DOTDIR-marker string contract a prior PR deliberately built and pinned.
