### PR TITLE
fix(engine): make way for an entry over a directory on the local-copy path

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -219,6 +219,13 @@ pub(crate) struct CopyContext<'a> {
     /// sets `got_xfer_error` without aborting the transfer.
     // upstream: sender.c:395 successful_send(); log.c:311 got_xfer_error
     sender_remove_error: bool,
+    /// Set when a directory obstacle could not be removed to make way for an
+    /// incoming regular file, symlink, or special. That one entry is skipped
+    /// and the run continues, but this flag drives the final `RERR_PARTIAL`
+    /// (exit 23) exit code, mirroring upstream's `could not make way for %s
+    /// %s` at `FERROR_XFER`.
+    // upstream: delete.c:283-285; log.c:310-311 got_xfer_error
+    make_way_error: bool,
     /// Set when the delete emitter reported a genuine swallowed unlink/rmdir
     /// error during the recursive peel (an `EACCES` and friends the walker
     /// logged and stepped over). The pass keeps deleting the rest of the

--- a/crates/engine/src/local_copy/context_impl/backup.rs
+++ b/crates/engine/src/local_copy/context_impl/backup.rs
@@ -444,7 +444,7 @@ impl<'a> CopyContext<'a> {
     /// `delete_dir_contents()` recursion (delete.c:83): the children are
     /// reported like delete-pass deletions (DEL_MAKE_ROOM stripped) while the
     /// directory node itself is removed silently by the caller.
-    fn record_make_room_contents(
+    pub(crate) fn record_make_room_contents(
         &mut self,
         destination: &Path,
         relative: Option<&Path>,

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -70,6 +70,7 @@ impl<'a> CopyContext<'a> {
             iconv_conversion_error: false,
             unsupported_operation_skipped: false,
             sender_remove_error: false,
+            make_way_error: false,
             delete_io_error: false,
             multi_source: false,
             verified_parents: HashMap::new(),
@@ -533,6 +534,25 @@ impl<'a> CopyContext<'a> {
     /// even though every other entry was copied.
     pub(super) const fn sender_remove_error_occurred(&self) -> bool {
         self.sender_remove_error
+    }
+
+    /// Records that a directory obstacle survived the `rmdir` that had to make
+    /// way for an incoming regular file, symlink, or special. The entry is
+    /// skipped, the rest of the transfer continues, and the run finishes
+    /// `RERR_PARTIAL` (23).
+    ///
+    /// upstream: `delete.c:283-285` emits `could not make way for %s %s` at
+    /// `FERROR_XFER`, `log.c:310-311` sets `got_xfer_error`, and
+    /// `cleanup.c:217-218` lifts a zero exit to `RERR_PARTIAL`.
+    pub(crate) fn record_make_way_error(&mut self) {
+        self.make_way_error = true;
+    }
+
+    /// Reports whether any obstacle removal was refused, so the transfer can
+    /// finish with exit code 23 (`RERR_PARTIAL`) even though every other entry
+    /// was copied.
+    pub(super) const fn make_way_error_occurred(&self) -> bool {
+        self.make_way_error
     }
 
     /// Records that a source file ended before the length this transfer was

--- a/crates/engine/src/local_copy/error.rs
+++ b/crates/engine/src/local_copy/error.rs
@@ -397,12 +397,6 @@ pub enum LocalCopyArgumentError {
     LinkNameUnavailable,
     /// Encountered a file type that is unsupported.
     UnsupportedFileType,
-    /// Attempted to replace an existing directory with a symbolic link.
-    ReplaceDirectoryWithSymlink,
-    /// Attempted to replace an existing directory with a regular file.
-    ReplaceDirectoryWithFile,
-    /// Attempted to replace an existing directory with a special file.
-    ReplaceDirectoryWithSpecial,
     /// Attempted to replace a non-directory with a directory.
     ReplaceNonDirectoryWithDirectory,
     /// Encountered an operand that refers to a remote host or module.
@@ -423,13 +417,6 @@ impl LocalCopyArgumentError {
             Self::FileNameUnavailable => "cannot determine file name",
             Self::LinkNameUnavailable => "cannot determine link name",
             Self::UnsupportedFileType => "unsupported file type encountered",
-            Self::ReplaceDirectoryWithSymlink => {
-                "cannot replace existing directory with symbolic link"
-            }
-            Self::ReplaceDirectoryWithFile => "cannot replace existing directory with regular file",
-            Self::ReplaceDirectoryWithSpecial => {
-                "cannot replace existing directory with special file"
-            }
             Self::ReplaceNonDirectoryWithDirectory => {
                 "cannot replace non-directory destination with directory"
             }
@@ -657,9 +644,6 @@ mod tests {
             LocalCopyArgumentError::FileNameUnavailable,
             LocalCopyArgumentError::LinkNameUnavailable,
             LocalCopyArgumentError::UnsupportedFileType,
-            LocalCopyArgumentError::ReplaceDirectoryWithSymlink,
-            LocalCopyArgumentError::ReplaceDirectoryWithFile,
-            LocalCopyArgumentError::ReplaceDirectoryWithSpecial,
             LocalCopyArgumentError::ReplaceNonDirectoryWithDirectory,
             LocalCopyArgumentError::RemoteOperandUnsupported,
         ];

--- a/crates/engine/src/local_copy/executor/cleanup.rs
+++ b/crates/engine/src/local_copy/executor/cleanup.rs
@@ -707,7 +707,7 @@ fn delete_leaf(
 /// Whether an `rmdir` error means the directory was left non-empty (upstream
 /// `DR_NOT_EMPTY`). ENOTEMPTY is 39 on Linux and 66 on BSD/macOS; the raw errno
 /// check keeps this platform-independent without a libc dependency.
-fn is_dir_not_empty(error: &io::Error) -> bool {
+pub(super) fn is_dir_not_empty(error: &io::Error) -> bool {
     error.kind() == io::ErrorKind::DirectoryNotEmpty
         || matches!(error.raw_os_error(), Some(39) | Some(66))
 }

--- a/crates/engine/src/local_copy/executor/file/copy/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/mod.rs
@@ -90,40 +90,64 @@ pub(crate) fn copy_file(
     };
 
     let mut destination_previously_existed = existing_metadata.is_some();
+    let destination_had_entry = destination_previously_existed;
 
-    if let Some(existing) = existing_metadata.as_ref()
-        && existing.file_type().is_dir()
+    // upstream: generator.c:1780-1804 - the `ignore_existing` skip is tested at
+    // `statret == 0` and `goto cleanup`s BEFORE either make-way removal
+    // (generator.c:2149 / 2477-2483), so `--ignore-existing` leaves the
+    // directory standing rather than clearing it; the skip itself is recorded
+    // by `handle_existing_skips` further down, which still sees the directory.
+    if existing_metadata
+        .as_ref()
+        .is_some_and(|existing| existing.file_type().is_dir())
+        && !context.ignore_existing_enabled()
     {
-        // upstream: generator.c:1734-1739 recv_generator() - a regular file is
+        // upstream: generator.c:2148-2153 recv_generator() - a regular file is
         // arriving over a destination directory. Upstream calls
-        // delete_item(fname, mode, del_opts | DEL_FOR_FILE) to make room, with
-        // del_opts carrying DEL_RECURSE only under --delete/--force. So a
-        // conflicting destination directory is removed to make way for the file
-        // under those modes and the file is created in its place.
+        // delete_item(fname, mode, del_opts | DEL_FOR_FILE) UNCONDITIONALLY;
+        // del_opts carries DEL_RECURSE only under --delete/--force and that
+        // flag selects the RECURSION, not the removal (delete.c:207-209 - "If
+        // DEL_RECURSE is not set, this just reports emptiness"). So an empty
+        // directory is rmdir'd and the file placed with no options at all, and
+        // a populated one is refused out loud at exit 23.
         //
         // Multi-source merges are the exception: flist.c:3067-3081
         // flist_sort_and_clean() drops the colliding regular file and keeps the
-        // directory, so a file contributed by one source must never blow away a
-        // directory contributed by another. Guard the delete-mode removal on
-        // !multi_source to preserve that, keeping the explicit --force override.
-        let replace_conflicting_directory = context.force_replacements_enabled()
+        // directory, so the entry never reaches recv_generator at all and a file
+        // contributed by one source must never blow away a directory
+        // contributed by another. That skip is kept below, with the explicit
+        // --force override upstream's flist merge does not have.
+        let recurse = context.force_replacements_enabled()
             || (!context.multi_source() && context.options().delete_extraneous());
-        if replace_conflicting_directory {
-            context.force_remove_destination(destination, relative, existing)?;
-            // The conflicting directory is gone, so the incoming file is created
-            // fresh: upstream sets statret = -1 after the make-room delete
-            // (generator.c:1737), so dest_mode() applies new-file permissions and
-            // the itemize row reports a creation (`>f+++++++++`) rather than an
-            // update against the removed directory.
-            destination_previously_existed = false;
-            existing_metadata = None;
-        } else {
-            // Mirror upstream's goto cleanup: no error, no destination mutation.
+        if context.multi_source() && !context.force_replacements_enabled() {
             return Ok(true);
         }
+        if !crate::local_copy::clear_directory_obstacle(
+            context,
+            destination,
+            relative,
+            recurse,
+            crate::local_copy::MakeWayFor::File,
+        )? {
+            // upstream: generator.c:2150 `goto cleanup` - this entry is skipped,
+            // the rest of the transfer continues, and the run finishes 23.
+            return Ok(true);
+        }
+        // The conflicting directory is gone, so the incoming file is created
+        // fresh: upstream sets statret = -1 after the make-room delete
+        // (generator.c:2151), so dest_mode() applies new-file permissions and
+        // the itemize row reports a creation (`>f+++++++++`) rather than an
+        // update against the removed directory.
+        destination_previously_existed = false;
+        existing_metadata = None;
     }
 
-    if context.existing_only_enabled() && existing_metadata.is_none() {
+    // upstream: generator.c:1758-1766 - `ignore_non_existing` (`--existing`)
+    // is tested at `statret == -1 && stat_errno == ENOENT`, so it asks whether
+    // the destination existed BEFORE the make-way removal. Reading the
+    // post-removal `None` instead would skip the very entry the removal just
+    // cleared the way for, leaving neither the directory nor the file.
+    if context.existing_only_enabled() && !destination_had_entry {
         context.summary_mut().record_regular_file_skipped_missing();
         let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None)
             .virtualize_fake_super(source, metadata_options.fake_super_enabled());

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -4,6 +4,7 @@ mod cleanup;
 mod directory;
 mod file;
 mod iconv;
+mod obstacle;
 mod reference;
 mod sources;
 mod special;
@@ -40,6 +41,7 @@ pub(crate) use file::{
 pub(crate) use iconv::{
     emit_cannot_convert_filename, name_is_convertible, transcode_filename_component,
 };
+pub(crate) use obstacle::{MakeWayFor, clear_directory_obstacle};
 pub(crate) use reference::{
     ReferenceDecision, ReferenceQuery, find_compare_dest_symlink, find_copy_dest_basis,
     find_copy_dest_symlink, find_reference_action, reference_attrs_unchanged,

--- a/crates/engine/src/local_copy/executor/obstacle.rs
+++ b/crates/engine/src/local_copy/executor/obstacle.rs
@@ -1,0 +1,348 @@
+//! The local-copy path's single decision site for a DIRECTORY standing where a
+//! regular file, symlink, FIFO, socket, or device node has to be written.
+//!
+//! Upstream reaches this decision from two call sites, and neither of them
+//! gates the removal on an option:
+//!
+//! ```text
+//! generator.c:2148-2153            (a regular file is arriving)
+//! if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
+//!         if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
+//!                 goto cleanup;
+//!         statret = -1;
+//!
+//! generator.c:2477-2483            (atomic_create(), a symlink/device/special)
+//! if (make_backups > 0 && !dir_in_the_way) {
+//!         if (!make_backup(fname, skip_atomic))
+//!                 return 0;
+//! } else if (skip_atomic) {
+//!         int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
+//!         if (delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag) != 0)
+//!                 return 0;
+//! }
+//! ```
+//!
+//! `del_opts` carries `DEL_RECURSE` only under `--delete` / `--force`, and
+//! `DEL_RECURSE` selects the RECURSION, not the removal: `delete_item()` runs
+//! either way and `delete_dir_contents()` "just reports emptiness" when the flag
+//! is clear (`delete.c:207-209`). So an EMPTY directory obstacle is `rmdir`'d
+//! and the replacement placed at exit 0 with no options at all, and a POPULATED
+//! one is refused OUT LOUD - `cannot delete non-empty directory` on stdout,
+//! `could not make way for new <noun>` on stderr, that one entry skipped, and
+//! the run finishing `RERR_PARTIAL` (23) with every other entry transferred.
+//!
+//! oc's local-copy executor gated the whole removal on `--force` / `--delete`
+//! instead, so without them a regular file arriving over a destination
+//! directory was dropped in silence at exit 0, and a symlink or special aborted
+//! the run with an oc-only argument error that has no upstream analogue.
+//!
+//! `dir_in_the_way` also forces `skip_atomic` (`generator.c:2469-2472`), which
+//! is why the `make_backup` arm above is unreachable for a directory in EITHER
+//! mode. `delete_item()` then splits the same way one level down - the `rmdir`
+//! arm at `delete.c:221-226`, the `make_backup`/`unlink` arm in the `else` at
+//! `delete.c:227-238` - so the directory NODE is never backed up. Its CONTENTS
+//! are: the `DEL_RECURSE` peel calls `delete_item()` per child, and that child
+//! takes the `make_backup` arm under `--backup`. With a `--backup-dir` the
+//! children move out and the `rmdir` then succeeds; with a plain `~` suffix they
+//! are renamed in place, the directory never empties, and upstream refuses at 23
+//! even though `--force` was given. Both are measured cells, not readings.
+//!
+//! # Upstream Reference
+//!
+//! - `generator.c:2148-2153` - the `DEL_FOR_FILE` removal ahead of a regular-file transfer
+//! - `generator.c:2469-2483` - `atomic_create()`'s `dir_in_the_way` / `skip_atomic` / `del_opts`
+//! - `delete.c:204-214` - `delete_dir_contents()` reached first for a directory
+//! - `delete.c:221-226` - the `rmdir` arm
+//! - `delete.c:259-268` - the `ENOTEMPTY` / `rsyserr` / `ENOENT` split
+//! - `delete.c:272-286` - `could not make way for %s %s: %s` at `FERROR_XFER`
+//! - `log.c:310-311` - `case FERROR_XFER: got_xfer_error = 1;`
+//! - `cleanup.c:217-218` - `got_xfer_error` lifts a zero exit to `RERR_PARTIAL`
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use super::cleanup::is_dir_not_empty;
+use crate::local_copy::{CopyContext, LocalCopyError};
+
+/// The kind of item the local-copy executor is clearing the way for.
+///
+/// Names the `DEL_FOR_*` flag upstream ORs into `delete_item`'s flags, which
+/// selects the noun in the `could not make way for new %s: %s` diagnostic.
+/// Upstream picks it from the *new* entry's type, not the obstacle's.
+///
+/// # Upstream Reference
+///
+/// - `delete.c:275-282` - the `DEL_MAKE_ROOM` switch that picks the noun
+#[derive(Clone, Copy)]
+pub(crate) enum MakeWayFor {
+    /// upstream `DEL_FOR_FILE` - `"regular file"`.
+    File,
+    /// upstream `DEL_FOR_SYMLINK` - `"symlink"`.
+    Symlink,
+    /// upstream `DEL_FOR_DEVICE` - `"device file"`.
+    Device,
+    /// upstream `DEL_FOR_SPECIAL` - `"special file"`.
+    Special,
+}
+
+impl MakeWayFor {
+    /// upstream: `delete.c:275-279` - the `desc` assigned per `DEL_FOR_*`.
+    const fn description(self) -> &'static str {
+        match self {
+            Self::File => "regular file",
+            Self::Symlink => "symlink",
+            Self::Device => "device file",
+            Self::Special => "special file",
+        }
+    }
+}
+
+/// Removes a directory standing where `make_way_for` has to be written.
+///
+/// Returns `Ok(true)` when the path is clear and the caller may create the
+/// replacement, `Ok(false)` when the obstacle survived - the caller then skips
+/// that entry, exactly as upstream's `goto cleanup` / `return 0` does, and the
+/// run finishes `RERR_PARTIAL` (23) with every other entry transferred.
+///
+/// `recurse` is upstream's `DEL_RECURSE`: `delete_mode || force_delete`. It
+/// selects whether the contents are peeled first, never whether the `rmdir` is
+/// attempted.
+pub(crate) fn clear_directory_obstacle(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    recurse: bool,
+    make_way_for: MakeWayFor,
+) -> Result<bool, LocalCopyError> {
+    // upstream: delete.c:204-214 - `delete_item()` calls
+    // `delete_dir_contents()` FIRST for a directory, and a DR_NOT_EMPTY from
+    // there short-circuits the `rmdir` entirely. The emptiness probe is a
+    // `get_dirlist()` readdir (delete.c:110-117), not an errno, so it still
+    // refuses under `--dry-run` - where the `rmdir` itself would have returned
+    // 0 without touching anything (`syscall.c do_rmdir_at()`'s `if (dry_run)
+    // return 0`).
+    if !peel_or_probe(context, destination, relative, recurse)? {
+        report_not_empty(destination, relative);
+        report_make_way_failure(context, destination, relative, make_way_for);
+        return Ok(false);
+    }
+
+    if context.mode().is_dry_run() {
+        context.register_progress();
+        return Ok(true);
+    }
+
+    match fs::remove_dir(destination) {
+        Ok(()) => {
+            context.register_progress();
+            Ok(true)
+        }
+        // upstream: delete.c:267 - `errno == ENOENT` maps to DR_SUCCESS.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            context.register_progress();
+            Ok(true)
+        }
+        Err(error) => {
+            if is_dir_not_empty(&error) {
+                // upstream: delete.c:260-262 - the SECOND site the same notice
+                // comes from. A `--backup` peel renames each child in place, so
+                // `delete_dir_contents()` returns DR_SUCCESS and only the rmdir
+                // errno reveals that the directory refilled itself.
+                report_not_empty(destination, relative);
+            } else {
+                // upstream: delete.c:264-266 - rsyserr(FERROR_XFER, errno,
+                // "delete_file: %s(%s) failed", what, fbuf).
+                eprintln!(
+                    "rsync: [receiver] delete_file: rmdir({}) failed: {}",
+                    display_name(destination, relative),
+                    crate::local_copy::upstream_io_error(&error),
+                );
+            }
+            report_make_way_failure(context, destination, relative, make_way_for);
+            Ok(false)
+        }
+    }
+}
+
+/// Runs `delete_dir_contents()`: the emptiness probe when `recurse` is clear,
+/// the itemize-and-peel when it is set.
+///
+/// Returns `false` for upstream's `DR_NOT_EMPTY`, which the caller turns into
+/// the notice plus the make-way refusal without ever reaching the `rmdir`.
+///
+/// # Upstream Reference
+///
+/// - `delete.c:110-118` - `get_dirlist()`, then `if (!dirlist->used) goto done`
+/// - `delete.c:115-118` - `if (!(flags & DEL_RECURSE)) { ret = DR_NOT_EMPTY; goto done; }`
+fn peel_or_probe(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    recurse: bool,
+) -> Result<bool, LocalCopyError> {
+    if !recurse {
+        return directory_is_empty(destination);
+    }
+
+    // upstream: delete.c:141-163 - the children are reported like delete-pass
+    // deletions (DEL_MAKE_ROOM is stripped for them) while the directory node
+    // itself stays silent.
+    context.record_make_room_contents(destination, relative)?;
+    if !context.mode().is_dry_run() {
+        clear_contents(context, destination, relative)?;
+    }
+    Ok(true)
+}
+
+/// Reports whether `directory` holds no entries at all.
+///
+/// A directory that vanished counts as empty: upstream maps the `ENOENT` that
+/// follows to `DR_SUCCESS` (`delete.c:267`).
+fn directory_is_empty(directory: &Path) -> Result<bool, LocalCopyError> {
+    match fs::read_dir(directory) {
+        Ok(mut entries) => match entries.next() {
+            None => Ok(true),
+            Some(Ok(_)) => Ok(false),
+            Some(Err(error)) => Err(LocalCopyError::io("read directory", directory, error)),
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(LocalCopyError::io("read directory", directory, error)),
+    }
+}
+
+/// Emits `cannot delete non-empty directory: %s`.
+///
+/// `FINFO` carries no `INFO_GTE` gate at either upstream site, so it prints at
+/// default verbosity and is suppressed only by `--quiet`; level 0 keeps
+/// `info_gte` trivially true and leaves the quiet check to the renderer.
+///
+/// # Upstream Reference
+///
+/// - `delete.c:178-181` - the `delete_dir_contents()` site
+/// - `delete.c:260-262` - the `rmdir`-errno site
+fn report_not_empty(destination: &Path, relative: Option<&Path>) {
+    logging::info_log!(
+        Del,
+        0,
+        "cannot delete non-empty directory: {}",
+        display_name(destination, relative)
+    );
+}
+
+/// Emits `could not make way for new %s: %s` and records the transfer error.
+///
+/// The line is `FERROR_XFER`, which sets `got_xfer_error` and so lifts a zero
+/// exit to `RERR_PARTIAL` (23) without aborting the run.
+///
+/// # Upstream Reference
+///
+/// - `delete.c:272-286` - the `DEL_MAKE_ROOM` block reached via `check_ret`
+fn report_make_way_failure(
+    context: &mut CopyContext,
+    destination: &Path,
+    relative: Option<&Path>,
+    make_way_for: MakeWayFor,
+) {
+    eprintln!(
+        "could not make way for new {}: {}",
+        make_way_for.description(),
+        display_name(destination, relative),
+    );
+    context.record_make_way_error();
+}
+
+/// Renders the transfer-relative name upstream's `f_name()` would print, not
+/// the absolute destination path.
+fn display_name(destination: &Path, relative: Option<&Path>) -> String {
+    relative
+        .map(Path::to_path_buf)
+        .or_else(|| destination.file_name().map(PathBuf::from))
+        .unwrap_or_else(|| destination.to_path_buf())
+        .display()
+        .to_string()
+        .replace('\\', "/")
+}
+
+/// Peels a directory obstacle's contents the way `delete_dir_contents()` does.
+///
+/// Each child reaches `delete_item()` in turn, so a non-directory child takes
+/// the `make_backup` arm under `--backup` rather than being unlinked. That is
+/// what makes a `--backup-dir` run empty the directory (the children move out)
+/// and a plain-suffix run fail to (`child` becomes `child~` in place) - the
+/// caller's `rmdir` then reports whichever happened.
+///
+/// A sub-directory that survives its own `rmdir` for the same reason is left
+/// standing rather than raised: upstream's `DR_NOT_EMPTY` is not a failure, and
+/// the caller's `rmdir` of the parent is what turns it into the operator-facing
+/// refusal.
+///
+/// # Upstream Reference
+///
+/// - `delete.c:91-181` - `delete_dir_contents()`
+/// - `delete.c:227-238` - the `make_backup` / `unlink` arm `delete_item()` takes per child
+fn clear_contents(
+    context: &mut CopyContext,
+    directory: &Path,
+    relative: Option<&Path>,
+) -> Result<(), LocalCopyError> {
+    // Read the whole directory before mutating it: an in-place `--backup`
+    // renames `child` to `child~` inside this very directory, and a live
+    // `ReadDir` may or may not hand the new name back depending on the
+    // filesystem.
+    let mut children = Vec::new();
+    match fs::read_dir(directory) {
+        Ok(entries) => {
+            for entry in entries {
+                let entry = entry
+                    .map_err(|error| LocalCopyError::io("read directory", directory, error))?;
+                let file_type = entry.file_type().map_err(|error| {
+                    LocalCopyError::io("inspect directory entry", directory, error)
+                })?;
+                children.push((entry.file_name(), entry.path(), file_type));
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(LocalCopyError::io("read directory", directory, error)),
+    }
+
+    for (name, path, file_type) in children {
+        let child_relative = relative.map(|parent| parent.join(&name));
+        if file_type.is_dir() {
+            clear_contents(context, &path, child_relative.as_deref())?;
+            // DR_NOT_EMPTY here is benign; the parent's rmdir reports it.
+            match fs::remove_dir(&path) {
+                Ok(()) => {}
+                Err(error)
+                    if error.kind() == io::ErrorKind::NotFound || is_dir_not_empty(&error) => {}
+                Err(error) => {
+                    return Err(LocalCopyError::io("remove existing directory", path, error));
+                }
+            }
+            continue;
+        }
+
+        // upstream: delete.c:228 - `make_backups > 0 && !(flags &
+        // DEL_FOR_BACKUP) && (backup_dir || !is_backup_file(fbuf))`.
+        if context.options().should_backup_before_delete(&name) {
+            // upstream: delete.c:230 - `make_backup(fbuf, True)`; the item is
+            // unlinked outright right after whichever strategy placed the
+            // backup, so the hard-link tier is skipped.
+            context.backup_existing_entry(&path, child_relative.as_deref(), file_type, true)?;
+        }
+
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(LocalCopyError::io(
+                    "remove existing destination",
+                    path,
+                    error,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -601,6 +601,15 @@ pub(crate) fn copy_sources(
             if context.sender_remove_error_occurred() {
                 return Err(LocalCopyError::partial_transfer());
             }
+            // upstream: delete.c:283-285 - a directory obstacle that survived
+            // its rmdir logs `could not make way for new %s: %s` at
+            // FERROR_XFER, which sets got_xfer_error (log.c:310-311) without
+            // aborting; cleanup.c:217-218 then lifts the exit to RERR_PARTIAL
+            // (23). The per-entry diagnostics were already printed at the
+            // refusal site, so surface only the summary error here.
+            if context.make_way_error_occurred() {
+                return Err(LocalCopyError::partial_transfer());
+            }
             // upstream: sender.c:787-795 - a source that shrank mid-transfer
             // sets `io_error |= IOERR_GENERAL` and logs one `read errors
             // mapping %s` at FERROR_XFER without aborting; main.c then exits

--- a/crates/engine/src/local_copy/executor/special/device.rs
+++ b/crates/engine/src/local_copy/executor/special/device.rs
@@ -17,9 +17,9 @@ use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyArgumentError, LocalCopyChangeSet,
-    LocalCopyError, LocalCopyMetadata, LocalCopyRecord, map_metadata_error,
-    overrides::create_hard_link, remove_source_entry_if_requested,
+    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
+    LocalCopyMetadata, LocalCopyRecord, map_metadata_error, overrides::create_hard_link,
+    remove_source_entry_if_requested,
 };
 #[cfg(unix)]
 use ::metadata::create_device_node_with_fake_super;
@@ -94,20 +94,46 @@ pub(crate) fn copy_device(
 
     let destination_previously_existed = existing_metadata.is_some();
 
-    if let Some(existing) = existing_metadata.as_ref()
-        && existing.file_type().is_dir()
+    if existing_metadata
+        .as_ref()
+        .is_some_and(|existing| existing.file_type().is_dir())
     {
-        if context.force_replacements_enabled() {
-            context.force_remove_destination(destination, relative, existing)?;
-            existing_metadata = None;
-        } else {
-            return Err(LocalCopyError::invalid_argument(
-                LocalCopyArgumentError::ReplaceDirectoryWithSpecial,
-            ));
+        // upstream: generator.c:1780-1804 - the `ignore_existing` skip is tested
+        // at `statret == 0` and `goto cleanup`s BEFORE either make-way removal
+        // (generator.c:2149 / 2477-2483), so `--ignore-existing` leaves the
+        // directory standing rather than clearing it.
+        if context.ignore_existing_enabled() {
+            return Ok(());
         }
+        // upstream: generator.c:2469-2483 atomic_create() - `dir_in_the_way`
+        // forces `skip_atomic`, so a directory obstacle takes the
+        // `delete_item()` arm whether or not --backup is set, and `del_opts`
+        // carries DEL_RECURSE only under --delete/--force. That flag selects
+        // the RECURSION, not the removal: an empty directory is rmdir'd and the
+        // device node placed with no options at all, and a populated one is
+        // refused out loud at exit 23. Upstream never aborts the run for an
+        // obstacle, so there is no argument error here.
+        let recurse = context.force_replacements_enabled() || context.options().delete_extraneous();
+        if !crate::local_copy::clear_directory_obstacle(
+            context,
+            destination,
+            relative,
+            recurse,
+            crate::local_copy::MakeWayFor::Device,
+        )? {
+            // upstream: generator.c:2482 `return 0` - atomic_create() creates
+            // nothing, the caller skips this entry, and the run finishes 23.
+            return Ok(());
+        }
+        existing_metadata = None;
     }
 
-    if context.existing_only_enabled() && existing_metadata.is_none() {
+    // upstream: generator.c:1758-1766 - `ignore_non_existing` (`--existing`)
+    // is tested at `statret == -1 && stat_errno == ENOENT`, so it asks whether
+    // the destination existed BEFORE the make-way removal. Reading the
+    // post-removal `None` instead would skip the very entry the removal just
+    // cleared the way for, leaving neither the directory nor the file.
+    if context.existing_only_enabled() && !destination_previously_existed {
         if let Some(path) = &record_path {
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
             context.record(LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/special/fifo.rs
+++ b/crates/engine/src/local_copy/executor/special/fifo.rs
@@ -17,9 +17,9 @@ use crate::local_copy::sync_acls_if_requested;
 #[cfg(all(unix, feature = "xattr"))]
 use crate::local_copy::sync_xattrs_if_requested;
 use crate::local_copy::{
-    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyArgumentError, LocalCopyChangeSet,
-    LocalCopyError, LocalCopyMetadata, LocalCopyRecord, map_metadata_error,
-    overrides::create_hard_link, remove_source_entry_if_requested,
+    CopyContext, CreatedEntryKind, LocalCopyAction, LocalCopyChangeSet, LocalCopyError,
+    LocalCopyMetadata, LocalCopyRecord, map_metadata_error, overrides::create_hard_link,
+    remove_source_entry_if_requested,
 };
 #[cfg(unix)]
 use ::metadata::create_fifo_with_fake_super;
@@ -98,20 +98,46 @@ pub(crate) fn copy_fifo(
 
     let destination_previously_existed = existing_metadata.is_some();
 
-    if let Some(existing) = existing_metadata.as_ref()
-        && existing.file_type().is_dir()
+    if existing_metadata
+        .as_ref()
+        .is_some_and(|existing| existing.file_type().is_dir())
     {
-        if context.force_replacements_enabled() {
-            context.force_remove_destination(destination, relative, existing)?;
-            existing_metadata = None;
-        } else {
-            return Err(LocalCopyError::invalid_argument(
-                LocalCopyArgumentError::ReplaceDirectoryWithSpecial,
-            ));
+        // upstream: generator.c:1780-1804 - the `ignore_existing` skip is tested
+        // at `statret == 0` and `goto cleanup`s BEFORE either make-way removal
+        // (generator.c:2149 / 2477-2483), so `--ignore-existing` leaves the
+        // directory standing rather than clearing it.
+        if context.ignore_existing_enabled() {
+            return Ok(());
         }
+        // upstream: generator.c:2469-2483 atomic_create() - `dir_in_the_way`
+        // forces `skip_atomic`, so a directory obstacle takes the
+        // `delete_item()` arm whether or not --backup is set, and `del_opts`
+        // carries DEL_RECURSE only under --delete/--force. That flag selects
+        // the RECURSION, not the removal: an empty directory is rmdir'd and the
+        // FIFO or socket placed with no options at all, and a populated one is
+        // refused out loud at exit 23. Upstream never aborts the run for an
+        // obstacle, so there is no argument error here.
+        let recurse = context.force_replacements_enabled() || context.options().delete_extraneous();
+        if !crate::local_copy::clear_directory_obstacle(
+            context,
+            destination,
+            relative,
+            recurse,
+            crate::local_copy::MakeWayFor::Special,
+        )? {
+            // upstream: generator.c:2482 `return 0` - atomic_create() creates
+            // nothing, the caller skips this entry, and the run finishes 23.
+            return Ok(());
+        }
+        existing_metadata = None;
     }
 
-    if context.existing_only_enabled() && existing_metadata.is_none() {
+    // upstream: generator.c:1758-1766 - `ignore_non_existing` (`--existing`)
+    // is tested at `statret == -1 && stat_errno == ENOENT`, so it asks whether
+    // the destination existed BEFORE the make-way removal. Reading the
+    // post-removal `None` instead would skip the very entry the removal just
+    // cleared the way for, leaving neither the directory nor the file.
+    if context.existing_only_enabled() && !destination_previously_existed {
         if let Some(path) = &record_path {
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, None);
             context.record(LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -170,20 +170,46 @@ pub(crate) fn copy_symlink(
 
     let destination_previously_existed = destination_metadata.is_some();
 
-    if let Some(existing) = destination_metadata.as_ref()
-        && existing.file_type().is_dir()
+    if destination_metadata
+        .as_ref()
+        .is_some_and(|existing| existing.file_type().is_dir())
     {
-        if context.force_replacements_enabled() {
-            context.force_remove_destination(destination, relative, existing)?;
-            destination_metadata = None;
-        } else {
-            return Err(LocalCopyError::invalid_argument(
-                LocalCopyArgumentError::ReplaceDirectoryWithSymlink,
-            ));
+        // upstream: generator.c:1780-1804 - the `ignore_existing` skip is tested
+        // at `statret == 0` and `goto cleanup`s BEFORE either make-way removal
+        // (generator.c:2149 / 2477-2483), so `--ignore-existing` leaves the
+        // directory standing rather than clearing it.
+        if context.ignore_existing_enabled() {
+            return Ok(());
         }
+        // upstream: generator.c:2469-2483 atomic_create() - `dir_in_the_way`
+        // forces `skip_atomic`, so a directory obstacle takes the
+        // `delete_item()` arm whether or not --backup is set, and `del_opts`
+        // carries DEL_RECURSE only under --delete/--force. That flag selects
+        // the RECURSION, not the removal: an empty directory is rmdir'd and the
+        // symlink placed with no options at all, and a populated one is
+        // refused out loud at exit 23. Upstream never aborts the run for an
+        // obstacle, so there is no argument error here.
+        let recurse = context.force_replacements_enabled() || context.options().delete_extraneous();
+        if !crate::local_copy::clear_directory_obstacle(
+            context,
+            destination,
+            relative,
+            recurse,
+            crate::local_copy::MakeWayFor::Symlink,
+        )? {
+            // upstream: generator.c:2482 `return 0` - atomic_create() creates
+            // nothing, the caller skips this entry, and the run finishes 23.
+            return Ok(());
+        }
+        destination_metadata = None;
     }
 
-    if context.existing_only_enabled() && destination_metadata.is_none() {
+    // upstream: generator.c:1758-1766 - `ignore_non_existing` (`--existing`)
+    // is tested at `statret == -1 && stat_errno == ENOENT`, so it asks whether
+    // the destination existed BEFORE the make-way removal. Reading the
+    // post-removal `None` instead would skip the very entry the removal just
+    // cleared the way for, leaving neither the directory nor the file.
+    if context.existing_only_enabled() && !destination_previously_existed {
         if let Some(relative_path) = record_path.as_ref() {
             let metadata_snapshot = LocalCopyMetadata::from_metadata(metadata, Some(target));
             context.record(LocalCopyRecord::new(

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -1613,8 +1613,20 @@ fn backup_dir_with_inplace_no_whole_file_copies_matched_blocks() {
     );
 }
 
+// upstream: `--backup` turns the DEL_RECURSE peel into a set of in-place
+// renames. `delete_dir_contents()` (delete.c:141-163) calls `delete_item()` per
+// child, and a non-directory child takes the `make_backup` arm
+// (delete.c:227-232); with a plain `~` suffix and no --backup-dir that renames
+// `inner.txt` to `inner.txt~` INSIDE the directory being cleared. The directory
+// never empties, the rmdir fails ENOTEMPTY, and upstream refuses the entry at
+// 23 with both diagnostics - even though --force was given.
+//
+// Measured against rsync 3.5.0 on this exact fixture: rc=23, `dest/source/item`
+// still a directory holding `inner.txt~`, `cannot delete non-empty directory:
+// source/item` on stdout and `could not make way for new regular file:
+// source/item` on stderr. This cell used to assert `item` had become a file.
 #[test]
-fn backup_with_force_directory_replaced_by_file() {
+fn backup_with_force_leaves_the_backed_up_child_and_refuses() {
     let ctx = test_helpers::setup_copy_test();
     fs::create_dir_all(&ctx.dest).expect("create dest");
 
@@ -1636,16 +1648,18 @@ fn backup_with_force_directory_replaced_by_file() {
         .force_replacements(true)
         .backup(true);
 
-    plan.execute_with_options(LocalCopyExecution::Apply, options)
-        .expect("copy succeeds");
+    let error = plan
+        .execute_with_options(LocalCopyExecution::Apply, options)
+        .expect_err("the in-place backup refills the directory, so the rmdir fails");
+    assert_eq!(error.exit_code(), 23, "upstream finishes RERR_PARTIAL here");
 
     assert!(
-        dest_root.join("item").is_file(),
-        "item should be a file now"
+        dest_root.join("item").is_dir(),
+        "the directory survives its own rmdir"
     );
     assert_eq!(
-        fs::read(dest_root.join("item")).expect("read dest"),
-        b"file content"
+        fs::read(dest_root.join("item/inner.txt~")).expect("the child is backed up IN PLACE"),
+        b"inner",
     );
 }
 

--- a/crates/engine/src/local_copy/tests/execute_force.rs
+++ b/crates/engine/src/local_copy/tests/execute_force.rs
@@ -39,15 +39,17 @@ fn force_file_replaces_non_empty_directory() {
     assert_eq!(summary.files_copied(), 1);
 }
 
+// upstream: generator.c:2148-2153 makes room for the arriving regular file with
+// `delete_item(fname, mode, del_opts | DEL_FOR_FILE)`, called with no option
+// gate at all; `del_opts` carries DEL_RECURSE only under --delete/--force and
+// selects the RECURSION (delete.c:207-209). An EMPTY directory obstacle is
+// therefore rmdir'd and the file written, with no --force.
+//
+// The flist.c:3067-3081 rule this cell used to cite is the MULTI-SOURCE merge -
+// see `force_disabled_multi_source_keeps_the_directory` - and a single source
+// never reaches it. Measured against rsync 3.5.0.
 #[test]
-fn force_disabled_file_silently_skips_directory_collision_in_recursive_copy() {
-    // upstream: flist.c:3067-3081 flist_sort_and_clean() drops the conflicting
-    // file entry when a directory of the same name is also in the file list;
-    // generator.c:1734 likewise bails via `goto cleanup` without --force.
-    // Multi-source merge depends on this: a regular file in one source must
-    // not overwrite a directory contributed by another source. Mirror upstream
-    // by silently leaving the destination directory in place - no error,
-    // no destination mutation, exit code 0.
+fn force_disabled_file_replaces_an_empty_directory_in_recursive_copy() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source root");
@@ -65,11 +67,11 @@ fn force_disabled_file_silently_skips_directory_collision_in_recursive_copy() {
         LocalCopyExecution::Apply,
         LocalCopyOptions::default().force_replacements(false),
     )
-    .expect("upstream silently keeps the directory");
+    .expect("an empty directory obstacle is rmdir'd, not refused");
 
-    assert!(
-        dest_root.join("item").is_dir(),
-        "directory should remain untouched"
+    assert_eq!(
+        fs::read(dest_root.join("item")).expect("the file must replace the directory"),
+        b"replacement",
     );
 }
 
@@ -235,11 +237,21 @@ fn force_replaces_file_entry_with_directory_during_recursive_copy() {
     );
 }
 
+// upstream: generator.c:2148-2153 calls `delete_item(fname, mode, del_opts |
+// DEL_FOR_FILE)` UNCONDITIONALLY when a regular file arrives over a
+// destination that is not a regular file. `del_opts` carries `DEL_RECURSE`
+// only under `--delete`/`--force`, and delete.c:207-209 says what that flag
+// selects: "If DEL_RECURSE is not set, this just reports emptiness". So an
+// EMPTY directory is rmdir'd and the file written with no options at all.
+//
+// This cell used to assert the opposite - that the directory survived and the
+// file was silently dropped at exit 0 - citing flist.c:3067-3081. That
+// citation is the MULTI-SOURCE merge rule (see
+// `force_disabled_multi_source_keeps_the_directory` below); it does not reach
+// a single-source recursive copy, where the file is in the flist and the
+// generator makes room for it. Measured against rsync 3.5.0.
 #[test]
-fn force_disabled_recursive_copy_silently_skips_type_conflict() {
-    // upstream: flist.c:3067-3081 keeps the directory and drops the duplicate
-    // regular file entry. Without --force, oc-rsync mirrors that by leaving
-    // the destination directory intact and not raising an error.
+fn force_disabled_recursive_copy_replaces_an_empty_directory() {
     let temp = tempdir().expect("tempdir");
     let source_root = temp.path().join("source");
     fs::create_dir_all(&source_root).expect("create source root");
@@ -260,10 +272,54 @@ fn force_disabled_recursive_copy_silently_skips_type_conflict() {
         LocalCopyExecution::Apply,
         LocalCopyOptions::default().force_replacements(false),
     )
-    .expect("upstream silently keeps the directory");
+    .expect("an empty directory obstacle is rmdir'd, not refused");
 
-    // The conflicting directory should still be intact
-    assert!(dest_root.join("item").is_dir());
+    assert_eq!(
+        fs::read(dest_root.join("item")).expect("the file must replace the directory"),
+        b"file-data",
+    );
+}
+
+// The multi-source exception the cell above used to claim for itself.
+//
+// upstream: flist.c:3067-3081 flist_sort_and_clean() drops the colliding
+// regular file and keeps the directory, so the entry never reaches
+// recv_generator and the destination directory is left alone at exit 0.
+#[test]
+fn force_disabled_multi_source_keeps_the_directory() {
+    let temp = tempdir().expect("tempdir");
+    let first = temp.path().join("first");
+    let second = temp.path().join("second");
+    fs::create_dir_all(&first).expect("create first source");
+    fs::create_dir_all(second.join("item")).expect("create second source dir");
+    fs::write(first.join("item"), b"file-data").expect("write colliding file");
+    fs::write(second.join("item/child"), b"child").expect("write child");
+
+    let dest_root = temp.path().join("dest");
+    fs::create_dir_all(dest_root.join("item")).expect("create conflicting directory");
+
+    let mut first_operand = first.into_os_string();
+    first_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let mut second_operand = second.into_os_string();
+    second_operand.push(std::path::MAIN_SEPARATOR.to_string());
+    let operands = vec![
+        first_operand,
+        second_operand,
+        dest_root.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().force_replacements(false),
+    )
+    .expect("the colliding file is dropped, not an error");
+
+    assert!(
+        dest_root.join("item").is_dir(),
+        "a file contributed by one source must never blow away a directory \
+         contributed by another"
+    );
 }
 
 #[test]
@@ -371,11 +427,20 @@ fn force_symlink_replaces_non_empty_directory() {
     assert_eq!(fs::read_link(&destination).expect("read link"), link_target);
 }
 
+// upstream: generator.c:2469-2483 atomic_create() - `dir_in_the_way` forces
+// `skip_atomic`, so a directory obstacle takes the `delete_item()` arm whether
+// or not --backup is set, and `del_opts` selects only the RECURSION. An EMPTY
+// directory is therefore rmdir'd and the symlink created in its place at exit
+// 0, with no --force.
+//
+// This cell used to assert that the run FAILED with the oc-only
+// `ReplaceDirectoryWithSymlink` argument error. Upstream has no such error and
+// never aborts a run for an obstacle; a POPULATED directory is refused per
+// entry at exit 23 instead (tests/local_directory_obstacle_removal.rs pins
+// that half end to end). Measured against rsync 3.5.0.
 #[cfg(unix)]
 #[test]
-fn force_disabled_symlink_cannot_replace_directory_in_recursive_copy() {
-    // When copying source/ -> dest/, if source has "link" as a symlink but dest
-    // has "link" as a directory, rsync must fail without --force.
+fn force_disabled_symlink_replaces_an_empty_directory_in_recursive_copy() {
     use std::os::unix::fs::symlink;
 
     let temp = tempdir().expect("tempdir");
@@ -393,22 +458,18 @@ fn force_disabled_symlink_cannot_replace_directory_in_recursive_copy() {
     let operands = vec![source_operand, dest_root.clone().into_os_string()];
     let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
 
-    let error = plan
-        .execute_with_options(
-            LocalCopyExecution::Apply,
-            LocalCopyOptions::default()
-                .links(true)
-                .force_replacements(false),
-        )
-        .expect_err("should fail without force");
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .links(true)
+            .force_replacements(false),
+    )
+    .expect("an empty directory obstacle is rmdir'd, not refused");
 
-    match error.kind() {
-        LocalCopyErrorKind::InvalidArgument(reason) => {
-            assert_eq!(*reason, LocalCopyArgumentError::ReplaceDirectoryWithSymlink);
-        }
-        other => panic!("unexpected error kind: {other:?}"),
-    }
-    assert!(dest_root.join("link").is_dir(), "directory should remain");
+    assert_eq!(
+        fs::read_link(dest_root.join("link")).expect("the symlink must replace the directory"),
+        link_target,
+    );
 }
 
 // Creates no socket, so the Apple exclusion the neighbouring socket tests

--- a/tests/local_directory_obstacle_removal.rs
+++ b/tests/local_directory_obstacle_removal.rs
@@ -1,0 +1,466 @@
+//! The LOCAL-COPY path answers upstream's make-way decision the way the
+//! receiver path already does: a directory standing where a regular file,
+//! symlink, or special has to be written is `rmdir`'d when empty and refused
+//! OUT LOUD when populated - never gated on `--force` or `--delete`.
+//!
+//! `tests/directory_obstacle_removal.rs` pins the same decision on the
+//! RECEIVER, and its own header says why a second file is needed: a local
+//! transfer "takes the engine's local-copy executor ... and exercises none of
+//! the receiver path under test". The two paths are siblings, the receiver one
+//! was fixed first, and the local one kept the old behaviour - which is the
+//! failure mode this file exists to stop recurring. Every cell below therefore
+//! runs a PLAIN LOCAL invocation with no `--rsh`.
+//!
+//! # What upstream does
+//!
+//! Both upstream call sites reach `delete_item()` unconditionally:
+//!
+//! ```text
+//! generator.c:2148-2153                      (a regular file is arriving)
+//! if (statret == 0 && !(stype == FT_REG || (write_devices && stype == FT_DEVICE))) {
+//!         if (delete_item(fname, sx.st.st_mode, del_opts | DEL_FOR_FILE) != 0)
+//!                 goto cleanup;
+//!
+//! generator.c:2477-2483                      (atomic_create(), symlink/special)
+//! } else if (skip_atomic) {
+//!         int del_opts = delete_mode || force_delete ? DEL_RECURSE : 0;
+//!         if (delete_item(fname, sxp->st.st_mode, del_opts | del_for_flag) != 0)
+//!                 return 0;
+//! ```
+//!
+//! `del_opts` selects the RECURSION, not the removal - `delete.c:207-209`,
+//! "If DEL_RECURSE is not set, this just reports emptiness". oc gated the whole
+//! removal on `--force` / `--delete` instead, so on the local path:
+//!
+//! | src kind | obstacle | rsync 3.5.0 | oc before |
+//! |---|---|---|---|
+//! | regular | empty dir     | 0, file placed | **0 in silence**, dir kept, file never written |
+//! | regular | non-empty dir | 23 + two diagnostics | **0 in silence**, dir kept |
+//! | symlink | empty dir     | 0, symlink placed | 23, oc-only `cannot replace existing directory with symbolic link` |
+//! | symlink | non-empty dir | 23 + two diagnostics | 23, that same oc-only line, neither upstream line |
+//! | fifo    | empty dir     | 0, fifo placed | 23, oc-only `cannot replace existing directory with special file` |
+//! | fifo    | non-empty dir | 23 + two diagnostics | 23, that same oc-only line |
+//! | symlink | non-empty dir, `--delete` | 0, symlink placed | 23, refused |
+//!
+//! The two regular-file rows are the reason this shipped as a fix rather than a
+//! diagnostic tidy-up: exit 0 having not written the file the operator asked
+//! for is data loss from where they stand.
+//!
+//! Measured against `rsync 3.5.0` (protocol 32) as an unprivileged user on
+//! APFS, over a 120-cell sweep of `{regular, fifo, symlink, directory}` sources
+//! crossed with `{regular, fifo, socket, symlink, empty dir, populated dir}`
+//! obstacles and `{plain, --backup, --force, --delete, --backup --force}`. The
+//! expectations below are that binary's output, not a reading of its source.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
+
+const SIBLING: &str = "sibling payload\n";
+const PAYLOAD: &str = "regular payload\n";
+
+/// What the source names `obstacle`.
+#[derive(Clone, Copy)]
+enum Source {
+    Symlink,
+    Fifo,
+    Regular,
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+}
+
+/// Builds `src/{obstacle,sibling}` and `dst/obstacle/`, where `dst/obstacle` is
+/// a directory and `src/obstacle` is the entry that has to replace it.
+///
+/// `sibling` is load-bearing: upstream keeps transferring it when the obstacle
+/// is refused, so it separates "the obstacle entry was skipped" from "the whole
+/// transfer stopped".
+fn fixture(source: Source, populate_obstacle: bool) -> Fixture {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let root = temp.path().to_path_buf();
+    fs::create_dir_all(root.join("src")).expect("create src");
+    fs::create_dir_all(root.join("dst/obstacle")).expect("create dst obstacle");
+
+    match source {
+        Source::Symlink => {
+            std::os::unix::fs::symlink("target", root.join("src/obstacle"))
+                .expect("plant source symlink");
+        }
+        Source::Fifo => {
+            // Same `mkfifo(1)` shell-out as tests/directory_obstacle_removal.rs,
+            // rather than a new unsafe libc call in the test tree.
+            let status = std::process::Command::new("mkfifo")
+                .arg(root.join("src/obstacle"))
+                .status()
+                .expect("spawn mkfifo");
+            assert!(status.success(), "mkfifo failed: {status}");
+        }
+        Source::Regular => {
+            fs::write(root.join("src/obstacle"), PAYLOAD).expect("write source payload");
+        }
+    }
+    fs::write(root.join("src/sibling"), SIBLING).expect("write src sibling");
+    if populate_obstacle {
+        fs::write(root.join("dst/obstacle/occupant"), "occupant\n").expect("populate obstacle");
+    }
+
+    Fixture { _temp: temp, root }
+}
+
+/// Copies `src/` to `dst/` with a PLAIN LOCAL invocation - no `--rsh`, no
+/// `--server` child - so the engine's local-copy executor is the code under
+/// test.
+fn copy(fx: &Fixture, extra: &[&str]) -> (Option<i32>, String, String) {
+    let out = test_support::OcRsyncCliRunner::new()
+        // -l keeps symlinks as symlinks, -D materialises the fifo, -I defeats
+        // the quick check so the obstacle entry is always reconsidered.
+        .args(["-rlDI"])
+        .args(extra)
+        .arg(format!("{}/src/", fx.root.display()))
+        .arg(format!("{}/dst/", fx.root.display()))
+        .run()
+        .expect("copy did not finish");
+    (
+        out.status,
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn obstacle(fx: &Fixture) -> PathBuf {
+    fx.root.join("dst/obstacle")
+}
+
+fn sibling_landed(fx: &Fixture) -> bool {
+    fs::read_to_string(fx.root.join("dst/sibling")).is_ok_and(|body| body == SIBLING)
+}
+
+/// The headline. A regular file arriving over an EMPTY destination directory:
+/// upstream `rmdir`s it and writes the file at exit 0. oc exited 0 having
+/// written nothing at all.
+///
+/// upstream: `generator.c:2148-2153` -> `delete.c:221-226`, the `rmdir` arm.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_regular_file() {
+    let fx = fixture(Source::Regular, false);
+
+    let (status, stdout, stderr) = copy(&fx, &[]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(obstacle(&fx)).unwrap_or_default(),
+        PAYLOAD,
+        "oc exited 0 here while leaving the directory standing and never \
+         writing the file - silent data loss, not a loud failure"
+    );
+}
+
+/// The other silent row, and the one no exit-code assertion alone would catch:
+/// a POPULATED directory must be refused AUDIBLY at 23, with the rest of the
+/// batch still landing.
+///
+/// upstream: `delete.c:260-262` `cannot delete non-empty directory: %s` at
+/// `FINFO` (stdout), then `delete.c:283-285` `could not make way for %s %s: %s`
+/// at `FERROR_XFER` (stderr), whose `got_xfer_error` lifts the exit to 23
+/// (`log.c:310-311`, `cleanup.c:217-218`).
+#[test]
+fn a_populated_directory_obstacle_is_refused_at_23_for_a_regular_file() {
+    let fx = fixture(Source::Regular, true);
+
+    let (status, stdout, stderr) = copy(&fx, &[]);
+
+    assert_eq!(
+        status,
+        Some(23),
+        "oc exited 0 in silence here. stdout: {stdout} stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("cannot delete non-empty directory: obstacle"),
+        "upstream reports the emptiness probe at FINFO, which is STDOUT. \
+         stdout was: {stdout}"
+    );
+    assert!(
+        stderr.contains("could not make way for new regular file: obstacle"),
+        "upstream's FERROR_XFER line is STDERR and is what makes the run exit \
+         non-zero; without it the obstacle is skipped in silence. stderr was: \
+         {stderr}"
+    );
+    assert!(
+        obstacle(&fx).is_dir(),
+        "the contents are never removed to make room - `del_opts` carries no \
+         DEL_RECURSE here"
+    );
+    assert!(
+        sibling_landed(&fx),
+        "a refused obstacle skips its own entry only; upstream keeps going"
+    );
+}
+
+/// A FIFO over an empty directory. oc aborted the whole run with an oc-only
+/// argument error (`cannot replace existing directory with special file`) that
+/// has no upstream analogue - upstream never aborts a run for an obstacle.
+///
+/// upstream: `generator.c:2469-2483` `atomic_create()`.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_fifo() {
+    let fx = fixture(Source::Fifo, false);
+
+    let (status, stdout, stderr) = copy(&fx, &[]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    let meta = fs::symlink_metadata(obstacle(&fx)).expect("obstacle must still exist");
+    assert!(
+        meta.file_type().is_fifo(),
+        "the fifo has to actually replace the directory. The obstacle is now: \
+         {meta:?}"
+    );
+    assert!(
+        !stderr.contains("cannot replace existing directory"),
+        "the oc-only argument error has no upstream analogue. stderr: {stderr}"
+    );
+}
+
+/// A symlink over an empty directory, the third source kind through the same
+/// decision.
+#[test]
+fn an_empty_directory_obstacle_is_removed_for_a_symlink() {
+    let fx = fixture(Source::Symlink, false);
+
+    let (status, stdout, stderr) = copy(&fx, &[]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("target"),
+    );
+}
+
+/// The noun in the refusal comes from the NEW entry's type, not the obstacle's.
+///
+/// upstream: `generator.c:2041-2047` picks `DEL_FOR_DEVICE` or
+/// `DEL_FOR_SPECIAL`; `delete.c:275-282` turns it into the printed noun.
+#[test]
+fn the_refusal_names_the_new_entrys_kind() {
+    let fifo = fixture(Source::Fifo, true);
+    let (fifo_status, _out, fifo_err) = copy(&fifo, &[]);
+    assert_eq!(fifo_status, Some(23), "stderr: {fifo_err}");
+    assert!(
+        fifo_err.contains("could not make way for new special file: obstacle"),
+        "a FIFO is DEL_FOR_SPECIAL. stderr was: {fifo_err}"
+    );
+
+    let link = fixture(Source::Symlink, true);
+    let (link_status, _out, link_err) = copy(&link, &[]);
+    assert_eq!(link_status, Some(23), "stderr: {link_err}");
+    assert!(
+        link_err.contains("could not make way for new symlink: obstacle"),
+        "a symlink is DEL_FOR_SYMLINK, so the same shape says `symlink` here \
+         and `special file` above. stderr was: {link_err}"
+    );
+}
+
+/// `dir_in_the_way` excludes a directory from `make_backup` in BOTH modes
+/// (`generator.c:2469-2477`), so under `--backup` the empty directory is still
+/// `rmdir`'d, the entry still lands at exit 0, and NO `obstacle~` appears.
+///
+/// This is the non-vacuity companion: a change that only added diagnostics
+/// would leave this cell as it was, and a change that routed the directory into
+/// the backup area would pass every exit-code assertion above.
+#[test]
+fn a_directory_obstacle_is_never_backed_up() {
+    let fx = fixture(Source::Symlink, false);
+
+    let (status, stdout, stderr) = copy(&fx, &["--backup"]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    assert_eq!(
+        fs::read_link(obstacle(&fx)).expect("obstacle must now be a symlink"),
+        Path::new("target"),
+    );
+    assert!(
+        fs::symlink_metadata(fx.root.join("dst/obstacle~")).is_err(),
+        "upstream never backs up the directory NODE - the make_backup arm is \
+         unreachable for it whether or not --backup is set"
+    );
+}
+
+/// `--delete` supplies `DEL_RECURSE` just as `--force` does
+/// (`generator.c:2481` `delete_mode || force_delete`). oc honoured only
+/// `--force` at the special/symlink sites, so this shape was refused at 23.
+#[test]
+fn delete_recurses_a_populated_obstacle_like_force() {
+    for flag in ["--delete", "--force"] {
+        let fx = fixture(Source::Symlink, true);
+
+        let (status, stdout, stderr) = copy(&fx, &[flag]);
+
+        assert_eq!(status, Some(0), "{flag}: stdout: {stdout} stderr: {stderr}");
+        assert_eq!(
+            fs::read_link(obstacle(&fx))
+                .unwrap_or_else(|error| panic!("{flag}: obstacle must now be a symlink: {error}")),
+            Path::new("target"),
+        );
+    }
+}
+
+/// The `--backup --force` shape, where upstream refuses even WITH `--force`.
+///
+/// `DEL_RECURSE` peels the directory by calling `delete_item()` per child, and
+/// a child takes the `make_backup` arm under `--backup` (`delete.c:227-232`).
+/// With a plain `~` suffix the child is renamed IN PLACE, so the directory
+/// never empties and the caller's `rmdir` fails: upstream leaves `occupant~`
+/// inside the surviving directory and exits 23. A peel implemented as a plain
+/// recursive delete would exit 0 with the directory gone.
+#[test]
+fn backup_leaves_the_peeled_child_in_place_and_refuses() {
+    let fx = fixture(Source::Symlink, true);
+
+    let (status, stdout, stderr) = copy(&fx, &["--backup", "--force"]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    assert!(
+        obstacle(&fx).is_dir(),
+        "the directory survives its own rmdir because the in-place backup \
+         refilled it"
+    );
+    assert!(
+        fs::symlink_metadata(fx.root.join("dst/obstacle/occupant~")).is_ok(),
+        "the peel must back the child up in place, not unlink it; \
+         dst/obstacle now holds: {:?}",
+        fs::read_dir(obstacle(&fx))
+            .map(|entries| entries.flatten().map(|e| e.file_name()).collect::<Vec<_>>())
+            .unwrap_or_default()
+    );
+    assert!(
+        stderr.contains("could not make way for new symlink: obstacle"),
+        "stderr was: {stderr}"
+    );
+}
+
+/// `--ignore-existing` short-circuits BEFORE the make-way removal, so the
+/// directory is left standing and nothing is written.
+///
+/// The removal and the skip decisions are ORDERED, not independent: reading the
+/// destination state AFTER the removal makes `--ignore-existing` clear a
+/// directory it was asked to leave alone.
+///
+/// upstream: `generator.c:1780-1804` - the `ignore_existing` test is at
+/// `statret == 0` and `goto cleanup`s ahead of `generator.c:2149` /
+/// `generator.c:2477-2483`.
+#[test]
+fn ignore_existing_leaves_the_directory_obstacle_standing() {
+    for source in [Source::Regular, Source::Fifo, Source::Symlink] {
+        let fx = fixture(source, false);
+
+        let (status, stdout, stderr) = copy(&fx, &["--ignore-existing"]);
+
+        assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+        assert!(
+            obstacle(&fx).is_dir(),
+            "--ignore-existing must not clear the obstacle it was asked to skip"
+        );
+    }
+}
+
+/// `--existing` asks whether the destination existed BEFORE the make-way
+/// removal. A directory obstacle IS an existing destination, so the entry is
+/// transferred and the directory removed.
+///
+/// The failure this pins is the exact mirror of the cell above: reading the
+/// post-removal `None` skips the very entry the removal cleared the way for,
+/// leaving NEITHER the directory NOR the file - a strictly worse outcome than
+/// the silent skip this whole change set replaced.
+///
+/// upstream: `generator.c:1758-1766` - `ignore_non_existing` is tested at
+/// `statret == -1 && stat_errno == ENOENT`.
+#[test]
+fn existing_only_still_replaces_a_directory_obstacle() {
+    let fx = fixture(Source::Regular, false);
+
+    let (status, stdout, stderr) = copy(&fx, &["--existing"]);
+
+    assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+    assert_eq!(
+        fs::read_to_string(obstacle(&fx)).unwrap_or_default(),
+        PAYLOAD,
+        "the destination existed - as a directory - so --existing does not skip \
+         it, and the file must land where the directory was"
+    );
+}
+
+/// Under `--dry-run` the refusal still happens, because upstream's emptiness
+/// probe is a `get_dirlist()` READDIR, not the `rmdir` errno - and `rmdir`
+/// itself returns 0 without touching anything under `--dry-run`
+/// (`syscall.c do_rmdir_at()`).
+///
+/// A make-way implemented purely on the `rmdir` errno reports success here and
+/// itemizes a transfer that the real run refuses.
+///
+/// upstream: `delete.c:110-118` and `delete.c:204-209`.
+#[test]
+fn a_dry_run_refuses_a_populated_obstacle_too() {
+    let fx = fixture(Source::Regular, true);
+
+    let (status, stdout, stderr) = copy(&fx, &["--dry-run"]);
+
+    assert_eq!(status, Some(23), "stdout: {stdout} stderr: {stderr}");
+    assert!(
+        stdout.contains("cannot delete non-empty directory: obstacle"),
+        "stdout was: {stdout}"
+    );
+    assert!(
+        stderr.contains("could not make way for new regular file: obstacle"),
+        "stderr was: {stderr}"
+    );
+}
+
+/// NEGATIVE CONTROL. No obstacle at all: every source kind lands over a plain
+/// regular-file destination at exit 0 with nothing printed.
+///
+/// This cell must stay GREEN under every mutation of the make-way decision. A
+/// mutation that reddens it has broken the ordinary path rather than the
+/// obstacle path, and a suite where it reddens alongside the cells above cannot
+/// tell the two apart.
+#[test]
+fn a_non_directory_destination_is_untouched_by_the_make_way_decision() {
+    for source in [Source::Regular, Source::Fifo, Source::Symlink] {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path().to_path_buf();
+        fs::create_dir_all(root.join("src")).expect("create src");
+        fs::create_dir_all(root.join("dst")).expect("create dst");
+        match source {
+            Source::Symlink => {
+                std::os::unix::fs::symlink("target", root.join("src/obstacle")).expect("symlink");
+            }
+            Source::Fifo => {
+                let status = std::process::Command::new("mkfifo")
+                    .arg(root.join("src/obstacle"))
+                    .status()
+                    .expect("spawn mkfifo");
+                assert!(status.success());
+            }
+            Source::Regular => {
+                fs::write(root.join("src/obstacle"), PAYLOAD).expect("write payload");
+            }
+        }
+        fs::write(root.join("src/sibling"), SIBLING).expect("write sibling");
+        fs::write(root.join("dst/obstacle"), "pre-existing\n").expect("plant dest file");
+
+        let fx = Fixture { _temp: temp, root };
+        let (status, stdout, stderr) = copy(&fx, &[]);
+
+        assert_eq!(status, Some(0), "stdout: {stdout} stderr: {stderr}");
+        assert!(
+            !stdout.contains("cannot delete non-empty directory")
+                && !stderr.contains("could not make way"),
+            "the make-way diagnostics belong to a directory obstacle only. \
+             stdout: {stdout} stderr: {stderr}"
+        );
+        assert!(sibling_landed(&fx));
+    }
+}


### PR DESCRIPTION
A plain `oc-rsync -a src/ dst/` takes the **local-copy** path, which never reaches
the receiver's `make_way_for_replacement`. So when a destination entry is a
directory and the source is not, the local path had no correct disposition: four
cells exited **0 silently, leaving the directory in place and the file
untransferred**.

## Upstream

The decision keys on the **operation**, not on a flag.

- `generator.c:2148-2153`, `generator.c:2469-2483` - `delete_item()` is called
  unconditionally when a non-directory must replace a directory.
- `delete.c:91-286` - `del_opts` (`delete_mode || force_delete`) carries only
  `DEL_RECURSE`, and `delete.c:207-209` states what that selects: "If DEL_RECURSE
  is not set, this just reports emptiness."

So an empty directory obstacle is `rmdir`'d with no options at all; a populated
one is refused per-entry at exit 23. `--force` / `--delete` enable the recursive
peel, they do not enable the removal.

## Change

New `crates/engine/src/local_copy/executor/obstacle.rs` holds one
`clear_directory_obstacle`, reached by all four local obstacle sites (regular /
symlink / fifo-socket / device). Removal is no longer gated on
`--force`/`--delete`; those now gate only the recursive peel. The peel is a
per-child `delete_item` mirror, so `--backup` backs children up in place
(reproducing upstream's `--backup --force` refusal) and `--backup-dir` moves them
out. Emptiness is probed by readdir rather than the rmdir errno, so `--dry-run`
refuses too. A new `make_way_error` flag lifts the exit to 23 without aborting.

62 sites across the repo decide obstacle disposition (30 receiver, 32 local); this
change owns the local four.

## Oracle

120 cells: source `{regular, fifo, symlink, directory}` x destination obstacle
`{regular, fifo, socket, symlink, empty dir, populated dir}` x flags `{-a,
--backup, --force, --delete, --backup --force}`, run against real rsync 3.5.0 and
then oc, capturing exit code, stdout, stderr, backup placement, final destination
state, and whether a sibling entry still landed. Plus a 40-cell `--backup-dir`
sweep and separate `--dry-run` / `--quiet` / `--existing` / `--ignore-existing`
cells. Run both as a plain local invocation and over a real `--server` child.

**Local path: 21/120 divergent -> 2/120.**

The 2 remaining are a separate defect: an *identical* destination FIFO gets a
spurious backup because oc lacks upstream's `quick_check_ok(FT_SPECIAL)`
short-circuit (`generator.c:2049-2060`). That is a different decision - whether to
recreate at all - and would touch itemization, so it is reported, not fixed here.

## Corrections to the filed report

- **"oc backs up a directory upstream never backs up" does not reproduce** on
  master, on either path, with or without `--backup-dir`. That was the pre-fix
  receiver behaviour, already fixed. The measured divergence at head was the
  opposite: with `--backup-dir --force` upstream moves the obstacle's contents
  into the backup area and oc did not.
- **The silent exit-0 rows are source = regular file over a directory obstacle**
  (4 cells), not the FIFO rows. The FIFO/symlink rows exited 23 with an oc-only
  argument error that has no upstream analogue.

## Non-inertness

Five mutations, each reverted in isolation, rebuilt, re-run:

| mutation | killed | left/right |
|---|---|---|
| restore the `--force\|\|--delete` gate | 4 cells | `left: ""` / `right: "regular payload\n"`; `left: Some(0)` / `right: Some(23)` |
| drop `record_make_way_error` (keep both diagnostics) | 4 cells | `left: Some(0)` / `right: Some(23)`, diagnostics still printed |
| peel without honouring `--backup` per child | 1 cell | `left: Some(0)` / `right: Some(23)` |
| `recurse = force` only, dropping `--delete` | 1 cell | `left: Some(0)` / `right: Some(23)` |
| rename the directory node into the backup area | 2 cells | kills `a_directory_obstacle_is_never_backed_up` |

Negative control `a_non_regular_destination_is_untouched_by_the_make_way_decision`
(all three source kinds over a plain regular-file destination) stayed green under
every mutation.

⚠ A first "back up the directory" mutation was **inert**, and that is the useful
record: the guard in `backup_existing_entry` is no longer what protects the
directory node - the local make-way path simply has no call that could back one
up. Immunity by absence, not by defence. It was replaced with a mutation that
adds such a call.

## A regression caught before it shipped

Clearing the obstacle *before* the `--existing` / `--ignore-existing` checks made
`--existing` delete the directory and write nothing (6 cells). Upstream tests both
*before* the removal. Fixed, and pinned by two of the new cells.

## Verification

Full workspace `cargo nextest --all-features`: **33148/33149**. The one failure
(`xtask backdated_tree_populates_and_backdates_the_root`) fails identically on
unmodified master - BSD `touch -d @...`. An earlier run showed 4 extra failures
that were host-load artifacts of a concurrent nextest; they pass on a quiet host,
on master and on this branch alike.

## Reported, not fixed

- **Receiver path, 20 wire cells**: source = directory over a non-dir obstacle ->
  oc exits 11 `server error: Not a directory`. `classify_dir_destination`
  (`crates/transfer/src/receiver/directory/creation.rs:117-135`) removes only a
  *symlink*; a regular file, FIFO or socket where a directory must go falls into
  `Ok(_) => Existing`. Upstream removes any of them (`generator.c:1841`).
- **Receiver path, 4 cells**: a symlink obstacle is not backed up under `--backup`
  where upstream backs it up.
- oc prints the two make-way lines in the opposite interleaving to upstream on the
  wire path, and omits the trailing `rsync error: ... (code 23)` summary there.
- `--max-delete` does not cap the peel (matches the prior `remove_dir_all`
  behaviour; upstream counts peeled children against it).

Measured on macOS/APFS, non-root. Device-node obstacles were unreachable without
root, so `MakeWayFor::Device` is wired but not measured end to end.
