### PR TITLE
fix(transfer): supply the module-root argument at the relative_walk_base test site

### DIFF
--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -872,7 +872,10 @@ mod relative_operand_name_tests {
         ];
 
         for (operand, want_base, want_path) in cases {
-            let (base, path) = relative_walk_base(Path::new(operand));
+            // `None` is the non-daemon arm: every case above expects the walk
+            // base derived from the operand itself (`.`, `/`, or the `/./`
+            // head), never a served module root.
+            let (base, path) = relative_walk_base(Path::new(operand), None);
             assert_eq!(
                 (wire_name(&base), wire_name(&path)),
                 (want_base.to_owned(), want_path.to_owned()),


### PR DESCRIPTION
Master has not compiled since `eff06c7d1`. `fmt + clippy` fails on three consecutive commits (`eff06c7d1` #7700, `5ecbdff33` #7701, `3697af50d` #7702) with the same error:

```
error[E0061]: this function takes 2 arguments but 1 argument was supplied
  --> crates/transfer/src/generator/file_list/mod.rs:875:32
875 |             let (base, path) = relative_walk_base(Path::new(operand));
    |                                ^^^^^^^^^^^^^^^^^^-------------------- argument #2 of type `std::option::Option<&std::path::Path>` is missing
note: function defined here
  --> crates/transfer/src/generator/file_list/mod.rs:691:4
error: could not compile `transfer` (lib test) due to 1 previous error
```

## Cause: a semantic merge conflict

Both #7698 and #7700 touched `crates/transfer/src/generator/file_list/mod.rs`.

- #7698 added the test `relative_operand_name_drops_the_marker_upstream_normalises_away`, which calls `relative_walk_base` with **one** argument.
- #7700 then gave `relative_walk_base` a second parameter, `module_root: Option<&Path>`, and updated the **single production call site** at `:122` to pass `daemon_module_root.as_deref()`.

Each PR compiled against its own base and the two merged with no textual conflict. The combination does not build. **No PR check could have caught this** — neither base contained the other's change, and GitHub's `MERGEABLE` flag is a statement about text, not about compilation.

The site is inside `#[cfg(test)]`, which is why the failure surfaces as `transfer (lib test)` and not in the ordinary build.

## The fix

`None`, at the one test call site.

That is not just the argument that compiles — it is the correct one. Every case in the test's table is a non-daemon operand whose expected walk base comes from the operand itself:

| operand | expected base |
|---|---|
| `src/d`, `src/d/`, `src/d/.` | `.` |
| `/abs/d/`, `/abs/d/.` | `/` |
| `src/./d/`, `src/./d/.`, `src/./` | `src` |

None is served out of a module root, so the daemon arm #7700 added is not under test here and must not be entered. A comment records that so the `None` is not later mistaken for a placeholder.

Both tests in that block are unchanged in behaviour and still pass.

## Verification

On the **pinned 1.88.0 toolchain** from `rust-toolchain.toml`, not stable — verifying this class of change on stable has previously produced both phantom clippy errors and a false fmt-clean:

- `cargo clippy --locked -p transfer --all-targets --no-deps` — clean
- `tools/ci/check_rustfmt_all.py` — exit 0, 3415 files at edition 2024
- `cargo nextest run --locked -p transfer --lib` — **2460/2460 passed**
