### PR TITLE
fix(filters): keep a merge directive's trailing whitespace in its filename

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -37,7 +37,15 @@ pub(super) fn parse_long_merge_directive(
         Err(error) => return Some(Err(error)),
     };
 
-    let mut path_text = remainder.trim_end();
+    // The merge PATH is the rest of the rule verbatim: upstream consumes one
+    // separator after the keyword (exclude.c:1444-1445) and then takes
+    // `len = strlen(s)` (exclude.c:1465); `parse_merge_name` (exclude.c:696-752)
+    // only runs `clean_fname` (:734), which collapses slashes and `..` but never
+    // whitespace. MEASURED against rsync 3.5.0 with a filter file literally
+    // named `.rsync-filter ` (trailing space) holding `- b`: upstream opens it
+    // through `--filter='merge DIR/.rsync-filter '` and copies only `a`; oc
+    // trimmed the path and aborted with `failed to open exclude file` (exit 11).
+    let mut path_text = remainder;
     if path_text.is_empty() {
         if assume_cvsignore {
             path_text = ".cvsignore";
@@ -95,7 +103,15 @@ pub(super) fn parse_dir_merge_alias(
         Err(error) => return Some(Err(error)),
     };
 
-    let mut path_text = remainder.trim_end();
+    // The dir-merge FILENAME is the rest of the rule verbatim: one separator is
+    // consumed after the keyword (exclude.c:1444-1445), the length is
+    // `strlen(s)` (exclude.c:1465), and `parse_merge_name` (exclude.c:696-752)
+    // only runs `clean_fname` (:734). MEASURED against rsync 3.5.0 over a source
+    // holding `a`, `b` and a filter file literally named `.rsync-filter `
+    // (trailing space) that reads `- b`, with
+    // `--filter='dir-merge .rsync-filter '`: upstream copies only `a`; oc
+    // trimmed the name, found no merge file, and copied `b` too.
+    let mut path_text = remainder;
     if path_text.is_empty() {
         if assume_cvsignore {
             path_text = ".cvsignore";

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -168,7 +168,19 @@ pub(super) fn parse_short_merge_directive(
         Err(error) => return Some(Err(error)),
     };
 
-    let pattern = rest.trim();
+    // `split_short_merge_modifiers` already consumed the ONE separator that ends
+    // the modifier run (upstream exclude.c:1444-1445, `if (*s) s++`), and the
+    // merge FILENAME is then the rest of the rule verbatim (`len = strlen(s)`,
+    // exclude.c:1465). `parse_merge_name` (exclude.c:696-752) only runs
+    // `clean_fname` over it (:734), which collapses slashes and `..`, never
+    // whitespace. So a trailing space is part of the merge file's NAME.
+    //
+    // Trimming here changed WHICH FILES TRANSFER. MEASURED against rsync 3.5.0
+    // over a source holding `a`, `b` and a filter file literally named
+    // `.rsync-filter ` (trailing space) that reads `- b`, with
+    // `--filter=': .rsync-filter '`: upstream finds the merge file and copies
+    // only `a`; oc trimmed the name, found nothing, and copied `b` too.
+    let pattern = rest;
     let pattern = if pattern.is_empty() {
         if assume_cvsignore {
             ".cvsignore"
@@ -409,18 +421,53 @@ mod tests {
         assert!(result.is_some());
     }
 
+    /// `:  ` is NOT a missing file name: one separator is consumed
+    /// (exclude.c:1444-1445) and the remaining space is the name
+    /// (exclude.c:1465). MEASURED against rsync 3.5.0: `--filter=':  '` exits 0
+    /// and transfers a source file literally named `  `, so the dir-merge name
+    /// it registered was ` `.
     #[test]
-    fn parse_short_merge_directive_missing_file_error() {
-        let result = parse_short_merge_directive(arg(":  "));
-        assert!(result.is_some());
-        assert!(result.unwrap().is_err());
+    fn parse_short_merge_directive_keeps_a_space_only_name() {
+        let result = parse_short_merge_directive(arg(":  "))
+            .expect("`:  ` is a dir-merge directive")
+            .expect("a space is a legal file name");
+        match result {
+            FilterDirective::Rule(rule) => assert_eq!(rule.pattern(), " "),
+            other => panic!("expected a dir-merge rule, got {other:?}"),
+        }
     }
 
+    /// The `.` sibling of the cell above. MEASURED against rsync 3.5.0:
+    /// `--filter='.  '` reports `failed to open exclude file  ` and exits 11,
+    /// naming the file ` ` - it is a real path, not a parse error.
     #[test]
-    fn parse_short_merge_directive_dot_missing_file_error() {
-        let result = parse_short_merge_directive(arg(".  "));
-        assert!(result.is_some());
-        assert!(result.unwrap().is_err());
+    fn parse_short_merge_directive_dot_keeps_a_space_only_path() {
+        let result = parse_short_merge_directive(arg(".  "))
+            .expect("`.  ` is a merge directive")
+            .expect("a space is a legal file path");
+        match result {
+            FilterDirective::Merge(directive) => {
+                assert_eq!(directive.source(), OsString::from(" "));
+            }
+            other => panic!("expected a merge directive, got {other:?}"),
+        }
+    }
+
+    /// Non-vacuity control for the two cells above: a directive with NO
+    /// remainder at all is still the missing-name error, so those cells cannot
+    /// pass merely because the parser stopped erroring.
+    #[test]
+    fn parse_short_merge_directive_still_errors_with_no_name() {
+        assert!(
+            parse_short_merge_directive(arg(":"))
+                .expect("`:` is a dir-merge directive")
+                .is_err()
+        );
+        assert!(
+            parse_short_merge_directive(arg("."))
+                .expect("`.` is a merge directive")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -47,7 +47,14 @@ pub(super) fn parse_merge_directive(
         ));
     }
 
-    let path_text = remainder.trim_end();
+    // The merge PATH is the rest of the rule verbatim: upstream consumes one
+    // separator after the keyword (exclude.c:1444-1445) and then takes
+    // `len = strlen(s)` (exclude.c:1465); `parse_merge_name` (exclude.c:696-752)
+    // only runs `clean_fname` (:734), which never touches whitespace. MEASURED
+    // against rsync 3.5.0 with a `.rsync-filter` holding `merge inner ` and a
+    // filter file literally named `inner `: upstream opens it and excludes `b`;
+    // oc trimmed the name and failed the transfer with exit 24.
+    let path_text = remainder;
     let path_text = if path_text.is_empty() {
         if assume_cvsignore {
             ".cvsignore"
@@ -96,7 +103,19 @@ pub(super) fn parse_short_merge_directive_line(
     let (modifiers, rest) = split_short_merge_modifiers(remainder, allow_extended);
     let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, text, allow_extended)?;
 
-    let pattern = rest.trim();
+    // `split_short_merge_modifiers` already consumed the ONE separator that ends
+    // the modifier run (upstream exclude.c:1444-1445, `if (*s) s++`), and the
+    // merge FILENAME is then the rest of the rule verbatim (`len = strlen(s)`,
+    // exclude.c:1465). `parse_merge_name` (exclude.c:696-752) only runs
+    // `clean_fname` over it (:734), which collapses slashes and `..`, never
+    // whitespace. So a trailing space is part of the merge file's NAME.
+    //
+    // Trimming here changed WHICH FILES TRANSFER. MEASURED against rsync 3.5.0
+    // with a `.rsync-filter` holding `: inner ` over a source containing `a`,
+    // `b` and a filter file literally named `inner ` that reads `- b`:
+    // upstream copies `a` and `inner `; oc trimmed the name, found nothing,
+    // and copied `b` too. `. inner ` failed the transfer outright (exit 24).
+    let pattern = rest;
     let pattern = if pattern.is_empty() {
         if assume_cvsignore {
             ".cvsignore"
@@ -273,14 +292,24 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// upstream: exclude.c:1444-1445 consumes ONE separator after the `.`, and
+    /// exclude.c:1465 then takes `len = strlen(s)`, so every remaining byte -
+    /// two more leading spaces and three trailing ones - is part of the merge
+    /// file's NAME. `parse_merge_name` (exclude.c:696-752) only runs
+    /// `clean_fname` (:734), which never strips whitespace.
+    ///
+    /// This test previously asserted the trimmed name. MEASURED against rsync
+    /// 3.5.0, `--filter=':  '` transfers a file literally named `  ` and
+    /// `--filter='.  '` fails to open the merge file named ` `; both prove the
+    /// whitespace survives.
     #[test]
-    fn parse_short_merge_trims_pattern() {
+    fn parse_short_merge_keeps_the_whitespace_around_its_name() {
         let result = parse_short_merge_directive_line(".   .rsync-filter   ");
         assert!(result.is_ok());
         let directive = result.unwrap().unwrap();
         match directive {
             ParsedFilterDirective::Merge { path, .. } => {
-                assert_eq!(path, PathBuf::from(".rsync-filter"));
+                assert_eq!(path, PathBuf::from("  .rsync-filter   "));
             }
             _ => panic!("expected Merge directive"),
         }

--- a/tests/merge_directive_filename_whitespace.rs
+++ b/tests/merge_directive_filename_whitespace.rs
@@ -1,0 +1,232 @@
+//! A merge directive's FILENAME keeps its trailing whitespace.
+//!
+//! Sibling of `filter_rule_whitespace_is_pattern_text.rs`, which covers the
+//! rule PATTERN. This file covers the other half: the file NAME a `merge` /
+//! `dir-merge` directive points at.
+//!
+//! `parse_rule_tok` consumes exactly ONE separator after the rule character or
+//! keyword (`exclude.c:1444-1445`, `if (*s) s++`) and then takes the rest of
+//! the rule verbatim, `len = strlen((char*)s)` (`exclude.c:1465`). The merge
+//! name reaches `parse_merge_name` (`exclude.c:696-752`), whose only transform
+//! is `clean_fname` (`:734`) - it collapses `//` and `..`, and never touches
+//! whitespace. So `: .rsync-filter ` names a merge file whose last byte is a
+//! space, and a trailing space is a legal byte in a filename.
+//!
+//! MEASURED against rsync 3.5.0 over a source holding `a`, `b` and a filter
+//! file literally named `.rsync-filter ` (trailing space) reading `- b`:
+//!
+//! | directive                         | upstream 3.5.0 | oc before        |
+//! |-----------------------------------|----------------|------------------|
+//! | `--filter=': .rsync-filter '`     | copies `a`     | copies `a` + `b` |
+//! | `--filter='dir-merge .rsync-... '`| copies `a`     | copies `a` + `b` |
+//! | `--filter='merge DIR/.rsync-... '`| copies `a`     | exit 11          |
+//! | `.rsync-filter` holding `: inner `| copies `a`     | copies `a` + `b` |
+//! | `.rsync-filter` holding `merge inner ` | copies `a` | exit 24          |
+//!
+//! Five readers had to agree and did not: the CLI short `.`/`:` parser, the
+//! CLI long `merge` and `dir-merge` parsers, and the engine's short and long
+//! merge parsers inside a `.rsync-filter` file. The engine's long `dir-merge`
+//! parser already matched upstream, which is what made this a per-reader drift
+//! rather than a uniform choice.
+//!
+//! Every cell asserts on the DESTINATION TREE, so none of them can pass by
+//! parsing the name "correctly" into a string nobody opens.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// The file the merge rule excludes when the merge file is found.
+const EXCLUDED: &str = "b";
+/// The file no cell may exclude: the negative control inside every fixture.
+const KEPT: &str = "a";
+
+/// A filter file whose name ends in a space.
+const FILTER_SPACED: &str = ".rsync-filter ";
+/// A nested filter file whose name ends in a space.
+const INNER_SPACED: &str = "inner ";
+
+/// Seeds `<dir>/src` with `a` and `b` plus an empty `<dir>/dest`.
+fn seed(dir: &TestDir) {
+    dir.mkdir("src").expect("src");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/a", b"keep\n").expect("a");
+    dir.write_file("src/b", b"drop\n").expect("b");
+}
+
+/// Runs `oc-rsync -r --filter=<rule> src/ dest/` inside `dir`.
+fn transfer(dir: &TestDir, rule: &str) -> RsyncCommand {
+    let mut command = RsyncCommand::new();
+    command
+        .arg("-r")
+        .arg(format!("--filter={rule}"))
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()));
+    command
+}
+
+/// Asserts the merge file was found and honoured: `b` excluded, `a` copied.
+fn assert_merge_applied(dir: &TestDir, rule: &str) {
+    assert!(
+        !dir.exists(&format!("dest/{EXCLUDED}")),
+        "`{rule}` must find the merge file whose name ends in a space and \
+         honour its `- {EXCLUDED}` rule (exclude.c:1465, :734)"
+    );
+    assert!(
+        dir.exists(&format!("dest/{KEPT}")),
+        "`{rule}` must not exclude `{KEPT}`"
+    );
+}
+
+/// `: NAME ` names a merge file whose last byte is a space.
+///
+/// The headline cell for the CLI short form. Trimming made oc look for
+/// `.rsync-filter`, find nothing, and copy `b`.
+#[test]
+fn a_short_dir_merge_keeps_its_filenames_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file(&format!("src/{FILTER_SPACED}"), b"- b\n")
+        .expect("filter");
+
+    let rule = ": .rsync-filter ";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}
+
+/// `dir-merge NAME ` behaves the same as its `:` short form.
+#[test]
+fn a_long_dir_merge_keeps_its_filenames_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file(&format!("src/{FILTER_SPACED}"), b"- b\n")
+        .expect("filter");
+
+    let rule = "dir-merge .rsync-filter ";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}
+
+/// `merge PATH ` opens the file at `PATH ` - trailing space included.
+///
+/// Trimming made oc open `PATH` instead, which does not exist, and abort with
+/// `failed to open exclude file` (exit 11) where upstream exits 0.
+#[test]
+fn a_long_merge_keeps_its_paths_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file(&format!("src/{FILTER_SPACED}"), b"- b\n")
+        .expect("filter");
+
+    let path = dir.path().join("src").join(FILTER_SPACED);
+    let rule = format!("merge {}", path.display());
+    transfer(&dir, &rule).assert_success();
+    assert_merge_applied(&dir, &rule);
+}
+
+/// `. PATH ` (the short merge form) keeps the trailing space too.
+#[test]
+fn a_short_merge_keeps_its_paths_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file(&format!("src/{FILTER_SPACED}"), b"- b\n")
+        .expect("filter");
+
+    let path = dir.path().join("src").join(FILTER_SPACED);
+    let rule = format!(". {}", path.display());
+    transfer(&dir, &rule).assert_success();
+    assert_merge_applied(&dir, &rule);
+}
+
+/// The ENGINE parser: a `: inner ` line INSIDE a `.rsync-filter` file.
+///
+/// This cell reaches `crates/engine/.../dir_merge/parse/merge.rs`, a different
+/// parser from the four above. It trimmed independently.
+#[test]
+fn a_nested_short_dir_merge_keeps_its_filenames_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b": inner \n")
+        .expect("outer");
+    dir.write_file(&format!("src/{INNER_SPACED}"), b"- b\n")
+        .expect("inner");
+
+    let rule = ": .rsync-filter";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}
+
+/// The ENGINE parser's long form: a `merge inner ` line inside a
+/// `.rsync-filter` file. Trimming aborted the transfer with exit 24.
+#[test]
+fn a_nested_long_merge_keeps_its_paths_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"merge inner \n")
+        .expect("outer");
+    dir.write_file(&format!("src/{INNER_SPACED}"), b"- b\n")
+        .expect("inner");
+
+    let rule = ": .rsync-filter";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}
+
+/// The ENGINE parser's short merge form: a `. inner ` line inside a
+/// `.rsync-filter` file.
+#[test]
+fn a_nested_short_merge_keeps_its_paths_trailing_space() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b". inner \n")
+        .expect("outer");
+    dir.write_file(&format!("src/{INNER_SPACED}"), b"- b\n")
+        .expect("inner");
+
+    let rule = ": .rsync-filter";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}
+
+/// A name with a trailing space must NOT find the file without one.
+///
+/// The discriminating direction: the cells above would also pass if the parser
+/// tried both spellings. Here only the unspaced file exists, so a name that
+/// keeps its space must find nothing and `b` must transfer.
+#[test]
+fn a_spaced_name_does_not_match_the_unspaced_file() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"- b\n")
+        .expect("filter");
+
+    transfer(&dir, ": .rsync-filter ").assert_success();
+
+    assert!(
+        dir.exists(&format!("dest/{EXCLUDED}")),
+        "`: .rsync-filter ` names `.rsync-filter ` (with the space), which \
+         does not exist here, so no rule applies and `{EXCLUDED}` transfers"
+    );
+    assert!(
+        dir.exists(&format!("dest/{KEPT}")),
+        "`{KEPT}` must transfer as well"
+    );
+}
+
+/// The unchanged baseline: a merge directive with no stray whitespace still
+/// works.
+///
+/// This is the control that must stay GREEN under the mutation that restores
+/// the trimming - a cell that flips both ways would prove nothing about the
+/// cells above.
+#[test]
+fn a_plain_merge_directive_is_unaffected() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"- b\n")
+        .expect("filter");
+
+    let rule = ": .rsync-filter";
+    transfer(&dir, rule).assert_success();
+    assert_merge_applied(&dir, rule);
+}


### PR DESCRIPTION
A trailing space is a legal byte in a filename, so trimming one off a
`merge`/`dir-merge` directive changes **which file** is opened as a filter file,
and therefore **which files transfer**. Five parsers had to agree on this and
four trimmed.

## Upstream rule

Upstream strips no trailing whitespace anywhere in filter-rule parsing:

- `parse_rule_tok` skips *leading* whitespace only under `FILTRULE_WORD_SPLIT`
  (`exclude.c:1249-1253`).
- After the modifier run it consumes **exactly one** separator,
  `if (*s) s++` (`exclude.c:1444-1445`).
- The pattern length is then `len = strlen((char*)s)` (`exclude.c:1465`) -
  verbatim to end of string.
- The merge name reaches `parse_merge_name` (`exclude.c:696-752`), whose only
  transform is `clean_fname` (`:734`): it collapses `//` and `..` and never
  touches whitespace.
- `add_rule` even warns `-- CAUTION: trailing whitespace!` at `-vv`
  (`exclude.c:265-273`) - which only makes sense because the whitespace is kept.

## Measured, `oc-rsync` vs the real 3.5.0 binary

Source holds `a`, `b` and a filter file literally named `.rsync-filter `
(trailing space) reading `- b`:

| directive | upstream 3.5.0 | oc before |
|---|---|---|
| `--filter=': .rsync-filter '` | copies `a` | copies `a`+`b` (exit 0) |
| `--filter='dir-merge .rsync-filter '` | copies `a` | copies `a`+`b` (exit 0) |
| `--filter='merge DIR/.rsync-filter '` | copies `a` | exit 11 |
| `.rsync-filter` holding `: inner ` | copies `a` | copies `a`+`b` (exit 0) |
| `.rsync-filter` holding `merge inner ` | copies `a` | exit 24 |
| `.rsync-filter` holding `dir-merge inner ` | copies `a` | copies `a` - already correct |

Three diverged **silently at exit 0**; two failed the transfer outright. After
the fix all 8 measured cells are byte-identical to upstream.

## Scope

⚠ The rule-**pattern** half of this class was already fixed by #7699
(`a00e5746f`), guarded by `tests/filter_rule_whitespace_is_pattern_text.rs`.
Untouched here. This PR is the merge-directive **filename** half.

Trims removed at the four defective sites:

- `crates/cli/src/frontend/filter_rules/parsing/merge.rs` (`.`/`:` short form)
- `crates/cli/src/frontend/filter_rules/parsing/directives.rs` x2 (long
  `merge`, long `dir-merge`)
- `crates/engine/src/local_copy/dir_merge/parse/merge.rs` x2

`dir_merge.rs` was already correct (leading-only trim) and is left alone, as is
`filters::merge::parse`.

⚠ Three unit tests **encoded the bug** and are re-pointed at measured upstream
behaviour: `:  ` is a dir-merge on the name `␣` rather than a missing-name
error, and `.  ` exits 11 upstream naming the file `␣`. A new
`parse_short_merge_directive_still_errors_with_no_name` control keeps those
cells from passing merely because the parser stopped erroring.

## Non-vacuity

Pinned toolchain 1.88.0, `--no-fail-fast` throughout.

Trims restored at all five sites:

- `--test merge_directive_filename_whitespace --test filter_rule_whitespace_is_pattern_text`:
  **21 run, 13 passed, 8 failed** - 8 of 9 new cells killed;
  `a_plain_merge_directive_is_unaffected` and all 12 sibling rule-pattern cells
  stay green.
- `-p cli -p engine -E 'test(parse_short_merge)'`: **17 run, 14 passed, 3
  failed** - the 3 re-pointed unit cells killed.

Fix in place: the integration pair is 21/21; `-p cli -p engine -p filters` is
10403 run / 10400 passed / 3 failed / 27 skipped. Those 3 are the APFS sparse
cells (`execute_with_sparse_enabled_creates_holes`,
`execute_sparse_with_multiple_hole_patterns`,
`transfer_request_with_sparse_preserves_holes`), **verified pre-existing** by
restoring the three source files to HEAD and re-running - identical 3 failed
(`sparse: 8192, dense: 8072`). `cargo fmt --all -- --check` clean; workspace
clippy `--all-targets --all-features` 0 warnings.

## Adjacent divergences found, NOT fixed here

1. **Leading over-consumption after the long keyword.** oc uses
   `trim_start_matches` (a whole run) where upstream consumes one separator, so
   `--filter='dir-merge  '` transfers a file named `␣␣` upstream and exits 1 in
   oc. The short forms are already correct.
2. **`mergeX` acceptance.** oc's `strip_prefix("merge")` has no separator check,
   so `mergeX` parses as a merge of `X`; upstream's `rule_strcmp` dies with
   `Unknown filter rule`.
3. **Empty merge pattern.** Upstream defaults it to `.cvsignore`
   unconditionally (`exclude.c:1554-1557`); oc errors unless `C` was given.
