### PR TITLE
fix(engine): diagnose a shrinking source on the delta mover too

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -582,6 +582,26 @@ impl<'a> CopyContext<'a> {
             })?;
         }
 
+        // The loop stops at whatever EOF the source presented, so a source that
+        // shrank after it was sized leaves `total_bytes` below the length this
+        // transfer was sized from. That is upstream's `map_ptr()` read returning
+        // 0 with the window unfilled (fileio.c:359-365), which `unmap_file()`
+        // hands back as `ENODATA` and the sender reports as one
+        // `read errors mapping %s` line plus `io_error |= IOERR_GENERAL`
+        // (sender.c:787-795) - `RERR_PARTIAL` (23) at the end of the run.
+        //
+        // Upstream has a single mover for every transfer, so the diagnosis is
+        // unconditional there. Here it is the fourth content path to need the
+        // call: the kernel tier, the dense loop and the sparse loop already make
+        // it. Without it a `--no-whole-file` copy over a destination that
+        // already exists - the one input that routes here - wrote a short file,
+        // printed nothing and exited 0.
+        self.note_short_source_read(
+            source,
+            total_bytes,
+            total_size.saturating_sub(initial_bytes),
+        );
+
         // upstream: match.c:433-435 folds the per-file counters into the run
         // totals after match_sums() returns; do the same so the end-of-run
         // `-vv` `total:` line reports cumulative figures.

--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -649,10 +649,14 @@ impl<'a> CopyContext<'a> {
     /// from - it shrank after the file list recorded it - and lets the run
     /// continue with the remaining entries.
     ///
-    /// Every content path funnels its byte count through here so the three of
+    /// Every content path funnels its byte count through here so the four of
     /// them cannot drift: a `copy_file_range` that returns short, a dense read
-    /// loop that hits EOF early, and the sparse loop all describe the same
-    /// upstream condition.
+    /// loop that hits EOF early, the sparse loop, and the delta loop that runs
+    /// whenever `--no-whole-file` finds a basis to match against all describe
+    /// the same upstream condition. Upstream has one mover, `map_ptr()`, so a
+    /// path that skips this call reports data loss as success on exactly the
+    /// inputs that reach it - for the delta loop, a destination that already
+    /// exists.
     ///
     /// # Upstream Reference
     ///
@@ -664,7 +668,7 @@ impl<'a> CopyContext<'a> {
     ///   IOERR_GENERAL; rsyserr(FERROR_XFER, j, "read errors mapping %s",
     ///   full_fname(fname)); }` - one line, then the loop moves to the next
     ///   file-list entry, and the run finishes `RERR_PARTIAL` (23).
-    fn note_short_source_read(&mut self, source: &Path, copied: u64, expected: u64) {
+    pub(super) fn note_short_source_read(&mut self, source: &Path, copied: u64, expected: u64) {
         if copied >= expected {
             return;
         }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
@@ -533,3 +533,141 @@ fn no_whole_file_copy_of_a_complete_source_records_no_read_error() {
         "the --no-whole-file copy did not reproduce the source"
     );
 }
+
+/// Length of the basis a `--no-whole-file` copy matches against, and the length
+/// the file list recorded for the source that then shrank.
+const DELTA_BASIS_LEN: usize = 64 * 1024;
+
+/// Bytes the shrunken source still holds by the time the copy reads it.
+const DELTA_SHRUNK_LEN: usize = 4096;
+
+/// What one delta copy produced: whether the run recorded a short source, what
+/// the writer ended up holding, and what the source actually contained.
+struct DeltaCopyOutcome {
+    recorded_short_read: bool,
+    written: Vec<u8>,
+    source: Vec<u8>,
+}
+
+/// Drives one delta copy - the mover a `--no-whole-file` transfer reaches
+/// whenever the destination already exists - against a basis of
+/// `DELTA_BASIS_LEN` bytes.
+///
+/// The source is written at `source_len` while the copy is told it was sized
+/// from `declared_len`. That is "the source shrank after the file list recorded
+/// it" without racing a real truncation, the same technique the three sibling
+/// movers are pinned with.
+fn delta_copy_outcome(source_len: usize, declared_len: u64) -> DeltaCopyOutcome {
+    let temp = TempDir::new().expect("tempdir");
+    let source = temp.path().join("src.bin");
+    let basis = temp.path().join("dst.bin");
+    let staging = temp.path().join(".dst.bin.tmp");
+
+    // A non-empty destination is the only input that routes a copy through the
+    // delta mover: `build_delta_signature` returns `None` for an empty one and
+    // the executor then falls back to a straight copy.
+    write_bytes(&basis, DELTA_BASIS_LEN);
+    write_bytes(&source, source_len);
+
+    let basis_metadata = fs::metadata(&basis).expect("stat basis");
+    let index =
+        super::super::super::comparison::build_delta_signature(&basis, &basis_metadata, None)
+            .expect("build the basis signature")
+            .expect("a non-empty basis always yields an index");
+
+    let mut reader = File::open(&source).expect("open source");
+    let mut writer = File::create(&staging).expect("create staging file");
+    let mut buffer = vec![0u8; 128 * 1024];
+
+    let mut context = CopyContext::new(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default(),
+        None,
+        temp.path().to_path_buf(),
+    );
+
+    context
+        .copy_file_contents(
+            &mut reader,
+            &mut writer,
+            &mut buffer,
+            false,
+            false,
+            false,
+            &source,
+            &basis,
+            Path::new("src.bin"),
+            Some(&index),
+            declared_len,
+            0,
+            0,
+            Instant::now(),
+            false,
+        )
+        .expect("a short source must not abort the copy");
+    drop(writer);
+
+    DeltaCopyOutcome {
+        recorded_short_read: context.source_read_error_occurred(),
+        written: fs::read(&staging).expect("read staging file"),
+        source: fs::read(&source).expect("read source"),
+    }
+}
+
+/// A source that ends before the length it was sized from must be diagnosed on
+/// the delta mover too, not reported as a complete copy.
+///
+/// This is the fourth content path and the last one that skipped the call. The
+/// kernel tier, the dense loop and the sparse loop each record a short source;
+/// the delta loop stopped at whatever EOF the source presented, wrote a short
+/// destination, printed nothing and let the run exit 0 - data loss reported as
+/// success. It is reached by exactly the transfer the other three are not: a
+/// `--no-whole-file` copy over a destination that already exists, which is why
+/// upstream's `source-change-size-continues` cell - which copies into an empty
+/// destination - never saw it.
+///
+/// upstream has one mover. `map_ptr()` records `ENODATA` when a read returns 0
+/// before the mapped window is filled (fileio.c:359-365), `unmap_file()` hands
+/// that status back (fileio.c:385), and the sender logs one
+/// `read errors mapping %s` at `FERROR_XFER` with `io_error |= IOERR_GENERAL`
+/// before moving to the next entry (sender.c:787-795), which main.c reports as
+/// `RERR_PARTIAL` (23). Measured against rsync 3.5.0 on that shape - a
+/// pre-seeded destination, `-a --no-whole-file`, the source truncated at the
+/// first read of its own fd - upstream exits 23 with that line while oc exited
+/// 0 and printed nothing.
+#[test]
+fn delta_copy_records_a_source_that_ended_early() {
+    let outcome = delta_copy_outcome(DELTA_SHRUNK_LEN, DELTA_BASIS_LEN as u64);
+
+    assert!(
+        outcome.recorded_short_read,
+        "a delta copy of a source that ended {} bytes early was not recorded, so the run \
+         would exit 0 on a short destination",
+        DELTA_BASIS_LEN - DELTA_SHRUNK_LEN
+    );
+    assert_eq!(
+        outcome.written,
+        outcome.source,
+        "the delta copy wrote {} bytes for a source that held {}",
+        outcome.written.len(),
+        outcome.source.len()
+    );
+}
+
+/// Non-vacuity companion: the same delta mover, a source that matches the
+/// length it was sized from. The flag must stay clear and the writer must hold
+/// the source byte for byte. Without this, a delta loop that reported a short
+/// read unconditionally would satisfy the cell above.
+#[test]
+fn delta_copy_of_a_complete_source_records_no_read_error() {
+    let outcome = delta_copy_outcome(DELTA_BASIS_LEN, DELTA_BASIS_LEN as u64);
+
+    assert!(
+        !outcome.recorded_short_read,
+        "a delta copy of a source that matched its recorded length was reported as short"
+    );
+    assert_eq!(
+        outcome.written, outcome.source,
+        "the delta copy did not reproduce a complete {DELTA_BASIS_LEN}-byte source"
+    );
+}


### PR DESCRIPTION
A source that ends before the length the transfer was sized from is data loss.
Three of oc's four local-copy content movers diagnose it. The fourth - the delta
loop - wrote a short destination, printed nothing and exited 0.

## Upstream rule

Upstream has **one** mover, so the diagnosis is unconditional:

- `map_ptr()` records `ENODATA` when a `read()` returns 0 with the mapped window
  unfilled and zeroes the buffer, commenting "the file has changed mid transfer"
  (`fileio.c:357-368`). First status wins.
- `unmap_file()` hands that status back (`fileio.c:385`).
- `send_files()` logs one line and continues to the next file-list entry
  (`sender.c:788-795`):

  ```c
  j = unmap_file(mbuf);
  if (j) {
          io_error |= IOERR_GENERAL;
          rsyserr(FERROR_XFER, j, "read errors mapping %s", full_fname(fname));
  }
  ```

  The run finishes `RERR_PARTIAL` (23).

The size the map is built from is the **fstat on the opened handle**
(`sender.c:707-724`), not the file-list length - oc mirrors that already
(`execute/mod.rs:357-363`).

## Measured, oc vs the real 3.5.0 binary

macOS/APFS, a `DYLD_INSERT_LIBRARIES` interpose that truncates the source at the
first `read()` of its own fd - deterministic, not a race.

| cell | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `-a --no-whole-file`, **empty** dest, shrank | 23 + `read errors mapping ...` | identical | identical |
| `-a --no-whole-file`, empty dest, grew | 0, silent | identical | identical |
| `-a --no-whole-file`, empty dest, unchanged (control) | 0, silent | identical | identical |
| `-a --no-whole-file`, **pre-seeded** dest, shrank | **23** + message, dest 0 B, later entry still transfers | **0, silent** | **23 + identical message** |

Only the fourth row moved. A pre-seeded destination is the one input that routes
through the delta mover: `build_delta_signature` returns `None` for an empty
basis and the executor falls back to a straight copy. Upstream's own
`source-change-size-continues` cell copies into an **empty** destination, which
is why it never saw this.

Also measured and worth stating: upstream does **not** diagnose a source that
*grew* - the map was already sized from the fstat, so the appended tail is simply
not sent, silently, exit 0. oc matches.

## Change

- `delta_transfer.rs` - call `note_short_source_read` after the delta loop, with
  the remaining expected bytes `total_size - initial_bytes`, matching the
  progress accounting the same loop already uses.
- `transfer.rs` - `note_short_source_read` widened to `pub(super)`; its doc said
  three movers, now four.
- Two cells driving the real `copy_file_contents` against a real basis
  signature, plus the negative control.

## Non-vacuity

Pinned toolchain 1.88.0, `--no-fail-fast`.

- Delete the new call: **4995 run, 2 failed** - kills exactly
  `delta_copy_records_a_source_that_ended_early`; the control stays green.
- Make it always fire (`copied = 0`): **4995 run, 41 failed** - kills the control
  plus 40 existing delta tests, so a blanket-fire implementation cannot pass.
- `-p engine` pristine and with the fix: both 4993 run / 4992 passed / 1 failed -
  the same single pre-existing failure.
- Full workspace with the fix: 32825 run / 32820 passed / 5 failed. All 5
  reproduce on the reverted tree: the four known APFS sparse-hole cells and
  `xtask ...backdated_tree_populates_and_backdates_the_root`.

`cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace
--all-targets --all-features --no-deps` exit 0. No expect manifest touched.

## Adjacent, NOT fixed here

The delta loop reads to EOF rather than clamping to `total_size`, so a source
that *grows* after the fstat would be over-copied on this path where the dense
and sparse loops clamp. The grow fixture above used an empty destination and so
did not reach it - traced, not measured, and left for its own change.
