### PR TITLE
fix(engine): keep the DOTDIR marker out of the local-copy operand stat

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/metadata.rs
+++ b/crates/engine/src/local_copy/executor/sources/metadata.rs
@@ -1,5 +1,6 @@
 //! Source metadata fetching, symlink resolution, and relative path computation.
 
+use std::borrow::Cow;
 use std::fs::{FileType, Metadata};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -10,6 +11,97 @@ use crate::local_copy::{CopyContext, LocalCopyError, SourceSpec};
 use super::super::follow_symlink_metadata;
 use super::orchestration::delete_missing_source_entry;
 use super::types::SourceMetadataResult;
+
+/// Whether this operand's trailing DOTDIR marker still governs its own stat.
+///
+/// Under `--relative` the marker rides on the name upstream stats directly
+/// (`flist.c:2652-2657` strips it and records it in `name_type`). Without
+/// `--relative` upstream splits the operand at its last `/` (`flist.c:2607-2618`),
+/// so a trailing marker makes the WHOLE operand the directory
+/// `change_pathname()` chdir()s into before `.` is stat'd - and that chdir
+/// follows symlinks and demands a real directory, which is exactly what the
+/// unstripped `lstat("operand/")` already reports.
+fn marker_governs_operand_stat(context: &CopyContext, source: &SourceSpec) -> bool {
+    context.relative_paths_enabled() && source.copy_contents()
+}
+
+/// Returns the path a source operand is stat'd and read through, with any
+/// trailing DOTDIR marker removed.
+///
+/// Upstream keeps TWO facts about a command-line operand apart: the name it
+/// works on (`fbuf`, stripped of the marker at `flist.c:2652-2657`) and
+/// `name_type`, the marker itself (`flist.c:115-118` - `NORMAL_NAME`,
+/// `SLASH_ENDING_NAME`, `DOTDIR_NAME`). `SourceSpec::copy_contents` is oc's
+/// `name_type != NORMAL_NAME`, so the marker survives the strip.
+///
+/// The strip matters because `lstat("sym-to-dir/")` is not `lstat("sym-to-dir")`:
+/// the kernel resolves the trailing slash, so the raw form silently behaves like
+/// a `stat()` that additionally demands a directory. That turns a symlink to a
+/// file into `ENOTDIR` and a dangling symlink into `ENOENT`, where upstream
+/// transfers the symlink itself.
+///
+/// Scoped by [`marker_governs_operand_stat`].
+pub(super) fn operand_stat_path<'a>(
+    context: &CopyContext,
+    source: &'a SourceSpec,
+) -> Cow<'a, Path> {
+    let path = source.path();
+    if !marker_governs_operand_stat(context, source) {
+        return Cow::Borrowed(path);
+    }
+
+    let bytes = path.as_os_str().as_encoded_bytes();
+    if bytes.len() > 1 && (bytes.ends_with(b"/") || bytes.ends_with(b"/.")) {
+        Cow::Owned(path.components().collect())
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+/// Stats a source operand the way upstream's `link_stat()` does.
+///
+/// `flist.c:2697` feeds the operand's marker into the stat as the second
+/// disjunct of `follow_dirlinks`:
+///
+/// ```text
+/// link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)
+/// ```
+///
+/// and `link_stat()` itself (`flist.c:286-301`) is a two-step, not one
+/// decision: it lstat()s first, and replaces that result with the stat ONLY
+/// when the target is a directory. A symlink to a file, a dangling symlink, or
+/// a plain non-directory operand therefore keeps its lstat result and is
+/// transferred as itself - which is what distinguishes this from `--copy-links`.
+///
+/// Upstream's `copy_links` short-circuit (`flist.c:289`) is applied only to a
+/// marked operand. Every other operand keeps reaching
+/// [`resolve_effective_metadata`], which already reproduces both it and the
+/// dir-only `--copy-dirlinks` rule from the lstat result returned here; the
+/// marked operand cannot, because a `--copy-links` stat that FAILS is an
+/// operand-level `link_stat` failure (exit 23) upstream, not a file that
+/// vanished mid-transfer (exit 24).
+fn operand_link_stat(
+    context: &CopyContext,
+    source: &SourceSpec,
+    source_path: &Path,
+) -> io::Result<Metadata> {
+    if context.copy_links_enabled() && marker_governs_operand_stat(context, source) {
+        return std::fs::metadata(source_path);
+    }
+
+    let metadata = std::fs::symlink_metadata(source_path)?;
+
+    let follow_dirlinks = context.copy_dirlinks_enabled() || source.copy_contents();
+    if follow_dirlinks && metadata.file_type().is_symlink() {
+        if let Ok(followed) = std::fs::metadata(source_path) {
+            if followed.file_type().is_dir() {
+                return Ok(followed);
+            }
+        }
+    }
+
+    Ok(metadata)
+}
 
 /// Attempts to fetch metadata for a source path, handling missing source scenarios.
 ///
@@ -26,7 +118,7 @@ pub(super) fn fetch_source_metadata(
     relative_root: Option<&Path>,
     metadata_start: Instant,
 ) -> Result<SourceMetadataResult, LocalCopyError> {
-    match std::fs::symlink_metadata(source_path) {
+    match operand_link_stat(context, source, source_path) {
         Ok(metadata) => Ok(SourceMetadataResult::Found(metadata)),
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             context.record_file_list_generation(metadata_start.elapsed());

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -24,7 +24,7 @@ use super::destination::{ensure_destination_directory, query_destination_state};
 use super::handlers::{
     handle_directory_contents_copy, handle_directory_copy, handle_non_directory_source,
 };
-use super::metadata::{compute_relative_paths, fetch_source_metadata};
+use super::metadata::{compute_relative_paths, fetch_source_metadata, operand_stat_path};
 use super::types::{SourceMetadataResult, SourceProcessingContext};
 
 /// Returns the current time truncated to whole seconds since the Unix epoch.
@@ -663,9 +663,17 @@ pub(crate) fn copy_sources(
 /// Returns `None` when the operand has no parent (a bare relative name, or
 /// `/`), leaving the open to the `O_NOFOLLOW` leaf rule alone rather than
 /// anchoring somewhere arbitrary.
+///
+/// The marker alone does not make the operand a root: upstream's chdir lands
+/// only when the name resolves to a DIRECTORY (`change_pathname()` ->
+/// `change_dir()`). A marked operand that stats to a file, a symlink to a
+/// file, or a dangling symlink keeps its `link_stat` result (`flist.c:292-297`
+/// replaces the lstat only for a directory target) and is transferred as an
+/// entry under its parent, so the parent is its anchor. The stat follows
+/// symlinks because the chdir does.
 fn source_confinement_anchor(source: &SourceSpec) -> Option<PathBuf> {
     let path = source.path();
-    if source.copy_contents() {
+    if source.copy_contents() && fs::metadata(path).is_ok_and(|meta| meta.is_dir()) {
         return Some(path.to_path_buf());
     }
     path.parent()
@@ -686,7 +694,14 @@ fn process_single_source(
     context.set_safety_depth_offset(0);
     context.enforce_timeout()?;
 
-    let source_path = source.path();
+    // upstream: flist.c:2652-2657 - the operand's trailing DOTDIR marker is
+    // stripped from the name that gets stat'd, opened and read; the marker
+    // itself lives on in `name_type` (here `SourceSpec::copy_contents`). The
+    // two must stay separate: the raw `operand/` form makes the kernel resolve
+    // the trailing slash, which silently converts the lstat into a stat that
+    // also demands a directory.
+    let operand_path = operand_stat_path(context, source);
+    let source_path = operand_path.as_ref();
     let metadata_start = Instant::now();
 
     let (relative_root, relative_parent) = compute_relative_paths(context, source);

--- a/crates/engine/tests/relative_dotdir_operand_link_stat.rs
+++ b/crates/engine/tests/relative_dotdir_operand_link_stat.rs
@@ -1,0 +1,233 @@
+//! Regression coverage for a `--relative` source operand that carries a
+//! trailing DOTDIR marker (`sym-to-dir/`, `sym-to-dir/.`).
+//!
+//! Upstream keeps TWO facts about such an operand apart, and collapsing them
+//! into one decision is what this pins:
+//!
+//! 1. The NAME it stats is the operand with the marker stripped
+//!    (`flist.c:2652-2657` - `fn[--len] = '\0'` before `name_type` is set).
+//!    Stating the raw `operand/` form instead makes the kernel resolve the
+//!    trailing slash, which silently turns the `lstat` into a `stat` that also
+//!    demands a directory: a symlink to a FILE came back `ENOTDIR` and a
+//!    dangling symlink came back `ENOENT`, so both operands aborted the
+//!    transfer at exit 23 instead of being sent.
+//! 2. The marker itself survives as `name_type` and feeds the stat's follow
+//!    decision (`flist.c:2697` - `copy_dirlinks || name_type != NORMAL_NAME`).
+//!    `link_stat()` (`flist.c:286-301`) is then a two-step: `lstat` first, and
+//!    the `stat` result replaces it ONLY when the target is a directory.
+//!
+//! So `sym-to-dir/` is the directory it points at, while `sym-to-file/`,
+//! `dangling/`, and a plain-file operand keep their own `lstat` identity. The
+//! assertions are on WHAT LANDS AT THE DESTINATION, since both halves of the
+//! mechanism are observable only there.
+//!
+//! # Upstream Reference
+//!
+//! - `flist.c:115-118` - `NORMAL_NAME` / `SLASH_ENDING_NAME` / `DOTDIR_NAME`.
+//! - `flist.c:286-301` - `link_stat()`, the lstat-then-dir-only-upgrade pair.
+//! - `flist.c:2652-2657` - the marker is stripped from the name it stats.
+//! - `flist.c:2697` - `link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)`.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use tempfile::tempdir;
+
+/// Builds `from/{realdir/{f.txt,sub/g.txt},realfile.txt}` plus the three
+/// symlinks the follow decision has to tell apart, and returns the `/./`-
+/// anchored `-R` operand for `leaf` (marker appended verbatim) followed by the
+/// destination root.
+fn fixture(leaf_with_marker: &str) -> (Vec<OsString>, PathBuf, tempfile::TempDir) {
+    let temp = tempdir().expect("tempdir");
+    let from = temp.path().join("from");
+    let to = temp.path().join("to");
+    fs::create_dir_all(from.join("realdir/sub")).expect("create source tree");
+    fs::create_dir_all(&to).expect("create destination root");
+    fs::write(from.join("realdir/f.txt"), b"hello").expect("write f.txt");
+    fs::write(from.join("realdir/sub/g.txt"), b"deep").expect("write g.txt");
+    fs::write(from.join("realfile.txt"), b"plain").expect("write realfile.txt");
+    symlink("realdir", from.join("sym-to-dir")).expect("symlink to dir");
+    symlink("realfile.txt", from.join("sym-to-file")).expect("symlink to file");
+    symlink("nowhere", from.join("dangling")).expect("dangling symlink");
+
+    // `from/./<leaf-with-marker>`: the dot anchor makes the relative chain
+    // exactly the leaf, so the entry lands at `to/<leaf>`.
+    let mut operand = OsString::from(from.as_os_str());
+    operand.push("/./");
+    operand.push(leaf_with_marker);
+
+    (vec![operand, to.clone().into_os_string()], to, temp)
+}
+
+fn base_options() -> LocalCopyOptions {
+    LocalCopyOptions::default()
+        .recursive(true)
+        .relative_paths(true)
+        .links(true)
+}
+
+fn run(leaf_with_marker: &str, options: LocalCopyOptions) -> (PathBuf, tempfile::TempDir) {
+    let (operands, to, temp) = fixture(leaf_with_marker);
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    plan.execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("a marked operand must not abort the transfer");
+    (to, temp)
+}
+
+fn symlink_target(path: &Path) -> PathBuf {
+    fs::read_link(path).expect("destination entry must be a symlink")
+}
+
+/// A symlink to a DIRECTORY with a trailing slash is the directory it points
+/// at: the marker's follow yields a directory, so the `stat` result wins and
+/// the whole subtree is walked. Upstream `rsync -aR from/./sym-to-dir/ to/`.
+#[test]
+fn marked_symlink_to_dir_transfers_the_directory_it_points_at() {
+    let (to, _temp) = run("sym-to-dir/", base_options());
+
+    let landed = to.join("sym-to-dir");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-dir must land")
+            .is_dir(),
+        "the marker's follow yielded a directory, so it is sent as a real directory"
+    );
+    assert_eq!(
+        fs::read(landed.join("f.txt")).expect("f.txt must land"),
+        b"hello",
+        "the directory's contents are walked through the symlink"
+    );
+    assert_eq!(
+        fs::read(landed.join("sub/g.txt")).expect("sub/g.txt must land"),
+        b"deep"
+    );
+}
+
+/// `sym-to-dir/.` is the same DOTDIR marker in its explicit spelling and must
+/// resolve identically.
+#[test]
+fn marked_symlink_to_dir_dot_form_transfers_the_directory() {
+    let (to, _temp) = run("sym-to-dir/.", base_options());
+
+    let landed = to.join("sym-to-dir");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-dir must land")
+            .is_dir()
+    );
+    assert_eq!(
+        fs::read(landed.join("f.txt")).expect("f.txt must land"),
+        b"hello"
+    );
+}
+
+/// A symlink to a FILE with the same trailing slash keeps its own identity:
+/// `link_stat()` attempts the follow and DISCARDS it because the target is not
+/// a directory, so the symlink itself is transferred. Before the fix the raw
+/// `sym-to-file/` stat returned `ENOTDIR` and the run aborted at exit 23 with
+/// nothing transferred.
+#[test]
+fn marked_symlink_to_file_stays_a_symlink() {
+    let (to, _temp) = run("sym-to-file/", base_options());
+
+    let landed = to.join("sym-to-file");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-file must land")
+            .file_type()
+            .is_symlink(),
+        "the follow is discarded when the target is not a directory"
+    );
+    assert_eq!(symlink_target(&landed), Path::new("realfile.txt"));
+}
+
+/// A DANGLING symlink with a trailing slash is transferred as the symlink it
+/// is: the `lstat` succeeds, and the follow that fails changes nothing. Before
+/// the fix the raw `dangling/` stat returned `ENOENT` and the run aborted at
+/// exit 23 as a `link_stat` failure.
+#[test]
+fn marked_dangling_symlink_stays_a_symlink() {
+    let (to, _temp) = run("dangling/", base_options());
+
+    let landed = to.join("dangling");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("dangling must land")
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(symlink_target(&landed), Path::new("nowhere"));
+}
+
+/// A plain REGULAR FILE with a trailing slash is transferred as the file: the
+/// marker never made it a directory, so neither the stat nor the destination
+/// layout may treat it as one.
+#[test]
+fn marked_regular_file_transfers_as_a_file() {
+    let (to, _temp) = run("realfile.txt/", base_options());
+
+    let landed = to.join("realfile.txt");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("realfile.txt must land")
+            .is_file()
+    );
+    assert_eq!(fs::read(&landed).expect("contents"), b"plain");
+}
+
+/// `--copy-dirlinks` is the OTHER disjunct of the same follow decision and
+/// carries the same dir-only rule: it must not turn a symlink-to-file into its
+/// target. Pins that the two disjuncts were not collapsed into one clause.
+#[test]
+fn copy_dirlinks_keeps_the_dir_only_rule_for_a_marked_operand() {
+    let (to, _temp) = run("sym-to-file/", base_options().copy_dirlinks(true));
+
+    let landed = to.join("sym-to-file");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-file must land")
+            .file_type()
+            .is_symlink(),
+        "--copy-dirlinks follows only symlinks to directories"
+    );
+}
+
+/// `--copy-links` DOES follow a marked symlink to a file, all the way to the
+/// regular file - the negative control for the two tests above, so a fix that
+/// simply never follows cannot pass the set.
+#[test]
+fn copy_links_follows_a_marked_symlink_to_a_file() {
+    let (to, _temp) = run("sym-to-file/", base_options().copy_links(true));
+
+    let landed = to.join("sym-to-file");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-file must land")
+            .is_file(),
+        "--copy-links resolves the symlink to its target"
+    );
+    assert_eq!(fs::read(&landed).expect("contents"), b"plain");
+}
+
+/// Without the marker the same symlink operand stays `NORMAL_NAME`: no follow
+/// is attempted at all. The negative control for the follow itself - a fix
+/// that followed unconditionally would turn this into a directory.
+#[test]
+fn unmarked_symlink_to_dir_stays_a_symlink() {
+    let (to, _temp) = run("sym-to-dir", base_options());
+
+    let landed = to.join("sym-to-dir");
+    assert!(
+        fs::symlink_metadata(&landed)
+            .expect("sym-to-dir must land")
+            .file_type()
+            .is_symlink(),
+        "an operand without the marker is NORMAL_NAME and is never followed"
+    );
+    assert_eq!(symlink_target(&landed), Path::new("realdir"));
+}


### PR DESCRIPTION
A `--relative` operand carrying a trailing marker (`sym-to-file/`, `dangling/`,
`fifo/`) aborted the whole transfer at exit 23 where upstream sends the symlink
or special itself. The local-copy engine stat'd the operand with the marker
still attached, and the kernel resolves a trailing slash — so `lstat("x/")`
silently behaves like a `stat()` that additionally demands a directory.

⚠ **The filed claim this came from is REFUTED.** `sym-to-dir/` was never lstat'd
as a symlink: oc handled it correctly in all 14 shapes measured, on both the
local and the wire path. The *mechanism* the claim named — the dropped DOTDIR
marker — is real, but it breaks the neighbouring operands, not that one.

## Upstream rule

Two decisions, deliberately kept apart:

1. **The name it stats** — `flist.c:2652-2657` strips the marker from `fbuf`
   (`fn[--len] = '\0'`) and records it separately as `name_type`
   (`flist.c:115-118`: `NORMAL_NAME` / `SLASH_ENDING_NAME` / `DOTDIR_NAME`).
2. **Whether to follow** — `flist.c:2697`:
   `link_stat(fbuf, &st, copy_dirlinks || name_type != NORMAL_NAME)`.

`link_stat()` (`flist.c:286-301`) is itself a two-step, not one decision: it
lstats first, and the stat result replaces it **only when the target is a
directory**. So a symlink to a file, a dangling symlink, a fifo, or a plain
non-directory keeps its lstat result and transfers as itself — which is what
separates this from `--copy-links`.

Scope is `--relative` only: without it, `flist.c:2607-2618` splits the operand
at its last `/`, so a trailing marker makes the whole operand the directory
`change_pathname()` chdir's into — which follows symlinks and demands a real
directory, exactly what the unstripped lstat already reports.

## Measured, oc vs the real 3.5.0 binary

`tree` column is what landed; `D/F/L/P` = dir / file / symlink / fifo.

| operand | flags | upstream | oc before | oc after |
|---|---|---|---|---|
| `src/./realdir/` | -aR | D+contents | same | same |
| `src/./sym-to-dir/` | -aR | D+contents | **same — claim refuted** | same |
| `src/./realfile.txt/` | -aR | `F` | **23 ENOTDIR** | match |
| `src/./sym-to-file/` | -aR | `L` | **23 ENOTDIR** | match |
| `src/./dangling/` | -aR | `L` | **23 ENOENT** | match |
| `src/./fifo/` | -aR | `P` | **23 ENOTDIR** | match |
| `src/./sym-to-fifo/` | -aR | `L` | **23 ENOTDIR** | match |
| `src/realfile.txt/` (no pivot) | -aR | `D:src F:…` | **23** | match |
| `src/sym-to-file/`, `src/dangling/`, `src/sym-to-fifo/` | -aR | `D:src L:…` | **23** ×3 | match |
| `src/./sym-to-file/`, `src/./realfile.txt/` | -aR -L | `F` | **23** | match |
| `src/./sym-to-file/` | -aR --copy-dirlinks | `L` | **23** | match |
| `src/./sym-to-dir/` | -aR --copy-dirlinks | D+contents | same | same |
| `src/./dangling/` | -aR -L | 23 link_stat fail | 23 | 23 |
| four marked operands, non-relative | -a | 23 ×4 | 23 ×4 | unchanged |

26 further cells matched before and after: bare `sym-to-dir` / `sym-to-dir/`
across `-r`/`-a`/`-L`/`--copy-dirlinks`/`-d -l`/no flags, `--files-from` with a
`sym-to-dir/` entry, `--no-inc-recursive`, `--no-implied-dirs`,
`src/./sym-to-dir/sub`, `src/./sym-to-dir/.`, exclusion interactions.

**The wire path was already correct on every cell** —
`generator/file_list/walk.rs:928-1001` already implements the two-step. The
divergence was confined to the local-copy engine.

## Change

- `sources/metadata.rs` — `marker_governs_operand_stat()` (the `--relative`
  scope gate), `operand_stat_path()` (strips the trailing `/` or `/.` before the
  stat, open and read), `operand_link_stat()` (the two-step, with **both**
  disjuncts `copy_dirlinks || copy_contents` and the dir-only guard on the
  follow).
- `sources/orchestration.rs` — `source_confinement_anchor()` treated any marked
  operand as a confinement root, but upstream's chdir lands only on a directory,
  so it now requires the operand to resolve to one. Without this the fixed stat
  routed a marked regular-file operand into a directory-shaped open (EISDIR).

`compute_relative_paths` still receives the **unstripped** operand — the pivot
marker governs the relative root, the stripped name governs the stat, and the
two stay separate exactly as upstream keeps them.

## Mutation proof

New `crates/engine/tests/relative_dotdir_operand_link_stat.rs`, 8 tests
asserting on what lands at the destination (file type + link target + contents),
not on exit codes alone.

| mutation | result |
|---|---|
| unmutated | 8 run, **8 passed** |
| revert both files | 8 run, **5 failed** |
| drop `\|\| source.copy_contents()` (the marker disjunct) | 8 run, **2 failed** — both sym-to-dir cells |
| drop the `is_dir()` guard on the follow | 8 run, **2 failed** — sym-to-file + copy-dirlinks |
| drop the marker strip, keep the follow | 8 run, **5 failed** |
| revert only the confinement-anchor guard | 8 run, **1 failed** |

Every component is independently lethal, and the marker-disjunct and
dir-only-guard mutations kill **disjoint** cells — the two upstream decisions
are not collapsed into one. `unmarked_symlink_to_dir_stays_a_symlink` stayed
green under all five as the negative control, and
`copy_links_follows_a_marked_symlink_to_a_file` guards against a fix that simply
never follows.

## Verification

`cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace
--all-targets --all-features --no-deps` clean; pinned toolchain 1.88.0
throughout; `cargo build --locked --bin oc-rsync` before every shell-out.

Full workspace: 32831 run / 32818 passed / 13 failed. Five reproduce with the
change reverted (four APFS sparse-hole cells and one xtask backdated-tree cell —
the known environmental set). The other eight are `bin::` integration cells that
pass 8/8 in isolation with the fix in place; they tripped the #7385 binary
freshness guard because the binary was rebuilt mid-run. **CI is the confirming
instrument for those eight** — a clean-build full workspace is exactly what
settles it.

No expect manifest touched. I could not identify a 3.5.0 testsuite cell that
pins this shape; the adjacent ones (`relative-implied-symlink`,
`relative-symlinked-parent`, `relative-content`, `trimslash`, …) cover different
shapes and already pass on every leg.

## Found, reported, NOT fixed

- **Trailing `..` operands** (`src/..`, `src/sym-to-dir/..`): oc exits 23
  `cannot determine directory name`; upstream (`flist.c:2600-2606`) appends `/.`,
  marks `DOTDIR_NAME` and transfers the parent. A distinct mechanism with no
  counterpart anywhere in oc — `handlers.rs:159` uses `Path::file_name()`, which
  returns `None` on a `ParentDir` tail, and the generator path has the same hole
  silently.
- **Wire path, non-relative `src/sym-to-file/`**: upstream exits 23 with a
  `change_dir` diagnostic; oc exits **0 silently**.
- Diagnostic wording differs on the non-relative error cells
  (`change_dir "…" failed` vs `failed to access source '…'`); exit codes match.
