### PR TITLE
fix(filters): consume one separator after a long filter keyword

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -11,6 +11,7 @@ use core::message::{Message, Role};
 use core::rsync_error;
 
 use super::super::directive::{FilterDirective, MergeDirective};
+use super::helpers::split_long_keyword_tail;
 use super::merge::parse_merge_modifiers;
 use super::rule_line::RuleLine;
 
@@ -20,18 +21,10 @@ pub(super) fn parse_long_merge_directive(
     line: RuleLine<'_>,
 ) -> Option<Result<FilterDirective, Message>> {
     let text = line.text();
-    let remainder = text.strip_prefix("merge")?;
-    let mut remainder =
-        remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    let mut modifiers = "";
-    if let Some(next) = remainder.strip_prefix(',') {
-        let mut split = next.splitn(2, |ch: char| ch.is_ascii_whitespace() || ch == '_');
-        modifiers = split.next().unwrap_or("");
-        remainder = split
-            .next()
-            .unwrap_or("")
-            .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    }
+    let after = text.strip_prefix("merge")?;
+    // upstream: exclude.c:1218-1227 `rule_strcmp` requires a separator after the
+    // keyword and exclude.c:1444-1445 consumes exactly ONE of them.
+    let (modifiers, remainder) = split_long_keyword_tail(after)?;
     let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, line, false) {
         Ok(result) => result,
         Err(error) => return Some(Err(error)),
@@ -79,24 +72,16 @@ pub(super) fn parse_dir_merge_alias(
     line: RuleLine<'_>,
 ) -> Option<Result<FilterDirective, Message>> {
     let trimmed = line.text();
-    // upstream: exclude.c:1143 RULE_STRCMP(s, "dir-merge") is a case-sensitive
+    // upstream: exclude.c:1294 RULE_STRCMP(s, "dir-merge") is a case-sensitive
     // strncmp reached via `case 'd'`, so `DIR-MERGE`/`Dir-Merge` never match the
     // keyword. Compare bytes exactly; "dir-merge" is ASCII, so a matching prefix
     // lands on a char boundary, keeping the slices below panic-safe. (upstream
     // has no other dir-merge spelling, so no alias is accepted.)
     const KEYWORD: &str = "dir-merge";
-    let remainder = trimmed.strip_prefix(KEYWORD)?;
-    let mut remainder =
-        remainder.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    let mut modifiers = "";
-    if let Some(rest) = remainder.strip_prefix(',') {
-        let mut split = rest.splitn(2, |ch: char| ch.is_ascii_whitespace() || ch == '_');
-        modifiers = split.next().unwrap_or("");
-        remainder = split
-            .next()
-            .unwrap_or("")
-            .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    }
+    let after = trimmed.strip_prefix(KEYWORD)?;
+    // upstream: exclude.c:1218-1227 `rule_strcmp` requires a separator after the
+    // keyword and exclude.c:1444-1445 consumes exactly ONE of them.
+    let (modifiers, remainder) = split_long_keyword_tail(after)?;
 
     let (options, assume_cvsignore) = match parse_merge_modifiers(modifiers, line, true) {
         Ok(result) => result,

--- a/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/helpers.rs
@@ -22,6 +22,57 @@ pub(super) fn consume_rule_separator(remainder: &str) -> &str {
     }
 }
 
+/// Splits the text that follows a long-form filter keyword into
+/// `(modifiers, pattern)`, or returns `None` when the keyword is not terminated
+/// by a separator and is therefore not this keyword at all.
+///
+/// upstream: exclude.c:1218-1227 `rule_strcmp` - the keyword matches only when
+/// the byte after it is whitespace, `_`, `,`, or the end of the string. Any
+/// other byte returns NULL, `ch` stays 0, and the rule falls to the inner
+/// switch's `default:` and dies with `Unknown filter rule` (exclude.c:1363), so
+/// `mergeX` is a syntax error rather than a merge of `X`.
+///
+/// A `,` returns `str + rule_len` (exclude.c:1225-1226), which puts the modifier
+/// loop's `*++s` on the first modifier byte. Every other separator returns
+/// `str + rule_len - 1` (exclude.c:1223), so `*++s` lands ON the separator and
+/// the loop stops at once: a long keyword only ever carries modifiers after a
+/// comma. Either way exactly ONE separator is then consumed by `if (*s) s++`
+/// (exclude.c:1444-1445) and the pattern is the remainder verbatim
+/// (`len = strlen(s)`, exclude.c:1465) - never a whole run of whitespace.
+///
+/// MEASURED against rsync 3.5.0: `--filter='dir-merge  '` (two trailing spaces)
+/// merges a per-directory file literally named ` `, and `--filter='merge  X'`
+/// tries to open ` X`; oc trimmed the run and merged `X`. `--filter='mergeX'`
+/// exits 1 with `Unknown filter rule`; oc merged `X`.
+pub(super) fn split_long_keyword_tail(after: &str) -> Option<(&str, &str)> {
+    let mut chars = after.chars();
+    match chars.next() {
+        None => Some(("", "")),
+        Some(',') => {
+            let body = chars.as_str();
+            Some(match body.find(is_rule_separator) {
+                // The separator is ASCII, so `idx + 1` stays on a char boundary.
+                Some(idx) => (&body[..idx], &body[idx + 1..]),
+                None => (body, ""),
+            })
+        }
+        Some(ch) if is_rule_separator(ch) => Some(("", &after[ch.len_utf8()..])),
+        Some(_) => None,
+    }
+}
+
+/// The bytes that end a rule keyword or modifier run in this parser.
+///
+/// upstream's modifier loop terminates on `' '`/`'_'` alone (exclude.c:1365),
+/// while `rule_strcmp` accepts any `isspace` (exclude.c:1222); a tab therefore
+/// reaches upstream's `default:` arm as an invalid modifier. oc has treated the
+/// whole ASCII whitespace class as a separator throughout this module since
+/// before these parsers existed, and this helper keeps that one convention
+/// rather than introducing a second.
+fn is_rule_separator(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_whitespace()
+}
+
 /// An unrecognised modifier byte, located by its offset within the scanned
 /// slice. Callers add the offset of that slice within the whole rule to
 /// reproduce upstream's absolute position.

--- a/crates/cli/src/frontend/filter_rules/parsing/rules.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/rules.rs
@@ -123,12 +123,16 @@ pub(super) fn parse_short_include_rule(
 /// mirror upstream; an unknown keyword yields a syntax error.
 pub(super) fn parse_keyword_rule(line: RuleLine<'_>) -> Result<FilterDirective, Message> {
     let trimmed = line.text();
-    let mut parts = trimmed.splitn(2, |ch: char| ch.is_ascii_whitespace());
+    // upstream: exclude.c:1222 `rule_strcmp` accepts `_` as a keyword separator
+    // alongside `isspace`, and exclude.c:1444-1445 then consumes exactly that one
+    // byte. MEASURED against rsync 3.5.0: `--filter='exclude_b.txt'` excludes
+    // `b.txt`; oc split on whitespace only and rejected the rule as unknown.
+    let mut parts = trimmed.splitn(2, |ch: char| ch == '_' || ch.is_ascii_whitespace());
     let keyword = parts.next().expect("split always yields at least one part");
     let remainder = parts.next().unwrap_or("");
     let (keyword, keyword_modifiers) = split_keyword_modifiers(keyword);
-    // `splitn` on the first whitespace already consumed the single separator
-    // between the keyword and the pattern (upstream exclude.c:1290-1291), so the
+    // `splitn` on the first separator already consumed the single separator
+    // between the keyword and the pattern (upstream exclude.c:1444-1445), so the
     // remainder is the pattern verbatim. Do not trim further leading separators.
     let pattern = remainder;
 

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -1151,3 +1151,183 @@ fn an_over_long_file_sourced_rule_is_reported_without_its_text() {
     );
     assert!(!messages[0].contains('Q'));
 }
+
+/// The long-keyword separator rule, measured against rsync 3.5.0.
+///
+/// `rule_strcmp` (exclude.c:1218-1227) accepts a keyword only when the next
+/// byte is whitespace, `_`, `,`, or the end of the string, and returns
+/// `str + rule_len - 1` for the first three of those. The modifier loop's
+/// `*++s` then lands ON the separator and stops, and `if (*s) s++`
+/// (exclude.c:1444-1445) consumes exactly ONE byte. `len = strlen(s)`
+/// (exclude.c:1465) takes everything after it verbatim.
+mod long_keyword_separator {
+    use super::*;
+
+    fn merge_path(text: &str) -> String {
+        let directive =
+            parse_filter_directive(OsStr::new(text), RuleSource::Argument).expect("parses");
+        match directive {
+            FilterDirective::Merge(merge) => merge.source().to_string_lossy().into_owned(),
+            other => panic!("expected a Merge directive, got {other:?}"),
+        }
+    }
+
+    fn dir_merge_name(text: &str) -> String {
+        let directive =
+            parse_filter_directive(OsStr::new(text), RuleSource::Argument).expect("parses");
+        match directive {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::DirMerge);
+                spec.pattern().to_owned()
+            }
+            other => panic!("expected a dir-merge Rule directive, got {other:?}"),
+        }
+    }
+
+    /// MEASURED: `--filter='merge  X'` makes rsync 3.5.0 exit 11 with
+    /// `failed to open exclude file  X`, so the surviving space is part of the
+    /// NAME. oc trimmed the run and opened `X`.
+    #[test]
+    fn a_second_space_after_merge_belongs_to_the_file_name() {
+        assert_eq!(merge_path("merge  X"), " X");
+        assert_eq!(merge_path("merge   X"), "  X");
+    }
+
+    /// MEASURED: `--filter='merge__X'` exits 11 on `_X`. `_` is a separator
+    /// (exclude.c:1222) and exactly one of them is consumed.
+    #[test]
+    fn a_second_underscore_after_merge_belongs_to_the_file_name() {
+        assert_eq!(merge_path("merge__X"), "_X");
+    }
+
+    /// MEASURED: `--filter='merge,  X'` exits 11 on ` X`. The modifier run ends
+    /// at the first separator and only that one byte is consumed.
+    #[test]
+    fn modifiers_after_a_comma_still_consume_one_separator() {
+        assert_eq!(merge_path("merge,C  X"), " X");
+    }
+
+    /// MEASURED: `--filter='dir-merge  '` (two trailing spaces) transfers
+    /// successfully under rsync 3.5.0 and merges a per-directory file literally
+    /// named ` `; oc exited 1 with "missing a file name".
+    #[test]
+    fn a_dir_merge_of_two_spaces_names_a_file_called_space() {
+        assert_eq!(dir_merge_name("dir-merge  "), " ");
+    }
+
+    #[test]
+    fn a_second_space_after_dir_merge_belongs_to_the_file_name() {
+        assert_eq!(dir_merge_name("dir-merge  X"), " X");
+    }
+
+    /// MEASURED: `--filter='mergeX'` and `--filter='dir-mergeX'` both exit 1
+    /// with `Unknown filter rule` under rsync 3.5.0 - `rule_strcmp` returns NULL
+    /// (exclude.c:1227), `ch` stays 0, and the inner switch's `default:` reaches
+    /// `filter_rule_err` (exclude.c:1363). oc merged a file called `X`.
+    #[test]
+    fn a_keyword_not_followed_by_a_separator_is_not_that_keyword() {
+        assert!(parse_long_merge_directive(arg("mergeX")).is_none());
+        assert!(parse_dir_merge_alias(arg("dir-mergeX")).is_none());
+        assert!(parse_filter_directive(OsStr::new("mergeX"), RuleSource::Argument).is_err());
+        assert!(parse_filter_directive(OsStr::new("dir-mergeX"), RuleSource::Argument).is_err());
+    }
+
+    /// Non-vacuity companion: the separated spellings must still parse, or the
+    /// rejection test above would pass on a parser that recognises nothing.
+    #[test]
+    fn every_accepted_separator_still_reaches_the_merge_parsers() {
+        assert_eq!(merge_path("merge X"), "X");
+        assert_eq!(merge_path("merge_X"), "X");
+        assert_eq!(merge_path("merge,C"), ".cvsignore");
+        assert_eq!(dir_merge_name("dir-merge X"), "X");
+        assert_eq!(dir_merge_name("dir-merge_X"), "X");
+        assert_eq!(dir_merge_name("dir-merge,C"), ".cvsignore");
+    }
+
+    /// MEASURED: `--filter='exclude_b.txt'` excludes `b.txt` under rsync 3.5.0,
+    /// because `rule_strcmp` accepts `_` as a keyword separator
+    /// (exclude.c:1222). oc split the keyword on whitespace only and refused the
+    /// rule as unknown.
+    #[test]
+    fn an_underscore_separates_a_keyword_rule_from_its_pattern() {
+        for (text, kind) in [
+            ("exclude_b.txt", FilterRuleKind::Exclude),
+            ("include_b.txt", FilterRuleKind::Include),
+            // `hide` is a sender-side exclude (exclude.c:1348-1351).
+            ("hide_b.txt", FilterRuleKind::Exclude),
+        ] {
+            match parse_keyword_rule(arg(text)).expect("keyword rule parses") {
+                FilterDirective::Rule(spec) => {
+                    assert_eq!(spec.kind(), kind, "{text}");
+                    assert_eq!(spec.pattern(), "b.txt", "{text}");
+                }
+                other => panic!("expected a Rule directive for {text}, got {other:?}"),
+            }
+        }
+    }
+
+    /// REFUTATION, pinned. An empty merge name does NOT fall back to
+    /// `.cvsignore` on its own: `parse_rule_tok` raises
+    /// `unexpected end of filter rule` first (exclude.c:1474-1475) unless the
+    /// rule carries FILTRULE_CVS_IGNORE, which only the `C` modifier sets
+    /// (exclude.c:1402-1409). The `.cvsignore` default at exclude.c:1553-1557 is
+    /// therefore reachable only through `C`.
+    ///
+    /// MEASURED: rsync 3.5.0 exits 1 on `--filter='merge'`, `--filter='merge '`,
+    /// `--filter='dir-merge'` and `--filter='dir-merge '`, and exits 0 merging
+    /// `.cvsignore` on `--filter='merge,C'` and `--filter='dir-merge,C'`. oc
+    /// already agreed on every one of those six.
+    #[test]
+    fn an_empty_merge_name_needs_the_c_modifier_to_mean_cvsignore() {
+        for text in ["merge", "merge "] {
+            assert!(
+                parse_long_merge_directive(arg(text))
+                    .expect("the keyword matches")
+                    .is_err(),
+                "{text}"
+            );
+        }
+        for text in ["dir-merge", "dir-merge "] {
+            assert!(
+                parse_dir_merge_alias(arg(text))
+                    .expect("the keyword matches")
+                    .is_err(),
+                "{text}"
+            );
+        }
+        assert_eq!(merge_path("merge,C"), ".cvsignore");
+        assert_eq!(dir_merge_name("dir-merge,C"), ".cvsignore");
+    }
+
+    /// NEGATIVE CONTROL. None of the fixes above touches the short `.`, `:`,
+    /// `+` or `-` forms, nor a long keyword separated by a single space, so
+    /// every assertion here must stay green under a mutation that reverts any
+    /// one of them.
+    #[test]
+    fn negative_control_the_untouched_forms_keep_their_patterns() {
+        assert_eq!(merge_path(". X"), "X");
+        assert_eq!(merge_path(".  X"), " X");
+        assert_eq!(dir_merge_name(": X"), "X");
+        assert_eq!(dir_merge_name(":  X"), " X");
+        assert_eq!(merge_path("merge X"), "X");
+        assert_eq!(dir_merge_name("dir-merge X"), "X");
+
+        for (text, kind, pattern) in [
+            ("- b.txt", FilterRuleKind::Exclude, "b.txt"),
+            ("-  b.txt", FilterRuleKind::Exclude, " b.txt"),
+            ("+ b.txt", FilterRuleKind::Include, "b.txt"),
+            ("exclude b.txt", FilterRuleKind::Exclude, "b.txt"),
+            ("exclude  b.txt", FilterRuleKind::Exclude, " b.txt"),
+        ] {
+            match parse_filter_directive(OsStr::new(text), RuleSource::Argument)
+                .expect("directive parses")
+            {
+                FilterDirective::Rule(spec) => {
+                    assert_eq!(spec.kind(), kind, "{text}");
+                    assert_eq!(spec.pattern(), pattern, "{text}");
+                }
+                other => panic!("expected a Rule directive for {text}, got {other:?}"),
+            }
+        }
+    }
+}

--- a/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/dir_merge.rs
@@ -1,3 +1,4 @@
+use super::modifiers::split_long_keyword_tail;
 use super::types::{FilterParseError, ParsedFilterDirective};
 use crate::local_copy::filter_program::{DirMergeEnforcedKind, DirMergeOptions};
 use std::path::PathBuf;
@@ -32,25 +33,17 @@ pub(super) fn parse_dir_merge_directive(
         }
     }
 
-    let Some((label, mut remainder)) = matched else {
+    let Some((label, after)) = matched else {
         return Ok(None);
     };
 
-    if let Some(ch) = remainder.chars().next()
-        && ch != ','
-        && !ch.is_ascii_whitespace()
-    {
+    // upstream: exclude.c:1218-1227 `rule_strcmp` requires a separator after the
+    // keyword and exclude.c:1444-1445 consumes exactly ONE of them; the previous
+    // `trim_start()` ate the whole run, so `dir-merge  ` found no file name where
+    // upstream merges a per-directory file literally named ` `.
+    let Some((modifiers, remainder)) = split_long_keyword_tail(after) else {
         return Ok(None);
-    }
-
-    remainder = remainder.trim_start();
-
-    let mut modifiers = "";
-    if let Some(rest) = remainder.strip_prefix(',') {
-        let mut split = rest.splitn(2, char::is_whitespace);
-        modifiers = split.next().unwrap_or("");
-        remainder = split.next().unwrap_or("").trim_start();
-    }
+    };
 
     let mut options = DirMergeOptions::default();
     let mut saw_plus = false;
@@ -417,5 +410,36 @@ mod tests {
             }
             _ => panic!("expected DirMerge directive"),
         }
+    }
+
+    fn dir_merge_name(text: &str) -> PathBuf {
+        match parse_dir_merge_directive(text)
+            .expect("not a parse error")
+            .expect("the dir-merge keyword matches")
+        {
+            ParsedFilterDirective::DirMerge { pattern, .. } => pattern,
+            other => panic!("expected a DirMerge directive, got {other:?}"),
+        }
+    }
+
+    /// upstream: exclude.c:1444-1445 `if (*s) s++` consumes exactly ONE
+    /// separator after the keyword, and exclude.c:1465 then takes
+    /// `len = strlen(s)`. MEASURED against rsync 3.5.0: `--filter='dir-merge  '`
+    /// (two trailing spaces) merges a per-directory file literally named ` `,
+    /// where oc exited 1 reporting a missing file name.
+    #[test]
+    fn parse_dir_merge_consumes_exactly_one_separator() {
+        assert_eq!(dir_merge_name("dir-merge  "), PathBuf::from(" "));
+        assert_eq!(dir_merge_name("dir-merge  X"), PathBuf::from(" X"));
+        assert_eq!(dir_merge_name("dir-merge_X"), PathBuf::from("X"));
+        assert_eq!(dir_merge_name("dir-merge,n  X"), PathBuf::from(" X"));
+    }
+
+    /// Non-vacuity companion: the single-separator spellings must still parse,
+    /// or the test above would pass on a parser that recognises nothing.
+    #[test]
+    fn parse_dir_merge_accepts_every_upstream_separator() {
+        assert_eq!(dir_merge_name("dir-merge X"), PathBuf::from("X"));
+        assert_eq!(dir_merge_name("dir-merge,C"), PathBuf::from(".cvsignore"));
     }
 }

--- a/crates/engine/src/local_copy/dir_merge/parse/line.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/line.rs
@@ -399,7 +399,10 @@ fn classify_filter_directive_line(
         return Ok(Some(ParsedFilterDirective::Rule(rule)));
     }
 
-    let mut parts = text.splitn(2, char::is_whitespace);
+    // upstream: exclude.c:1222 `rule_strcmp` accepts `_` as a keyword separator
+    // alongside `isspace`. MEASURED against rsync 3.5.0: `--filter='exclude_b'`
+    // excludes `b`; oc split on whitespace only and rejected the rule.
+    let mut parts = text.splitn(2, |ch: char| ch == '_' || ch.is_whitespace());
     let keyword = parts.next().unwrap_or("");
     // `splitn` already consumed the single separator between the keyword and
     // the pattern (upstream exclude.c:1444-1445), so the remainder is the
@@ -967,5 +970,21 @@ mod tests {
             rendered.contains("src/.rsync-filter line 1"),
             "the diagnostic must name the merge file and line: {rendered}"
         );
+    }
+
+    /// upstream: exclude.c:1222 - `rule_strcmp` accepts `_` as a keyword
+    /// separator alongside `isspace`, and exclude.c:1444-1445 consumes exactly
+    /// that one byte. MEASURED against rsync 3.5.0: `--filter='exclude_b.txt'`
+    /// excludes `b.txt`; oc split the keyword on whitespace only and refused the
+    /// rule outright.
+    #[test]
+    fn an_underscore_separates_a_keyword_from_its_pattern() {
+        assert_eq!(rule_of("exclude_b.txt").pattern(), "b.txt");
+        assert_eq!(rule_of("include_b.txt").pattern(), "b.txt");
+        assert_eq!(rule_of("hide_b.txt").pattern(), "b.txt");
+        // Non-vacuity: a `_` inside the PATTERN is not a separator, because
+        // only the first one is consumed.
+        assert_eq!(rule_of("exclude a_b").pattern(), "a_b");
+        assert_eq!(rule_of("exclude__b").pattern(), "_b");
     }
 }

--- a/crates/engine/src/local_copy/dir_merge/parse/merge.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/merge.rs
@@ -1,5 +1,5 @@
 use super::{
-    modifiers::{parse_merge_modifiers, split_short_merge_modifiers},
+    modifiers::{parse_merge_modifiers, split_long_keyword_tail, split_short_merge_modifiers},
     types::{FilterParseError, ParsedFilterDirective},
 };
 use std::path::PathBuf;
@@ -28,16 +28,11 @@ pub(super) fn parse_merge_directive(
         return Ok(None);
     }
 
-    let mut remainder = rest.trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    let mut modifiers = "";
-    if let Some(next) = remainder.strip_prefix(',') {
-        let mut split = next.splitn(2, |ch: char| ch.is_ascii_whitespace() || ch == '_');
-        modifiers = split.next().unwrap_or("");
-        remainder = split
-            .next()
-            .unwrap_or("")
-            .trim_start_matches(|ch: char| ch == '_' || ch.is_ascii_whitespace());
-    }
+    // upstream: exclude.c:1218-1227 `rule_strcmp` requires a separator after the
+    // keyword and exclude.c:1444-1445 consumes exactly ONE of them.
+    let Some((modifiers, remainder)) = split_long_keyword_tail(rest) else {
+        return Ok(None);
+    };
 
     let (options, assume_cvsignore) = parse_merge_modifiers(modifiers, text, false)?;
 
@@ -302,6 +297,53 @@ mod tests {
     /// 3.5.0, `--filter=':  '` transfers a file literally named `  ` and
     /// `--filter='.  '` fails to open the merge file named ` `; both prove the
     /// whitespace survives.
+    fn merge_path(text: &str) -> PathBuf {
+        match parse_merge_directive(text)
+            .expect("not a parse error")
+            .expect("the merge keyword matches")
+        {
+            ParsedFilterDirective::Merge { path, .. } => path,
+            other => panic!("expected a Merge directive, got {other:?}"),
+        }
+    }
+
+    /// upstream: exclude.c:1444-1445 `if (*s) s++` consumes exactly ONE
+    /// separator after the keyword, and exclude.c:1465 then takes
+    /// `len = strlen(s)`. MEASURED against rsync 3.5.0: `--filter='merge  X'`
+    /// exits 11 on a merge file named ` X`, and `--filter='merge__X'` on `_X`;
+    /// oc trimmed the whole run and opened `X`.
+    #[test]
+    fn parse_merge_directive_consumes_exactly_one_separator() {
+        assert_eq!(merge_path("merge  X"), PathBuf::from(" X"));
+        assert_eq!(merge_path("merge   X"), PathBuf::from("  X"));
+        assert_eq!(merge_path("merge__X"), PathBuf::from("_X"));
+        assert_eq!(merge_path("merge,C  X"), PathBuf::from(" X"));
+    }
+
+    /// upstream: exclude.c:1218-1227 `rule_strcmp` returns NULL unless the
+    /// keyword is followed by whitespace, `_`, `,` or the end of the string, so
+    /// `ch` stays 0 and the rule dies with `Unknown filter rule`
+    /// (exclude.c:1363). MEASURED: rsync 3.5.0 exits 1 on `--filter='mergeX'`;
+    /// oc merged a file called `X`.
+    #[test]
+    fn parse_merge_directive_requires_a_separator_after_the_keyword() {
+        assert!(
+            parse_merge_directive("mergeX")
+                .expect("declining is not a parse error")
+                .is_none()
+        );
+    }
+
+    /// Non-vacuity companion for the two tests above: every separator upstream
+    /// accepts must still reach the parser, or they would pass on a parser that
+    /// recognises no merge spelling at all.
+    #[test]
+    fn parse_merge_directive_accepts_every_upstream_separator() {
+        assert_eq!(merge_path("merge X"), PathBuf::from("X"));
+        assert_eq!(merge_path("merge_X"), PathBuf::from("X"));
+        assert_eq!(merge_path("merge,C"), PathBuf::from(".cvsignore"));
+    }
+
     #[test]
     fn parse_short_merge_keeps_the_whitespace_around_its_name() {
         let result = parse_short_merge_directive_line(".   .rsync-filter   ");

--- a/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
+++ b/crates/engine/src/local_copy/dir_merge/parse/modifiers.rs
@@ -16,6 +16,43 @@ fn consume_rule_separator(remainder: &str) -> &str {
     }
 }
 
+/// Splits the text that follows a long-form filter keyword into
+/// `(modifiers, pattern)`, or returns `None` when the keyword is not terminated
+/// by a separator and is therefore not this keyword at all.
+///
+/// upstream: exclude.c:1218-1227 `rule_strcmp` - the keyword matches only when
+/// the byte after it is whitespace, `_`, `,`, or the end of the string. Any
+/// other byte returns NULL, `ch` stays 0, and the rule dies with
+/// `Unknown filter rule` (exclude.c:1363), so `mergeX` is a syntax error rather
+/// than a merge of `X`.
+///
+/// A `,` returns `str + rule_len` (exclude.c:1225-1226) and the modifier loop
+/// starts on the first modifier byte; every other separator returns
+/// `str + rule_len - 1` (exclude.c:1223), so the loop stops immediately and a
+/// long keyword only carries modifiers after a comma. Exactly ONE separator is
+/// then consumed (exclude.c:1444-1445) and the pattern is the remainder
+/// verbatim (`len = strlen(s)`, exclude.c:1465).
+///
+/// MEASURED against rsync 3.5.0: `--filter='merge  X'` (two spaces) opens a
+/// merge file named ` X`, and `--filter='dir-merge  '` merges a per-directory
+/// file named ` `; oc trimmed the whole run.
+pub(super) fn split_long_keyword_tail(after: &str) -> Option<(&str, &str)> {
+    let mut chars = after.chars();
+    match chars.next() {
+        None => Some(("", "")),
+        Some(',') => {
+            let body = chars.as_str();
+            Some(match body.find(['_', ' ']) {
+                // The separator is ASCII, so `idx + 1` stays on a char boundary.
+                Some(idx) => (&body[..idx], &body[idx + 1..]),
+                None => (body, ""),
+            })
+        }
+        Some(ch) if ch == '_' || ch == ' ' => Some(("", &after[ch.len_utf8()..])),
+        Some(_) => None,
+    }
+}
+
 /// Splits the modifier prefix of a short-form `+`/`-` rule from its pattern.
 ///
 /// Returns `(modifiers, pattern)`. The caller validates each modifier byte, so


### PR DESCRIPTION
A long filter keyword consumes **exactly one** separator upstream. Four oc
parsers ate the whole whitespace run, and two matched the keyword by bare
prefix, so `mergeX` became a merge of `X` where upstream calls it a syntax
error. Both change **which file is opened as a filter file**, and therefore
which files transfer.

## Upstream rule

`rule_strcmp` (`exclude.c:1218-1227`) decides both halves at once:

```c
if (strncmp((char*)str, rule, rule_len) != 0)
        return NULL;
if (isspace(str[rule_len]) || str[rule_len] == '_' || !str[rule_len])
        return str + rule_len - 1;
if (str[rule_len] == ',')
        return str + rule_len;
return NULL;
```

- A keyword matches only when the next byte is whitespace, `_`, `,` or end of
  string. Anything else returns NULL, `ch` stays 0, and the inner switch's
  `default:` dies with `Unknown filter rule` (`exclude.c:1363`).
- The `-1` vs no-`-1` split is what makes a long keyword carry modifiers **only
  after a comma**: the modifier loop's `*++s` lands on the separator itself for
  whitespace/`_`, so it stops immediately.
- Then `if (*s) s++` consumes exactly ONE byte (`exclude.c:1444-1445`) and
  `len = strlen(s)` takes the rest verbatim (`exclude.c:1465`) — never a run.

`_` being a separator is the half that had no oc counterpart at all.

## Measured, oc vs the real 3.5.0 binary

Oracle: `target/interop/upstream-src/rsync-3.5.0/rsync`, same argv, same
fixture. All 22 rows agree after the fix, on exit code *and* on which files
transfer.

| `--filter=` | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `merge␣␣X` | 11, opens `␣X` | **0, opens `X`** | match |
| `merge__X` | 11, opens `_X` | **0, opens `X`** | match |
| `merge,␣␣X` | 11, opens `␣X` | **0, opens `X`** | match |
| `merge␣␣` | 0, merges file `␣` | **1** | match |
| `dir-merge␣␣` | 0, per-dir file `␣` | **1** | match |
| `mergeX` | 1 Unknown | **0, merged `X`** | match |
| `dir-mergeX` | 1 Unknown | **0, merged `X`** | match |
| `exclude_b.txt`, `include_b.txt`, `hide_b.txt` | 0, rule applies | **1 refused** | match |
| `merge` / `merge␣` / `dir-merge` / `dir-merge␣` | 1 | 1 (agreed) | 1 |
| `merge,C` / `dir-merge,C` | 0, `.cvsignore` | 0 (agreed) | 0 |
| `.␣␣X`, `-␣␣b.txt` (short forms) | — | already correct | unchanged |

Three of the divergences were **silent at exit 0** — the wrong filter file was
opened and the transfer completed.

## Sites

Seven keyword matchers exist. `crates/filters/src/merge/parse.rs`
`try_parse_long_form` was already a faithful `rule_strcmp` and served as the
model; the other six were fixed or tightened:

| site | defect |
|---|---|
| `cli/…/parsing/directives.rs` `parse_long_merge_directive` | trim-run + no separator check |
| `cli/…/parsing/directives.rs` `parse_dir_merge_alias` | same two |
| `engine/…/dir_merge/parse/merge.rs` | same two |
| `engine/…/dir_merge/parse/dir_merge.rs` | trim-run; had a check but missed `_` |
| `cli/…/parsing/rules.rs` `parse_keyword_rule` | `_` missing |
| `engine/…/dir_merge/parse/line.rs` | `_` missing |

`split_long_keyword_tail` is the one owner of the rule; the comma arm returns
`(modifiers, pattern)`, every other separator returns `("", pattern)`, and a
non-separator returns `None` so the caller reports `Unknown filter rule`.

## The third reported divergence is REFUTED

The brief claimed an empty merge name defaults to `.cvsignore` unconditionally
and oc wrongly required `C`. Read from the C: `exclude.c:1553-1557` *is*
unconditional, but only once reached — `parse_rule_tok` raises `unexpected end
of filter rule` first at `exclude.c:1474-1475`:

```c
} else if (!len && !(rule->rflags & FILTRULE_CVS_IGNORE)) {
        filter_rule_err("unexpected end of filter rule", *rulestr_ptr);
```

and only the `C` modifier sets `FILTRULE_CVS_IGNORE` (`exclude.c:1402-1409`).
The real binary exits 1 on `merge`, `merge␣`, `dir-merge`, `dir-merge␣` and
merges `.cvsignore` on `merge,C` / `dir-merge,C` — exactly what oc already did.
**No fix invented**; pinned instead by
`an_empty_merge_name_needs_the_c_modifier_to_mean_cvsignore`.

## Mutation proof

19 tests, `-p cli -p engine`, pinned toolchain 1.88.0.

| mutation | run/passed/failed | killed |
|---|---|---|
| none | 19 / 19 / 0 | — |
| one-separator → trim whole run | 19 / 12 / **7** | 5 cli `long_keyword_separator::*` + both engine `consumes_exactly_one_separator` |
| drop the separator requirement | 19 / 16 / **3** | the three `mergeX` cells |
| drop `_` as a separator | 19 / 17 / **2** | both `underscore_separates_*` |

Disjoint kill sets, so the three components are independently lethal.
`negative_control_the_untouched_forms_keep_their_patterns` (short `.`/`:`/`+`/`-`
and single-space long forms) stayed green under all three, as did the refutation
pin.

No existing test encoded the bug — unlike #7705, nothing had to be re-pointed.

## Verification

`cargo fmt --all -- --check` clean; `cargo clippy --locked --workspace
--all-targets --all-features --no-deps` zero warnings; `cargo xtask citations`
passes (9266 citations); citation-drift ratchet OK (transfer 6→4). Pinned
toolchain throughout.

Full workspace: 32853 run / 32848 passed / 5 failed. All five attributed away —
re-run in isolation they give 4 passed / 1 failed **identically on the pristine
base** `a742a2e8e` and on this commit: the four APFS sparse-hole cells are a
full-run parallelism artefact, and the xtask backdated-tree cell fails on the
base too.

No expect manifest touched.

## Found, reported, NOT fixed

- **TAB is not an upstream separator.** `rule_strcmp` accepts any `isspace`, but
  the modifier loop (`exclude.c:1365`) terminates only on `' '`/`'_'`, so
  `--filter=$'exclude\tb.txt'` gives upstream `invalid modifier '\t' at position
  7`. oc accepts a tab for the long keywords **and** for the `-`/`+`/`.`/`:`
  short forms, so closing it means changing `scan_modifiers`, which #7705
  authored — out of scope here. This change deliberately keeps each crate's
  existing separator set so the tab behaviour is unchanged rather than made
  inconsistent between the two.
- **`per-dir` alias.** The engine's dir-merge parser accepts an oc-only `per-dir`
  spelling inside merge files; upstream has no such keyword (measured: exit 1).
  oc's CLI path already agrees — only the merge-file path diverges.
- **Diagnostic wording.** oc says `unsupported filter rule '<rule>': this build
  currently supports only …` where upstream says `Unknown filter rule: <rule>`.
  Exit codes match; the existing comment records this as deliberate.
