### PR TITLE
fix(engine): treat a source operand ending in `..` as a DOTDIR

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -437,10 +437,14 @@ fn run_client_internal(
         .as_deref()
         .unwrap_or_else(|| config.transfer_args());
 
-    let plan = match LocalCopyPlan::from_operands(plan_operands) {
-        Ok(plan) => plan,
-        Err(error) => return Err(map_local_copy_error(error)),
-    };
+    // `--relative` scopes upstream's trailing-`..` DOTDIR rule
+    // (flist.c:2595-2602 sits in the arm flist.c:2581-2583 short-circuits past),
+    // so the plan has to be built with the flag in hand.
+    let plan =
+        match LocalCopyPlan::from_operands_with_relative(plan_operands, config.relative_paths()) {
+            Ok(plan) => plan,
+            Err(error) => return Err(map_local_copy_error(error)),
+        };
 
     // upstream: main.c:760 validates destination directory access early,
     // returning FILE_SELECTION (3) for PermissionDenied instead of

--- a/crates/engine/src/local_copy/operands.rs
+++ b/crates/engine/src/local_copy/operands.rs
@@ -15,7 +15,15 @@ pub(crate) struct SourceSpec {
 }
 
 impl SourceSpec {
-    pub(crate) fn from_operand(operand: &OsString) -> Result<Self, LocalCopyError> {
+    /// Builds a source operand.
+    ///
+    /// `relative_paths` is `--relative`. It scopes the trailing-`..` DOTDIR
+    /// rule, which upstream places in the arm `--relative` never reaches - see
+    /// [`operand_ends_in_parent_dir`].
+    pub(crate) fn from_operand(
+        operand: &OsString,
+        relative_paths: bool,
+    ) -> Result<Self, LocalCopyError> {
         if operand.is_empty() {
             return Err(LocalCopyError::invalid_argument(
                 LocalCopyArgumentError::EmptySourceOperand,
@@ -28,8 +36,9 @@ impl SourceSpec {
             ));
         }
 
-        let copy_contents =
-            has_trailing_separator(operand.as_os_str()) || operand_is_dot_dir(operand.as_os_str());
+        let copy_contents = has_trailing_separator(operand.as_os_str())
+            || operand_is_dot_dir(operand.as_os_str())
+            || (!relative_paths && operand_ends_in_parent_dir(operand.as_os_str()));
         let has_dot_dir_marker = detect_dot_dir_marker(operand.as_os_str());
         Ok(Self {
             path: PathBuf::from(operand),
@@ -381,6 +390,80 @@ pub(crate) fn has_trailing_separator(path: &OsStr) -> bool {
     }
 }
 
+/// Returns `true` when the operand's final path component is `..` (the operand
+/// is exactly `..` or ends with `/..`).
+///
+/// Upstream does not stat such an operand as typed. It APPENDS `/.` to it and
+/// records `DOTDIR_NAME`:
+///
+/// ```text
+/// } else if (len > 1 && fbuf[len-1] == '.' && fbuf[len-2] == '.'
+///     && (len == 2 || fbuf[len-3] == '/')) {
+///         fbuf[len++] = '/';
+///         fbuf[len++] = '.';
+///         fbuf[len] = '\0';
+///         name_type = DOTDIR_NAME;
+/// ```
+///
+/// The append is what makes the non-relative split at `flist.c:2610-2621` cut
+/// `src/../.` at its LAST `/`, yielding `dir = "src/.."` and `fn = "."`: the
+/// parent directory is chdir()ed into and its CONTENTS are transferred, exactly
+/// as a trailing `/` does. oc reaches the same place by flagging the operand
+/// `copy_contents` and leaving the path as typed, since it resolves operands
+/// instead of chdir()ing.
+///
+/// # Scope: NOT under `--relative`
+///
+/// The rule sits in the arm `--relative` never reaches. `flist.c:2581-2583`
+/// short-circuits the whole marker chain to `NORMAL_NAME` when
+/// `relative_paths` is set, and a `..` in the ACTIVE part of a `--relative`
+/// operand is instead rejected outright at `flist.c:2658-2667`
+/// (`found ".." dir in relative path: %s`, `exit_cleanup(RERR_SYNTAX)`).
+/// Callers must gate on `!--relative`; oc does not yet implement that
+/// rejection, so under `--relative` such an operand keeps its existing
+/// (divergent) handling rather than silently gaining contents semantics.
+///
+/// # Upstream Reference
+///
+/// - `flist.c:2595-2602` - the append and the `DOTDIR_NAME` assignment.
+/// - `flist.c:2581-2583` - the `--relative` short-circuit above it.
+/// - `flist.c:2658-2667` - the `--relative` `..` rejection.
+pub(crate) fn operand_ends_in_parent_dir(path: &OsStr) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+
+        let bytes = path.as_bytes();
+        let len = bytes.len();
+        len > 1
+            && bytes[len - 1] == b'.'
+            && bytes[len - 2] == b'.'
+            && (len == 2 || bytes[len - 3] == b'/')
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+
+        const DOT: u16 = b'.' as u16;
+        const SLASH: u16 = b'/' as u16;
+        const BACKSLASH: u16 = b'\\' as u16;
+
+        let units: Vec<u16> = path.encode_wide().filter(|ch| *ch != 0).collect();
+        let len = units.len();
+        len > 1
+            && units[len - 1] == DOT
+            && units[len - 2] == DOT
+            && (len == 2 || units[len - 3] == SLASH || units[len - 3] == BACKSLASH)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let text = path.to_string_lossy();
+        text == ".." || text.ends_with("/..") || text.ends_with("\\..")
+    }
+}
+
 /// Returns `true` when the operand's final path component is a bare `.`
 /// (the operand is exactly `.` or ends with `/.`). Upstream treats such a
 /// source as contents-only, identical to a trailing slash. See upstream
@@ -497,14 +580,14 @@ mod tests {
 
     #[test]
     fn source_spec_from_operand_valid() {
-        let spec = SourceSpec::from_operand(&OsString::from("/tmp/file.txt")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/tmp/file.txt"), false).unwrap();
         assert_eq!(spec.path(), Path::new("/tmp/file.txt"));
         assert!(!spec.copy_contents());
     }
 
     #[test]
     fn source_spec_from_operand_with_trailing_slash() {
-        let spec = SourceSpec::from_operand(&OsString::from("/tmp/dir/")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/tmp/dir/"), false).unwrap();
         assert!(spec.copy_contents());
     }
 
@@ -514,9 +597,53 @@ mod tests {
         // identical to a trailing slash; a bare `.` must not error out trying
         // to derive a directory name from `file_name()`.
         for operand in [".", "foo/.", "/tmp/dir/."] {
-            let spec = SourceSpec::from_operand(&OsString::from(operand)).unwrap();
+            let spec = SourceSpec::from_operand(&OsString::from(operand), false).unwrap();
             assert!(spec.copy_contents(), "{operand:?} should copy contents");
         }
+    }
+
+    /// upstream flist.c:2595-2602 - a trailing `..` component is a DOTDIR
+    /// operand: upstream appends `/.` and sets `DOTDIR_NAME`, so the parent's
+    /// contents are what gets transferred.
+    #[test]
+    fn source_spec_from_operand_parent_dir_copies_contents() {
+        for operand in ["..", "foo/..", "/tmp/dir/..", "foo/./.."] {
+            let spec = SourceSpec::from_operand(&OsString::from(operand), false).unwrap();
+            assert!(spec.copy_contents(), "{operand:?} should copy contents");
+        }
+    }
+
+    /// upstream flist.c:2581-2583 forces `NORMAL_NAME` before the `..` arm is
+    /// reached, and flist.c:2658-2667 rejects the operand instead. `--relative`
+    /// therefore never acquires the contents semantics.
+    #[test]
+    fn source_spec_from_operand_parent_dir_is_scoped_to_non_relative() {
+        for operand in ["..", "foo/..", "/tmp/dir/.."] {
+            let spec = SourceSpec::from_operand(&OsString::from(operand), true).unwrap();
+            assert!(
+                !spec.copy_contents(),
+                "{operand:?} must not copy contents under --relative"
+            );
+        }
+    }
+
+    /// The guard is `fbuf[len-1] == '.' && fbuf[len-2] == '.' &&
+    /// (len == 2 || fbuf[len-3] == '/')` (flist.c:2595-2596): a whole trailing
+    /// COMPONENT, not the two bytes.
+    #[test]
+    fn operand_ends_in_parent_dir_classification() {
+        assert!(operand_ends_in_parent_dir(OsStr::new("..")));
+        assert!(operand_ends_in_parent_dir(OsStr::new("foo/..")));
+        assert!(operand_ends_in_parent_dir(OsStr::new("/tmp/dir/..")));
+        assert!(operand_ends_in_parent_dir(OsStr::new("/..")));
+
+        assert!(!operand_ends_in_parent_dir(OsStr::new(".")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("...")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("weird..")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("foo/../bar")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("foo/../")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("foo/../.")));
+        assert!(!operand_ends_in_parent_dir(OsStr::new("")));
     }
 
     #[test]
@@ -532,26 +659,26 @@ mod tests {
 
     #[test]
     fn source_spec_from_operand_empty_fails() {
-        let result = SourceSpec::from_operand(&OsString::from(""));
+        let result = SourceSpec::from_operand(&OsString::from(""), false);
         assert!(result.is_err());
     }
 
     #[test]
     fn source_spec_from_operand_remote_fails() {
-        let result = SourceSpec::from_operand(&OsString::from("host:/path"));
+        let result = SourceSpec::from_operand(&OsString::from("host:/path"), false);
         assert!(result.is_err());
     }
 
     #[test]
     fn source_spec_relative_root_simple() {
-        let spec = SourceSpec::from_operand(&OsString::from("file.txt")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("file.txt"), false).unwrap();
         let root = spec.relative_root();
         assert_eq!(root, Some(PathBuf::from("file.txt")));
     }
 
     #[test]
     fn source_spec_relative_root_absolute() {
-        let spec = SourceSpec::from_operand(&OsString::from("/tmp/file.txt")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/tmp/file.txt"), false).unwrap();
         let root = spec.relative_root();
         assert_eq!(root, Some(PathBuf::from("tmp/file.txt")));
     }
@@ -578,28 +705,28 @@ mod tests {
 
     #[test]
     fn source_spec_eq() {
-        let a = SourceSpec::from_operand(&OsString::from("/src")).unwrap();
-        let b = SourceSpec::from_operand(&OsString::from("/src")).unwrap();
+        let a = SourceSpec::from_operand(&OsString::from("/src"), false).unwrap();
+        let b = SourceSpec::from_operand(&OsString::from("/src"), false).unwrap();
         assert_eq!(a, b);
     }
 
     #[test]
     fn source_spec_has_dot_dir_marker_leading() {
-        let spec = SourceSpec::from_operand(&OsString::from("./a/b")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("./a/b"), false).unwrap();
         assert!(spec.has_dot_dir_marker());
     }
 
     #[test]
     fn source_spec_has_dot_dir_marker_mid_path() {
-        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b"), false).unwrap();
         assert!(spec.has_dot_dir_marker());
     }
 
     #[test]
     fn source_spec_has_dot_dir_marker_absent() {
-        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b"), false).unwrap();
         assert!(!spec.has_dot_dir_marker());
-        let spec = SourceSpec::from_operand(&OsString::from("a/b/c")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("a/b/c"), false).unwrap();
         assert!(!spec.has_dot_dir_marker());
     }
 
@@ -623,7 +750,7 @@ mod tests {
     #[test]
     fn a_trailing_dot_is_not_a_relative_root_pivot() {
         for operand in ["tree/.", "tree/sub/.", "/src/a/."] {
-            let spec = SourceSpec::from_operand(&OsString::from(operand)).unwrap();
+            let spec = SourceSpec::from_operand(&OsString::from(operand), false).unwrap();
             assert!(
                 !spec.has_dot_dir_marker(),
                 "trailing `/.` must not pivot the --relative root: {operand}"
@@ -638,7 +765,7 @@ mod tests {
     #[test]
     fn a_dot_followed_by_a_separator_still_pivots() {
         for operand in ["tree/./", "tree/./sub", "./a/b", "/src/./a"] {
-            let spec = SourceSpec::from_operand(&OsString::from(operand)).unwrap();
+            let spec = SourceSpec::from_operand(&OsString::from(operand), false).unwrap();
             assert!(
                 spec.has_dot_dir_marker(),
                 "`/./` must pivot the --relative root: {operand}"
@@ -649,19 +776,19 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn source_spec_dot_dir_anchor_with_prefix() {
-        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/src/./a/b"), false).unwrap();
         assert_eq!(spec.dot_dir_anchor(), Some(PathBuf::from("/src")));
     }
 
     #[test]
     fn source_spec_dot_dir_anchor_leading_returns_cwd_dot() {
-        let spec = SourceSpec::from_operand(&OsString::from("./a/b/c")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("./a/b/c"), false).unwrap();
         assert_eq!(spec.dot_dir_anchor(), Some(PathBuf::from(".")));
     }
 
     #[test]
     fn source_spec_dot_dir_anchor_none_when_no_marker() {
-        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b")).unwrap();
+        let spec = SourceSpec::from_operand(&OsString::from("/src/a/b"), false).unwrap();
         assert_eq!(spec.dot_dir_anchor(), None);
     }
 }

--- a/crates/engine/src/local_copy/plan/plan_impl.rs
+++ b/crates/engine/src/local_copy/plan/plan_impl.rs
@@ -21,7 +21,10 @@ pub struct LocalCopyPlan {
 }
 
 impl LocalCopyPlan {
-    /// Constructs a plan from CLI-style operands.
+    /// Constructs a plan from CLI-style operands, with `--relative` off.
+    ///
+    /// Use [`Self::from_operands_with_relative`] when the flag is known; it is
+    /// the operand rule at `flist.c:2595-2602` that reads it.
     ///
     /// The operands must contain at least one source and a destination. A
     /// trailing path separator on a source operand mirrors upstream rsync's
@@ -49,6 +52,23 @@ impl LocalCopyPlan {
     /// assert_eq!(plan.destination(), std::path::Path::new("dst"));
     /// ```
     pub fn from_operands(operands: &[OsString]) -> Result<Self, LocalCopyError> {
+        Self::from_operands_with_relative(operands, false)
+    }
+
+    /// [`Self::from_operands`] with `--relative` known.
+    ///
+    /// The flag scopes one operand rule: upstream's trailing-`..` DOTDIR
+    /// append (`flist.c:2595-2602`) sits in the arm `--relative` short-circuits
+    /// past (`flist.c:2581-2583`). See
+    /// `operands::operand_ends_in_parent_dir`, which carries the full citation.
+    ///
+    /// # Errors
+    ///
+    /// As [`Self::from_operands`].
+    pub fn from_operands_with_relative(
+        operands: &[OsString],
+        relative_paths: bool,
+    ) -> Result<Self, LocalCopyError> {
         if operands.len() < 2 {
             return Err(LocalCopyError::missing_operands());
         }
@@ -59,7 +79,7 @@ impl LocalCopyPlan {
         // the same directory or file from being processed multiple times.
         let all_sources: Vec<SourceSpec> = operands[..operands.len() - 1]
             .iter()
-            .map(SourceSpec::from_operand)
+            .map(|operand| SourceSpec::from_operand(operand, relative_paths))
             .collect::<Result<_, _>>()?;
         let mut seen = HashSet::with_capacity(all_sources.len());
         let sources: Vec<SourceSpec> = all_sources

--- a/crates/engine/src/local_copy/tests/relative.rs
+++ b/crates/engine/src/local_copy/tests/relative.rs
@@ -3,7 +3,7 @@
 #[test]
 fn relative_root_drops_absolute_prefix_without_marker() {
     let operand = OsString::from("/var/log/messages");
-    let spec = SourceSpec::from_operand(&operand).expect("source spec");
+    let spec = SourceSpec::from_operand(&operand, true).expect("source spec");
     let expected = Path::new("var").join("log").join("messages");
     assert_eq!(spec.relative_root(), Some(expected));
 }
@@ -12,7 +12,7 @@ fn relative_root_drops_absolute_prefix_without_marker() {
 #[test]
 fn relative_root_respects_marker_boundary() {
     let operand = OsString::from("/srv/./data/file.txt");
-    let spec = SourceSpec::from_operand(&operand).expect("source spec");
+    let spec = SourceSpec::from_operand(&operand, true).expect("source spec");
     assert_eq!(
         spec.relative_root(),
         Some(Path::new("data/file.txt").to_path_buf())
@@ -22,7 +22,7 @@ fn relative_root_respects_marker_boundary() {
 #[test]
 fn relative_root_keeps_relative_paths_without_marker() {
     let operand = OsString::from("nested/dir/file.txt");
-    let spec = SourceSpec::from_operand(&operand).expect("source spec");
+    let spec = SourceSpec::from_operand(&operand, true).expect("source spec");
     assert_eq!(
         spec.relative_root(),
         Some(Path::new("nested/dir/file.txt").to_path_buf())
@@ -32,7 +32,7 @@ fn relative_root_keeps_relative_paths_without_marker() {
 #[test]
 fn relative_root_counts_parent_components_before_marker() {
     let operand = OsString::from("dir/.././trimmed/file.txt");
-    let spec = SourceSpec::from_operand(&operand).expect("source spec");
+    let spec = SourceSpec::from_operand(&operand, true).expect("source spec");
     assert_eq!(
         spec.relative_root(),
         Some(Path::new("trimmed/file.txt").to_path_buf())
@@ -43,7 +43,7 @@ fn relative_root_counts_parent_components_before_marker() {
 #[test]
 fn relative_root_handles_windows_drive_prefix() {
     let operand = OsString::from(r"C:\\path\\.\\to\\file.txt");
-    let spec = SourceSpec::from_operand(&operand).expect("source spec");
+    let spec = SourceSpec::from_operand(&operand, true).expect("source spec");
     assert_eq!(
         spec.relative_root(),
         Some(Path::new("to/file.txt").to_path_buf())

--- a/crates/engine/tests/parentdir_operand_is_a_dotdir.rs
+++ b/crates/engine/tests/parentdir_operand_is_a_dotdir.rs
@@ -1,0 +1,279 @@
+//! A source operand whose last component is `..` is a DOTDIR operand.
+//!
+//! Upstream never stats such an operand as typed. It APPENDS `/.` to it and
+//! records `DOTDIR_NAME` (`flist.c:2595-2602`), which makes the non-relative
+//! split at `flist.c:2610-2621` cut `src/../.` at its LAST `/`: `dir` becomes
+//! `src/..`, `fn` becomes `.`, and the parent directory's CONTENTS are
+//! transferred - exactly what a trailing `/` does.
+//!
+//! oc used `Path::file_name()` on the operand instead. That returns `None` for
+//! a `ParentDir` final component, and the `None` became
+//! `LocalCopyArgumentError::DirectoryNameUnavailable` - "cannot determine
+//! directory name", exit 23, nothing transferred. MEASURED against rsync 3.5.0:
+//! `src/..`, `src/./..`, `src/sym-to-dir/..` and a bare `..` all aborted at 23
+//! where upstream exits 0 having copied the parent's contents.
+//!
+//! # Scope: NOT under `--relative`
+//!
+//! The rule sits in the arm `--relative` short-circuits past
+//! (`flist.c:2581-2583`); a `..` in the ACTIVE part of a `--relative` operand is
+//! rejected instead, at `flist.c:2658-2667`. `parent_dir_rule_is_scoped_to_non_relative`
+//! pins that boundary.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/flist.c:2595-2602` - the `/.` append and `DOTDIR_NAME`.
+//! - `rsync-3.5.0/flist.c:2581-2583` - the `--relative` short-circuit above it.
+//! - `rsync-3.5.0/flist.c:2610-2621` - the non-relative last-`/` split.
+//! - `rsync-3.5.0/flist.c:2658-2667` - the `--relative` `..` rejection.
+//! - `rsync-3.5.0/flist.c:115-118` - `NORMAL_NAME` / `DOTDIR_NAME`.
+
+#![cfg(unix)]
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use engine::local_copy::{LocalCopyExecution, LocalCopyOptions, LocalCopyPlan};
+use tempfile::{TempDir, tempdir};
+
+/// Plants, under `<temp>/base`:
+///
+/// ```text
+/// base/from/{a.txt, sub/b.txt, sym-to-dir -> ../other/dir_target}
+/// base/sibling.txt
+/// base/other/dir_target/c.txt
+/// ```
+///
+/// `base/from/..` is `base`; `base/from/sym-to-dir/..` is `base/other`, which
+/// the kernel resolves THROUGH the symlink - so the two operands under test name
+/// different directories and cannot be satisfied by one hard-coded answer.
+///
+/// The destination is `<temp>/to`, a sibling of `base`, so copying `base`'s
+/// contents can never re-enter the destination.
+fn fixture() -> (TempDir, PathBuf, PathBuf) {
+    let temp = tempdir().expect("tempdir");
+    let base = temp.path().join("base");
+    let to = temp.path().join("to");
+    fs::create_dir_all(base.join("from/sub")).expect("mkdir from/sub");
+    fs::create_dir_all(base.join("other/dir_target")).expect("mkdir other/dir_target");
+    fs::create_dir_all(&to).expect("mkdir to");
+    fs::write(base.join("from/a.txt"), b"AAA").expect("write a.txt");
+    fs::write(base.join("from/sub/b.txt"), b"BBB").expect("write b.txt");
+    symlink("../other/dir_target", base.join("from/sym-to-dir")).expect("plant sym-to-dir");
+    fs::write(base.join("sibling.txt"), b"SSS").expect("write sibling.txt");
+    fs::write(base.join("other/dir_target/c.txt"), b"CCC").expect("write c.txt");
+    (temp, base, to)
+}
+
+/// A sorted snapshot of everything under `root`: relative path, entry kind, and
+/// the bytes (or link target) that distinguish one entry from another.
+///
+/// Asserting on this rather than on an exit code is deliberate - a wrong
+/// operand rule can exit 0 and still deliver the wrong tree.
+fn snapshot(root: &Path) -> Vec<String> {
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<String>) {
+        let mut entries: Vec<PathBuf> = fs::read_dir(dir)
+            .unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()))
+            .map(|e| e.expect("dir entry").path())
+            .collect();
+        entries.sort();
+        for path in entries {
+            let rel = path.strip_prefix(root).expect("under root").display();
+            let meta = fs::symlink_metadata(&path).expect("symlink_metadata");
+            if meta.file_type().is_symlink() {
+                let target = fs::read_link(&path).expect("read_link");
+                out.push(format!("{rel} -> {}", target.display()));
+            } else if meta.is_dir() {
+                out.push(format!("{rel}/"));
+                walk(root, &path, out);
+            } else {
+                let bytes = fs::read(&path).expect("read file");
+                out.push(format!("{rel} = {}", String::from_utf8_lossy(&bytes)));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out
+}
+
+fn options() -> LocalCopyOptions {
+    LocalCopyOptions::default().recursive(true).links(true)
+}
+
+/// Runs `operand -> to` through the local-copy executor and snapshots `to`.
+fn run(operand: &Path, to: &Path, options: LocalCopyOptions) -> Vec<String> {
+    let operands = vec![
+        OsString::from(operand.as_os_str()),
+        OsString::from(to.as_os_str()),
+    ];
+    let plan =
+        LocalCopyPlan::from_operands_with_relative(&operands, options.relative_paths_enabled())
+            .expect("plan");
+    plan.execute_with_report(LocalCopyExecution::Apply, options)
+        .expect("a trailing `..` operand must not abort the transfer");
+    snapshot(to)
+}
+
+/// `from/..` transfers the CONTENTS of `from`'s parent, not `from` and not a
+/// directory literally named `..`.
+#[test]
+fn parent_dir_operand_transfers_the_parents_contents() {
+    let (_temp, base, to) = fixture();
+
+    let got = run(&base.join("from/.."), &to, options());
+
+    assert_eq!(
+        got,
+        vec![
+            "from/".to_owned(),
+            "from/a.txt = AAA".to_owned(),
+            "from/sub/".to_owned(),
+            "from/sub/b.txt = BBB".to_owned(),
+            "from/sym-to-dir -> ../other/dir_target".to_owned(),
+            "other/".to_owned(),
+            "other/dir_target/".to_owned(),
+            "other/dir_target/c.txt = CCC".to_owned(),
+            "sibling.txt = SSS".to_owned(),
+        ],
+        "`<dir>/..` is DOTDIR_NAME (flist.c:2595-2602), so the parent's contents \
+         land directly in the destination - upstream rsync 3.5.0 exits 0 with \
+         exactly this tree",
+    );
+}
+
+/// The `..` spelling is indistinguishable from the two DOTDIR spellings oc
+/// already handled. Pinning the EQUALITY rather than a second literal keeps the
+/// three from drifting apart.
+#[test]
+fn parent_dir_operand_matches_the_trailing_slash_and_dot_spellings() {
+    let mut seen: Vec<(&str, Vec<String>)> = Vec::new();
+    for suffix in ["/..", "/../", "/../.", "/./.."] {
+        let (_temp, base, to) = fixture();
+        let operand = PathBuf::from(format!("{}/from{suffix}", base.display()));
+        seen.push((suffix, run(&operand, &to, options())));
+    }
+
+    let (first_suffix, first) = &seen[0];
+    for (suffix, rows) in &seen[1..] {
+        assert_eq!(
+            rows, first,
+            "`from{suffix}` and `from{first_suffix}` are both DOTDIR operands \
+             (flist.c:2584-2604) and must deliver the same tree",
+        );
+    }
+}
+
+/// `..` after a symlink resolves through it, so `from/sym-to-dir/..` is
+/// `other`, NOT `from`. A fix that special-cased the operand's own lexical
+/// parent would deliver `from`'s contents here.
+#[test]
+fn parent_dir_operand_resolves_through_a_symlinked_component() {
+    let (_temp, base, to) = fixture();
+
+    let got = run(&base.join("from/sym-to-dir/.."), &to, options());
+
+    assert_eq!(
+        got,
+        vec![
+            "dir_target/".to_owned(),
+            "dir_target/c.txt = CCC".to_owned(),
+        ],
+        "`from/sym-to-dir/..` names `other` - the kernel resolves `..` from the \
+         symlink's TARGET, and upstream chdir()s to the operand verbatim \
+         (flist.c:2610-2621, flist.c:2677-2679)",
+    );
+}
+
+/// NEGATIVE CONTROL. An ordinary directory operand is `NORMAL_NAME`
+/// (`flist.c:2605-2606`): it lands under its own name. Nothing in this cell
+/// touches the trailing-`..` rule, so it must stay green whether that rule is
+/// present or reverted.
+#[test]
+fn an_ordinary_directory_operand_still_lands_under_its_own_name() {
+    let (_temp, base, to) = fixture();
+
+    let got = run(&base.join("from"), &to, options());
+
+    assert_eq!(
+        got,
+        vec![
+            "from/".to_owned(),
+            "from/a.txt = AAA".to_owned(),
+            "from/sub/".to_owned(),
+            "from/sub/b.txt = BBB".to_owned(),
+            "from/sym-to-dir -> ../other/dir_target".to_owned(),
+        ],
+        "a NORMAL_NAME operand keeps its basename",
+    );
+}
+
+/// A `..` that is not the LAST component is `NORMAL_NAME`. This is the cell a
+/// fix that simply always appended `/.`, or that tested `contains("..")`, would
+/// fail: `other` would arrive as loose contents instead of a directory.
+#[test]
+fn a_dotdot_that_is_not_the_last_component_is_a_normal_name() {
+    let (_temp, base, to) = fixture();
+
+    let got = run(&base.join("from/../other"), &to, options());
+
+    assert_eq!(
+        got,
+        vec![
+            "other/".to_owned(),
+            "other/dir_target/".to_owned(),
+            "other/dir_target/c.txt = CCC".to_owned(),
+        ],
+        "upstream's guard is `fbuf[len-1] == '.' && fbuf[len-2] == '.' && \
+         (len == 2 || fbuf[len-3] == '/')` (flist.c:2595-2596) - an interior \
+         `..` never reaches the append",
+    );
+}
+
+/// A file operand whose name merely ENDS in the two bytes `..` is not a
+/// `ParentDir` component. `fbuf[len-3] == '/'` is what upstream requires.
+#[test]
+fn a_basename_ending_in_two_dots_is_not_a_parent_dir_component() {
+    let (_temp, base, to) = fixture();
+    fs::write(base.join("from/weird.."), b"WW").expect("write weird..");
+
+    let got = run(&base.join("from/weird.."), &to, options());
+
+    assert_eq!(
+        got,
+        vec!["weird.. = WW".to_owned()],
+        "`weird..` has `fbuf[len-3] == 'd'`, so flist.c:2595-2596 does not fire",
+    );
+}
+
+/// The rule is scoped to NON-relative operands, because upstream's marker chain
+/// is: `flist.c:2581-2583` forces `NORMAL_NAME` under `--relative` before the
+/// `..` arm is reached, and `flist.c:2658-2667` rejects the operand outright
+/// with `found ".." dir in relative path: %s` / `exit_cleanup(RERR_SYNTAX)`.
+///
+/// oc does not implement that rejection yet (MEASURED: rsync 3.5.0 exits 1,
+/// oc exits 23 - a KNOWN residual divergence, unchanged by this fix). What this
+/// cell pins is only the SCOPE: `--relative` must not quietly acquire contents
+/// semantics, which upstream never grants it.
+#[test]
+fn parent_dir_rule_is_scoped_to_non_relative() {
+    let (_temp, base, to) = fixture();
+    let operands = vec![
+        OsString::from(base.join("from/..").as_os_str()),
+        OsString::from(to.as_os_str()),
+    ];
+    let relative = options().relative_paths(true);
+    let plan = LocalCopyPlan::from_operands_with_relative(&operands, true).expect("plan");
+
+    let result = plan.execute_with_report(LocalCopyExecution::Apply, relative);
+
+    assert!(
+        result.is_err(),
+        "under `--relative` upstream REJECTS a `..` operand (flist.c:2658-2667); \
+         it must not be granted the DOTDIR contents semantics of the \
+         non-relative arm. Destination held: {:?}",
+        snapshot(&to),
+    );
+}

--- a/crates/transfer/src/generator/file_list/mod.rs
+++ b/crates/transfer/src/generator/file_list/mod.rs
@@ -129,6 +129,18 @@ impl GeneratorContext {
             // transmitted name, which is why the follow at flist.c:2697 still
             // fires for a `--relative` operand whose name is now marker-free.
             // Read it from the raw operand for exactly that reason.
+            //
+            // The trailing-`..` DOTDIR spelling (flist.c:2595-2602) is
+            // deliberately NOT folded in here. `is_dotdir` feeds exactly one
+            // thing, `resolve_symlink_metadata`'s follow disjunct, and that
+            // disjunct only fires when the operand itself lstat()s as a
+            // symlink. `lstat("X/..")` never can: `..` is resolved by the
+            // kernel, so the result is a directory or an error (MEASURED:
+            // real dir, symlinked dir, dangling symlink, and `/` all confirm
+            // it). Adding the disjunct there was inert - a mutation that
+            // reverted it killed no test - so it is left out rather than
+            // carried as a second, unexercised spelling of the same rule.
+            // `non_relative_walk_base` is where the spelling does its work.
             let operand_is_dotdir = operand_has_dotdir_marker(base_path);
             // upstream: flist.c:2254-2272 - pre-stat each top-level source and
             // apply missing_args handling. Separates "source never existed" from
@@ -593,6 +605,53 @@ pub(super) fn operand_has_dotdir_marker(path: &Path) -> bool {
     bytes == b"." || bytes.ends_with(b"/") || bytes.ends_with(b"/.")
 }
 
+/// Is this operand's last path component `..`?
+///
+/// Upstream does not stat such an operand as typed. It APPENDS `/.` and marks
+/// it `DOTDIR_NAME`:
+///
+/// ```text
+/// } else if (len > 1 && fbuf[len-1] == '.' && fbuf[len-2] == '.'
+///     && (len == 2 || fbuf[len-3] == '/')) {
+///         fbuf[len++] = '/';
+///         fbuf[len++] = '.';
+///         fbuf[len] = '\0';
+///         name_type = DOTDIR_NAME;
+/// ```
+///
+/// so the last-`/` split at `flist.c:2610-2621` cuts `src/../.` into
+/// `dir = "src/.."` and `fn = "."`. The parent directory becomes the walk root
+/// and its CONTENTS ride the wire under their own names - identical to the
+/// trailing-slash spelling, which is why this feeds
+/// [`non_relative_walk_base`]'s existing DOTDIR branch rather than a second one.
+///
+/// Without it `Path::parent()` hands the walk a base of `src` and a path of
+/// `src/..`, whose lexical `strip_prefix` leaves the transmitted name `..` -
+/// a name every conforming receiver rejects
+/// ("ABORTING due to unsafe pathname from sender: ..").
+///
+/// # Scope: NOT under `--relative`
+///
+/// `flist.c:2581-2583` short-circuits the whole marker chain to `NORMAL_NAME`
+/// when `relative_paths` is set; a `..` in the ACTIVE part of a `--relative`
+/// operand is rejected instead, at `flist.c:2658-2667`. The scoping is
+/// structural: the sole caller is [`non_relative_walk_base`], which IS the
+/// `else` arm of that same test (`flist.c:2610` `if (!relative_paths)`).
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/flist.c:2595-2602` - the append and `DOTDIR_NAME`.
+/// - `rsync-3.5.0/flist.c:2581-2583` - the `--relative` short-circuit above it.
+/// - `rsync-3.5.0/flist.c:2658-2667` - the `--relative` `..` rejection.
+pub(super) fn operand_ends_in_parent_dir(path: &Path) -> bool {
+    let bytes = path.as_os_str().as_encoded_bytes();
+    let len = bytes.len();
+    len > 1
+        && bytes[len - 1] == b'.'
+        && bytes[len - 2] == b'.'
+        && (len == 2 || bytes[len - 3] == b'/')
+}
+
 /// Normalises a `--relative` operand into the name that rides the wire.
 ///
 /// Upstream runs the operand through
@@ -785,7 +844,10 @@ fn non_relative_walk_base(path: &Path) -> (PathBuf, PathBuf) {
     // trailing `/.` is DOTDIR just as much as a trailing `/`, and routing it
     // through `Path::parent()` instead would name the entries under the
     // operand's own basename rather than transferring its contents.
-    if operand_has_dotdir_marker(path) {
+    // A trailing `..` is the third DOTDIR spelling (flist.c:2595-2602 appends
+    // `/.` to reach exactly this branch). Ungated here because this function IS
+    // the `!relative_paths` arm - flist.c:2610 `if (!relative_paths)`.
+    if operand_has_dotdir_marker(path) || operand_ends_in_parent_dir(path) {
         return (path.to_path_buf(), path.to_path_buf());
     }
     // `Path::parent()` returns the parent directory or `None` for a path

--- a/crates/transfer/tests/uts_parentdir_operand_is_a_dotdir.rs
+++ b/crates/transfer/tests/uts_parentdir_operand_is_a_dotdir.rs
@@ -1,0 +1,288 @@
+//! A sender operand whose last component is `..` is a DOTDIR operand.
+//!
+//! This is the wire half of the same rule the local-copy executor carries.
+//! Upstream appends `/.` to such an operand and marks it `DOTDIR_NAME`
+//! (`flist.c:2595-2602`), so the non-relative split at `flist.c:2610-2621` cuts
+//! `src/../.` at its LAST `/`: `dir` is `src/..`, `fn` is `.`, and the parent
+//! directory becomes the walk root whose CONTENTS ride the wire under their own
+//! names.
+//!
+//! Without that, oc handed `Path::parent()` the job: `src/..` got a walk base of
+//! `src`, and the purely lexical `strip_prefix` left the transmitted name `..`.
+//! This half was the SILENT one - no error is raised at the sender. MEASURED
+//! against rsync 3.5.0 over an `--rsh` loopback: oc-rsync died at the RECEIVER
+//! with "ABORTING due to unsafe pathname from sender: .." (exit 4) where
+//! upstream exits 0 having transferred the parent's contents.
+//!
+//! Assertions are on the transmitted NAMES, since that is where the defect
+//! lives; the receiver's refusal is a downstream symptom of them.
+//!
+//! # Scope: NOT under `--relative`
+//!
+//! `flist.c:2581-2583` short-circuits the marker chain to `NORMAL_NAME` under
+//! `--relative`, and `flist.c:2658-2667` rejects a `..` in the active part of a
+//! relative operand instead. `parent_dir_rule_is_scoped_to_non_relative` pins
+//! that boundary.
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/flist.c:2595-2602` - the `/.` append and `DOTDIR_NAME`.
+//! - `rsync-3.5.0/flist.c:2581-2583` - the `--relative` short-circuit above it.
+//! - `rsync-3.5.0/flist.c:2610-2621` - the non-relative last-`/` split.
+//! - `rsync-3.5.0/flist.c:2658-2667` - the `--relative` `..` rejection.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use protocol::ProtocolVersion;
+use protocol::flist::FileType;
+use transfer::{
+    GeneratorContext, HandshakeResult, ServerConfig, ServerRole, TransferPhase, TransferPipeline,
+};
+
+/// A non-relative recursive sender. `-R` is deliberately absent: the rule under
+/// test lives in the arm `--relative` short-circuits past.
+fn generator_config(operand: &Path, relative: bool) -> ServerConfig {
+    let flags = if relative {
+        "-rR.iLsfxCIvu"
+    } else {
+        "-r.iLsfxCIvu"
+    };
+    let mut config = ServerConfig::from_flag_string_and_args(
+        ServerRole::Generator,
+        flags.to_owned(),
+        vec![operand.to_path_buf().into_os_string()],
+    )
+    .expect("server config");
+    config.connection.client_mode = true;
+    assert_eq!(
+        config.flags.relative, relative,
+        "the --relative scope of this cell must be the one it asked for"
+    );
+    assert!(
+        !config.flags.copy_dirlinks,
+        "the walk must descend because of the operand marker, not because of -k"
+    );
+    assert!(!config.flags.copy_links, "-L would follow every symlink");
+    config
+}
+
+fn test_handshake() -> HandshakeResult {
+    HandshakeResult {
+        protocol: ProtocolVersion::try_from(32u8).unwrap(),
+        buffered: Vec::new(),
+        compat_exchanged: true,
+        client_args: None,
+        io_timeout: None,
+        negotiated_algorithms: None,
+        compat_flags: None,
+        checksum_seed: 0,
+    }
+}
+
+fn test_pipeline() -> TransferPipeline {
+    let mut pipeline = TransferPipeline::new(ServerRole::Generator);
+    pipeline
+        .advance_to(TransferPhase::FilterExchange)
+        .expect("advance to FilterExchange");
+    pipeline
+        .advance_to(TransferPhase::FileListTransfer)
+        .expect("advance to FileListTransfer");
+    pipeline
+}
+
+/// Plants, under `<scratch>`:
+///
+/// ```text
+/// realdir/{f.txt, sub/g.txt}
+/// symdir -> realdir
+/// ```
+///
+/// so `realdir/..` is `<scratch>` and its contents are `realdir` plus `symdir`.
+fn build_source_tree(scratch: &TempDir) {
+    let realdir = scratch.path().join("realdir");
+    fs::create_dir_all(realdir.join("sub")).expect("mkdir realdir/sub");
+    fs::write(realdir.join("f.txt"), b"payload").expect("write realdir/f.txt");
+    fs::write(realdir.join("sub/g.txt"), b"deeper").expect("write realdir/sub/g.txt");
+    symlink("realdir", scratch.path().join("symdir")).expect("plant symdir -> realdir");
+}
+
+/// Builds the flist for `operand` and returns every transmitted name paired
+/// with its file type, in wire order.
+fn flist(operand: &Path, relative: bool) -> Vec<(String, FileType)> {
+    let config = generator_config(operand, relative);
+    let mut ctx = GeneratorContext::new(&test_handshake(), config, test_pipeline());
+    ctx.build_file_list(&[operand.to_path_buf()])
+        .expect("build_file_list");
+    ctx.file_list()
+        .iter()
+        .map(|e| (e.name().to_owned(), e.file_type()))
+        .collect()
+}
+
+fn names(rows: &[(String, FileType)]) -> Vec<&str> {
+    rows.iter().map(|(n, _)| n.as_str()).collect()
+}
+
+/// `realdir/..` transfers the parent's CONTENTS, rooted at `.`, with no name
+/// containing a `..` component.
+///
+/// Sorted, because `build_file_list` runs before `flist_sort_and_clean()`
+/// (`flist.c:2816`) and emits in directory-walk order. The property under test
+/// is WHICH names the operand selects, not the order they were discovered in.
+#[test]
+fn parent_dir_operand_sends_the_parents_contents_rooted_at_dot() {
+    let scratch = TempDir::new().expect("tempdir");
+    build_source_tree(&scratch);
+    let operand = scratch.path().join("realdir/..");
+
+    let rows = flist(&operand, false);
+    let mut got = names(&rows);
+    got.sort_unstable();
+
+    assert_eq!(
+        got,
+        vec![
+            ".",
+            "realdir",
+            "realdir/f.txt",
+            "realdir/sub",
+            "realdir/sub/g.txt",
+            "symdir",
+        ],
+        "`<dir>/..` is DOTDIR_NAME (flist.c:2595-2602): the parent becomes the \
+         transfer root `.` and its contents ride under their own names",
+    );
+}
+
+/// Not one transmitted name may carry a `..` component. This is the byte the
+/// receiver refuses ("ABORTING due to unsafe pathname from sender: ..").
+#[test]
+fn no_transmitted_name_carries_a_parent_dir_component() {
+    let scratch = TempDir::new().expect("tempdir");
+    build_source_tree(&scratch);
+
+    for suffix in ["/..", "/../", "/../.", "/./.."] {
+        let operand = PathBuf::from(format!("{}/realdir{suffix}", scratch.path().display()));
+        let rows = flist(&operand, false);
+        let unsafe_names: Vec<&str> = names(&rows)
+            .into_iter()
+            .filter(|n| {
+                *n == ".." || n.starts_with("../") || n.ends_with("/..") || n.contains("/../")
+            })
+            .collect();
+        assert!(
+            unsafe_names.is_empty(),
+            "`realdir{suffix}` put {unsafe_names:?} on the wire; every conforming \
+             receiver refuses those: flist.c:851-855 aborts with RERR_UNSUPPORTED (4) when clean_fname(CFN_REFUSE_DOT_DOT_DIRS) rejects the name",
+        );
+    }
+}
+
+/// The `..` spelling is indistinguishable on the wire from the DOTDIR spellings
+/// oc already handled.
+#[test]
+fn parent_dir_operand_matches_the_trailing_slash_and_dot_spellings() {
+    let mut seen: Vec<(&str, Vec<String>)> = Vec::new();
+    for suffix in ["/..", "/../", "/../.", "/./.."] {
+        let scratch = TempDir::new().expect("tempdir");
+        build_source_tree(&scratch);
+        let operand = PathBuf::from(format!("{}/realdir{suffix}", scratch.path().display()));
+        let rows = flist(&operand, false);
+        let mut got: Vec<String> = names(&rows).iter().map(|s| (*s).to_owned()).collect();
+        got.sort_unstable();
+        seen.push((suffix, got));
+    }
+
+    let (first_suffix, first) = &seen[0];
+    for (suffix, got) in &seen[1..] {
+        assert_eq!(
+            got, first,
+            "`realdir{suffix}` and `realdir{first_suffix}` are both DOTDIR \
+             operands (flist.c:2584-2604) and must transmit identical names",
+        );
+    }
+}
+
+/// NEGATIVE CONTROL. An ordinary directory operand is `NORMAL_NAME`
+/// (`flist.c:2605-2606`) and its names are rooted at its own basename. Nothing
+/// here touches the trailing-`..` rule, so this cell must stay green whether
+/// that rule is present or reverted.
+#[test]
+fn an_ordinary_directory_operand_still_sends_itself() {
+    let scratch = TempDir::new().expect("tempdir");
+    build_source_tree(&scratch);
+
+    let rows = flist(&scratch.path().join("realdir"), false);
+
+    assert_eq!(
+        names(&rows),
+        vec![
+            "realdir",
+            "realdir/f.txt",
+            "realdir/sub",
+            "realdir/sub/g.txt"
+        ],
+        "a NORMAL_NAME operand is rooted at its own basename, not at `.`",
+    );
+}
+
+/// A `..` that is not the LAST component is `NORMAL_NAME`. This is the cell a
+/// fix that always appended `/.`, or that tested `contains("..")`, would fail:
+/// `symdir` would arrive as a `.`-rooted content listing instead of one entry.
+#[test]
+fn a_dotdot_that_is_not_the_last_component_is_a_normal_name() {
+    let scratch = TempDir::new().expect("tempdir");
+    build_source_tree(&scratch);
+
+    let rows = flist(&scratch.path().join("realdir/../symdir"), false);
+
+    assert_eq!(
+        rows,
+        vec![("symdir".to_owned(), FileType::Symlink)],
+        "upstream's guard is `fbuf[len-1] == '.' && fbuf[len-2] == '.' && \
+         (len == 2 || fbuf[len-3] == '/')` (flist.c:2595-2596) - an interior \
+         `..` never reaches the append, so the operand stays a single \
+         NORMAL_NAME symlink entry",
+    );
+}
+
+/// The rule is scoped to NON-relative operands. Under `--relative` upstream
+/// forces `NORMAL_NAME` (`flist.c:2581-2583`) and then rejects the operand at
+/// `flist.c:2658-2667`; it never grants it contents semantics.
+///
+/// oc does not implement that rejection yet (MEASURED: rsync 3.5.0 exits 1 with
+/// `found ".." dir in relative path: ...`, oc does not - a KNOWN residual
+/// divergence, unchanged by this fix). What this cell pins is the SCOPE: the
+/// `--relative` names must not become the `.`-rooted DOTDIR listing.
+#[test]
+fn parent_dir_rule_is_scoped_to_non_relative() {
+    let scratch = TempDir::new().expect("tempdir");
+    build_source_tree(&scratch);
+
+    let rows = flist(&scratch.path().join("realdir/.."), true);
+    // Sorted on BOTH sides: an order-sensitive `assert_ne!` would pass on a
+    // reordering alone and never test the names at all.
+    let mut got = names(&rows);
+    got.sort_unstable();
+
+    assert_ne!(
+        got,
+        vec![
+            ".",
+            "realdir",
+            "realdir/f.txt",
+            "realdir/sub",
+            "realdir/sub/g.txt",
+            "symdir",
+        ],
+        "`--relative` must not acquire the non-relative arm's DOTDIR contents \
+         semantics - upstream rejects the operand there instead \
+         (flist.c:2658-2667)",
+    );
+}


### PR DESCRIPTION
A source operand whose last component is `..` aborted the transfer at exit 23
(`cannot determine directory name`) on the local path, and exit 4
(`unsafe pathname from sender: ..`) over the wire. Upstream transfers the
parent's contents. `Path::file_name()` returns `None` on a `ParentDir` tail, and
that `None` became the diagnostic.

## Upstream rule

`flist.c:2595-2602` — when the last component is `..`, upstream appends `/.` and
records `DOTDIR_NAME`. The append is what does the work: the non-relative split
at `flist.c:2610-2621` then cuts `src/../.` at its **last** `/`, giving
`dir = "src/.."` and `fn = "."`, so it chdirs into the parent and sends its
*contents* — exactly as a trailing `/` does.

⚠ **The rule is NOT `--relative`-scoped — it is the opposite.** `flist.c:2581-2583`
short-circuits the whole marker chain the moment `relative_paths` is set:

```c
if (relative_paths) {
        /* We clean up fbuf below. */
        name_type = NORMAL_NAME;
} else if (!len || fbuf[len - 1] == '/') {
```

so `:2584-2606` is reachable only **without** `-R`. Under `-R`, a `..` in the
active part is instead rejected at `flist.c:2658-2667` with
`found ".." dir in relative path: %s` + `exit_cleanup(RERR_SYNTAX)` — confirmed
by the oracle reporting `flist.c(2665)`. This fix is therefore non-`-R`-only,
and `parent_dir_rule_is_scoped_to_non_relative` pins that boundary on both
paths.

Two citations already in the tree do not resolve and are corrected here: the
sender's sort is `flist.c:2816` (not 3004), and the receiver's `..` refusal is
`flist.c:851-855` (not 3071).

## Measured, oc vs the real 3.5.0 binary, on BOTH paths

Oracle `target/interop/upstream-src/rsync-3.5.0/rsync`; wire leg over an
`--rsh` loopback. Assertions are on the destination tree — file type, link
target, content checksum — not exit codes.

| operand | flags | upstream | oc before | oc after |
|---|---|---|---|---|
| `src/..` | `-a` / `-aL` / `-a --copy-dirlinks` | 0, parent's contents | **23**; wire **4** | 0, identical |
| `src/sym-to-dir/..` | same | 0, contents of `other/` (resolved *through* the symlink) | 23 / wire 4 | 0, identical |
| `src/./..` | same | 0, parent's contents | 23 / wire 4 | 0, identical |
| `src/../` | same | 0, parent's contents | 0 (already correct) | unchanged |
| `..` | same | 0, grandparent's contents | 23 / wire 4 | 0, identical |
| all of the above | `-aR`, `-aRL`, `-aR --copy-dirlinks` | **1** `found ".." dir in relative path` | 23 | 23 (unchanged) |

Of the 15 non-`-R` cells that reproduced the defect (5 shapes × 3 flag sets), 3
matched before and **all 15 match now, on both paths**. A wider sweep (8 shapes
× 7 flag sets, adding `-d`, `src/../sibling.txt`, `src/../other`, `nosuch/..`)
leaves **zero non-`-R` divergences per path**; the 24 `-R` cells per path are
untouched.

## Change

- **Local copy** — `operands.rs` gains `operand_ends_in_parent_dir`, a byte
  transcription of `flist.c:2595-2596` (`len > 1 && fbuf[len-1]=='.' &&
  fbuf[len-2]=='.' && (len == 2 || fbuf[len-3] == '/')`). `SourceSpec::from_operand`
  folds it into `copy_contents`, gated on `!relative_paths`, threaded through
  `LocalCopyPlan::from_operands_with_relative`.
- **Wire** — the same predicate in `generator/file_list/mod.rs`;
  `non_relative_walk_base` routes a trailing-`..` operand into its existing
  DOTDIR branch. Scoping there is **structural**: that function *is* the `else`
  arm of `if relative_paths`.

The path is never rewritten — oc resolves operands rather than chdir-ing — so
nothing downstream changed.

## Mutation proof

| mutation | engine suite | wire suite |
|---|---|---|
| revert the local-copy `copy_contents` rule | **7 run, 4 passed, 3 FAILED** | 6 run, 6 passed |
| revert `non_relative_walk_base` | 7 run, 7 passed | **6 run, 3 passed, 3 FAILED** |
| add the rule to the `is_dotdir` call site | — | **6 run, 6 passed — killed NOTHING** |

The third row is the informative one. `is_dotdir` feeds only
`resolve_symlink_metadata`'s follow disjunct, which fires only when the operand
itself lstats as a symlink — and `lstat("X/..")` never can, because the kernel
resolves `..`, so the result is a directory or an error (measured: real dir,
symlinked dir, dangling symlink, and `/`). That change was genuinely **inert**,
so it was **removed** rather than carried as an unexercised second spelling of
the same rule; the reasoning and measurement live in a comment at that site.

Negative controls green under every mutation:
`an_ordinary_directory_operand_still_lands_under_its_own_name` /
`...still_sends_itself`. Guards against an "always append `/.`" or a
`contains("..")` fix: `a_dotdot_that_is_not_the_last_component_is_a_normal_name`
(both suites) and `a_basename_ending_in_two_dots_is_not_a_parent_dir_component`
(`weird..`) — the latter is exactly upstream's `fbuf[len-3] == '/'` conjunct.

## Verification

Pinned toolchain 1.88.0. `cargo fmt --all -- --check` clean; `cargo clippy
--locked --workspace --all-targets --all-features --no-deps` clean. Full
workspace: 32861 run / 32860 passed / 1 failed — the known macOS xtask
`backdated_tree…` cell (BSD `touch -d @epoch`). An earlier run also showed
`verification_warning_gate…` and `write_devices_push_to_a_regular_file…`; both
pass on pristine `origin/master` *and* on this branch in isolation and did not
recur — contention from concurrent nextest runs on this host.

No expect manifest touched.

## Found, reported, NOT fixed

**oc has no `--relative` `..` rejection.** Upstream exits 1 with
`found ".." dir in relative path: %s` (`flist.c:2658-2667`) for *any* `..` in the
active part — including non-trailing ones like `-R src/../sibling.txt`, and
excluding `..` in the inactive prefix before a `/./` pivot (oracle-confirmed
both ways). oc exits 23 instead, and in three cells (`src/../ -aR`,
`src/../sibling.txt -aR`, `src/../other -aR`) **writes a partial, wrong tree
first**. Pre-existing and unchanged here: it needs a `RERR_SYNTAX` path on both
legs, which is a separate mechanism. Both suites document that the `-R`
behaviour remains divergent, and pin the scope boundary so `--relative` cannot
silently acquire contents semantics.

Also noted, untouched: three unresolved rustdoc intra-doc links in
`crates/engine/src/lib.rs` (`AsyncFileCopier`, `AsyncBatchCopier`,
`CopyProgress`) make `cargo doc -p engine` fail independently of this change.
