### PR TITLE
fix(engine): stop the delta mover at the length it was sized from

### DIFF
--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -164,6 +164,17 @@ impl<'a> CopyContext<'a> {
         let mut read_buffer = vec![0u8; buffer.len().max(index.block_length())];
         let mut buffer_len = 0usize;
         let mut buffer_pos = 0usize;
+        // How many source bytes this loop may still read. upstream sizes its one
+        // mover from the fstat of the OPENED handle - `do_fstat(fd, &st)`
+        // (sender.c:728) feeding `map_file(fd, st.st_size, ...)` (sender.c:757)
+        // - so a tail appended after that stat is never mapped and never sent.
+        //
+        // `total_bytes` cannot serve as the counter here: it tallies bytes
+        // *emitted*, and the rolling window holds up to a block that has been
+        // read but not yet emitted, so it lags the reader. Count what the reader
+        // consumed instead.
+        let expected_remaining = total_size.saturating_sub(initial_bytes);
+        let mut source_bytes_read = 0u64;
         // Inplace mode seeks to this position before each literal write.
         let mut output_position = 0u64;
         // 256KB interval - smaller than regular copy since delta is more
@@ -178,13 +189,29 @@ impl<'a> CopyContext<'a> {
                 bytes_since_timeout_check = 0;
             }
             if buffer_pos == buffer_len {
+                // Stop at the length the transfer was sized from rather than at
+                // whatever EOF the source now presents. Clamping the read itself
+                // - not just breaking between chunks - is what bounds a source
+                // that grew: the read buffer is larger than one block, so an
+                // unclamped final read pulls in the whole appended tail before
+                // any loop guard could look at it. The dense and sparse loops
+                // carry the same `min(remaining)` clamp, and the kernel tier
+                // takes the bound as an explicit length argument.
+                let remaining = expected_remaining.saturating_sub(source_bytes_read);
+                if remaining == 0 {
+                    break;
+                }
+                let chunk_len = read_buffer
+                    .len()
+                    .min(usize::try_from(remaining).unwrap_or(usize::MAX));
                 buffer_len = reader
-                    .read(&mut read_buffer)
+                    .read(&mut read_buffer[..chunk_len])
                     .map_err(|error| LocalCopyError::io("copy file", source, error))?;
                 buffer_pos = 0;
                 if buffer_len == 0 {
                     break;
                 }
+                source_bytes_read = source_bytes_read.saturating_add(buffer_len as u64);
             }
 
             let byte = read_buffer[buffer_pos];

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
@@ -541,6 +541,33 @@ const DELTA_BASIS_LEN: usize = 64 * 1024;
 /// Bytes the shrunken source still holds by the time the copy reads it.
 const DELTA_SHRUNK_LEN: usize = 4096;
 
+/// Bytes the source grew by after it was sized - larger than the read buffer,
+/// so an unclamped loop overshoots by more than one chunk.
+const DELTA_APPENDED_LEN: usize = 256 * 1024;
+
+/// Offset at which the source stops reproducing the basis. Bytes before it
+/// match the basis block for block, bytes after it can only be emitted as
+/// literals, so one delta copy of this source drives both branches of the loop,
+/// and a destination that merely reproduced the basis fails the content
+/// assertion instead of passing by coincidence.
+const DELTA_DIVERGE_AT: usize = DELTA_BASIS_LEN / 2;
+
+/// Writes a source that reproduces the basis up to `DELTA_DIVERGE_AT` and
+/// diverges from it after that.
+fn write_partly_divergent_bytes(path: &Path, len: usize) {
+    let mut file = File::create(path).expect("create source");
+    let block: Vec<u8> = (0..len)
+        .map(|i| {
+            if i < DELTA_DIVERGE_AT {
+                (i.wrapping_mul(31) % 251) as u8
+            } else {
+                (i.wrapping_mul(17) % 241) as u8
+            }
+        })
+        .collect();
+    file.write_all(&block).expect("write source");
+}
+
 /// What one delta copy produced: whether the run recorded a short source, what
 /// the writer ended up holding, and what the source actually contained.
 struct DeltaCopyOutcome {
@@ -558,6 +585,21 @@ struct DeltaCopyOutcome {
 /// it" without racing a real truncation, the same technique the three sibling
 /// movers are pinned with.
 fn delta_copy_outcome(source_len: usize, declared_len: u64) -> DeltaCopyOutcome {
+    delta_copy_outcome_with(source_len, declared_len, write_bytes)
+}
+
+/// `delta_copy_outcome` with control over how the source is laid out, so a cell
+/// that asserts on destination CONTENT can seed a source the basis does not
+/// already supply.
+///
+/// A `declared_len` above `source_len` is "the source shrank after it was
+/// sized"; one below it is "the source grew". Neither races a real change to
+/// the file.
+fn delta_copy_outcome_with(
+    source_len: usize,
+    declared_len: u64,
+    write_source: fn(&Path, usize),
+) -> DeltaCopyOutcome {
     let temp = TempDir::new().expect("tempdir");
     let source = temp.path().join("src.bin");
     let basis = temp.path().join("dst.bin");
@@ -567,7 +609,7 @@ fn delta_copy_outcome(source_len: usize, declared_len: u64) -> DeltaCopyOutcome 
     // delta mover: `build_delta_signature` returns `None` for an empty one and
     // the executor then falls back to a straight copy.
     write_bytes(&basis, DELTA_BASIS_LEN);
-    write_bytes(&source, source_len);
+    write_source(&source, source_len);
 
     let basis_metadata = fs::metadata(&basis).expect("stat basis");
     let index =
@@ -669,5 +711,89 @@ fn delta_copy_of_a_complete_source_records_no_read_error() {
     assert_eq!(
         outcome.written, outcome.source,
         "the delta copy did not reproduce a complete {DELTA_BASIS_LEN}-byte source"
+    );
+}
+
+/// A delta copy must move exactly the length the transfer was sized from, even
+/// when the file on disk has grown past it.
+///
+/// This is the fourth content mover and the only one that read to EOF. The
+/// kernel tier takes `total_size - initial_bytes` as an explicit length, and
+/// the dense and sparse loops each carry a per-read
+/// `chunk_len.min(expected_remaining - total_bytes)` clamp -
+/// `dense_copy_moves_exactly_the_length_it_was_sized_from` and its sparse twin
+/// pin both. The delta loop read `reader.read(&mut read_buffer)` unbounded and
+/// stopped only at EOF, so a source appended to after it was sized had the
+/// appended tail copied on this path and dropped on the other three.
+///
+/// upstream has one mover and sizes it from the OPENED handle:
+/// `do_fstat(fd, &st)` (sender.c:728) then
+/// `mbuf = map_file(fd, st.st_size, read_size, s->blength)` (sender.c:757), so
+/// a tail appended after that fstat is never mapped and never sent. Nothing
+/// diagnoses it - `map_ptr()` records a status only when a read returns 0 with
+/// the mapped window still unfilled
+/// (`map->status = nread ? errno : ENODATA`, fileio.c:359-363), which is the
+/// SHRINK case. Measured on rsync 3.5.0 with `-a --no-whole-file` over a
+/// pre-seeded destination and a source appended to between the fstat and the
+/// read: upstream exits 0, prints nothing, and leaves the destination at the
+/// fstat length. So the rule is stop silently, not report.
+///
+/// A `--no-whole-file` copy over a destination that already exists is the one
+/// input that routes here: `build_delta_signature` returns `None` for an empty
+/// destination and the executor then falls back to a straight copy, which is
+/// why the sibling grow cells above - which copy into a fresh destination -
+/// could not see this.
+#[test]
+fn delta_copy_moves_exactly_the_length_it_was_sized_from() {
+    let outcome = delta_copy_outcome_with(
+        DELTA_BASIS_LEN + DELTA_APPENDED_LEN,
+        DELTA_BASIS_LEN as u64,
+        write_partly_divergent_bytes,
+    );
+
+    assert_eq!(
+        outcome.written.len(),
+        DELTA_BASIS_LEN,
+        "the delta copy overshot the length it was sized from by {} bytes",
+        outcome.written.len().saturating_sub(DELTA_BASIS_LEN),
+    );
+    assert_eq!(
+        outcome.written,
+        outcome.source[..DELTA_BASIS_LEN],
+        "the delta copy did not reproduce the declared prefix of the source"
+    );
+    assert!(
+        !outcome.recorded_short_read,
+        "a source that grew was reported as a short read; upstream sizes the map from the \
+         fstat and drops the appended tail silently, exit 0"
+    );
+}
+
+/// Negative control for the cell above: the same divergent source through the
+/// same mover, at exactly the length it was sized from. It differs in one
+/// variable - whether any bytes sit past the declared length - so a clamp that
+/// fired when it should not, or one that truncated what it was given, shows up
+/// here rather than being absorbed.
+#[test]
+fn delta_copy_of_a_source_at_its_declared_length_moves_all_of_it() {
+    let outcome = delta_copy_outcome_with(
+        DELTA_BASIS_LEN,
+        DELTA_BASIS_LEN as u64,
+        write_partly_divergent_bytes,
+    );
+
+    assert_eq!(
+        outcome.written.len(),
+        DELTA_BASIS_LEN,
+        "the delta copy of an unchanged source wrote {} bytes for a {DELTA_BASIS_LEN}-byte source",
+        outcome.written.len(),
+    );
+    assert_eq!(
+        outcome.written, outcome.source,
+        "the delta copy did not reproduce an unchanged source byte for byte"
+    );
+    assert!(
+        !outcome.recorded_short_read,
+        "a delta copy of a source that matched its declared length was reported as short"
     );
 }


### PR DESCRIPTION
oc's local-copy engine has four content movers. Three clamp their read to the
length the transfer was sized from. The fourth — the delta loop — read to EOF,
so a source that **grew** after it was sized was over-copied: 327,680 bytes
written where upstream writes 65,536.

This was traced, not measured, when the adjacent shrink case landed
(`a742a2e8e`). It reproduces.

## Upstream rule

Upstream sizes the map from the **fstat on the opened handle**, not the
file-list length, and never reads past it:

- `sender.c:728` — `do_fstat(fd, &st)`
- `sender.c:757` — `mbuf = map_file(fd, st.st_size, read_size, s->blength)`
- `fileio.c:359-363` — the read loop sets a status **only when the read
  returns `<= 0`**:

  ```c
  int32 nread = read(map->fd, map->p + read_offset, read_size);
  if (nread <= 0) {
          if (!map->status)
                  map->status = nread ? errno : ENODATA;
          /* The best we can do is zero the buffer -- the file
           * has changed mid transfer! */
  ```

So the *shrink* case becomes `ENODATA` → `read errors mapping %s`
(`sender.c:787-795`) → exit 23, which oc already mirrors. The *grow* case is
simply never read past `st.st_size`: **silently truncated, exit 0, no
diagnostic.** That is the bar this change has to meet — clamp, do not
diagnose.

⚠ The line numbers carried in the original brief had drifted (`sender.c:707-724`,
`fileio.c:357-368`); the verified ones above are what the code and commit now
cite.

## Measured, oc vs the real 3.5.0 binary

Deterministic — a `DYLD_INSERT_LIBRARIES` interpose keyed on the source's
**inode via `fstat`**, appending 262,144 bytes at the first `read()` of that
inode, strictly after the sizing fstat. Not a race, and not keyed on an
interposed `open` (which would depend on which `open` variant the callee links
against).

| binary | dst length | dst sha256 | exit | stderr |
|---|---|---|---|---|
| upstream 3.5.0 | 65,536 | `755682d23142311e…` | 0 | none |
| **oc before** | **327,680** | `d29d6029ca7159ec…` | 0 | none |
| oc after | 65,536 | `755682d23142311e…` | 0 | none |

Declared length 65,536; the source held 327,680 by the time the loop finished.
After the fix oc is byte-identical to upstream on the staging arm **and** under
`--inplace`.

**The fixture shape is the load-bearing detail.** The destination must be
pre-seeded *non-empty and differing in both content and length*:

- an **empty** basis makes `build_delta_signature` return `None`, so the
  executor falls back to a straight copy and never reaches the delta mover —
  this is what made the original finding "traced, not measured";
- differing **content alone** is not enough either: matching size+mtime makes
  the quick check skip the file entirely. That cost one false measurement
  before it was caught.

## The other three movers

All three already clamp, as claimed. The kernel tier passes
`total_size - initial_bytes` as an explicit length (honoured by io_uring,
`copy_file_range`, and the read/write fallback); the dense and sparse loops
each carry `chunk_len.min(expected_remaining - total_bytes)`, and both are
already pinned by existing grow cells.

## Mutation proof

`-p engine --lib`. ⚠ Counts are noisy: this worktree has **114 pre-existing
environmental failures on pristine `origin/master` too**, all one cause
(`create backup` → `FilesystemLoop`, os error 62), wobbling 113–115 between
runs. So failure **sets** were diffed, not counts.

| mutation | result | killed |
|---|---|---|
| baseline (fixed) | 4620 passed / 114 failed | — |
| **A — clamp removed** | 4619 / 115 | exactly `delta_copy_moves_exactly_the_length_it_was_sized_from` |
| **B — clamp to 0** | 4586 / **148** | 36 tests, incl. 32 unrelated delta cells (append-verify, block-size override, inplace, tail-match) |

A is lethal and surgical; B proves a blanket implementation could not pass.
Neither hung.

**Negative control** `delta_copy_of_a_source_at_its_declared_length_moves_all_of_it`
— same divergent source, same mover, one variable changed. Green under A.

⚠ It goes **red under B**, and necessarily so: clamping to 0 breaks every copy,
so no negative control on a copy path can survive that mutation. Surviving
**A** is the property that isolates the fix; "green under every mutation" was
the wrong bar to set here.

## Verification

Pinned toolchain 1.88.0: `cargo fmt --all -- --check` clean; `cargo clippy
--locked --workspace --all-targets --all-features --no-deps` **0 warnings**.
Citation drift gate exit 0.

Full workspace via `nextest --profile ci --all-features --no-fail-fast`
(matching `ci.yml:354`): **33207 run / 33202 passed / 4 failed** — the four
known environmental cells (`transfer_request_with_sparse_preserves_holes`,
`run_client_sparse_copy_creates_holes`,
`execute_with_sparse_enabled_creates_holes`, and the xtask
`backdated_tree_populates_and_backdates_the_root`).

No expect manifest touched.

## Found, reported, NOT fixed

The **reflink/clonefile tier** is a fifth, path-based mover with no length
parameter at all — whole-file by construction. It is gated on
`existing_metadata.is_none()` so it never overlaps the delta mover, but a
source growing between its sizing fstat and the clone would be over-copied.
This is **observed, not measured**: `clonefile()` issues no `read()`, so the
interpose above cannot reach it. It belongs in its own change.

## Process notes

- Plain `cargo test --workspace` **blocks indefinitely** on
  `bwlimit_rate_limiting.rs` (0:00.00 CPU over 29 min). nextest's 120s
  slow-timeout is what makes a full run tractable — and it is what CI uses.
- Temporarily symlinking `target/interop` to satisfy the citation gate
  manufactured **4 extra failures** by exposing upstream binaries this worktree
  normally lacks. Symlink removed, untracked, never committed.
