### PR TITLE
fix(daemon): scope the module symlink opt-out to its own connection

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -99,6 +99,16 @@ fn apply_module_transfer_directives(module: &ModuleDefinition, cfg: &mut ServerC
     // and let the transfer layer strip it.
     cfg.connection.daemon_module_root = Some(module.path.clone());
 
+    // upstream: syscall.c:122-127 `symlink_optout_allowed()` - the `am_daemon`
+    // arm is `module_id >= 0 && lp_insecure_links(module_id)`, so the opt-out
+    // is a property of the SERVED MODULE and never of the forwarded argv.
+    // Recording it on the connection is what makes it per-connection: upstream
+    // forks a child per connection, so its global is already private, while oc
+    // serves every connection on a worker thread of one process. Left in a
+    // global, a module with `insecure links = yes` switches off the
+    // confinement of a concurrent connection to a module that never opted out.
+    cfg.connection.daemon_insecure_links = module.insecure_links;
+
     // upstream: clientserver.c:1111-1112
     if module.ignore_errors {
         cfg.deletion.ignore_errors = true;

--- a/crates/transfer/src/config/mod.rs
+++ b/crates/transfer/src/config/mod.rs
@@ -202,6 +202,29 @@ pub struct ConnectionConfig {
     /// - `clientserver.c:993` - `change_dir(module_chdir, CD_NORMAL)`
     /// - `util1.c:1285` - `p1 = curr_dir + module_dirlen`
     pub daemon_module_root: Option<PathBuf>,
+    /// The served module's `insecure links` setting, carried per connection.
+    ///
+    /// This is the daemon arm of upstream's `symlink_optout_allowed()`:
+    /// `module_id >= 0 && lp_insecure_links(module_id)`. A peer-supplied
+    /// `--insecure-links` can never reach it - a client cannot switch off a
+    /// daemon's confinement - so it is read from the module, never from the
+    /// forwarded argv.
+    ///
+    /// It lives on the connection rather than in a process-global because oc
+    /// serves each daemon connection on a worker thread of ONE process, while
+    /// upstream forks a child per connection. A global answers whichever module
+    /// published last, so a module with `insecure links = yes` would switch off
+    /// the confinement of a *concurrent* connection to a module that never
+    /// opted out - measured at 47 of 80 concurrent rounds before this field
+    /// existed. `false` outside a daemon server process, which is the safe
+    /// default and upstream's own (`options.c:134` `int insecure_links = 0;`).
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `syscall.c:122-127` - `symlink_optout_allowed()`; the `am_daemon` arm
+    ///   is `module_id >= 0 && lp_insecure_links(module_id)`.
+    /// - `syscall.c:116-121` - why a forwarded `--insecure-links` is inert here.
+    pub daemon_insecure_links: bool,
     /// `--confine-root=DIR`: the confinement root for a NON-daemon server.
     ///
     /// Upstream keeps one `confinement_root()` accessor and picks the root by

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -1575,14 +1575,23 @@ mod device_guard_tests {
 ///   (`options.c:2382-2386` nulls it out for a daemon before it is read).
 /// - `syscall.c:123-127` - `symlink_optout_allowed()`.
 fn confinement_root(connection: &crate::config::ConnectionConfig) -> Option<PathBuf> {
+    // The opt-out is read on the SAME axis as the root, because upstream's two
+    // arms read disjoint state: a daemon consults `lp_insecure_links(module_id)`
+    // and a non-daemon consults the `insecure_links` flag. Splitting them - a
+    // per-connection root but a process-global opt-out - is what let a
+    // concurrent connection answer this question for a module that never opted
+    // out, since oc serves connections on worker threads of one process rather
+    // than forking as upstream does.
+    if connection.is_daemon_connection {
+        if connection.daemon_insecure_links {
+            return None;
+        }
+        return connection.daemon_module_root.clone();
+    }
     if fast_io::confinement::session_optout_allowed() {
         return None;
     }
-    if connection.is_daemon_connection {
-        connection.daemon_module_root.clone()
-    } else {
-        connection.confine_root.clone()
-    }
+    connection.confine_root.clone()
 }
 
 #[cfg(test)]
@@ -1595,14 +1604,22 @@ mod confinement_root_tests {
     };
     use std::path::PathBuf;
 
-    /// Safe against the process-global session opt-out because this workspace
-    /// runs under cargo-nextest, which executes each test in its own process.
-    fn daemon_serving(root: &str) -> ConnectionConfig {
+    /// A daemon connection serving `root`, carrying its OWN module's opt-out.
+    ///
+    /// The opt-out is a field rather than an ambient global because oc serves
+    /// concurrent connections on worker threads of one process; see
+    /// `ConnectionConfig::daemon_insecure_links`.
+    fn daemon_serving_with_optout(root: &str, insecure_links: bool) -> ConnectionConfig {
         ConnectionConfig {
             is_daemon_connection: true,
             daemon_module_root: Some(PathBuf::from(root)),
+            daemon_insecure_links: insecure_links,
             ..Default::default()
         }
+    }
+
+    fn daemon_serving(root: &str) -> ConnectionConfig {
+        daemon_serving_with_optout(root, false)
     }
 
     fn serve_module(insecure_links: bool) {
@@ -1624,9 +1641,30 @@ mod confinement_root_tests {
     fn module_optout_releases_the_daemon_confinement_root() {
         serve_module(true);
         assert_eq!(
-            confinement_root(&daemon_serving("/srv/mod")),
+            confinement_root(&daemon_serving_with_optout("/srv/mod", true)),
             None,
             "`insecure links = yes` must release the sender's confinement root"
+        );
+    }
+
+    /// The race, at unit scale: another connection published `insecure links =
+    /// yes` into the process-global, but THIS connection's module never opted
+    /// out, so its root must survive.
+    ///
+    /// Upstream can read that answer from a global because it forks a child per
+    /// connection; oc serves connections on worker threads of one process, so
+    /// the global names whichever module published last. Measured end to end,
+    /// reading it here leaked a module out of its own root in 47 of 80
+    /// concurrent rounds (`tests/daemon_concurrent_module_confinement.rs`).
+    #[test]
+    fn another_connections_optout_does_not_release_this_ones_root() {
+        // Stand in for a concurrent worker thread serving an opted-out module.
+        serve_module(true);
+        assert_eq!(
+            confinement_root(&daemon_serving_with_optout("/srv/strict", false)),
+            Some(PathBuf::from("/srv/strict")),
+            "a concurrent module's `insecure links = yes` must not unconfine \
+             a connection whose own module never opted out"
         );
     }
 

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -131,15 +131,23 @@ impl GeneratorContext {
     /// it reads.
     ///
     /// The root is passed to `fast_io` rather than left ambient. `read_dir`'s
-    /// own anchor is the process-global session pin, which oc never installs
-    /// for a daemon, so this walk silently degraded to an ordinary
+    /// own anchor is the process-global session pin, which at the time was not
+    /// installed for a daemon, so this walk silently degraded to an ordinary
     /// absolute-path read, while [`Self::confine_root`] (already
     /// daemon-correct) was consulted only by the CONTENT open. That split is
     /// exactly what let a module symlink be enumerated but not read.
-    /// Installing the global per
-    /// connection is not the alternative: oc serves each connection on a worker
-    /// thread of one process, so a per-connection value in a global would race
-    /// between concurrent connections on different modules.
+    ///
+    /// The daemon DOES publish that global today - `publish_module_confinement`
+    /// (daemon/sections/module_access/transfer/sandbox.rs) calls
+    /// `install_daemon_session` on every served connection - which is precisely
+    /// why the anchor still must not be read from it here. oc serves each
+    /// connection on a worker thread of one process, so a per-connection value
+    /// in a global answers whichever module published LAST. That is not
+    /// theoretical: the sibling opt-out bit in the same global let a module
+    /// with `insecure links = yes` switch off the confinement of a concurrent
+    /// connection to a module that never opted out, measured at 47 of 80
+    /// concurrent rounds (see `tests/daemon_concurrent_module_confinement.rs`).
+    /// Passing the root in is what keeps this call correct under threads.
     ///
     /// # Upstream Reference
     ///

--- a/tests/daemon_concurrent_module_confinement.rs
+++ b/tests/daemon_concurrent_module_confinement.rs
@@ -1,0 +1,262 @@
+//! One module's `insecure links = yes` must not unconfine a CONCURRENT
+//! connection to a module that never opted out.
+//!
+//! Upstream's `symlink_optout_allowed()` (syscall.c:122-127) answers
+//! `module_id >= 0 && lp_insecure_links(module_id)` for a daemon - a property
+//! of the SERVED MODULE. Upstream may keep that in a global because it forks a
+//! child per connection (clientserver.c:1040-1122 all run in the child), so the
+//! global is already private to one module.
+//!
+//! oc serves every daemon connection on a worker thread of ONE process
+//! (`spawn_connection_worker`,
+//! daemon/sections/server_runtime/connection.rs:198-229). A process-global
+//! opt-out therefore answers whichever module published LAST. Measured before
+//! the fix, against an rsync 3.5.0 client driving two simultaneous pulls: the
+//! module that never opted out followed a symlink out of its own root in 47 of
+//! 80 rounds, materialising a file from outside the module. That is a
+//! confinement WIDENING driven entirely by an unrelated connection.
+//!
+//! The fix carries the opt-out as a per-connection value
+//! (`ConnectionConfig::daemon_insecure_links`), read on the same axis as the
+//! module root by `confinement_root()`
+//! (transfer/src/generator/context.rs). This test is the guard on that: it is
+//! the only thing standing between the value-threaded shape and a future
+//! author "simplifying" it back into the global, which looks correct in every
+//! serial test.
+//!
+//! # Non-vacuity
+//!
+//! [`loose_alone_still_opts_out`] is the positive control and it is load
+//! bearing. If the opt-out were simply broken - confinement hard-on for every
+//! module - the concurrency assertion below would pass for the wrong reason and
+//! this file would be inert. That test fails if the feature stops working, so
+//! the pair can only be green when the opt-out works AND stays scoped to its
+//! own connection.
+//!
+//! Skip condition (test passes with a printed reason): loopback TCP is
+//! unavailable, the platform cannot create symlinks, or the daemon does not
+//! answer.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// The file that lives OUTSIDE both module roots. Its arrival under a
+/// destination is the escape.
+const SECRET: &str = "secret.txt";
+const SECRET_BODY: &[u8] = b"outside both modules\n";
+
+/// Concurrent rounds. The pre-fix leak rate was ~59% per round, so this is far
+/// past the point where a surviving race would go unnoticed; it stays small
+/// enough to keep the test quick.
+const ROUNDS: usize = 24;
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|l| l.local_addr().ok())
+        .map(|a| a.port())
+}
+
+/// Builds the fixture: two modules, each holding a symlink that escapes its own
+/// root into a shared outside directory.
+///
+/// Both modules carry the escape so the two differ ONLY in the `insecure links`
+/// setting - if the escape were present in just one, a difference in outcome
+/// could be attributed to the fixture rather than to the opt-out.
+fn build_fixture(root: &Path) -> std::io::Result<(PathBuf, PathBuf)> {
+    let outside = root.join("outside");
+    fs::create_dir_all(&outside)?;
+    fs::write(outside.join(SECRET), SECRET_BODY)?;
+
+    let strict = root.join("strict");
+    let loose = root.join("loose");
+    for module in [&strict, &loose] {
+        fs::create_dir_all(module.join("sub"))?;
+        for i in 0..8 {
+            fs::write(module.join("sub").join(format!("f{i}")), b"in module\n")?;
+        }
+        std::os::unix::fs::symlink(&outside, module.join("escape"))?;
+    }
+    Ok((strict, loose))
+}
+
+fn write_config(conf: &Path, port: u16, strict: &Path, loose: &Path) -> std::io::Result<()> {
+    fs::write(
+        conf,
+        format!(
+            "port = {port}\n\
+             \n\
+             [strict]\n\
+             \tpath = {strict}\n\
+             \tread only = yes\n\
+             \tuse chroot = no\n\
+             \n\
+             [loose]\n\
+             \tpath = {loose}\n\
+             \tread only = yes\n\
+             \tuse chroot = no\n\
+             \tinsecure links = yes\n",
+            strict = strict.display(),
+            loose = loose.display(),
+        ),
+    )
+}
+
+fn spawn_daemon(conf: &Path, port: u16) -> Option<Child> {
+    let mut child = Command::new(oc_binary())
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Some(child);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    None
+}
+
+/// Pulls a whole module with `-L`, so a symlink is resolved by the SENDER and
+/// the escape decision is the daemon's, not the client's.
+fn pull(port: u16, module: &str, dest: &Path) {
+    let _ = Command::new(oc_binary())
+        .arg("-r")
+        .arg("-L")
+        .arg("--timeout=20")
+        .arg(format!("rsync://127.0.0.1:{port}/{module}/"))
+        .arg(format!("{}/", dest.display()))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+/// Whether the outside file arrived through the module's escaping symlink.
+fn escaped(dest: &Path) -> bool {
+    dest.join("escape").join(SECRET).exists()
+}
+
+/// Reaps the daemon even if an assertion below panics.
+struct Reaper(Child);
+impl Drop for Reaper {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    root: PathBuf,
+    port: u16,
+    _daemon: Reaper,
+}
+
+/// Returns `None` when the environment cannot host the test.
+fn setup() -> Option<Fixture> {
+    let port = free_port()?;
+    let tmp = tempfile::tempdir().ok()?;
+    let root = tmp.path().to_path_buf();
+    let (strict, loose) = build_fixture(&root).ok()?;
+    let conf = root.join("rsyncd.conf");
+    write_config(&conf, port, &strict, &loose).ok()?;
+    let daemon = spawn_daemon(&conf, port)?;
+    Some(Fixture {
+        _root: tmp,
+        root,
+        port,
+        _daemon: Reaper(daemon),
+    })
+}
+
+/// Positive control. Without this, a build that confined every module
+/// unconditionally would satisfy the concurrency test vacuously.
+#[test]
+fn loose_alone_still_opts_out() {
+    let Some(fx) = setup() else {
+        println!("skipping: loopback TCP unavailable or daemon did not answer");
+        return;
+    };
+    let dest = fx.root.join("ctl_loose");
+    fs::create_dir_all(&dest).expect("dest");
+    pull(fx.port, "loose", &dest);
+    assert!(
+        escaped(&dest),
+        "`insecure links = yes` no longer opts out of the symlink confinement, \
+         so the concurrency assertion in this file proves nothing"
+    );
+}
+
+/// Negative control: the module that never opted out is confined when it is the
+/// only connection. Stays green under every mutation of the per-connection
+/// threading, because serially the global and the value always agree.
+#[test]
+fn strict_alone_is_confined() {
+    let Some(fx) = setup() else {
+        println!("skipping: loopback TCP unavailable or daemon did not answer");
+        return;
+    };
+    let dest = fx.root.join("ctl_strict");
+    fs::create_dir_all(&dest).expect("dest");
+    pull(fx.port, "strict", &dest);
+    assert!(
+        !escaped(&dest),
+        "a module without `insecure links` followed a symlink out of its own root \
+         even with no other connection in flight"
+    );
+}
+
+/// The defect: two simultaneous connections on DIFFERENT modules, where one has
+/// opted out and the other has not. Neither may observe the other's boundary.
+#[test]
+fn a_concurrent_optout_module_does_not_unconfine_a_strict_one() {
+    let Some(fx) = setup() else {
+        println!("skipping: loopback TCP unavailable or daemon did not answer");
+        return;
+    };
+
+    let mut leaked_rounds = Vec::new();
+    for round in 0..ROUNDS {
+        let strict_dest = fx.root.join(format!("s{round}"));
+        let loose_dest = fx.root.join(format!("l{round}"));
+        fs::create_dir_all(&strict_dest).expect("dest");
+        fs::create_dir_all(&loose_dest).expect("dest");
+
+        let port = fx.port;
+        // Both pulls must be in flight at once: the leak is one connection
+        // publishing its opt-out into state another connection reads.
+        std::thread::scope(|scope| {
+            let sd = &strict_dest;
+            let ld = &loose_dest;
+            scope.spawn(move || pull(port, "strict", sd));
+            scope.spawn(move || pull(port, "loose", ld));
+        });
+
+        if escaped(&strict_dest) {
+            leaked_rounds.push(round);
+        }
+    }
+
+    assert!(
+        leaked_rounds.is_empty(),
+        "the strict module escaped its own root in {} of {ROUNDS} concurrent rounds \
+         (rounds {leaked_rounds:?}) - a connection to `loose` switched off the \
+         confinement of a connection to `strict`",
+        leaked_rounds.len(),
+    );
+}


### PR DESCRIPTION
A daemon module configured `insecure links = yes` switched off the operator-path
symlink confinement of a **concurrent connection to a different module that never
opted out**. Measured: 47 of 80 concurrent rounds escaped; 0 of 80 after.

## Upstream rule

`symlink_optout_allowed()` (`syscall.c:122-127`) answers, for a daemon:

```c
int symlink_optout_allowed(void)
{
	if (am_daemon)
		return module_id >= 0 && lp_insecure_links(module_id);
	return insecure_links;
}
```

so the opt-out is a property of the **served module**, and never of the forwarded
argv — upstream says so itself two lines above (`syscall.c:116-121`): a client
cannot disable a daemon's confinement, and the daemon drops a connection that
sends it.

Upstream may keep that answer in a process global because it **forks a child per
connection** — the whole `chroot`/`chdir`/privilege-drop sequence at
`clientserver.c:1040-1122` runs in that child, so the global is already private
to one module.

## The divergence

oc serves every daemon connection on a **worker thread of one process**
(`spawn_connection_worker`). `publish_module_confinement`
(`crates/daemon/src/daemon/sections/module_access/transfer/sandbox.rs:36`) calls
`install_daemon_session` on **every served connection**, storing that
connection's answer into the process-global `SESSION_OPTOUT`. The global
therefore names whichever module published **last**, and the sender's
`confinement_root()` read it.

Note the asymmetry that made this reachable: the module **root** was already
per-connection (`ConnectionConfig::daemon_module_root`), while the opt-out —
the gate that can switch the whole mechanism off — was ambient.

## Measured, rsync 3.5.0 client against a two-module oc daemon

Each module holds a symlink out of its own root into a shared outside directory;
two simultaneous pulls.

| fixture | escape followed |
|---|---|
| strict alone (never opted out) | no |
| loose alone (`insecure links = yes`) | yes |
| **strict, concurrent with loose** | **47 of 80 rounds** |
| strict, concurrent with loose, after fix | **0 of 80** |

Run serially the strict module was always confined and the opted-out module
always followed its link, so the divergence is the **concurrency**, not the
fixture. The escape materialised a file from outside the module under the
client's destination.

## Change

The opt-out now travels with the connection as
`ConnectionConfig::daemon_insecure_links`, stamped in
`apply_module_transfer_directives` **beside the module root it belongs with**,
and `confinement_root()` reads it on the same axis as that root. The non-daemon
arm still reads the local `--insecure-links` global, which is correct there —
that flag *is* process-wide state.

Reading the root as a parameter rather than from ambient state is the shape
`550fedaed` established for the flist walk; this applies it to the gate **above**
that walk.

## Doc correction in the same commit

`scan_source_dir` (`generator/file_list/walk.rs:133`) asserted the process-global
session pin is *"never installed for a daemon"*. **That is false** —
`publish_module_confinement` installs it on every served connection, including
the early return taken when neither chroot nor a privilege drop is configured
(the commonest rootless deployment). The daemon publishing that global is
precisely why the walk must keep taking its anchor as a **parameter**, not the
reason it need not.

## Mutation proof

`tests/daemon_concurrent_module_confinement.rs`, two simultaneous connections on
different modules over 24 rounds.

| mutation | result | killed |
|---|---|---|
| none | 3 passed / 0 failed | — |
| gate reads the global again | 2 / 1 | the concurrency cell (6 of 24 escaped) |
| connection never stamped | 2 / 1 | the positive control |

`loose_alone_still_opts_out` is **load bearing**: without it a build that confined
every module unconditionally would satisfy the concurrency assertion vacuously.
`strict_alone_is_confined` is the negative control and stays green under both
mutations, because serially the global and the value always agree.

A unit-scale companion (`another_connections_optout_does_not_release_this_ones_root`)
pins the same rule in `confinement_root`'s own test module.

⚠ The first two concurrency probes written for this were **vacuous** — the
mutation killed nothing. The nested/opt-out fixture is what gave the test teeth.

## Verification

Full workspace: 32849 run / 32845 passed / 4 failed — all four reproduced on
pristine `origin/master`. No expect manifest touched.

## Found, reported, NOT fixed

`SESSION_ROOT` / `SESSION_ROOT_FD` carry the **same thread-vs-fork exposure**,
still read at `receiver/transfer/setup/sandbox.rs:36`,
`pinned_root::anchored_metadata`, `secure_dir.rs:111`, `landlock.rs:175`, and the
ownership walk. `install_session` clears the fd then sets the path while
`pin_session_root_fd` sets the fd later, so an A→B→A interleave can pair **one
connection's root spelling with another's descriptor**. Unmeasured, untouched —
separate sites, separate fixtures, and the fd/path pairing is the
highest-priority of them.
