### PR TITLE
fix(filters): end a filter-file record at a carriage return

### DIFF
--- a/crates/cli/src/frontend/filter_rules/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/merge.rs
@@ -239,7 +239,10 @@ fn parse_merge_contents(
     // upstream counts PHYSICAL lines: rule_src_line increments once per read
     // iteration (exclude.c:1759-1760), before the comment and empty-token
     // filter at :1806, so comments and blank lines advance the count.
-    for (index, line) in contents.lines().enumerate() {
+    // Records split via the single owner `filters::filter_file_records`
+    // (exclude.c:1774-1793): a lone `\r` ends a record and CRLF ends exactly
+    // one, which `str::lines` gets wrong for the former.
+    for (index, line) in filters::filter_file_records(contents).enumerate() {
         let line_number = index + 1;
         // upstream: exclude.c:1806 parse_filter_file. `filter_file_line_is_rule`
         // is the single owner of that test: whitespace is never stripped, so

--- a/crates/cli/src/frontend/filter_rules/sources.rs
+++ b/crates/cli/src/frontend/filter_rules/sources.rs
@@ -261,9 +261,10 @@ pub(crate) fn read_filter_patterns_from_standard_input(
 /// Splits a reader into filter pattern records, skipping EMPTY records and
 /// those whose FIRST BYTE is `#`/`;` - the test
 /// [`filters::filter_file_line_is_rule`] owns. Nothing is trimmed, so a
-/// whitespace-only record and an indented `#` are patterns. Records split on
-/// newline, or on NUL when `eol_nulls` is set (`--from0`), in which case
-/// embedded newlines are literal pattern bytes.
+/// whitespace-only record and an indented `#` are patterns. Records split at
+/// `\n`, at `\r`, or at `\r\n` - the boundary
+/// [`filters::filter_file_records`] owns - or on NUL when `eol_nulls` is set
+/// (`--from0`), in which case embedded newlines are literal pattern bytes.
 pub(super) fn read_filter_patterns<R: BufRead>(
     reader: &mut R,
     eol_nulls: bool,
@@ -285,13 +286,6 @@ pub(super) fn read_filter_patterns<R: BufRead>(
             break;
         }
 
-        if buffer.last() == Some(&delimiter) {
-            buffer.pop();
-        }
-        if !eol_nulls && buffer.last() == Some(&b'\r') {
-            buffer.pop();
-        }
-
         // upstream: exclude.c:1806. `filters::filter_file_line_is_rule` is the
         // single owner of that test; it looks at the FIRST BYTE and does not
         // trim. `--*clude-from` files are always line-parsed, never word-split.
@@ -301,12 +295,27 @@ pub(super) fn read_filter_patterns<R: BufRead>(
         // only line is `   `, upstream excludes the file named `   ` and oc
         // transferred it; with `  #a`, upstream excludes `  #a` and oc
         // transferred it. Both at exit 0 - silent data selection divergence.
-        let line = String::from_utf8_lossy(&buffer);
-        if !filters::filter_file_line_is_rule(&line, true) {
+        let chunk = String::from_utf8_lossy(&buffer);
+
+        if eol_nulls {
+            let mut line = chunk.into_owned();
+            if line.as_bytes().last() == Some(&b'\0') {
+                line.pop();
+            }
+            if filters::filter_file_line_is_rule(&line, true) {
+                patterns.push(line);
+            }
             continue;
         }
 
-        patterns.push(line.into_owned());
+        // `read_until(b'\n')` is only a buffering boundary: a lone `\r` also
+        // ends a record (exclude.c:1774-1793), so the chunk is re-split by the
+        // single owner `filters::filter_file_records`, terminator and all.
+        patterns.extend(
+            filters::filter_file_records(&chunk)
+                .filter(|line| filters::filter_file_line_is_rule(line, true))
+                .map(str::to_owned),
+        );
     }
 
     Ok(patterns)

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -584,7 +584,10 @@ pub(crate) fn load_dir_merge_rules_recursive(
             let allow_comments = *allow_comments;
             // upstream: exclude.c:1759-1760 - rule_src_line counts EVERY
             // physical line, so blanks and comments still advance it.
-            for (index, line) in contents.lines().enumerate() {
+            // Records split via the single owner `filters::filter_file_records`
+            // (exclude.c:1774-1793): a lone `\r` ends a record, CRLF ends
+            // exactly one.
+            for (index, line) in filters::filter_file_records(&contents).enumerate() {
                 let line_number = index + 1;
                 // upstream: exclude.c:1806. `filters::filter_file_line_is_rule`
                 // is the single owner of that test - it does NOT trim, so

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -150,8 +150,9 @@ pub use cvs::{DEFAULT_CVSIGNORE, default_patterns as cvs_default_patterns};
 pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{
-    MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded, filter_file_line_is_rule,
-    merge_name_overflows, merge_self_exclude_name, parse_rules, read_rules, read_rules_recursive,
+    FilterFileRecords, MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded,
+    filter_file_line_is_rule, filter_file_records, merge_name_overflows, merge_self_exclude_name,
+    parse_rules, read_rules, read_rules_recursive,
 };
 pub use overlong::{is_over_long, over_long_filter};
 pub use rule::FilterRule;

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -49,6 +49,7 @@ mod error;
 mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
+mod records;
 mod self_exclude;
 mod skip;
 
@@ -61,5 +62,6 @@ pub use overflow::merge_name_overflows;
 pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};
+pub use records::{FilterFileRecords, filter_file_records};
 pub use self_exclude::merge_self_exclude_name;
 pub use skip::filter_file_line_is_rule;

--- a/crates/filters/src/merge/parse.rs
+++ b/crates/filters/src/merge/parse.rs
@@ -41,7 +41,9 @@ use super::error::MergeFileError;
 pub fn parse_rules(content: &str, source_path: &Path) -> Result<Vec<FilterRule>, MergeFileError> {
     let mut rules = Vec::new();
 
-    for (line_num, line) in content.lines().enumerate() {
+    // `filter_file_records` is the single owner of the record split; see
+    // `merge::records` for why `str::lines` is the wrong boundary.
+    for (line_num, line) in crate::filter_file_records(content).enumerate() {
         let line_num = line_num + 1; // 1-indexed for error messages
 
         // upstream: exclude.c:1806 parse_filter_file. `filter_file_line_is_rule`
@@ -121,7 +123,9 @@ pub(crate) fn parse_rules_no_prefixes(
             push_token(token);
         }
     } else {
-        for line in content.lines() {
+        // Records split via the single owner `filter_file_records`
+        // (exclude.c:1774-1793), so a lone `\r` ends a rule here too.
+        for line in crate::filter_file_records(content) {
             // upstream: exclude.c:1806 parse_filter_file, via the single owner
             // `filter_file_line_is_rule`. The surviving line becomes a literal
             // pattern verbatim (FILTRULE_NO_PREFIXES takes strlen with no

--- a/crates/filters/src/merge/records.rs
+++ b/crates/filters/src/merge/records.rs
@@ -1,0 +1,135 @@
+//! The one owner of "where does a filter-file record end?".
+//!
+//! Every reader that turns a filter FILE into rules has to split it first, and
+//! upstream splits it in exactly one place - the character loop inside
+//! `parse_filter_file` (`exclude.c:1774-1793`):
+//!
+//! ```c
+//! if (eol_nulls? !ch : (ch == '\n' || ch == '\r')) {
+//!     if (ch == '\r') {   /* CRLF is one line, not two */
+//!         ...
+//!         } else if (nxt != '\n' && ungetc(nxt, fp) == EOF) {
+//!         ...
+//!     }
+//!     break;
+//! }
+//! ```
+//!
+//! A lone `\r` ends a record just as `\n` does, and `\r\n` ends exactly one.
+//! Rust's [`str::lines`] breaks only on `\n` and merely strips a `\r` that sits
+//! immediately before one, so a `\r`-separated filter file collapses into a
+//! single record whose pattern carries the `\r` and the following rules as
+//! literal bytes - it then matches nothing, and every file those rules were
+//! meant to exclude transfers instead.
+//!
+//! That is file selection, not formatting. MEASURED against rsync 3.5.0 over a
+//! source holding `a.txt` and `a.txt ` (trailing space), with a merge file
+//! holding `- a.txt \r`: upstream excluded `a.txt ` and oc transferred it, both
+//! at exit 0. The same divergence reproduced through `--exclude-from` and
+//! through a `.rsync-filter` dir-merge, because each of oc's four readers
+//! spelled the split for itself. Routing them all through one iterator is what
+//! stops the next reader from drifting again.
+
+/// Splits filter-file content into records the way upstream's reader does.
+///
+/// Records end at `\n`, at `\r`, or at `\r\n` (which ends exactly one), and the
+/// terminator is not part of the record. Unterminated trailing text is a final
+/// record; a trailing terminator does not manufacture an empty one.
+///
+/// The records are otherwise verbatim - nothing is trimmed, so trailing
+/// whitespace stays part of the pattern (`exclude.c:1465`, `len = strlen(s)`).
+/// Whether a record then carries a rule is [`super::filter_file_line_is_rule`].
+///
+/// NUL-delimited input (`--from0`, upstream's `eol_nulls`) is a different
+/// split and is not this iterator's job.
+#[must_use]
+pub fn filter_file_records(content: &str) -> FilterFileRecords<'_> {
+    FilterFileRecords {
+        rest: Some(content),
+    }
+}
+
+/// Iterator returned by [`filter_file_records`].
+#[derive(Debug, Clone)]
+pub struct FilterFileRecords<'a> {
+    rest: Option<&'a str>,
+}
+
+impl<'a> Iterator for FilterFileRecords<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        let rest = self.rest?;
+        let Some(end) = rest.find(['\n', '\r']) else {
+            self.rest = None;
+            return (!rest.is_empty()).then_some(rest);
+        };
+        let (record, tail) = rest.split_at(end);
+        // upstream: exclude.c:1775-1791 - on `\r` it looks one character ahead
+        // and swallows a following `\n`, so CRLF is one terminator.
+        self.rest = Some(match tail.strip_prefix("\r\n") {
+            Some(after) => after,
+            None => &tail[1..],
+        });
+        Some(record)
+    }
+}
+
+impl std::iter::FusedIterator for FilterFileRecords<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::filter_file_records;
+
+    fn records(content: &str) -> Vec<&str> {
+        filter_file_records(content).collect()
+    }
+
+    #[test]
+    fn newline_separates_records() {
+        assert_eq!(records("- a\n- b\n"), vec!["- a", "- b"]);
+    }
+
+    #[test]
+    fn a_lone_carriage_return_ends_a_record() {
+        // upstream: exclude.c:1774 - `ch == '\r'` breaks the record loop just
+        // as `\n` does. MEASURED against rsync 3.5.0: a merge file holding
+        // `- a.txt \r- b\r` excludes a file named `a.txt ` (trailing space).
+        assert_eq!(records("- a\r- b\r"), vec!["- a", "- b"]);
+        assert_eq!(records("- a\r"), vec!["- a"]);
+    }
+
+    #[test]
+    fn crlf_is_one_terminator() {
+        // upstream: exclude.c:1775-1791 - the `\n` after a `\r` is swallowed.
+        assert_eq!(records("- a\r\n- b\r\n"), vec!["- a", "- b"]);
+    }
+
+    #[test]
+    fn an_unterminated_tail_is_a_record() {
+        assert_eq!(records("- a\n- b"), vec!["- a", "- b"]);
+    }
+
+    #[test]
+    fn a_trailing_terminator_adds_no_empty_record() {
+        assert_eq!(records("- a\n"), vec!["- a"]);
+        assert_eq!(records("- a\r"), vec!["- a"]);
+        assert_eq!(records("- a\r\n"), vec!["- a"]);
+        assert!(records("").is_empty());
+    }
+
+    #[test]
+    fn a_blank_record_is_preserved_for_the_rule_predicate() {
+        // Line numbering is positional, so an empty record must still occupy
+        // its slot; dropping it would misreport the line of every later rule.
+        assert_eq!(records("- a\n\n- b\n"), vec!["- a", "", "- b"]);
+        assert_eq!(records("- a\r\r- b\r"), vec!["- a", "", "- b"]);
+    }
+
+    #[test]
+    fn trailing_whitespace_stays_in_the_record() {
+        // upstream: exclude.c:1465 - the pattern length is `strlen(s)`.
+        assert_eq!(records("- a \n"), vec!["- a "]);
+        assert_eq!(records("- a\t\n"), vec!["- a\t"]);
+    }
+}

--- a/crates/filters/src/merge/tests.rs
+++ b/crates/filters/src/merge/tests.rs
@@ -169,6 +169,34 @@ fn parse_comments_and_empty_lines() {
     assert_eq!(rules[0].pattern(), "*.txt");
 }
 
+/// A lone `\r` ends a rule here too, and CRLF ends exactly one.
+///
+/// upstream: exclude.c:1774-1793 - the read loop breaks on `\n` OR `\r`, and
+/// on `\r` it swallows a following `\n`. `str::lines` breaks only on `\n`, so
+/// a `\r`-separated file used to collapse into one unmatched pattern; the
+/// trailing space below is what makes the boundary decide the pattern.
+#[test]
+fn parse_splits_records_at_a_carriage_return() {
+    let rules = parse_rules("- a \r- b\r", Path::new("test")).unwrap();
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].pattern(), "a ");
+    assert_eq!(rules[1].pattern(), "b");
+
+    let crlf = parse_rules("- a \r\n- b\r\n", Path::new("test")).unwrap();
+    assert_eq!(crlf.len(), 2);
+    assert_eq!(crlf[0].pattern(), "a ");
+    assert_eq!(crlf[1].pattern(), "b");
+}
+
+/// The no-prefixes reader (`:-`/`:+` dir-merge) shares the boundary.
+#[test]
+fn parse_no_prefixes_splits_records_at_a_carriage_return() {
+    let rules = parse_rules_no_prefixes("a \rb\r", Path::new("test"), false, false, false);
+    assert_eq!(rules.len(), 2);
+    assert_eq!(rules[0].pattern(), "a ");
+    assert_eq!(rules[1].pattern(), "b");
+}
+
 #[test]
 fn parse_multiple_rules() {
     let content = "+ *.txt\n- *.bak\nP /important\n";

--- a/crates/filters/tests/exclude_from_file_parsing.rs
+++ b/crates/filters/tests/exclude_from_file_parsing.rs
@@ -600,18 +600,25 @@ mod line_ending_handling {
         assert_eq!(rules[2].pattern(), "*.log");
     }
 
-    /// Test: Old Mac line endings (CR only) - handled as single line.
+    /// Test: Old Mac line endings (CR only) - three separate rules.
+    ///
+    /// upstream: exclude.c:1774 - `ch == '\n' || ch == '\r'` ends the record,
+    /// so a CR-only file is three rules, not one. This test previously asserted
+    /// the opposite ("consistent with most Unix tools"), which is not the rule
+    /// rsync implements: the single record it produced carried the `\r` and the
+    /// later rules as pattern bytes and matched nothing, so every file those
+    /// rules named transferred instead. MEASURED against rsync 3.5.0.
     #[test]
     fn old_mac_line_endings() {
         let dir = create_tempdir();
         let path = dir.path().join("excludes.txt");
-        // CR-only line endings result in one long line
         fs::write(&path, "- *.tmp\r- *.bak\r- *.log\r").expect("write");
 
         let rules = read_rules(&path).expect("read rules");
-        // Old Mac CR-only is treated as one line (no proper line separation)
-        // This is consistent with most Unix tools
-        assert_eq!(rules.len(), 1);
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern(), "*.tmp");
+        assert_eq!(rules[1].pattern(), "*.bak");
+        assert_eq!(rules[2].pattern(), "*.log");
     }
 
     /// Test: No trailing newline.

--- a/crates/filters/tests/proptest_fuzz.rs
+++ b/crates/filters/tests/proptest_fuzz.rs
@@ -192,8 +192,13 @@ proptest! {
     }
 
     /// Comment-only inputs produce no rules.
+    ///
+    /// `rest` excludes BOTH record terminators. `.` already excludes `\n`, but
+    /// a `\r` ends a record too (upstream exclude.c:1774), so leaving it in
+    /// generates a second record - a rule, not a comment - and the property
+    /// under test would no longer be the one named.
     #[test]
-    fn parse_rules_comment_only(comment_char in "[#;]", rest in ".{0,80}") {
+    fn parse_rules_comment_only(comment_char in "[#;]", rest in "[^\n\r]{0,80}") {
         let input = format!("{comment_char}{rest}");
         let result = parse_rules(&input, Path::new("<fuzz>"));
         prop_assert!(result.is_ok());

--- a/tests/filter_file_record_ends_at_a_carriage_return.rs
+++ b/tests/filter_file_record_ends_at_a_carriage_return.rs
@@ -1,0 +1,162 @@
+//! A filter file's records end at `\r` as well as at `\n`.
+//!
+//! upstream reads a filter file one character at a time and ends the record on
+//! either terminator, collapsing `\r\n` into exactly one (`exclude.c:1774-1793`):
+//!
+//! ```c
+//! if (eol_nulls? !ch : (ch == '\n' || ch == '\r')) {
+//!     if (ch == '\r') {   /* CRLF is one line, not two */
+//!         ...
+//!         } else if (nxt != '\n' && ungetc(nxt, fp) == EOF) {
+//!             pending = nxt;
+//!         }
+//!     }
+//!     break;
+//! }
+//! ```
+//!
+//! All four oc readers spelled the split as Rust's `str::lines`/`read_until`,
+//! which breaks only on `\n` and merely strips a `\r` that sits immediately
+//! before one. A `\r`-separated filter file therefore collapsed into ONE
+//! record whose pattern carried the `\r` and every following rule as literal
+//! bytes - so it matched nothing, and each file those rules were meant to
+//! exclude transferred instead, at exit 0.
+//!
+//! MEASURED against rsync 3.5.0 with a source holding `a` and `a ` (trailing
+//! space) and a filter file of `- a \r`: upstream excludes `a ` and copies
+//! `a`; oc copied both. The same divergence reproduced through a `.rsync-filter`
+//! dir-merge, through `--filter='. FILE'`, and through `--exclude-from`. Every
+//! cell below is asserted against that measured upstream behaviour.
+//!
+//! These assert on the DESTINATION TREE rather than on a parsed record list,
+//! because the destination tree is the property that matters.
+
+mod integration;
+
+use integration::helpers::{RsyncCommand, TestDir};
+
+/// The plain name.
+const PLAIN: &str = "a";
+/// The same name with one trailing space, so the record boundary decides the
+/// match: a `\r` swallowed into the pattern makes the rule match neither name.
+const TRAILING: &str = "a ";
+/// An unrelated file, the negative control: no cell here may exclude it.
+const OTHER: &str = "b";
+
+/// Seeds `<dir>/src` with `a`, `a ` and `b`, and creates an empty `<dir>/dest`.
+fn seed(dir: &TestDir) {
+    dir.mkdir("src").expect("src");
+    dir.mkdir("dest").expect("dest");
+    dir.write_file("src/a", b"plain\n").expect("a");
+    dir.write_file("src/a ", b"trailing\n").expect("a-space");
+    dir.write_file("src/b", b"other\n").expect("b");
+}
+
+/// Runs `oc-rsync -r <extra...> src/ dest/` inside `dir`.
+fn transfer(dir: &TestDir, extra: &[String]) -> RsyncCommand {
+    let mut command = RsyncCommand::new();
+    command.arg("-r");
+    for argument in extra {
+        command.arg(argument);
+    }
+    command
+        .arg(format!("{}/", dir.path().join("src").display()))
+        .arg(format!("{}/", dir.path().join("dest").display()));
+    command
+}
+
+/// Asserts that `a ` was excluded while `a` and `b` landed.
+fn assert_trailing_excluded(dir: &TestDir, how: &str) {
+    assert!(
+        !dir.exists(&format!("dest/{TRAILING}")),
+        "{how}: the record ends at the carriage return, so the pattern is \
+         `a ` and upstream excludes `{TRAILING}` (exclude.c:1774)"
+    );
+    assert!(
+        dir.exists(&format!("dest/{PLAIN}")),
+        "{how}: the pattern `a ` must not match `{PLAIN}`"
+    );
+    assert!(
+        dir.exists(&format!("dest/{OTHER}")),
+        "{how}: the unrelated file must still transfer"
+    );
+}
+
+/// A dir-merge file whose only record is terminated by a lone `\r`.
+#[test]
+fn a_lone_carriage_return_ends_a_dir_merge_record() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"- a \r")
+        .expect("filter");
+
+    transfer(&dir, &["-F".to_owned()]).assert_success();
+
+    assert_trailing_excluded(&dir, "dir-merge, lone CR");
+}
+
+/// A `\r` BETWEEN two records separates them; the second one still applies.
+#[test]
+fn a_lone_carriage_return_separates_merge_file_records() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    let rules = dir.path().join("rules");
+    std::fs::write(&rules, b"- zzz\r- a \n").expect("rules");
+
+    transfer(&dir, &[format!("--filter=. {}", rules.display())]).assert_success();
+
+    assert_trailing_excluded(&dir, "merge file, embedded CR");
+}
+
+/// `--exclude-from` reads its records through the same boundary.
+#[test]
+fn a_lone_carriage_return_separates_exclude_from_records() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    let rules = dir.path().join("rules");
+    std::fs::write(&rules, b"zzz\ra \n").expect("rules");
+
+    transfer(&dir, &[format!("--exclude-from={}", rules.display())]).assert_success();
+
+    assert_trailing_excluded(&dir, "--exclude-from, embedded CR");
+}
+
+/// CRLF is ONE terminator, not two: it must not manufacture an empty record
+/// that then fails as `Unknown filter rule`.
+///
+/// upstream: `exclude.c:1775-1791` looks one character past the `\r` and
+/// swallows a following `\n`.
+#[test]
+fn crlf_is_one_terminator() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"- zzz\r\n- a \r\n")
+        .expect("filter");
+
+    transfer(&dir, &["-F".to_owned()]).assert_success();
+
+    assert_trailing_excluded(&dir, "dir-merge, CRLF");
+}
+
+/// The negative control: a plain LF-terminated file is untouched by all of
+/// this, and a rule WITHOUT trailing whitespace still means what it says.
+#[test]
+fn a_plain_newline_file_is_unaffected() {
+    let dir = TestDir::new().expect("scratch dir");
+    seed(&dir);
+    dir.write_file("src/.rsync-filter", b"- b\n")
+        .expect("filter");
+
+    transfer(&dir, &["-F".to_owned()]).assert_success();
+
+    assert!(
+        !dir.exists(&format!("dest/{OTHER}")),
+        "`- b` must still exclude `{OTHER}`"
+    );
+    for name in [PLAIN, TRAILING] {
+        assert!(
+            dir.exists(&format!("dest/{name}")),
+            "`- b` must not touch `{name}`"
+        );
+    }
+}


### PR DESCRIPTION
A lone `\r` ends a filter-file record upstream. All four oc readers split only
on `\n`, so a CR-separated filter file collapsed into **one** record that
matched nothing — and every file those rules named transferred instead, at
exit 0 with no diagnostic.

## Upstream rule

`parse_filter_file` reads one character at a time and ends the record on either
terminator, collapsing CRLF into exactly one (`exclude.c:1774-1793`):

```c
if (eol_nulls? !ch : (ch == '\n' || ch == '\r')) {
        if (ch == '\r') {   /* CRLF is one line, not two */
                int nxt;
                while ((nxt = getc(fp)) == EOF && ferror(fp) && errno == EINTR)
                        clearerr(fp);
                if (nxt == EOF) {
                        if (!ferror(fp))
                                ch = EOF;   /* real end of file */
                } else if (nxt != '\n' && ungetc(nxt, fp) == EOF) {
                        pending = nxt;
                }
        }
        break;
}
```

Rust's `str::lines` breaks only on `\n` and merely strips a `\r` sitting
immediately before one — so the `\r` and every following rule survived as
literal pattern bytes.

## Measured, oc vs the real 3.5.0 binary

Source holds `a.txt` and `a.txt ` (trailing space). Columns list what **landed
at the destination**, not exit codes.

| fixture | upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| merge file `- a.txt \r` | `a.txt` | `a.txt`, `a.txt ` | `a.txt` |
| merge file `- zzz\r- a.txt \n` | `a.txt` | `a.txt`, `a.txt ` | `a.txt` |
| `--exclude-from` `zzz\ra.txt \n` | `a.txt` | `a.txt`, `a.txt ` | `a.txt` |
| `.rsync-filter` `- zzz\r- a.txt \n` | `a.txt` | `a.txt`, `a.txt ` | `a.txt` |
| merge file `- a.txt \r\n` (CRLF) | `a.txt` | `a.txt` | `a.txt` |
| merge file `- a.txt \n` (control) | `a.txt` | `a.txt` | `a.txt` |

All four diverging cells **exit 0** — silent file-selection change.

**The trailing space is the load-bearing part of the fixture.** It is what makes
the record boundary decide the pattern: with it, a swallowed `\r` produces a
rule matching neither name, so the divergence is observable in the destination
tree rather than only in a parsed rule list.

## Change

`filters::filter_file_records` becomes the single owner of "where does a record
end?" — the sibling of the existing `filter_file_line_is_rule`, which already
owns "does this record carry a rule?". Four readers route through it:

- `filters::parse_rules` and `parse_rules_no_prefixes`
- the CLI merge loop (`cli/…/filter_rules/merge.rs`)
- the CLI `--exclude-from`/`--include-from` reader (`sources.rs`, previously
  `read_until(b'\n')`)

`--from0` keeps its own NUL split, exactly as upstream's `eol_nulls` arm does.

The line **number** follows from the same boundary, so a bad rule after a `\r`
is now reported at its own line: oc matches upstream's `line 2` for `;\r$`.

## Mutation proof

`tests/filter_file_record_ends_at_a_carriage_return.rs` asserts on the
destination tree, never on a parsed record list.

| mutation | failing cells | green cells |
|---|---|---|
| shared splitter → `str::lines` semantics | 3 CR cells | CRLF + LF control |
| revert `engine/…/dir_merge/load.rs` only | its own cell | other 4 |
| revert `cli/…/filter_rules/merge.rs` only | its own cell | other 4 |
| revert `cli/…/filter_rules/sources.rs` only | its own cell | other 4 |
| revert both `filters/merge/parse.rs` sites | 2 `filters` unit cells | all 5 integration cells |

Reverting each call site alone fails exactly that site's cell, so **no site is
inert**. The last row is the informative one: the two `filters` readers are not
reachable from the CLI-driven integration suite, so they carry unit cells in the
same shape rather than being left unproven.

`a_plain_newline_file_is_unaffected` is the negative control and stays green
under every mutation.

## Two test corrections

Neither is a re-baseline.

- `exclude_from_file_parsing.rs::old_mac_line_endings` **asserted the defect
  verbatim** — "Old Mac CR-only is treated as one line … consistent with most
  Unix tools". That is a rationalisation, not the rule rsync implements; it is
  re-pointed at the measured 3.5.0 behaviour (3 rules).
- `proptest_fuzz.rs::parse_rules_comment_only` drew `\r` out of `.` (which
  excludes `\n` but not `\r`). With `\r` now a terminator that generates a
  second record — a rule, not a comment — so the property under test would no
  longer be the one named. The generator is narrowed to `[^\n\r]`; the assertion
  is untouched.

## The originally filed premise is REFUTED

This began as "oc trims trailing whitespace off a merge-file rule". It does not,
and has not since #7699 and #7705. A 26-cell sweep (`--filter`, `. FILE` merge,
`: .rsync-filter` dir-merge, `--exclude-from`, `--include-from`) found every
trailing-space and trailing-tab cell already identical to upstream. The `\r`
boundary is what that sweep actually turned up.

Trim sites that remain are deliberate: the `exclude-if-present` marker
(`cli/…/parsing/rules.rs:65`, `engine/…/dir_merge/parse/line.rs:360`) is an
oc-only directive with no upstream counterpart — zero hits for it across
`rsync-3.5.0/*.c *.h` — and the CVSIGNORE token path is word-split, where the
trim is a no-op.

## Verification

Pinned toolchain 1.88.0. `cargo fmt --all -- --check` clean;
`cargo clippy --locked --workspace --all-targets --all-features --no-deps`
clean; `cargo test -p filters` fully green; 9 filter-related integration suites
green.

No expect manifest touched.
