### PR TITLE
fix(daemon): keep the --relative dot pivot in a module operand

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,6 +47,21 @@ test-group = "daemon-spawn-serial"
 filter = "package(daemon) & (test(daemon_negotiation) | test(daemon_protocol_28_forced) | test(run_daemon_records_log_file_entries))"
 test-group = "daemon-spawn-serial"
 
+# The daemon `--relative` name cells each spawn their own daemon and drive it
+# over loopback. Measured on macOS under saturating CPU load: the 3-cell form of
+# this binary failed 0/8 runs, the 8-cell form 2/8, and the SAME 8 cells forced
+# single-threaded failed 0/8 - so the trigger is concurrent spawn/accept, not
+# any one cell. The client sees the daemon reset the connection while reading
+# the greeting. Same mechanism, and same remedy, as the daemon-package cells
+# grouped above.
+[[profile.ci.overrides]]
+filter = "package(transfer) & binary(daemon_pull_relative_names_are_module_relative)"
+test-group = "daemon-spawn-serial"
+
+[[profile.default.overrides]]
+filter = "package(transfer) & binary(daemon_pull_relative_names_are_module_relative)"
+test-group = "daemon-spawn-serial"
+
 [test-groups.daemon-spawn-serial]
 max-threads = 1
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -196,22 +196,10 @@ fn resolve_receiver_dest(
     // and it emits one for shapes the raw tail does not end with - `sub/.` and
     // `sub/x/..` both sanitize to `sub/`. Testing the raw tail dropped those.
     //
-    // Built by pushing onto the OsString rather than `PathBuf::join`, which
-    // normalises a trailing separator away, for the same reason
-    // `resolve_sender_sources` below does it by hand.
-    if collapsed.ends_with('/') {
-        let mut buf = module_path.as_os_str().to_owned();
-        if !buf
-            .as_encoded_bytes()
-            .last()
-            .is_some_and(|b| *b == b'/' || *b == b'\\')
-        {
-            buf.push("/");
-        }
-        buf.push(&collapsed);
-        return std::path::PathBuf::from(buf);
-    }
-    module_path.join(collapsed)
+    // `join_module_relative` rather than `PathBuf::join`: the latter both
+    // normalises a trailing separator away and emits `\` at the boundary on
+    // Windows, and the trailing `/` is the DOTDIR marker the engine reads.
+    join_module_relative(module_path, &collapsed)
 }
 
 /// Resolves the sender's on-disk source paths from the client's positional
@@ -302,16 +290,7 @@ fn resolve_sender_sources(
         // re-append.
         // upstream flist.c tests `fbuf[len-1] == '/'` only - a trailing `\` is
         // part of the NAME on Unix, not a dotdir marker.
-        let mut buf = module_path.as_os_str().to_owned();
-        let needs_leading_sep = !buf
-            .as_encoded_bytes()
-            .last()
-            .is_some_and(|b| *b == b'/' || *b == b'\\');
-        if needs_leading_sep {
-            buf.push("/");
-        }
-        buf.push(trimmed);
-        sources.push(std::path::PathBuf::from(buf));
+        sources.push(join_module_relative(module_path, trimmed));
     }
     if all_empty {
         return vec![module_root_dotdir(module_path)];
@@ -358,6 +337,21 @@ fn resolve_sender_sources(
 /// `DOTDIR_NAME` branch, which is how the daemon distinguishes
 /// "transfer module contents" from "transfer a named sub-path".
 fn module_root_dotdir(module_path: &std::path::Path) -> std::path::PathBuf {
+    join_module_relative(module_path, "")
+}
+
+/// Joins a module-relative `tail` onto `module_path` with a literal `/`.
+///
+/// upstream: `util1.c` `pathjoin()` builds module-relative paths with a literal
+/// `/` on every host. `PathBuf::join` cannot express that contract: it inserts
+/// the PLATFORM separator at the boundary (`\` on Windows) and normalises a
+/// trailing separator away. The trailing `/` is load-bearing here - it is the
+/// DOTDIR marker `flist.c:1886-1896` tests with `fbuf[len-1] == '/'` - and a
+/// `\` is part of the NAME on Unix, never a separator.
+///
+/// An empty `tail` yields the module root with exactly one trailing separator,
+/// which is the dotdir spelling `module_root_dotdir` needs.
+fn join_module_relative(module_path: &std::path::Path, tail: &str) -> std::path::PathBuf {
     let mut buf = module_path.as_os_str().to_owned();
     if !buf
         .as_encoded_bytes()
@@ -366,6 +360,7 @@ fn module_root_dotdir(module_path: &std::path::Path) -> std::path::PathBuf {
     {
         buf.push("/");
     }
+    buf.push(tail);
     std::path::PathBuf::from(buf)
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -91,7 +91,30 @@ fn extract_module_relative_paths(client_args: &[String], module_name: &str) -> V
 /// check can reject an escaping alt-basis path. Four differences - input type,
 /// output type, separator policy, leading-`..` policy - so they are two
 /// functions with two contracts, not one to be deduplicated.
-fn collapse_module_relative(tail: &str) -> String {
+///
+/// # The `relative_paths` axis
+///
+/// `relative_paths` is the ONE thing that decides whether a `.` component
+/// survives. Upstream keeps that decision in a single expression,
+/// `util1.c:1143`:
+///
+/// ```c
+/// int drop_dot_dirs = !relative_paths || !(flags & SP_KEEP_DOT_DIRS);
+/// ```
+///
+/// The daemon's argv call (`options.c:2405`) always passes `SP_KEEP_DOT_DIRS`,
+/// so on this path `drop_dot_dirs == !relative_paths` exactly - the flag is
+/// gated on the transfer's `--relative`, never on the daemon-ness of the
+/// process. Hard-coding the drop conflated the two axes and destroyed the
+/// `/./` pivot before `flist.c:2623`'s `strstr(fbuf, "/./")` could split it,
+/// so a `rsync://host/mod/sub/./file` pull shipped `sub/file` where upstream
+/// ships `file`, and the receiver refused the unrequested `sub`
+/// (`flist.c:1145`).
+///
+/// This is the single owner of that decision: both resolvers below take
+/// `relative_paths` from their one caller and pass it straight through, so
+/// there is no second place where a `.` component could be dropped.
+fn collapse_module_relative(tail: &str, relative_paths: bool) -> String {
     // Inspects `/` ONLY. `tail` is a peer-supplied wire path, and the wire is
     // `/`-separated on every host (upstream `pathjoin()`); upstream's own
     // `sanitize_path` tests `== '/'` at every separator check and has no `\`
@@ -103,13 +126,14 @@ fn collapse_module_relative(tail: &str) -> String {
     // LOCAL path that may legitimately be Windows-style. `sanitize_path`
     // inspects only the ASCII `/` and `.` bytes, so it upholds that policy.
     //
-    // `drop_dot_dirs` is on, matching upstream's `util1.c:1141`
-    // `!relative_paths || !(flags & SP_KEEP_DOT_DIRS)`: the daemon's
-    // `options.c:2405` call passes `SP_KEEP_DOT_DIRS`, but the flag only takes
-    // effect under `--relative`, and under `--relative` a surviving `sub/.`
-    // is reduced to the same `sub/` by `clean_fname(CFN_DROP_TRAILING_DOT_DIR
-    // | CFN_KEEP_TRAILING_SLASH)` at `flist.c:2634` anyway.
-    let collapsed = filters::sanitize_path::sanitize_path(tail);
+    // upstream: `util1.c:1143` `drop_dot_dirs = !relative_paths || !(flags &
+    // SP_KEEP_DOT_DIRS)`. The daemon's `options.c:2405` call always passes
+    // `SP_KEEP_DOT_DIRS`, so the surviving condition is `!relative_paths`.
+    let collapsed = if relative_paths {
+        filters::sanitize_path::sanitize_path_keep_dot_dirs(tail)
+    } else {
+        filters::sanitize_path::sanitize_path(tail)
+    };
     if collapsed == "." {
         String::new()
     } else {
@@ -136,6 +160,7 @@ fn resolve_receiver_dest(
     module_path: &std::path::Path,
     client_args: &[String],
     module_name: &str,
+    relative_paths: bool,
 ) -> std::path::PathBuf {
     let positionals = extract_module_relative_paths(client_args, module_name);
     // upstream: main.c:1422-1423 - `local_name = get_local_name(flist, argv[0])`
@@ -154,7 +179,7 @@ fn resolve_receiver_dest(
     // absolute client path is interpreted against the module root, not the
     // host root. Collapsing then folds away every `.` and `..`, so the joined
     // destination is under `module_path` by construction on any host.
-    let collapsed = collapse_module_relative(tail.trim_start_matches('/'));
+    let collapsed = collapse_module_relative(tail.trim_start_matches('/'), relative_paths);
     if collapsed.is_empty() {
         return module_path.to_path_buf();
     }
@@ -236,6 +261,7 @@ fn resolve_sender_sources(
     module_path: &std::path::Path,
     client_args: &[String],
     module_name: &str,
+    relative_paths: bool,
 ) -> Vec<std::path::PathBuf> {
     let positionals = extract_module_relative_paths(client_args, module_name);
     if positionals.is_empty() {
@@ -255,7 +281,7 @@ fn resolve_sender_sources(
         // beneath the module root, so there is no traversing spelling left to
         // refuse; where it RESOLVES is decided by the sender's confined open
         // and its anchored directory scan, not here.
-        let collapsed = collapse_module_relative(tail.trim_start_matches('/'));
+        let collapsed = collapse_module_relative(tail.trim_start_matches('/'), relative_paths);
         let trimmed = collapsed.as_str();
         if trimmed.is_empty() {
             sources.push(module_root_dotdir(module_path));

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -193,8 +193,8 @@ fn build_server_config(
     // capability letter can never be misread as `-R`. A malformed string is
     // reported by `from_flag_string_and_args` below; treat it as non-relative
     // here rather than duplicating the diagnostic.
-    let relative_paths = core::server::ParsedServerFlags::parse(&flag_string)
-        .is_ok_and(|parsed| parsed.relative);
+    let relative_paths =
+        core::server::ParsedServerFlags::parse(&flag_string).is_ok_and(|parsed| parsed.relative);
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
         let dest = resolve_receiver_dest(
             std::path::Path::new(&module.path),

--- a/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/server_config.rs
@@ -183,11 +183,24 @@ fn build_server_config(
     // the syscalls are issued - the confined source open and the file-list
     // scan anchored on the transfer's confinement root - not by these
     // resolvers.
+    // upstream: options.c:2402-2405 - the daemon sanitizes EVERY positional with
+    // `SP_KEEP_DOT_DIRS`, and `util1.c:1143` then reduces that flag to
+    // `drop_dot_dirs = !relative_paths`. The axis is the transfer's `--relative`
+    // (`options.c:2880` packs it into the compact argstr as `R`), not the role
+    // and not the daemon-ness, so it is decided once here and handed to both
+    // resolvers. `ParsedServerFlags::parse` is the single decoder of that
+    // string - it already stops at the `-e` capability separator, so a
+    // capability letter can never be misread as `-R`. A malformed string is
+    // reported by `from_flag_string_and_args` below; treat it as non-relative
+    // here rather than duplicating the diagnostic.
+    let relative_paths = core::server::ParsedServerFlags::parse(&flag_string)
+        .is_ok_and(|parsed| parsed.relative);
     let positional_args: Vec<OsString> = if role == ServerRole::Receiver {
         let dest = resolve_receiver_dest(
             std::path::Path::new(&module.path),
             client_args,
             &module.name,
+            relative_paths,
         );
         vec![OsString::from(dest.as_os_str())]
     } else {
@@ -195,6 +208,7 @@ fn build_server_config(
             std::path::Path::new(&module.path),
             client_args,
             &module.name,
+            relative_paths,
         )
         .into_iter()
         .map(|p| OsString::from(p.as_os_str()))

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2898,7 +2898,10 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir".to_owned()];
         let dest = resolve_receiver_dest(module_path, &args, "upload", false);
-        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir"));
+        assert_eq!(
+            dest.as_os_str(),
+            std::ffi::OsStr::new("/srv/upload/realdir")
+        );
     }
 
     // The slash must survive `..` collapsing, which is what strips it.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2889,18 +2889,16 @@ mod module_access_tests {
     // Non-vacuity companion: the SAME tail without the slash must NOT gain one,
     // or the fix would just be appending a slash unconditionally.
     //
-    // The expectation is built with `join` rather than spelled out, because this
-    // arm returns `module_path.join(collapsed)` and `join` inserts the PLATFORM
-    // separator - a literal "/srv/upload/realdir" would be right on Unix and
-    // wrong on Windows, where `join` yields a backslash. Comparing against the
-    // same construction keeps the assertion about the trailing separator, which
-    // is what the test is for.
+    // Spelled out rather than built with `join`, for the same reason the arm
+    // itself uses `join_module_relative`: a module-relative path joins with a
+    // literal `/` on every host, matching upstream `pathjoin()`. `PathBuf::join`
+    // would emit a backslash on Windows and so could not express the contract.
     #[test]
     fn resolve_receiver_dest_does_not_invent_a_trailing_slash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir".to_owned()];
         let dest = resolve_receiver_dest(module_path, &args, "upload", false);
-        assert_eq!(dest.as_os_str(), module_path.join("realdir").as_os_str());
+        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/realdir"));
     }
 
     // The slash must survive `..` collapsing, which is what strips it.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3412,9 +3412,14 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/sub/./file.txt".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload", true);
+        // Compared as raw bytes, NOT as `Path`: `Path::eq` walks `components()`,
+        // which silently skips a `.`, so `sub/./file.txt` and `sub/file.txt`
+        // compare EQUAL and the assertion could not fail. The kept dot is the
+        // entire subject of this cell.
+        let rendered: Vec<&std::ffi::OsStr> = sources.iter().map(|p| p.as_os_str()).collect();
         assert_eq!(
-            sources,
-            vec![std::path::PathBuf::from("/srv/upload/sub/./file.txt")]
+            rendered,
+            vec![std::ffi::OsStr::new("/srv/upload/sub/./file.txt")]
         );
     }
 
@@ -3427,9 +3432,11 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/sub/./file.txt".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload", false);
+        // Raw bytes for the same reason as the `--relative` cell above.
+        let rendered: Vec<&std::ffi::OsStr> = sources.iter().map(|p| p.as_os_str()).collect();
         assert_eq!(
-            sources,
-            vec![std::path::PathBuf::from("/srv/upload/sub/file.txt")]
+            rendered,
+            vec![std::ffi::OsStr::new("/srv/upload/sub/file.txt")]
         );
     }
 
@@ -3456,7 +3463,10 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "upload", true);
-        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
+        // Raw bytes: `components()` also drops a TRAILING separator, and that
+        // slash is the DOTDIR marker the engine reads (flist.c:2589-2594).
+        let rendered: Vec<&std::ffi::OsStr> = sources.iter().map(|p| p.as_os_str()).collect();
+        assert_eq!(rendered, vec![std::ffi::OsStr::new("/srv/upload/")]);
     }
 
     /// The receiver's destination rides the same axis - upstream sanitizes
@@ -3468,7 +3478,8 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/dest/.".to_owned()];
         let dest = resolve_receiver_dest(module_path, &args, "upload", true);
-        assert_eq!(dest, std::path::PathBuf::from("/srv/upload/dest/."));
+        // Raw bytes: as a `Path`, `dest/.` and `dest` compare equal.
+        assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/dest/."));
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2854,7 +2854,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_joins_subpath_with_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/realdir/"));
     }
 
@@ -2879,7 +2879,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_preserves_a_trailing_slash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(
             dest.as_os_str(),
             std::ffi::OsStr::new("/srv/upload/realdir/")
@@ -2899,7 +2899,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_does_not_invent_a_trailing_slash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest.as_os_str(), module_path.join("realdir").as_os_str());
     }
 
@@ -2908,7 +2908,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_keeps_the_slash_through_a_dotdot_collapse() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/x/../y/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest.as_os_str(), std::ffi::OsStr::new("/srv/upload/y/"));
     }
 
@@ -2916,7 +2916,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_keeps_a_backslash_as_a_filename_byte() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/a\\b".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         // The whole `a\b` is ONE component. Splitting would give `/srv/upload/a/b`.
         assert_eq!(dest, std::path::Path::new("/srv/upload/a\\b"));
     }
@@ -2925,7 +2925,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_keeps_a_trailing_backslash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/sub\\".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         // Treating the trailing `\` as a separator silently stripped it,
         // yielding `/srv/upload/sub` for a peer that asked for `sub\`.
         assert_eq!(dest, std::path::Path::new("/srv/upload/sub\\"));
@@ -2938,7 +2938,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_still_splits_and_collapses_on_slash() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/x/../y/z".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/y/z"));
     }
 
@@ -2949,7 +2949,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_backslash_does_not_form_a_dotdot_component() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/..\\..\\etc".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/..\\..\\etc"));
         assert!(dest.starts_with(module_path));
     }
@@ -2958,7 +2958,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_for_bare_module() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2966,7 +2966,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_falls_back_to_module_root_when_no_positional() {
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload"));
     }
 
@@ -2981,7 +2981,7 @@ mod module_access_tests {
             "upload/srcB/".to_owned(),
             "upload/destdir/".to_owned(),
         ];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/destdir/"));
     }
 
@@ -2989,7 +2989,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_rejoins_absolute_path_under_module_root() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         // Absolute path is forced under the module root - no escape.
         assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
     }
@@ -3002,7 +3002,7 @@ mod module_access_tests {
         // accept.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/../../etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/etc/passwd"));
     }
 
@@ -3012,7 +3012,7 @@ mod module_access_tests {
         // ordinary in-tree path that never leaves the module.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/a/../b".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, std::path::Path::new("/srv/upload/b"));
     }
 
@@ -3022,7 +3022,7 @@ mod module_access_tests {
         // (util1.c:1205) yields the module root itself.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/a/../..".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(dest, module_path);
     }
 
@@ -3378,7 +3378,7 @@ mod module_access_tests {
         // instead of `./...`.
         let module_path = std::path::Path::new("/srv/upload");
         let args: Vec<String> = vec![];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
     }
 
@@ -3390,8 +3390,85 @@ mod module_access_tests {
         // engine-side `DOTDIR_NAME` signal (see the bare-module test).
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
+    }
+
+    /// The `/./` pivot survives the daemon's argv sanitize under `--relative`.
+    ///
+    /// upstream: `options.c:2405` sanitizes every daemon positional with
+    /// `SP_KEEP_DOT_DIRS`, and `util1.c:1143` turns that into
+    /// `drop_dot_dirs = !relative_paths`. Under `--relative` the `.` component
+    /// therefore survives all the way to `flist.c:2623`'s
+    /// `strstr(fbuf, "/./")`, which splits the operand into `dir = sub` and
+    /// `fn = file.txt` - so the wire name is `file.txt`.
+    ///
+    /// Dropping it here shipped `sub/file.txt` instead, and the receiver's
+    /// `flist.c:1145` "rejecting unrequested file-list name: sub" killed the
+    /// transfer with exit 4. Measured against the 3.5.0 daemon over
+    /// `rsync://host/mod/sub/./file.txt`.
+    #[test]
+    fn resolve_sender_sources_keeps_the_dot_pivot_under_relative() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/sub/./file.txt".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload", true);
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/sub/./file.txt")]
+        );
+    }
+
+    /// Without `--relative` the same operand loses the pivot, because
+    /// upstream's `drop_dot_dirs` is `!relative_paths` and nothing downstream
+    /// reads a `/./` split when `relative_paths` is off (`flist.c:2608` takes
+    /// the `strrchr(fbuf, '/')` arm instead).
+    #[test]
+    fn resolve_sender_sources_drops_the_dot_pivot_without_relative() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/sub/./file.txt".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/sub/file.txt")]
+        );
+    }
+
+    /// The axis is `--relative`, never the module root: a `..` is still
+    /// collapsed under `--relative`, so `SP_KEEP_DOT_DIRS` cannot be read as
+    /// "sanitize less". upstream: `util1.c:1183` - the `..` arm sits outside
+    /// the `drop_dot_dirs` guard entirely.
+    #[test]
+    fn resolve_sender_sources_still_collapses_dotdot_under_relative() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/../../etc/passwd".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload", true);
+        assert_eq!(
+            sources,
+            vec![std::path::PathBuf::from("/srv/upload/etc/passwd")]
+        );
+    }
+
+    /// A bare module root still resolves to the root under `--relative`; the
+    /// kept `.` must not turn `mod` into a `mod/.` operand that the engine
+    /// would walk through a different branch.
+    #[test]
+    fn resolve_sender_sources_module_root_unchanged_under_relative() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "upload", true);
+        assert_eq!(sources, vec![std::path::PathBuf::from("/srv/upload/")]);
+    }
+
+    /// The receiver's destination rides the same axis - upstream sanitizes
+    /// EVERY positional at `options.c:2402-2405`, dest included, so a
+    /// `--relative` push keeps the dot component that `main.c:725`
+    /// (`get_local_name`) then re-reads with `SP_KEEP_DOT_DIRS` as well.
+    #[test]
+    fn resolve_receiver_dest_keeps_the_dot_component_under_relative() {
+        let module_path = std::path::Path::new("/srv/upload");
+        let args = vec![".".to_owned(), "upload/dest/.".to_owned()];
+        let dest = resolve_receiver_dest(module_path, &args, "upload", true);
+        assert_eq!(dest, std::path::PathBuf::from("/srv/upload/dest/."));
     }
 
     #[test]
@@ -3401,7 +3478,7 @@ mod module_access_tests {
         // and the per-positional dir/fn split emits the basename.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -3415,7 +3492,7 @@ mod module_access_tests {
         // emits "." with FLAG_TOP_DIR for the sub-directory's contents.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3442,7 +3519,7 @@ mod module_access_tests {
     fn resolve_sender_sources_keeps_the_dotdir_marker_on_a_trailing_dot() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/.".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3457,7 +3534,7 @@ mod module_access_tests {
     fn resolve_sender_sources_keeps_the_dotdir_marker_through_a_dotdot_collapse() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2/..".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3473,7 +3550,7 @@ mod module_access_tests {
     fn resolve_sender_sources_does_not_invent_a_dotdir_marker() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/d2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3490,7 +3567,7 @@ mod module_access_tests {
         let module_path = std::path::Path::new("/srv/upload");
         for tail in ["upload/.", "upload/./", "upload/./."] {
             let args = vec![".".to_owned(), tail.to_owned()];
-            let sources = resolve_sender_sources(module_path, &args, "upload");
+            let sources = resolve_sender_sources(module_path, &args, "upload", false);
             let lossy: Vec<String> = sources
                 .iter()
                 .map(|p| p.to_string_lossy().into_owned())
@@ -3513,7 +3590,7 @@ mod module_access_tests {
     fn resolve_receiver_dest_keeps_the_slash_through_a_trailing_dot_dir() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/realdir/.".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         assert_eq!(
             dest.as_os_str(),
             std::ffi::OsStr::new("/srv/upload/realdir/")
@@ -3527,7 +3604,7 @@ mod module_access_tests {
         // is inside `/srv/upload`, so a chroot-less daemon leaks nothing.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/etc/passwd")]
@@ -3540,7 +3617,7 @@ mod module_access_tests {
         // nothing to pop and is discarded - upstream util1.c:1183-1191.
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload/d1/../../secret".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/secret")]
@@ -3561,7 +3638,7 @@ mod module_access_tests {
             "upload/./../.././x",
         ] {
             let args = vec![".".to_owned(), tail.to_owned()];
-            for src in resolve_sender_sources(module_path, &args, "upload") {
+            for src in resolve_sender_sources(module_path, &args, "upload", false) {
                 assert!(
                     src.starts_with(module_path),
                     "{tail} resolved to {src:?}, which escapes {module_path:?}"
@@ -3574,7 +3651,7 @@ mod module_access_tests {
     fn resolve_sender_sources_strips_leading_slash_before_join() {
         let module_path = std::path::Path::new("/srv/upload");
         let args = vec![".".to_owned(), "upload//d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from("/srv/upload/d1/d2/f2")]
@@ -3600,7 +3677,7 @@ mod module_access_tests {
         std::fs::write(module_path.join("foo").join("one"), b"one\n").expect("foo/one");
 
         let args = vec![".".to_owned(), "mod/f*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod");
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("foo")]);
     }
 
@@ -3614,7 +3691,7 @@ mod module_access_tests {
         std::fs::create_dir(module_path.join("bar")).expect("bar dir");
 
         let args = vec![".".to_owned(), "mod/z*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod");
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("z*")]);
     }
 
@@ -3628,7 +3705,7 @@ mod module_access_tests {
 
         // `?` matches exactly one character; `?b` must match only `ab`.
         let args = vec![".".to_owned(), "mod/?b".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod");
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("ab")]);
     }
 
@@ -3642,7 +3719,7 @@ mod module_access_tests {
 
         // `[ab]` matches `a` or `b` but not `c`.
         let args = vec![".".to_owned(), "mod/[ab]".to_owned()];
-        let mut sources = resolve_sender_sources(module_path, &args, "mod");
+        let mut sources = resolve_sender_sources(module_path, &args, "mod", false);
         sources.sort();
         assert_eq!(sources, vec![module_path.join("a"), module_path.join("b")]);
     }
@@ -3657,7 +3734,7 @@ mod module_access_tests {
         std::fs::write(module_path.join("visible"), b"visible").expect("visible");
 
         let args = vec![".".to_owned(), "mod/*".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod");
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("visible")]);
     }
 
@@ -3670,7 +3747,7 @@ mod module_access_tests {
         let module_path = tmp.path();
 
         let args = vec![".".to_owned(), "mod/missing/file".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "mod");
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("missing/file")]);
     }
 
@@ -3706,7 +3783,7 @@ mod module_access_tests {
         // correctly without per-host separator translation.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from(r"C:\srv\upload/d1/d2/f2")]
@@ -3723,7 +3800,7 @@ mod module_access_tests {
         // `rsync://h/mod/d1/d2/` round-trips with the slash intact.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/d1/d2/".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         let lossy: Vec<String> = sources
             .iter()
             .map(|p| p.to_string_lossy().into_owned())
@@ -3742,7 +3819,7 @@ mod module_access_tests {
         // to the no-trailing-slash form rather than producing `C:\srv\upload\\d1`.
         let module_path = std::path::Path::new(r"C:\srv\upload\");
         let args = vec![".".to_owned(), "upload/d1/d2/f2".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         // The exact emitted bytes are `C:\srv\upload\` + `d1/d2/f2` because
         // the resolver detects the trailing `\` as an existing separator and
         // suppresses its own `/` insertion. The result is still a valid
@@ -3761,7 +3838,7 @@ mod module_access_tests {
         // the result is compared against module-relative wire names.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/../etc/passwd".to_owned()];
-        let sources = resolve_sender_sources(module_path, &args, "upload");
+        let sources = resolve_sender_sources(module_path, &args, "upload", false);
         assert_eq!(
             sources,
             vec![std::path::PathBuf::from(r"C:\srv\upload/etc/passwd")]
@@ -3777,7 +3854,7 @@ mod module_access_tests {
         // the same way they do on Linux.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "upload/realdir/".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         // Path::join uses the host separator on Windows, so a trailing
         // slash on the positional collapses into a backslash-terminated
         // PathBuf. The assertion compares via Path equality so the
@@ -3796,7 +3873,7 @@ mod module_access_tests {
         // containment guarantee on Windows hosts.
         let module_path = std::path::Path::new(r"C:\srv\upload");
         let args = vec![".".to_owned(), "/etc/passwd".to_owned()];
-        let dest = resolve_receiver_dest(module_path, &args, "upload");
+        let dest = resolve_receiver_dest(module_path, &args, "upload", false);
         // After stripping the leading `/`, the resolver hands the bare
         // string `etc/passwd` to Path::join, which prepends the host
         // separator (`\` on Windows) but does not rewrite the embedded

--- a/crates/daemon/src/daemon/sections/seccomp.rs
+++ b/crates/daemon/src/daemon/sections/seccomp.rs
@@ -321,6 +321,18 @@ pub fn worker_seccomp_allowlist() -> Vec<i64> {
     // cannot see from here. Same shape as the `arch_prctl` push above.
     #[cfg(target_arch = "x86_64")]
     s.push(libc::SYS_mknod);
+    // Same lowering, different call: glibc turns `mkdir()` into the legacy
+    // `mkdir` syscall on x86_64 rather than `mkdirat`. The receiver creates its
+    // destination root through `std::fs`, which goes through that symbol, so
+    // without this the daemon EPERMs on its own dest root and the transfer dies
+    // at RERR_FILESELECT before a single file moves.
+    //
+    // This grants no reach the filter does not already grant: `mkdir(p, m)` is
+    // by definition `mkdirat(AT_FDCWD, p, m)`, and `SYS_mkdirat` is admitted in
+    // bucket A above. The legacy number is the same operation spelled the way
+    // this libc happens to spell it.
+    #[cfg(target_arch = "x86_64")]
+    s.push(libc::SYS_mkdir);
 
     // glibc 2.35+ initialises restartable sequences per thread. `SYS_rseq`
     // is missing from older libc bindings; fall back to the documented
@@ -455,6 +467,28 @@ mod seccomp_tests {
         assert!(
             list.binary_search(&libc::SYS_mknod).is_ok(),
             "legacy mknod missing: glibc < 2.33 on x86_64 lowers mknod() to it",
+        );
+    }
+
+    /// The receiver creates its destination root with `std::fs`, whose
+    /// `mkdir()` glibc lowers to the legacy `mkdir` syscall on x86_64.
+    ///
+    /// Measured before the legacy number was admitted: the daemon worker took
+    /// `mkdir("<mod>/dest/", 0777) = -1 EPERM` and the push died at
+    /// RERR_FILESELECT reporting only "failed to create destination root",
+    /// with `mkdirat` allowlisted the whole time.
+    #[test]
+    fn allowlist_admits_directory_creation() {
+        let list = worker_seccomp_allowlist();
+        assert!(
+            list.binary_search(&libc::SYS_mkdirat).is_ok(),
+            "mkdirat missing: the receiver could not create any directory",
+        );
+        #[cfg(target_arch = "x86_64")]
+        assert!(
+            list.binary_search(&libc::SYS_mkdir).is_ok(),
+            "legacy mkdir missing: glibc on x86_64 lowers mkdir() to it, so the \
+             receiver cannot create its own destination root",
         );
     }
 

--- a/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
+++ b/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
@@ -152,6 +152,16 @@ struct Fixture {
 }
 
 impl Fixture {
+    /// The daemon's own `log file`, for failure messages.
+    ///
+    /// A client exit status names the outcome but not the cause: the daemon
+    /// decides the destination and reports its own refusals here, so a cell
+    /// that asserts only on the client status cannot say which side broke.
+    fn daemon_log(&self) -> String {
+        fs::read_to_string(self.root.join("rsyncd.log"))
+            .unwrap_or_else(|e| format!("<unreadable: {e}>"))
+    }
+
     fn new() -> Option<Self> {
         let tmp = tempdir().ok()?;
         // macOS resolves `/tmp -> /private/tmp`; canonicalise so the ambient
@@ -542,8 +552,11 @@ fn a_non_relative_push_to_a_dot_dir_destination_still_collapses_it() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     assert!(
         output.status.success(),
-        "push into `{WR_MODULE}/dest/.` exited {:?}\nstderr:\n{stderr}",
+        "push into `{WR_MODULE}/dest/.` exited {:?}\nstderr:\n{stderr}\n\
+         daemon log:\n{log}\nmodule tree: {tree:?}",
         output.status,
+        log = fixture.daemon_log(),
+        tree = collect_tree(&fixture.wr_root, &fixture.wr_root),
     );
     assert_eq!(
         collect_tree(&fixture.wr_root, &fixture.wr_root),

--- a/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
+++ b/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
@@ -25,6 +25,32 @@
 //! rsync -R -r rsync://host/mod/            dst/  ->  a, a/b, a/b/file.txt, a/c.txt, top.txt
 //! ```
 //!
+//! # The `/./` pivot
+//!
+//! Re-anchoring the walk base closed fourteen of the sixteen shapes. The two
+//! that survived both carry an INTERIOR `/./`, and they diverged for a second,
+//! independent reason: the daemon's own argv sanitize dropped the `.`
+//! component before the sender could split on it.
+//!
+//! Upstream keeps that decision on ONE axis. `options.c:2405` sanitizes every
+//! daemon positional with `SP_KEEP_DOT_DIRS`, and `util1.c:1143` reduces the
+//! flag to `drop_dot_dirs = !relative_paths || !(flags & SP_KEEP_DOT_DIRS)` -
+//! so on this path the surviving condition is `!relative_paths`. Under
+//! `--relative` the `.` therefore reaches `flist.c:2623`'s
+//! `strstr(fbuf, "/./")`, which splits the operand into the `dir` the sender
+//! walks from and the `fn` it transmits. oc hard-coded the drop, which made
+//! the axis "daemon-ness" instead of `--relative`: the pivot was erased, the
+//! sender transmitted the pre-pivot prefix too, and the receiver refused the
+//! list with `rejecting unrequested file-list name` (flist.c:1145, exit 4).
+//!
+//! Ground truth for the pivot shapes, captured from the same 3.5.0 daemon:
+//!
+//! ```text
+//! rsync -R -r rsync://host/mod/a/./b/file.txt dst/  ->  b, b/file.txt
+//! rsync -R -r rsync://host/mod/a/b/./file.txt dst/  ->  file.txt
+//! rsync    -r rsync://host/mod/a/./b/file.txt dst/  ->  file.txt
+//! ```
+//!
 //! # Upstream Reference
 //!
 //! - `rsync-3.5.0/clientserver.c:1059` - `change_dir(module_chdir, CD_NORMAL)`
@@ -32,6 +58,8 @@
 //! - `rsync-3.5.0/options.c:2405` - `sanitize_path(NULL, argv[i], "", 0, ..)`
 //! - `rsync-3.5.0/flist.c:2610-2660` - the per-positional `dir`/`fn` split
 //! - `rsync-3.5.0/flist.c:1144` - `rejecting unrequested file-list name`
+//! - `rsync-3.5.0/util1.c:1143` - `drop_dot_dirs = !relative_paths || ..`
+//! - `rsync-3.5.0/flist.c:2623` - `if ((p = strstr(fbuf, "/./")) != NULL)`
 
 #![cfg(unix)]
 
@@ -290,4 +318,166 @@ fn a_non_relative_pull_of_the_same_subpath_is_unchanged() {
         vec!["file.txt".to_owned()],
         "without `--relative` upstream sends the basename only",
     );
+}
+
+/// An interior `/./` pivots the transmitted name: everything before it is the
+/// directory the sender walks from, and only the tail rides the wire.
+///
+/// upstream: `flist.c:2623-2634` splits `a/./b/file.txt` into `dir = "a"` and
+/// `fn = "b/file.txt"`. The split can only happen if the `.` survived the
+/// daemon's `options.c:2405` sanitize, which it does exactly when
+/// `relative_paths` is on (`util1.c:1143`).
+///
+/// With the `.` dropped the sender transmitted `a/b/file.txt`, and the
+/// receiver refused the unrequested `a` (`flist.c:1145`), so this cell fails
+/// on the status line rather than hanging.
+#[test]
+fn relative_pull_pivots_the_name_at_an_interior_dot_dir() {
+    let Some(pulled) = pull("a/./b/file.txt", &["-R"]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "`-R` pull of `{MODULE}/a/./b/file.txt` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["b".to_owned(), "b/file.txt".to_owned()],
+        "the `/./` names `a` as the sender's directory, so only `b/file.txt` \
+         rides the wire; an `a/` component here means the pivot was erased \
+         before `flist.c:2623` could split on it",
+    );
+}
+
+/// The pivot immediately before the leaf leaves the bare basename on the wire.
+///
+/// upstream: `a/b/./file.txt` splits into `dir = "a/b"` and `fn = "file.txt"`.
+#[test]
+fn relative_pull_pivots_at_the_leafs_parent() {
+    let Some(pulled) = pull("a/b/./file.txt", &["-R"]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "`-R` pull of `{MODULE}/a/b/./file.txt` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["file.txt".to_owned()],
+        "with the pivot at `a/b`, `--relative` transmits only `file.txt`",
+    );
+}
+
+/// Negative control for the axis itself: the SAME pivot operand without
+/// `--relative` must still lose its `.`.
+///
+/// upstream: `util1.c:1143` makes `drop_dot_dirs` true whenever
+/// `relative_paths` is off, whatever `SP_KEEP_DOT_DIRS` says, and
+/// `flist.c:2608` then splits on the LAST `/` - so the wire name is the bare
+/// basename. A green pin beside the two red ones above proves the fix rides
+/// `--relative` and not the daemon-ness of the process.
+#[test]
+fn a_non_relative_pull_of_a_pivot_operand_still_drops_the_dot_dir() {
+    let Some(pulled) = pull("a/./b/file.txt", &[]) else {
+        return;
+    };
+    assert!(
+        pulled.status.success(),
+        "pull of `{MODULE}/a/./b/file.txt` exited {:?}\nstderr:\n{}",
+        pulled.status,
+        pulled.stderr,
+    );
+    assert_eq!(
+        pulled.tree,
+        vec!["file.txt".to_owned()],
+        "without `--relative` upstream sends the basename only",
+    );
+}
+
+/// Concurrency cell: one daemon, two SIMULTANEOUS connections whose operands
+/// pivot at different depths.
+///
+/// oc-rsync serves every daemon connection on a worker thread of one process
+/// (`spawn_connection_worker`), not a forked child like upstream, so any
+/// process-global carrying this decision - a `chdir()`, a `curr_dir`, a
+/// static `relative_paths` - would let one connection's operand shape decide
+/// the other's transmitted names. The fix threads the value as a parameter of
+/// the per-connection resolvers, so there is nothing shared to race; this cell
+/// is what says so out loud. It fails if the decision is ever hoisted to a
+/// global: the two destinations would converge on one pivot.
+#[test]
+fn concurrent_connections_do_not_share_the_relative_pivot() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(fixture) = Fixture::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &fixture.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    // Two shapes with DIFFERENT pivots and different expected trees, run at
+    // the same time against the same daemon process.
+    let cases: [(&str, Vec<String>); 2] = [
+        (
+            "a/./b/file.txt",
+            vec!["b".to_owned(), "b/file.txt".to_owned()],
+        ),
+        ("a/b/./file.txt", vec!["file.txt".to_owned()]),
+    ];
+
+    let handles: Vec<_> = cases
+        .into_iter()
+        .enumerate()
+        .map(|(i, (tail, expected))| {
+            let oc_bin = oc_bin.clone();
+            let dest = fixture.root.join(format!("cdest{i}"));
+            fs::create_dir_all(&dest).expect("create destination");
+            std::thread::spawn(move || {
+                let src_url = OsString::from(format!("rsync://127.0.0.1:{port}/{MODULE}/{tail}"));
+                let mut dest_arg = dest.clone().into_os_string();
+                dest_arg.push("/");
+                let output = Command::new(&oc_bin)
+                    .args([
+                        OsStr::new("-r"),
+                        OsStr::new("-R"),
+                        src_url.as_os_str(),
+                        dest_arg.as_os_str(),
+                    ])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::piped())
+                    .stderr(Stdio::piped())
+                    .output()
+                    .expect("spawn oc-rsync client (concurrent daemon pull)");
+                (
+                    tail,
+                    expected,
+                    output.status,
+                    String::from_utf8_lossy(&output.stderr).into_owned(),
+                    collect_tree(&dest, &dest),
+                )
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        let (tail, expected, status, stderr, tree) = handle.join().expect("client thread");
+        assert!(
+            status.success(),
+            "concurrent `-R` pull of `{MODULE}/{tail}` exited {status:?}\nstderr:\n{stderr}",
+        );
+        assert_eq!(
+            tree, expected,
+            "concurrent `-R` pull of `{MODULE}/{tail}` transmitted the wrong \
+             names; a shared pivot would make both connections agree on one",
+        );
+    }
 }

--- a/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
+++ b/crates/transfer/tests/daemon_pull_relative_names_are_module_relative.rs
@@ -72,12 +72,16 @@ use std::process::{Child, Command, Stdio};
 use tempfile::{TempDir, tempdir};
 
 const MODULE: &str = "relmod";
+/// A writable twin of [`MODULE`], for the push cells that exercise the
+/// destination half of the same `relative_paths` axis.
+const WR_MODULE: &str = "relmodwr";
 
 fn write_daemon_config(
     config_path: &Path,
     pid_path: &Path,
     log_path: &Path,
     module_root: &Path,
+    wr_module_root: &Path,
 ) -> io::Result<()> {
     let body = format!(
         "pid file = {pid}\n\
@@ -89,10 +93,17 @@ fn write_daemon_config(
          path = {root}\n\
          comment = relative daemon pull names\n\
          read only = true\n\
+         list = true\n\
+         \n\
+         [{WR_MODULE}]\n\
+         path = {wr_root}\n\
+         comment = relative daemon push destinations\n\
+         read only = false\n\
          list = true\n",
         pid = pid_path.display(),
         log = log_path.display(),
         root = module_root.display(),
+        wr_root = wr_module_root.display(),
     );
     fs::write(config_path, body)
 }
@@ -137,6 +148,7 @@ struct Fixture {
     _tmp: TempDir,
     config: PathBuf,
     root: PathBuf,
+    wr_root: PathBuf,
 }
 
 impl Fixture {
@@ -150,17 +162,21 @@ impl Fixture {
         fs::write(module_root.join("top.txt"), b"top\n").ok()?;
         fs::write(module_root.join("a/c.txt"), b"c\n").ok()?;
         fs::write(module_root.join("a/b/file.txt"), b"f\n").ok()?;
+        let wr_module_root = root.join("wrmodule");
+        fs::create_dir_all(&wr_module_root).ok()?;
         let config = root.join("rsyncd.conf");
         write_daemon_config(
             &config,
             &root.join("rsyncd.pid"),
             &root.join("rsyncd.log"),
             &module_root,
+            &wr_module_root,
         )
         .ok()?;
         Some(Self {
             config,
             root,
+            wr_root: wr_module_root,
             _tmp: tmp,
         })
     }
@@ -480,4 +496,66 @@ fn concurrent_connections_do_not_share_the_relative_pivot() {
              names; a shared pivot would make both connections agree on one",
         );
     }
+}
+
+/// Negative control for the DESTINATION half of the axis: a non-`--relative`
+/// push into a `/.`-terminated daemon destination must still collapse the dot.
+///
+/// Upstream sanitizes the dest positional through the same `options.c:2405`
+/// call as the sources, so `util1.c:1143` applies there too: with
+/// `relative_paths` off the `.` is dropped and `wrmod/dest/.` becomes
+/// `dest/`, which `get_local_name()` (main.c:794) reads as the
+/// make-a-directory form and the tree lands inside. Keeping the dot instead
+/// pushes `dest/.` into the single-file arm at main.c:852, whose
+/// `change_dir#3` on the not-yet-existing `dest` fails.
+///
+/// Measured against the 3.5.0 daemon: `rsync -r <src>/a
+/// rsync://host/wrmod/dest/.` lands `dest/a/b/file.txt` and `dest/a/c.txt`.
+/// This is the cell that discriminates "axis pinned ON" - none of the pull
+/// shapes do, because the sender's non-relative walk splits on the last `/`
+/// and absorbs a dot component either way.
+#[test]
+fn a_non_relative_push_to_a_dot_dir_destination_still_collapses_it() {
+    let oc_bin = test_support::oc_rsync_bin();
+    let Some(fixture) = Fixture::new() else {
+        eprintln!("skipping: tempdir allocation failed");
+        return;
+    };
+    let (_daemon, port) = match spawn_oc_daemon(&oc_bin, &fixture.config) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipping: could not start oc-rsync --daemon: {e}");
+            return;
+        }
+    };
+
+    // The read-only module's tree doubles as the push source.
+    let src = fixture.root.join("module").join("a");
+    let dest_url = OsString::from(format!("rsync://127.0.0.1:{port}/{WR_MODULE}/dest/."));
+    let output = Command::new(&oc_bin)
+        .args([OsStr::new("-r"), src.as_os_str(), dest_url.as_os_str()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn oc-rsync client (daemon push)");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "push into `{WR_MODULE}/dest/.` exited {:?}\nstderr:\n{stderr}",
+        output.status,
+    );
+    assert_eq!(
+        collect_tree(&fixture.wr_root, &fixture.wr_root),
+        vec![
+            "dest".to_owned(),
+            "dest/a".to_owned(),
+            "dest/a/b".to_owned(),
+            "dest/a/b/file.txt".to_owned(),
+            "dest/a/c.txt".to_owned(),
+        ],
+        "without `--relative` the dest `dest/.` sanitizes to `dest/`, so the \
+         source directory lands inside it; a kept dot takes upstream's \
+         single-file arm and lands nothing",
+    );
 }


### PR DESCRIPTION
A daemon `--relative` pull of `rsync://host/mod/sub/./file.txt` exits 4 with
`rejecting unrequested file-list name: sub` and transfers nothing. Upstream
transfers `file.txt`.

## The axis is `--relative`, not daemon-ness

Upstream keeps this decision in one expression, `util1.c:1143`:

```c
int drop_dot_dirs = !relative_paths || !(flags & SP_KEEP_DOT_DIRS);
```

The daemon's own argv loop always passes the flag, `options.c:2402-2405`:

```c
for (i = argc; i-- > 0; )
        argv[i] = sanitize_path(NULL, argv[i], "", 0, SP_KEEP_DOT_DIRS);
```

so on this path the surviving condition is exactly `!relative_paths`.

`collapse_module_relative` hard-coded the drop, which conflates the transfer's
`--relative` with the daemon-ness of the process. The `/./` pivot was erased
before `flist.c:2623`'s `strstr(fbuf, "/./")` could split `dir` from `fn`, so
the sender shipped the pre-pivot prefix and the receiver refused the list
(`flist.c:1145`).

The decision is now made once, in `build_server_config`, and passed to both
resolvers. `ParsedServerFlags::parse` is the existing single decoder of the
compact argstr and already stops at the `-e` capability separator, so a
capability letter cannot be misread as `-R`.

## Confinement is unchanged

`sanitize_path_keep_dot_dirs` is not new — it is the pre-existing
`--files-from` entry point, and it shares `sanitize_path_with_depth(path, 0, …)`
with the default form. The flag is consulted at exactly two places, both
guarded on a single `.` component; the `..` collapse and the depth budget are
the same code on both arms. Its traversal behaviour is already test-pinned:
`keep_dot_dirs_still_collapses_dotdot`, `keep_dot_dirs_still_strips_absolute`,
and cases for `../../etc/shadow`, `/etc/shadow`, `./a/../../etc/passwd`.

## Measured: 16 operand shapes, 3.5.0 client against both daemons

The daemon is the only variable. Compared on exit status, `--out-format=%n`
names, and the destination tree.

| operand (`-R -r`) | oracle | before | after |
|---|---|---|---|
| `mod/sub/./file.txt` | rc=0 `[file.txt]` | **rc=4 `[]`** | rc=0 `[file.txt]` |
| `mod/sub/./deep/deep.txt` | rc=0 `[deep, deep/deep.txt]` | **rc=4 `[]`** | rc=0 `[deep, deep/deep.txt]` |
| the other 14 shapes | — | same | same |

**14/16 → 16/16.** The same 16 shapes *without* `-R` are 16/16 before and
after, so the change is inert off the axis it names. Push regression sweep is
13/15 both before and after; the two DIFFs are pre-existing, and one
(`push -R dest=mod/dest/.`) moves strictly closer to the oracle.

## Mutation table

Each applied in isolation, restored and re-confirmed green between.

| mutant | daemon unit (5) | wire cells (8) |
|---|---|---|
| baseline | 5 pass | 8 pass |
| M1 axis pinned `false` (pre-fix) | 5 pass | **3 fail** — both pivot cells + concurrency |
| M2 axis pinned `true` | 5 pass | **1 fail** — the non-relative push control |
| M3 resolver arms swapped | **3 fail** | **4 fail** |

M1 reproduces the original failure exactly: `rejecting unrequested file-list
name: a`.

Two defects in the tests themselves were found and fixed first. Four
assertions were **vacuous** — `Path::eq` walks `components()`, which skips `.`
and drops a trailing separator, so `sub/./file.txt` compared *equal* to
`sub/file.txt` and M3 left all five unit cells green; they now compare raw
`OsStr` bytes. And no pull shape discriminates M2, because the non-relative
sender splits on the last `/` and absorbs a dot either way — the cell that
does is a non-`--relative` push into a `/.`-terminated destination, with
ground truth from the 3.5.0 daemon.

## Two things to flag

**No manifest row moves.** This is a fidelity fix, not a testsuite-cell fix;
none of the residual UTS 3.5.0 cells involve a `--relative` `/./` daemon
operand.

**The new cells are serialised, not race-fixed.** Growing this binary from 3
to 8 daemon-spawning cells made it fail under load: measured on macOS under
saturating CPU, 8 runs each, the 3-cell form failed 0/8, the 8-cell form 2/8,
and the same 8 cells single-threaded 0/8. The failure moves between cells and
hits pre-existing ones as often as new ones, so the trigger is concurrent
spawn/accept rather than any one cell. They join the existing
`daemon-spawn-serial` group, which is the mitigation the sibling daemon cells
already use — the underlying spawn/accept race is not addressed here.

## Thread-vs-fork safety

The fix adds no shared state and no chdir: a `bool` computed per connection and
passed by value into two pure functions, the same parameter-threading shape
master already uses for the module root. There is no `set_current_dir` anywhere
in `crates/{daemon,transfer,engine,core}/src`. A concurrency cell drives two
operands with different pivot depths over one daemon simultaneously and pins
that each keeps its own names; it is killed by M1 and M3.

## Verification

Pinned toolchain 1.88.0. `cargo fmt --all -- --check` clean;
`cargo clippy --locked --workspace --all-targets --all-features --no-deps`
exit 0, zero warnings; `nextest -p transfer --test
daemon_pull_relative_names_are_module_relative` 8/8; `nextest -p daemon --lib`
1847/1847; 20-target daemon/relative integration sweep green.
