### PR TITLE
refactor(daemon): give the accept loop a session-worker seam and park the connection slot in the parent

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/connection.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/connection.rs
@@ -4,7 +4,7 @@
 /// and dual-stack accept loops, avoiding excessive parameter lists.
 struct AcceptLoopState<'a> {
     signal_flags: &'a SignalFlags,
-    workers: Vec<thread::JoinHandle<WorkerResult>>,
+    workers: Vec<SessionWorker>,
     served: usize,
     active_connections: usize,
     connection_counter: ConnectionCounter,
@@ -188,10 +188,15 @@ pub(crate) fn log_max_connections_rejection(
     log_message(log, &message);
 }
 
-/// Spawns a worker thread for an accepted connection.
+/// Spawns a worker for an accepted connection.
 ///
-/// Applies socket options, normalizes the peer address, and spawns a session
-/// handler thread with `catch_unwind` panic isolation. Returns the join handle.
+/// Normalizes the peer address, claims the connection's `max connections`
+/// slot, and spawns a session handler thread with `catch_unwind` panic
+/// isolation. Returns the [`SessionWorker`] pairing the two.
+///
+/// The slot is claimed here but held by the returned worker rather than by the
+/// session, so the accept loop's reap is what releases it. See
+/// [`SessionWorker`] for why that placement is load-bearing.
 ///
 /// upstream: clientserver.c - fork per connection; we use threads with
 /// `catch_unwind` for equivalent crash isolation.
@@ -199,7 +204,7 @@ fn spawn_connection_worker(
     stream: DaemonStream,
     raw_peer_addr: SocketAddr,
     state: &AcceptLoopState<'_>,
-) -> thread::JoinHandle<WorkerResult> {
+) -> SessionWorker {
     let peer_addr = normalize_peer_address(raw_peer_addr);
     // Build the shareable per-connection context once; the same context type
     // and `serve_session` core drive the async accept path, keeping the wire
@@ -214,10 +219,9 @@ fn spawn_connection_worker(
         state.proxy_policy.clone(),
         state.daemon_timeout,
     );
-    let conn_guard = state.connection_counter.acquire();
+    let slot = state.connection_counter.acquire();
 
-    thread::spawn(move || {
-        let _conn_guard = conn_guard;
+    let handle = thread::spawn(move || {
         // upstream rsync forks per connection, so a crash only kills that
         // child. `serve_session` isolates panics via `catch_unwind` so a
         // faulting connection cannot tear down the daemon.
@@ -225,7 +229,12 @@ fn spawn_connection_worker(
             Ok(()) => Ok(()),
             Err(error) => Err((Some(peer_addr), error)),
         }
-    })
+    });
+
+    SessionWorker {
+        handle,
+        _slot: slot,
+    }
 }
 
 /// Applies socket options to an accepted stream and logs any failure.
@@ -295,13 +304,23 @@ fn handle_accepted_connection(
         state.log_sink.as_ref(),
     );
 
+    // Release the slots of sessions that ended while the loop was blocked in
+    // `poll`, so the capacity decision below reads freshly-reaped state.
+    //
+    // The slot guard is parent-owned (see `SessionWorker`), so a finished
+    // worker keeps its slot until a reap. Without this call the next reap is
+    // the following iteration's, and a session that ended during the poll
+    // would refuse a connection the daemon has room for. Under a forked
+    // backing this is also where `reap_finished_children` belongs.
+    reap_finished_workers(&mut state.workers, state.log_sink.as_ref());
+
     if refuse_if_at_capacity(&mut stream, raw_peer_addr, state) {
         drop(stream);
         return false;
     }
 
-    let handle = spawn_connection_worker(stream, raw_peer_addr, state);
-    state.workers.push(handle);
+    let worker = spawn_connection_worker(stream, raw_peer_addr, state);
+    state.workers.push(worker);
     state.served = state.served.saturating_add(1);
 
     update_connection_status_after_accept(state);

--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -231,22 +231,26 @@ fn join_worker_swallows_panicking_thread() {
 /// session's outcome at all.
 #[test]
 fn reap_finished_workers_drains_session_failures_without_a_fatal_channel() {
-    let mut workers: Vec<thread::JoinHandle<WorkerResult>> = Vec::new();
+    let counter = ConnectionCounter::new();
+    let mut workers: Vec<SessionWorker> = Vec::new();
     for kind in [
         io::ErrorKind::InvalidData,
         io::ErrorKind::PermissionDenied,
         io::ErrorKind::BrokenPipe,
         io::ErrorKind::TimedOut,
     ] {
-        workers.push(thread::spawn(move || {
-            Err((
-                Some("127.0.0.1:12345".parse().unwrap()),
-                io::Error::new(kind, "session failure"),
-            ))
-        }));
+        workers.push(SessionWorker {
+            handle: thread::spawn(move || {
+                Err((
+                    Some("127.0.0.1:12345".parse().unwrap()),
+                    io::Error::new(kind, "session failure"),
+                ))
+            }),
+            _slot: counter.acquire(),
+        });
     }
-    for handle in &workers {
-        while !handle.is_finished() {
+    for worker in &workers {
+        while !worker.is_finished() {
             thread::yield_now();
         }
     }
@@ -259,6 +263,37 @@ fn reap_finished_workers_drains_session_failures_without_a_fatal_channel() {
     );
 }
 
+/// A finished worker keeps its `max connections` slot until the accept loop
+/// reaps it, and the reap is what releases it.
+///
+/// Both halves matter. The slot guard is parent-owned so that a forked child
+/// cannot carry the only copy away with it (see `SessionWorker`); the price is
+/// that a session ending mid-`poll` no longer frees its slot at that moment.
+/// Nothing else releases it, which is why `handle_accepted_connection` reaps
+/// immediately before consulting the cap rather than relying on the reap at
+/// the top of the iteration.
+#[test]
+fn a_finished_worker_holds_its_slot_until_reaped() {
+    let counter = ConnectionCounter::new();
+    let mut workers = vec![SessionWorker {
+        handle: thread::spawn(|| -> WorkerResult { Ok(()) }),
+        _slot: counter.acquire(),
+    }];
+    while !workers[0].is_finished() {
+        thread::yield_now();
+    }
+    assert_eq!(
+        counter.active(),
+        1,
+        "the session ended, but its slot belongs to the parent until the reap",
+    );
+    reap_finished_workers(&mut workers, None);
+    assert_eq!(
+        counter.active(),
+        0,
+        "reaping a finished worker must release the slot it was holding",
+    );
+}
 #[test]
 fn catch_unwind_isolates_panic_and_returns_ok() {
     let peer_addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
@@ -1214,6 +1249,63 @@ fn accept_loop_recovers_after_disconnect() {
     assert!(!refuse_if_at_capacity(&mut server_stream, peer, &state));
 }
 
+/// Admission reaps first, so a session that ended while the loop was blocked
+/// in `poll` does not hold its `max connections` slot against the next client.
+///
+/// The slot guard is parent-owned (see `SessionWorker`), which means a
+/// finished worker keeps its slot until some reap runs. The reap at the top of
+/// the accept iteration happens BEFORE the blocking poll, so without the reap
+/// inside `handle_accepted_connection` the cap would be read against a slot
+/// whose session has already ended.
+///
+/// `state.served` is what discriminates: the refusal arm returns before
+/// incrementing it, and both arms return `false`.
+#[test]
+fn admission_reaps_before_consulting_the_connection_cap() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let local = listener.local_addr().expect("local addr");
+    let client_handle = thread::spawn(move || TcpStream::connect(local).expect("connect"));
+    let (server_stream, peer) = listener.accept().expect("accept");
+    let _client = client_handle.join().expect("client connect");
+
+    let flags = no_op_signal_flags();
+    let config_path: Option<PathBuf> = None;
+    let limiter: Option<Arc<ConnectionLimiter>> = None;
+    let log_sink: Option<SharedLogSink> = None;
+    let notifier = systemd::ServiceNotifier::new();
+    let counter = ConnectionCounter::new();
+    let mut state = test_accept_loop_state(
+        &flags,
+        &config_path,
+        &limiter,
+        &log_sink,
+        &notifier,
+        counter.clone(),
+        Some(1),
+    );
+
+    // One worker whose session has already ended, still holding the only slot.
+    state.workers.push(SessionWorker {
+        handle: thread::spawn(|| -> WorkerResult { Ok(()) }),
+        _slot: counter.acquire(),
+    });
+    while !state.workers[0].is_finished() {
+        thread::yield_now();
+    }
+    assert_eq!(
+        counter.active(),
+        1,
+        "fixture must start at the cap, or the admission below proves nothing",
+    );
+
+    handle_accepted_connection(server_stream, peer, &mut state);
+
+    assert_eq!(
+        state.served, 1,
+        "the finished worker's slot must be reaped before the cap is read, so \
+         this connection is admitted rather than refused",
+    );
+}
 #[test]
 fn default_listen_backlog_matches_upstream() {
     // upstream: daemon-parm.txt declares `INTEGER listen_backlog 5` and

--- a/crates/daemon/src/daemon/sections/server_runtime/workers.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/workers.rs
@@ -1,18 +1,46 @@
 type WorkerResult = Result<(), (Option<SocketAddr>, io::Error)>;
+/// One in-flight connection, owned by the accept loop.
+///
+/// Pairs the session's backing handle with the `max connections` slot that
+/// connection occupies. The slot guard lives here, in the parent, rather than
+/// inside the session, so the slot's lifetime is decided by the accept loop's
+/// reap rather than by the session's own exit.
+///
+/// That placement is what lets the backing change from a thread to a forked
+/// child without the cap quietly stopping being enforced: a child inherits a
+/// COPY of everything the session owns, so a guard moved into the session
+/// would be released by the child's copy and never by the parent, leaving the
+/// parent's count raised for the life of the daemon.
+///
+/// upstream: socket.c:753-765 `start_accept_loop()` keeps the forked child's
+/// pid and reaps it later; the connection slot belongs to the parent, not to
+/// the session running inside it.
+struct SessionWorker {
+    handle: thread::JoinHandle<WorkerResult>,
+    /// The `max connections` slot, released when the accept loop reaps this
+    /// worker. Held for its `Drop`, never read.
+    _slot: ConnectionGuard,
+}
+impl SessionWorker {
+    /// Whether the session has ended, so the worker is ready to be reaped.
+    fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
+}
 
 /// Joins finished worker threads.
 ///
 /// Iterates through the worker list, joining any that have completed. This
 /// prevents unbounded thread handle accumulation in long-running daemons.
-fn reap_finished_workers(
-    workers: &mut Vec<thread::JoinHandle<WorkerResult>>,
-    log_sink: Option<&SharedLogSink>,
-) {
+fn reap_finished_workers(workers: &mut Vec<SessionWorker>, log_sink: Option<&SharedLogSink>) {
     let mut index = 0;
     while index < workers.len() {
         if workers[index].is_finished() {
-            let handle = workers.remove(index);
-            join_worker(handle, log_sink);
+            // Removing the worker drops its slot guard, which is the only
+            // thing that releases the `max connections` slot now that the
+            // guard is parent-owned.
+            let worker = workers.remove(index);
+            join_worker(worker.handle, log_sink);
         } else {
             index += 1;
         }
@@ -20,12 +48,9 @@ fn reap_finished_workers(
 }
 
 /// Waits for all remaining worker threads to complete.
-fn drain_workers(
-    workers: &mut Vec<thread::JoinHandle<WorkerResult>>,
-    log_sink: Option<&SharedLogSink>,
-) {
-    while let Some(handle) = workers.pop() {
-        join_worker(handle, log_sink);
+fn drain_workers(workers: &mut Vec<SessionWorker>, log_sink: Option<&SharedLogSink>) {
+    while let Some(worker) = workers.pop() {
+        join_worker(worker.handle, log_sink);
     }
 }
 


### PR DESCRIPTION
FORK-EPIC **F2a**. Behaviour-neutral groundwork for converting the daemon's per-connection worker from a thread to a forked child, which is what closes the largest actionable UTS-3.5.0 cluster: **4 cells x 3 legs = 12 of the 41 residual fail rows** (`daemon-chroot`, `daemon-chroot-munge-default`, `daemon-module-private-parent`, `daemon-symlink-escape-matrix`). Root cause there is that the daemon serves connections in *threads*, so `chroot()` leaks process-wide.

F2's precondition — `fork_session`'s "fork from a single-threaded accept path" — became satisfiable when #7681 collapsed the portable engines into one `poll(2)` accept thread. This PR closes the one residual that record names: the `max connections` guard.

### What changes

`AcceptLoopState.workers` becomes `Vec<SessionWorker>`, pairing each in-flight connection's backing handle with the slot it occupies, and the guard moves out of the worker closure into that parent-owned struct.

A forked child inherits a **copy** of everything the session owns. A guard moved into the session would be released by the child and never by the parent, so `max connections` would silently stop being enforced — with nothing failing. Putting the slot where the reap releases it, before any fork exists, is the point of this commit.

### The non-obvious half

Moving the guard is **not** behaviour-neutral on its own. Per iteration:

```
reap -> poll/accept (BLOCKS) -> refuse_if_at_capacity -> spawn
```

Today the guard drops the instant the thread exits, *including while the loop is blocked in `poll`*. Under parent ownership it drops only at the next iteration's reap — so a session that ends during the poll keeps its slot, and a connection accepted in that window is **refused where master admits it**. Narrow, real, and it would have surfaced later as a flaky `max connections` test rather than as this change.

So `handle_accepted_connection` now reaps immediately before consulting the cap. Under a forked backing that same call site is where `reap_finished_children` belongs.

### Tests — two, discriminating differently

| Test | Pins |
|---|---|
| `a_finished_worker_holds_its_slot_until_reaped` | **where** the slot is released |
| `admission_reaps_before_consulting_the_connection_cap` | the **ordering** |

`state.served` is the discriminator for the second: the refusal arm returns before the increment, and both arms return `false`, so the return value cannot tell them apart.

Mutation results:

- remove the reap-before-capacity call -> **only** `admission_reaps` fails (`left: 0, right: 1`, i.e. refused)
- make the reap leak the slot -> **both** fail, since both depend on the reap releasing it

Without the second test that new call would have been an unproven line.

### Verification

- daemon 1991/1991, 6 skipped
- workspace `clippy --all-targets --all-features` clean
- `tools/ci/check_rustfmt_all.py` clean (the whole-tree gate, not `cargo fmt --all`)

Next: **F2b** adds the fork-backed variant (sync engine only — the async engine refuses privileged modules at startup, so `chroot()` can never run there), **F2c** flips it and the 12 manifest rows in one commit.
