### PR TITLE
refactor(daemon): reap a session worker in one step and name how a session ended

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -196,29 +196,29 @@ fn describe_panic_payload_handles_non_string_payload() {
 }
 
 #[test]
-fn join_worker_handles_successful_thread() {
+fn a_successful_session_reports_nothing() {
     let handle = thread::spawn(|| Ok(()));
-    join_worker(handle, None);
+    report_worker_outcome(join_backing(handle), None);
 }
 
 #[test]
-fn join_worker_handles_connection_closed_error() {
+fn a_closed_connection_reports_nothing() {
     let handle = thread::spawn(|| {
         Err((
             Some("127.0.0.1:12345".parse().unwrap()),
             io::Error::new(io::ErrorKind::BrokenPipe, "connection closed"),
         ))
     });
-    join_worker(handle, None);
+    report_worker_outcome(join_backing(handle), None);
 }
 
 #[test]
-fn join_worker_swallows_panicking_thread() {
+fn a_panicking_session_is_reported_not_propagated() {
     let handle = thread::spawn(|| -> WorkerResult {
         panic!("simulated handler crash");
     });
-    // join_worker blocks until the thread completes - no sleep needed
-    join_worker(handle, None);
+    // `join_backing` blocks until the thread completes - no sleep needed.
+    report_worker_outcome(join_backing(handle), None);
 }
 
 /// The classification this fix rests on: a worker carries the outcome of one
@@ -250,7 +250,9 @@ fn reap_finished_workers_drains_session_failures_without_a_fatal_channel() {
         });
     }
     for worker in &workers {
-        while !worker.is_finished() {
+        // Read the backing directly: `try_reap` consumes the worker, so there
+        // is deliberately no borrowing readiness predicate on `SessionWorker`.
+        while !worker.handle.is_finished() {
             thread::yield_now();
         }
     }
@@ -279,7 +281,7 @@ fn a_finished_worker_holds_its_slot_until_reaped() {
         handle: thread::spawn(|| -> WorkerResult { Ok(()) }),
         _slot: counter.acquire(),
     }];
-    while !workers[0].is_finished() {
+    while !workers[0].handle.is_finished() {
         thread::yield_now();
     }
     assert_eq!(
@@ -1289,7 +1291,7 @@ fn admission_reaps_before_consulting_the_connection_cap() {
         handle: thread::spawn(|| -> WorkerResult { Ok(()) }),
         _slot: counter.acquire(),
     });
-    while !state.workers[0].is_finished() {
+    while !state.workers[0].handle.is_finished() {
         thread::yield_now();
     }
     assert_eq!(

--- a/crates/daemon/src/daemon/sections/server_runtime/workers.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/workers.rs
@@ -22,9 +22,69 @@ struct SessionWorker {
     _slot: ConnectionGuard,
 }
 impl SessionWorker {
-    /// Whether the session has ended, so the worker is ready to be reaped.
-    fn is_finished(&self) -> bool {
-        self.handle.is_finished()
+    /// Reaps this worker if its session has ended, yielding how it ended;
+    /// hands the worker back untouched if the session is still running.
+    ///
+    /// Observing that a session ended and collecting its outcome are ONE
+    /// step, not two. A thread backing could split them into an
+    /// `is_finished()` predicate plus a later join, but a forked child cannot:
+    /// `waitpid(pid, .., WNOHANG)` reports the child's exit AND consumes its
+    /// status in the same call, so a predicate would discard the outcome it
+    /// had just collected. Keeping them together is what lets the backing
+    /// change without every caller changing with it.
+    ///
+    /// Consuming `self` is the other half of the contract: reaping a worker
+    /// drops its `max connections` slot guard, and that drop is the only
+    /// thing that releases the slot (see [`SessionWorker`]).
+    fn try_reap(self) -> Result<SessionOutcome, Self> {
+        if self.handle.is_finished() {
+            // `is_finished` already reported the thread has ended, so this
+            // join returns without blocking.
+            Ok(join_backing(self.handle))
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Waits for the session to end, however long that takes, and reports how.
+    fn wait(self) -> SessionOutcome {
+        join_backing(self.handle)
+    }
+}
+
+/// How one session ended, independent of what backed it.
+///
+/// The accept loop needs to report a session's fate without knowing whether a
+/// thread or a forked child ran it, so the three ways a session can end are
+/// named here rather than left as a `thread::Result`, whose shape is a
+/// property of the thread backing alone.
+///
+/// upstream: socket.c:676-684 `sigchld_handler()` reaps with
+/// `waitpid(-1, NULL, WNOHANG)` - a NULL status pointer, so upstream's parent
+/// discards the session's fate entirely. oc reports it instead; see
+/// [`report_worker_outcome`] for why that is never fatal to the loop.
+enum SessionOutcome {
+    /// The session returned normally.
+    Ok,
+    /// The session failed, against this peer where one is known.
+    Failed(Option<SocketAddr>, io::Error),
+    /// The session died abnormally: a panic that escaped `catch_unwind`
+    /// today, or a fatal signal once a forked child backs it.
+    Died(String),
+}
+
+/// Collects a finished thread's outcome.
+///
+/// The only site that knows the backing is a thread. A fork-backed worker
+/// resolves its own `waitpid` status into the same [`SessionOutcome`].
+fn join_backing(handle: thread::JoinHandle<WorkerResult>) -> SessionOutcome {
+    match handle.join() {
+        Ok(Ok(())) => SessionOutcome::Ok,
+        Ok(Err((peer, error))) => SessionOutcome::Failed(peer, error),
+        Err(payload) => SessionOutcome::Died(format!(
+            "worker thread panicked (unwind escaped catch_unwind): {}",
+            describe_panic_payload(payload)
+        )),
     }
 }
 
@@ -33,24 +93,23 @@ impl SessionWorker {
 /// Iterates through the worker list, joining any that have completed. This
 /// prevents unbounded thread handle accumulation in long-running daemons.
 fn reap_finished_workers(workers: &mut Vec<SessionWorker>, log_sink: Option<&SharedLogSink>) {
-    let mut index = 0;
-    while index < workers.len() {
-        if workers[index].is_finished() {
-            // Removing the worker drops its slot guard, which is the only
-            // thing that releases the `max connections` slot now that the
-            // guard is parent-owned.
-            let worker = workers.remove(index);
-            join_worker(worker.handle, log_sink);
-        } else {
-            index += 1;
+    let mut still_running = Vec::with_capacity(workers.len());
+    for worker in workers.drain(..) {
+        match worker.try_reap() {
+            // The reaped worker is dropped here, and with it the slot guard -
+            // the only thing that releases the `max connections` slot now
+            // that the guard is parent-owned.
+            Ok(outcome) => report_worker_outcome(outcome, log_sink),
+            Err(worker) => still_running.push(worker),
         }
     }
+    *workers = still_running;
 }
 
 /// Waits for all remaining worker threads to complete.
 fn drain_workers(workers: &mut Vec<SessionWorker>, log_sink: Option<&SharedLogSink>) {
     while let Some(worker) = workers.pop() {
-        join_worker(worker.handle, log_sink);
+        report_worker_outcome(worker.wait(), log_sink);
     }
 }
 
@@ -75,16 +134,12 @@ fn drain_workers(workers: &mut Vec<SessionWorker>, log_sink: Option<&SharedLogSi
 /// `poll` failure (:738), `accept` failure (:748) and even `fork` failure
 /// (:766) each keep the loop running. Only listener setup is fatal, via
 /// `exit_cleanup(RERR_SOCKETIO)` at socket.c:699 and socket.c:715.
-fn join_worker(handle: thread::JoinHandle<WorkerResult>, log_sink: Option<&SharedLogSink>) {
-    match handle.join() {
-        Ok(Ok(())) => {}
-        Ok(Err((peer, error))) => report_session_failure(peer, &error, log_sink),
-        Err(payload) => {
-            let description = describe_panic_payload(payload);
-            let error = io::Error::other(format!(
-                "worker thread panicked (unwind escaped catch_unwind): {description}"
-            ));
-            eprintln!("{error} [daemon={}]", env!("CARGO_PKG_VERSION"));
+fn report_worker_outcome(outcome: SessionOutcome, log_sink: Option<&SharedLogSink>) {
+    match outcome {
+        SessionOutcome::Ok => {}
+        SessionOutcome::Failed(peer, error) => report_session_failure(peer, &error, log_sink),
+        SessionOutcome::Died(description) => {
+            eprintln!("{description} [daemon={}]", env!("CARGO_PKG_VERSION"));
         }
     }
 }


### PR DESCRIPTION
FORK-EPIC **F2b, step 1**. Behaviour-neutral, and the last structural blocker between the `SessionWorker` seam #7715 introduced and a fork-backed variant of it. F2 is what closes the largest actionable UTS-3.5.0 cluster — 4 cells x 3 legs = 12 of the 41 residual fail rows — because the daemon serves connections in *threads*, so `chroot()` leaks process-wide.

### The one thing a thread can do that a forked child cannot

`is_finished()` then `join()` is two steps. `waitpid(pid, …, WNOHANG)` is one: it reports the child's exit **and consumes its status** in the same call. Split across a predicate and a later join, the predicate would throw away the outcome it had just collected and the join would get `ECHILD`.

So the two collapse into

```rust
fn try_reap(self) -> Result<SessionOutcome, Self>
```

Consuming `self` also states the ownership rule the connection slot depends on: **reaping a worker is what drops its `max connections` guard**, which #7715 made parent-owned. `reap_finished_workers` drains and rebuilds instead of indexing, so a reaped worker is moved out and dropped while a still-running one is handed back untouched. `SessionWorker` deliberately no longer offers a borrowing readiness predicate for a caller to misuse — the tests read the backing handle directly, and that asymmetry is the point.

### Naming the outcome

`thread::Result<WorkerResult>` spelled the *backing* into every signature — precisely what a fork-backed variant has to replace. The three ways a session can end become a named `SessionOutcome`:

| variant | today | under fork |
|---|---|---|
| `Ok` | returned normally | `_exit(0)` |
| `Failed(peer, error)` | returned `Err` | non-zero exit |
| `Died(String)` | panic escaped `catch_unwind` | fatal signal |

`join_backing` is now the only site that knows a thread is involved.

upstream: `socket.c:676-684` `sigchld_handler()` reaps with `waitpid(-1, NULL, WNOHANG)` — a **NULL** status pointer, so upstream's parent discards the session's fate entirely. oc reports it instead, which is why the outcome needs a name; per #7590 none of its variants is fatal to the listener.

### Why this is behaviour-neutral, proven not asserted

#7715's two tests keep their **distinct** kill signatures across the refactor — which is the evidence that the guarantees survived, not just that the suite is green:

- leak the slot through the reap → **both** fail
- drop the reap-before-capacity call → **only** `admission_reaps_before_consulting_the_connection_cap` fails, `a_finished_worker_holds_its_slot_until_reaped` stays green

### Verification

On the **pinned 1.88.0 toolchain** (not stable — that mismatch was the shipping defect in #7655):

- daemon 1991/1991, 6 skipped
- workspace `clippy --all-targets --all-features --no-deps` clean
- `tools/ci/check_rustfmt_all.py` clean, 3422 files (the whole-tree gate, not `cargo fmt --all`)

### Next

**F2b step 2** adds the fork-backed variant. Two requirements read from `socket.c:752-766` that the epic brief never named, and they are what makes that step larger than this one:

1. **The child must close every listening socket** and the pid-file fd, or a child outliving the parent keeps the port bound. oc's listeners live in `PollAcceptEngine.listeners`, which `handle_accepted_connection` cannot reach — that plumbing is the real cost.
2. **Per-pid reaping, never `waitpid(-1)`.** The daemon spawns non-session children for `name converter`, pre/post-xfer exec and auth; a bulk reaper would steal their statuses and make `Child::wait()` fail `ECHILD`. `session_fork::reap_finished_children` is therefore **not** the function to wire up as shipped.

One open question for step 2: upstream sleeps 2s on fork failure as an anti-spin measure. This repo's policy is no retry/backoff, and oc's next loop action is a blocking `poll(…, -1)`, so I lean toward omitting it and documenting why rather than porting it silently.
