### PR TITLE
docs(daemon): correct two comments that still describe the deleted acceptor threads

### DIFF
--- a/crates/daemon/src/daemon/runtime_options/types.rs
+++ b/crates/daemon/src/daemon/runtime_options/types.rs
@@ -94,9 +94,15 @@ pub(crate) struct RuntimeOptions {
     /// Number of SO_REUSEPORT listener replicas to bind per address family.
     ///
     /// When set above 1, the daemon binds N kernel-load-balanced listener
-    /// sockets per family (each with its own acceptor thread) instead of one,
-    /// distributing inbound connection load across CPUs on platforms that
-    /// support SO_REUSEPORT. `None` preserves the single-listener default.
+    /// sockets per family instead of one, on platforms that support
+    /// SO_REUSEPORT. `None` preserves the single-listener default.
+    ///
+    /// The replicas do **not** buy CPU parallelism: every listener fd is polled
+    /// from the one accept thread (`PollAcceptEngine`), so the kernel chooses
+    /// which socket receives a connection but a single thread accepts them all.
+    /// The engine is single-threaded on purpose - `platform::session_fork` may
+    /// only be called from a single-threaded accept path - so this directive
+    /// spreads accept queues, not work.
     ///
     /// This is an oc-rsync perf extension with no upstream equivalent
     /// (upstream forks one child per accepted connection from a single

--- a/crates/daemon/src/daemon/sections/server_runtime/listener.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/listener.rs
@@ -468,9 +468,11 @@ fn bind_listeners_per_family(
         let requested_addr = SocketAddr::new(*addr, port);
 
         // Bind up to `replicas` SO_REUSEPORT sockets for this family. The kernel
-        // load-balances accepted connections across them, each driven by its own
-        // acceptor thread. With replicas == 1 this is the historical
-        // single-listener-per-family behaviour.
+        // load-balances accepted connections across them, but every replica is
+        // polled from the single accept thread - see `PollAcceptEngine`, whose
+        // single-threadedness is a fork precondition, not a preference. With
+        // replicas == 1 this is the historical single-listener-per-family
+        // behaviour.
         let mut family_bound = 0usize;
         let mut family_error: Option<io::Error> = None;
         for _ in 0..replicas {


### PR DESCRIPTION
docs(daemon): correct two comments that still describe the deleted acceptor threads

PR #7681 collapsed the portable accept engines into one `PollAcceptEngine`
that polls every listener fd from the accept thread, and deleted
`MultiListenerEngine` along with its per-listener acceptor threads. Two
comments were left behind describing the mechanism that no longer exists,
and they sit on exactly the surface a reader consults to reason about
whether the accept path is single-threaded.

`bind_listeners_per_family` said the SO_REUSEPORT replicas were "each driven
by its own acceptor thread". `accept_engine.rs` says the opposite four files
away: "Both engines are single-threaded, so the accept path spawns no threads
of [its] own." Only one of those can be true, and the engine's is the live
one - `grep -rn "spawn" crates/daemon/src/daemon/sections/server_runtime/`
finds exactly one production `thread::spawn`, the per-connection worker at
connection.rs:224.

`RuntimeOptions::acceptor_threads` carried a second claim that is now wrong
in a way an operator can act on: that the replicas distribute "inbound
connection load across CPUs". They do not. The kernel still chooses which
socket receives each connection, but one thread accepts them all, so the
directive spreads accept queues rather than work. Setting it above 1 buys no
CPU parallelism today. Stating that plainly is better than leaving a
performance promise the engine cannot keep.

Both replacements name the reason the engine is single-threaded rather than
just asserting it: `platform::session_fork` may only be called from a
single-threaded accept path, because a child forked from a multithreaded
parent can deadlock on an allocator lock held by a thread that does not exist
in the child. That is the constraint the deleted threads violated, and it is
why these comments must not drift back.

Measured, not inferred - a daemon built from a tree carrying the current
engine, dual-stack with `acceptor threads = 3`:

    /proc/<pid>/task -> 1 thread
    /proc/<pid>/fd   -> 6 listener sockets

Six listener fds, one thread. A build predating #7681 reports 4 threads for
the same config, which is what makes this a comment defect rather than a
behaviour one.

Comment-only: no code, no test, and no behaviour changes.
