### PR TITLE
test(daemon): wait for the session child to be reapable, not for its pipe to close

### DIFF
--- a/crates/daemon/src/daemon/sections/server_runtime/tests.rs
+++ b/crates/daemon/src/daemon/sections/server_runtime/tests.rs
@@ -254,16 +254,18 @@ fn a_child_end_is_classified_by_how_the_process_ended() {
 /// until that is true.
 ///
 /// The proof matters more than the fixture. On Unix a session is a forked
-/// child, so the only honest way to know it ended is to observe the *process*
-/// end: the child inherits a pipe write end, and the kernel closes it at
-/// `_exit`, so the parent's read hits EOF exactly then. A byte written by the
-/// child before exiting would prove only that it got close.
+/// child, so "ended" has to mean *reapable*: a single-shot reap assertion is
+/// only meaningful if `try_reap` is guaranteed to collect this child on its
+/// first call.
 ///
-/// Without that, every reap assertion below would race the child and pass or
-/// fail on scheduling.
+/// An inherited pipe closed at `_exit` looks like that guarantee and is not.
+/// The kernel closes the child's descriptors before it makes the child
+/// reapable, so EOF can arrive inside a window where `try_reap` still
+/// correctly reports the session as running - measured at 15% of runs on a
+/// loaded 4-core host. `await_child_end` waits for the state the reap
+/// actually consumes, and `WNOWAIT` leaves the status for it to collect.
 #[cfg(unix)]
 fn ended_session_worker(counter: &ConnectionCounter, exit_code: i32) -> SessionWorker {
-    let (mut ended, exited_marker) = std::io::pipe().expect("pipe");
     // Acquired before the fork, exactly as production does: the guard is
     // parent-owned, and the child's inherited copy dies unrun with `_exit`.
     let slot = counter.acquire();
@@ -274,10 +276,8 @@ fn ended_session_worker(counter: &ConnectionCounter, exit_code: i32) -> SessionW
             _slot: slot,
         },
     };
-    // The parent must not hold a write end of its own, or the read never ends.
-    drop(exited_marker);
-    let mut discard = Vec::new();
-    std::io::Read::read_to_end(&mut ended, &mut discard).expect("await the child's exit");
+    platform::session_fork::await_child_end(worker.backing.child_pid)
+        .expect("await the child becoming reapable");
     worker
 }
 

--- a/crates/platform/src/session_fork.rs
+++ b/crates/platform/src/session_fork.rs
@@ -175,6 +175,49 @@ pub fn try_reap(child_pid: i32) -> io::Result<Option<ChildEnd>> {
     }
 }
 
+/// Blocks until one specific child has ended, leaving its status collectable.
+///
+/// `WNOWAIT` reports the end without consuming it, so a later [`try_reap`]
+/// still returns the outcome. That is the whole point: this answers "has the
+/// session ended yet" for a caller that must not also decide "and here is how
+/// it ended".
+///
+/// # Why an out-of-band liveness signal will not do
+///
+/// A pipe whose write end only the child holds looks like an equivalent
+/// "child is gone" edge, and it is not. The kernel closes a dying child's
+/// descriptors before it makes the child reapable - `exit_files()` runs ahead
+/// of `exit_notify()` on Linux - so the reader can observe EOF during a window
+/// in which [`try_reap`] still correctly reports the child as running. Any
+/// caller that treats EOF as "reapable" is racing that window.
+#[allow(unsafe_code)]
+pub fn await_child_end(child_pid: i32) -> io::Result<()> {
+    loop {
+        // SAFETY: `waitid` writes only through `info`, a live local zeroed to
+        // a valid `siginfo_t`. `WNOWAIT` leaves the child waitable, so this
+        // cannot consume the status `try_reap` is expected to collect.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let waited = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child_pid as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if waited == -1 {
+            let error = io::Error::last_os_error();
+            // Not a retry policy: `EINTR` means the kernel never ran the wait,
+            // so nothing is being re-attempted and nothing is backed off.
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        return Ok(());
+    }
+}
+
 /// Blocks until one specific child ends, and reports how.
 ///
 /// The shutdown counterpart to [`try_reap`]: a draining daemon must not leave


### PR DESCRIPTION
`admission_reaps_before_consulting_the_connection_cap` failed on an unrelated
PR (the CI actions bump), all three nextest attempts, with:

    assertion `left == right` failed: the finished worker's slot must be reaped
    before the cap is read, so this connection is admitted rather than refused
      left: 0
     right: 1

## Root cause

The test asserts a single-shot property: one `handle_accepted_connection` must
reap the finished worker before it reads the `max connections` cap. That is
only meaningful if `try_reap` is guaranteed to collect the child on its first
call, and the fixture did not establish that.

`ended_session_worker` waited on EOF from a pipe whose write end only the
forked child held. The kernel closes a dying child's descriptors before it
makes the child reapable - `exit_files()` runs ahead of `exit_notify()` - so
EOF can arrive inside a window where `waitpid(pid, .., WNOHANG)` still
correctly reports the child as running. The slot stays held, the cap refuses,
and `state.served` stays 0.

The production reap is not at fault: the accept loop reaps on every iteration,
so a transient "not yet" is harmless there. Only the single-shot fixture needs
the child to be reapable by construction.

## Measured

Repeating the test 200 times against a fresh build at the pinned toolchain
(1.88.0), 4-core Linux host:

| build | load | failures / 200 |
|---|---|---|
| before | idle | 1 |
| before | six-way CPU | 30 |
| after | six-way CPU | 0 |

The loaded rate matches the CI signature - a busy runner losing all three
attempts.

## Fix

`platform::session_fork::await_child_end` waits for the state the reap actually
consumes. `WNOWAIT` leaves the status collectable, so `try_reap` still returns
the real outcome.

That last part is load-bearing rather than incidental. Consuming the status
here - by blocking on `wait_for_child`, say - would leave `try_reap` to fail
with `ECHILD`, and the `Err` arm *also* drops the worker and releases its slot.
The test would go green through the "cannot reap session child" error path
while proving nothing about the reap it exists to check.

The primitive lives in `platform` because `crates/daemon` is
`#![deny(unsafe_code)]`, and `session_fork` is already the owner of this
daemon's `fork`/`waitpid` calls.

## Verification

At the pinned toolchain on Linux: whole-tree rustfmt clean
(`tools/ci/check_rustfmt_all.py`), `clippy -p platform -p daemon --all-targets
--all-features -D warnings` clean, daemon suite 1861/1861, and the 200-run
loaded sweep above.
