### PR TITLE
fix(receiver): confine a daemon's absolute alt-dest basis to the module root

### DIFF
--- a/crates/fast_io/src/confinement.rs
+++ b/crates/fast_io/src/confinement.rs
@@ -62,6 +62,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// answer it produced.
 static SESSION_OPTOUT: AtomicBool = AtomicBool::new(false);
 
+/// The session's answer to [`Activation::chrooted`], published for code that
+/// must mirror an upstream decision branching on `am_chrooted`.
+///
+/// Stored for the same reason as [`SESSION_OPTOUT`]: upstream reads
+/// `am_chrooted` as a process global, and a chroot IS a process-wide fact -
+/// unlike a module's `insecure links` directive, which is per-connection
+/// policy and is therefore carried on the connection rather than here.
+///
+/// Only the derived bit is stored, never the whole [`DaemonState`]:
+/// [`Activation`] stays the single place the rule is written down.
+static SESSION_CHROOTED: AtomicBool = AtomicBool::new(false);
+
 /// Publish `activation`'s opt-out answer for the ownership walk.
 ///
 /// Call once, as early as the flag and the daemon/module state are both known.
@@ -73,6 +85,7 @@ static SESSION_OPTOUT: AtomicBool = AtomicBool::new(false);
 /// caller is without making it invent values for fields its arm ignores.
 pub fn install_session(activation: &Activation) {
     SESSION_OPTOUT.store(activation.optout_allowed(), Ordering::Relaxed);
+    SESSION_CHROOTED.store(activation.chrooted(), Ordering::Relaxed);
     // The pinned descriptor names the PREVIOUS root, so it stops being an
     // answer the moment the root changes. Dropping it here keeps one
     // invariant - the pin, when present, is always this root's - instead of
@@ -388,6 +401,20 @@ pub fn session_optout_allowed() -> bool {
     SESSION_OPTOUT.load(Ordering::Relaxed)
 }
 
+/// Whether this session runs inside a per-module `chroot()`.
+///
+/// This is upstream's `am_chrooted`, and it is the one fact in
+/// [`ModuleState`] that no per-connection config can answer: a chroot changes
+/// the process's root directory, so it is a property of the process and not of
+/// the connection.
+///
+/// upstream: `clientserver.c:1055` - the sole assignment of `am_chrooted`,
+/// inside `rsync_module()`'s per-module `use chroot` handling.
+#[must_use]
+pub fn session_is_chrooted() -> bool {
+    SESSION_CHROOTED.load(Ordering::Relaxed)
+}
+
 /// Which end of the transfer this process is.
 ///
 /// Upstream spells this `am_sender`. The generator is part of the receiving
@@ -610,7 +637,11 @@ impl Activation {
         matches!(self.daemon, DaemonState::Daemon(_))
     }
 
-    fn chrooted(&self) -> bool {
+    /// Whether this session runs inside a per-module `chroot()` - upstream's
+    /// `am_chrooted`. Always false off the daemon path, matching upstream's
+    /// single assignment site (`clientserver.c:1055`).
+    #[must_use]
+    pub fn chrooted(&self) -> bool {
         match &self.daemon {
             DaemonState::Daemon(module) => module.chrooted,
             DaemonState::NotDaemon => false,
@@ -655,6 +686,37 @@ mod tests {
             selected: true,
             insecure_links: ModuleInsecureLinks::default(),
         }
+    }
+
+    /// [`install_session`] must publish `am_chrooted`, not merely accept it.
+    /// A caller that branches on `session_is_chrooted()` reads a stale answer
+    /// otherwise, and a stale `false` silently applies a confinement upstream
+    /// stands down for a chrooted daemon.
+    ///
+    /// upstream: `clientserver.c:1055` - the sole assignment of `am_chrooted`.
+    #[test]
+    fn install_session_publishes_the_chroot_state() {
+        let mut chrooted_module = module_at("/srv/mod");
+        chrooted_module.chrooted = true;
+        install_session(&daemon(Role::Receiver, chrooted_module));
+        assert!(
+            session_is_chrooted(),
+            "a chrooted daemon session must report am_chrooted"
+        );
+
+        // Non-vacuity: the same installer clears it again, so the bit tracks
+        // the session rather than latching on first use.
+        install_session(&daemon(Role::Receiver, module_at("/srv/mod")));
+        assert!(
+            !session_is_chrooted(),
+            "a non-chrooted daemon session must clear am_chrooted"
+        );
+
+        install_session(&not_daemon(Role::Receiver));
+        assert!(
+            !session_is_chrooted(),
+            "upstream never sets am_chrooted off the daemon path"
+        );
     }
 
     /// One reachable combination of upstream's five inputs, with the value

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -432,8 +432,8 @@ pub use owner_walk::{
     operator_open_read_confined, operator_open_recv, operator_open_rw_create,
     operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
     operator_read_to_string_confined, operator_rename, operator_rename_confined,
-    operator_symlink_metadata, owner_trusted_parent, owner_trusted_parent_kind,
-    symlink_owner_is_trusted,
+    operator_symlink_metadata, operator_symlink_metadata_confined, owner_trusted_parent,
+    owner_trusted_parent_kind, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -1253,9 +1253,45 @@ pub fn operator_read_to_string_confined(path: &Path) -> io::Result<String> {
 /// leaf, and `io::ErrorKind::NotFound` when the path-based stat disagrees with
 /// the confined one about which inode the leaf names.
 pub fn operator_symlink_metadata(path: &Path) -> io::Result<std::fs::Metadata> {
+    operator_symlink_metadata_kind(path, crate::confinement::PathKind::Ancillary)
+}
+
+/// [`operator_symlink_metadata`] with the leaf additionally judged against the
+/// session's confinement root.
+///
+/// The ownership rule alone answers *who planted this symlink*; it does not
+/// answer *where following it lands*. A daemon's own module tree is owned by
+/// the daemon uid, so an in-module symlink pointing OUTSIDE the module is
+/// trusted-owned and the plain walk follows it. Confining the leaf is what
+/// turns that into a refusal, and it is the whole of upstream's second
+/// `basis_link_stat()` arm.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:1004-1018` `basis_link_stat()` arm 2 - it sets
+///   `operator_path_resolve = 1` around `owner_walk_parent()` and then
+///   `do_lstat_atfd()`s the leaf through the returned descriptor, so the walk
+///   applies the module-root boundary that the unflagged arm 1 does not.
+///
+/// # Errors
+///
+/// As [`operator_symlink_metadata`], plus the `ELOOP` that
+/// [`owner_trusted_parent_kind`] reports when the resolved leaf lands outside
+/// the confinement root.
+pub fn operator_symlink_metadata_confined(path: &Path) -> io::Result<std::fs::Metadata> {
+    operator_symlink_metadata_kind(path, crate::confinement::PathKind::Confined)
+}
+
+/// The shared body of the two `operator_symlink_metadata*` spellings: one
+/// implementation, with the confinement decision handed in rather than
+/// duplicated.
+fn operator_symlink_metadata_kind(
+    path: &Path,
+    kind: crate::confinement::PathKind,
+) -> io::Result<std::fs::Metadata> {
     use std::os::unix::fs::MetadataExt as _;
 
-    let (parent, leaf) = owner_trusted_parent(path)?;
+    let (parent, leaf) = owner_trusted_parent_kind(path, kind)?;
     let confined = crate::fstatat_nofollow(parent.as_fd(), &leaf)?;
     let meta = std::fs::symlink_metadata(path)?;
     if meta.dev() == confined.dev() && meta.ino() == confined.ino() {
@@ -1312,7 +1348,7 @@ mod tests {
             "motd line\n"
         );
     }
-    use super::operator_symlink_metadata;
+    use super::{operator_symlink_metadata, operator_symlink_metadata_confined};
     use std::io::{Read, Write};
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
@@ -1371,6 +1407,94 @@ mod tests {
     fn operator_symlink_metadata_reports_a_missing_leaf_as_an_error() {
         let temp = TempDir::new().expect("tempdir");
         assert!(operator_symlink_metadata(&temp.path().join("absent")).is_err());
+    }
+
+    /// The confined spelling refuses a parent symlink that leaves the session
+    /// root, and the unconfined one - on the SAME fixture, in the SAME session -
+    /// still follows it.
+    ///
+    /// The pair is the point. The link is owned by this euid, so the ownership
+    /// rule trusts it; only the module-root judgement on the resolved leaf
+    /// refuses it. A `operator_symlink_metadata_confined` that merely delegated
+    /// to the ancillary walk would pass every "does it work" test and close
+    /// nothing.
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:1004-1018` `basis_link_stat()` arm 2 -
+    /// the `operator_path_resolve = 1` that the ancillary arm 1 leaves clear.
+    #[test]
+    fn the_confined_stat_refuses_a_parent_that_leaves_the_module() {
+        use crate::confinement::{
+            LocalInsecureLinks, ModuleInsecureLinks, ModuleState, install_daemon_session,
+            install_local_session,
+        };
+
+        let temp = TempDir::new().expect("tempdir");
+        // The session root is stored PHYSICAL, and the walk resolves
+        // physically, so build the fixture from the canonical path.
+        let base = temp.path().canonicalize().expect("canonicalise tempdir");
+
+        let outside = base.join("outside");
+        std::fs::create_dir(&outside).expect("mkdir outside");
+        std::fs::write(outside.join("tgtfile"), b"secret").expect("write");
+
+        let module = base.join("module");
+        std::fs::create_dir(&module).expect("mkdir module");
+        symlink("../outside", module.join("evil")).expect("symlink");
+
+        install_daemon_session(ModuleState {
+            root: Some(module.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::from_module_config(false),
+        });
+
+        let basis = module.join("evil/tgtfile");
+        let confined = operator_symlink_metadata_confined(&basis);
+        let ancillary = operator_symlink_metadata(&basis);
+
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
+
+        assert!(
+            confined.is_err(),
+            "a leaf resolving outside the module root must be refused"
+        );
+        assert!(
+            ancillary.is_ok(),
+            "the ownership walk alone trusts this self-owned link, which is \
+             why the confined spelling has to exist"
+        );
+    }
+
+    /// Non-vacuity companion: inside the same module, the confined stat still
+    /// answers. Without it, "refuse everything" would satisfy the test above.
+    #[test]
+    fn the_confined_stat_still_answers_inside_the_module() {
+        use crate::confinement::{
+            LocalInsecureLinks, ModuleInsecureLinks, ModuleState, install_daemon_session,
+            install_local_session,
+        };
+
+        let temp = TempDir::new().expect("tempdir");
+        let base = temp.path().canonicalize().expect("canonicalise tempdir");
+        let module = base.join("module");
+        std::fs::create_dir(&module).expect("mkdir module");
+        std::fs::write(module.join("tgtfile"), b"payload").expect("write");
+
+        install_daemon_session(ModuleState {
+            root: Some(module.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::from_module_config(false),
+        });
+
+        let meta = operator_symlink_metadata_confined(&module.join("tgtfile"));
+
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
+
+        assert_eq!(
+            meta.expect("an in-module basis must still stat").len(),
+            b"payload".len() as u64
+        );
     }
 
     /// A plain path with no symlink anywhere resolves and opens normally - the

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -255,70 +255,248 @@ struct ReferenceMatch<'a> {
     level: MatchLevel,
 }
 
-/// Which of upstream's `basis_link_stat()` arms resolves an alt-dest basis entry.
+/// The receiver-side facts upstream's `basis_link_stat()` branches on,
+/// evaluated once per transfer.
 ///
-/// Upstream selects between an ownership-walked stat and a plain `link_stat()`
-/// from `am_daemon`; a daemon receiver deliberately keeps the plain stat because
-/// its confinement comes from elsewhere (chroot, the module-root resolver, and
-/// the `../` clamp `sanitize_path` already applied to a dest-relative basis).
-/// The distinction is spelled as a type rather than a `bool` so neither arm can
-/// be selected by accident at a call site.
+/// Upstream picks between four arms using `am_daemon`, `am_chrooted`, whether
+/// the basis path is absolute, and the symlink opt-out. The first two are
+/// session facts and are answered here; the third is per-path and is answered
+/// by [`BasisTrust::arm_for`]; the fourth is answered inside the walk itself,
+/// exactly where upstream answers it (`syscall.c:300-302`, at the top of
+/// `ona_open()`), so it is deliberately not restated at this predicate.
+///
+/// Spelled as a three-state type rather than a `bool` because the middle state
+/// is neither of the other two: a non-chrooted daemon neither walks by
+/// ownership alone nor stats by plain path.
 ///
 /// # Upstream Reference
 ///
-/// - `rsync-3.5.0/generator.c:962` `basis_link_stat()` - the arm selection.
+/// - `rsync-3.5.0/generator.c:962-1065` `basis_link_stat()` - the arm selection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum BasisTrust {
-    /// Non-daemon receiver: resolve the parent through the ownership walk.
+    /// Not a daemon: a local, SSH-server, or `rsync://`-CLIENT receiver.
     ///
-    /// upstream: `generator.c:978` - the `!am_daemon && am_root >= 0 &&
+    /// upstream: `generator.c:979` - the `!am_daemon && am_root >= 0 &&
     /// !symlink_optout_allowed()` arm.
-    OwnerWalk,
-    /// Daemon receiver: stat the basis by path, as upstream's fall-through does.
+    LocalReceiver,
+    /// A daemon serving a module WITHOUT a per-module `chroot()`.
     ///
-    /// upstream: `generator.c:1010` - the trailing plain `link_stat()`.
+    /// upstream: `generator.c:1004` - `am_daemon && !am_chrooted && path[0] ==
+    /// '/' && !symlink_optout_allowed()`.
+    NonChrootedDaemon,
+    /// A daemon serving a module inside a per-module `chroot()`.
+    ///
+    /// upstream: `generator.c:1046` selects `secure_relative_open()` for a
+    /// RELATIVE basis here, and `generator.c:1064` the plain `link_stat()` for
+    /// an absolute one. oc models only the latter; see [`BasisArm::PlainStat`].
+    ChrootedDaemon,
+}
+
+/// Which of upstream's `basis_link_stat()` arms resolves ONE basis path.
+///
+/// Separate from [`BasisTrust`] because upstream's arm choice is not a pure
+/// session property: arm 2 additionally requires `path[0] == '/'`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum BasisArm {
+    /// Resolve the parent through the ownership walk (arm 1).
+    OwnerWalk,
+    /// Resolve the parent through the ownership walk AND judge the resolved
+    /// leaf against the module root (arm 2, `operator_path_resolve = 1`).
+    ModuleConfinedWalk,
+    /// Stat the basis by path (arm 4, the trailing plain `link_stat()`).
+    ///
+    /// oc reaches this for a chrooted daemon on BOTH an absolute and a relative
+    /// basis. Upstream's arm 3 (`generator.c:1046` - a chrooted daemon with an
+    /// inner `/./` module boundary resolving a RELATIVE basis through
+    /// `secure_relative_open()`) has no oc counterpart yet; that gap is a
+    /// separate, named one and is not what this type papers over.
     PlainStat,
 }
 
 impl BasisTrust {
-    /// Picks the arm for a receiver, from the one fact upstream branches on.
+    /// Records the two session facts upstream branches on.
     ///
-    /// upstream: `generator.c:978` - `!am_daemon` selects the ownership walk.
+    /// `am_daemon` must be "this process serves a daemon module", NOT
+    /// `ConnectionConfig::is_daemon_connection` - the latter is set on BOTH
+    /// ends of an `rsync://` transfer while upstream's `am_daemon` is true only
+    /// in the serving process, so reading it would apply a daemon's confinement
+    /// to a CLIENT's own local destination. [`BasisTrust::for_connection`]
+    /// supplies `ConnectionConfig::served_module_root().is_some()`, oc's
+    /// designated spelling of `am_daemon`.
+    ///
+    /// `am_chrooted` is read from the process-wide session state rather than
+    /// from the connection, because a `chroot()` changes the process's root
+    /// directory and so is a property of the process - unlike a module's
+    /// `insecure links` directive, which is per-connection policy.
+    ///
+    /// upstream: `generator.c:979` / `:1004` / `:1046` - the three guarded arms.
     #[must_use]
-    pub(super) const fn for_receiver(is_daemon_connection: bool) -> Self {
-        if is_daemon_connection {
-            Self::PlainStat
+    pub(super) const fn for_receiver(am_daemon: bool, am_chrooted: bool) -> Self {
+        if !am_daemon {
+            Self::LocalReceiver
+        } else if am_chrooted {
+            Self::ChrootedDaemon
         } else {
-            Self::OwnerWalk
+            Self::NonChrootedDaemon
+        }
+    }
+
+    /// Reads both facts off one connection, so the call site states no policy.
+    ///
+    /// Sole owner of the mapping from oc's connection state onto upstream's two
+    /// globals; see [`BasisTrust::for_receiver`] for why each fact is read from
+    /// where it is.
+    #[must_use]
+    pub(super) fn for_connection(connection: &crate::config::ConnectionConfig) -> Self {
+        Self::for_receiver(
+            connection.served_module_root().is_some(),
+            fast_io::confinement::session_is_chrooted(),
+        )
+    }
+
+    /// Applies upstream's per-path `path[0] == '/'` term and yields the arm.
+    ///
+    /// Only an ABSOLUTE basis is module-confined. A RELATIVE basis
+    /// (`--link-dest=../01`) is a dest-relative sibling whose `../` upstream's
+    /// `sanitize_path` has already clamped to the module root, and it must keep
+    /// the plain stat below (#915/#930) - confining it re-opens the
+    /// `link-dest-relative-basis` regression, whose manifest row passes on both
+    /// pipe legs.
+    ///
+    /// upstream: `generator.c:997-1001` - the comment that spells out exactly
+    /// this split, and the `path[0] == '/'` term at `generator.c:1004`.
+    #[must_use]
+    pub(super) fn arm_for(self, path: &Path) -> BasisArm {
+        match self {
+            Self::LocalReceiver => BasisArm::OwnerWalk,
+            Self::NonChrootedDaemon if path.is_absolute() => BasisArm::ModuleConfinedWalk,
+            Self::NonChrootedDaemon | Self::ChrootedDaemon => BasisArm::PlainStat,
         }
     }
 }
 
 #[cfg(test)]
 mod basis_trust_tests {
-    use super::BasisTrust;
+    use std::path::{Path, PathBuf};
 
-    /// A daemon receiver must NOT take the ownership walk.
-    ///
-    /// This is the arm upstream selects, and taking the other one is not merely
-    /// stricter - the walk opens every component from `/` downward, which a
-    /// confined daemon worker cannot do, so the basis vanishes and every file
-    /// is re-transferred. That is the `link-dest-relative-basis` cell
-    /// (upstream #915/#930), whose manifest row is `pass` on both pipe legs.
-    ///
-    /// upstream: `rsync-3.5.0/generator.c:978` - the ownership-walk arm is
-    /// guarded by `!am_daemon`; `generator.c:1010` is the plain `link_stat()`
-    /// a daemon receiver falls through to.
-    #[test]
-    fn a_daemon_receiver_stats_the_basis_by_path() {
-        assert_eq!(BasisTrust::for_receiver(true), BasisTrust::PlainStat);
-    }
+    use fast_io::confinement::{
+        LocalInsecureLinks, ModuleInsecureLinks, ModuleState, install_daemon_session,
+        install_local_session,
+    };
 
-    /// Non-vacuity companion: the walk is still selected off the daemon path,
-    /// so the mapping is a real branch and not a constant.
+    use super::{BasisArm, BasisTrust};
+    use crate::config::ConnectionConfig;
+
+    /// A non-daemon receiver takes upstream's arm 1, whatever the basis looks
+    /// like. This covers the `rsync://` CLIENT too: `am_daemon` is false there,
+    /// even though the transfer is a daemon connection.
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:979` - `!am_daemon` selects the
+    /// ownership walk.
     #[test]
     fn a_non_daemon_receiver_walks_the_basis_parent() {
-        assert_eq!(BasisTrust::for_receiver(false), BasisTrust::OwnerWalk);
+        let trust = BasisTrust::for_receiver(false, false);
+        assert_eq!(trust, BasisTrust::LocalReceiver);
+        assert_eq!(trust.arm_for(Path::new("/backup/01")), BasisArm::OwnerWalk);
+        assert_eq!(trust.arm_for(Path::new("../01")), BasisArm::OwnerWalk);
+    }
+
+    /// A non-chrooted daemon with an ABSOLUTE basis takes upstream's arm 2: the
+    /// ownership walk WITH module-root confinement. This is the arm that closes
+    /// the `--compare-dest=/evil` read oracle, where `evil` is an in-module
+    /// symlink pointing out of the module and so is trusted-OWNED - the
+    /// ownership rule alone cannot refuse it.
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:1004-1018`.
+    #[test]
+    fn a_non_chrooted_daemon_confines_an_absolute_basis_to_the_module() {
+        let trust = BasisTrust::for_receiver(true, false);
+        assert_eq!(trust, BasisTrust::NonChrootedDaemon);
+        assert_eq!(
+            trust.arm_for(Path::new("/srv/mod/evil/tgtfile")),
+            BasisArm::ModuleConfinedWalk
+        );
+    }
+
+    /// Non-vacuity companion, and the regression this must NOT re-open: the
+    /// SAME non-chrooted daemon keeps the plain stat for a RELATIVE basis. A
+    /// "confine everything" predicate would pass the test above and break
+    /// `--link-dest=../01` (#915/#930).
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:1004` - the `path[0] == '/'` term.
+    #[test]
+    fn a_non_chrooted_daemon_keeps_the_plain_stat_for_a_relative_basis() {
+        let trust = BasisTrust::for_receiver(true, false);
+        assert_eq!(trust.arm_for(Path::new("../01")), BasisArm::PlainStat);
+        assert_eq!(trust.arm_for(Path::new("prev/01")), BasisArm::PlainStat);
+    }
+
+    /// A CHROOTED daemon falls through to the plain stat even for an absolute
+    /// basis: upstream's arm 2 is guarded by `!am_chrooted`, and the kernel
+    /// chroot is the confinement there. Without this the ownership walk would
+    /// start applying to a shape upstream leaves alone.
+    ///
+    /// upstream: `rsync-3.5.0/generator.c:1004` (`!am_chrooted`) and
+    /// `generator.c:1064` (the fall-through).
+    #[test]
+    fn a_chrooted_daemon_falls_through_to_the_plain_stat() {
+        let trust = BasisTrust::for_receiver(true, true);
+        assert_eq!(trust, BasisTrust::ChrootedDaemon);
+        assert_eq!(trust.arm_for(Path::new("/01")), BasisArm::PlainStat);
+        assert_eq!(trust.arm_for(Path::new("../01")), BasisArm::PlainStat);
+    }
+
+    /// The CLIENT end of an `rsync://` transfer is not a daemon.
+    ///
+    /// `ConnectionConfig::is_daemon_connection` is set on BOTH ends, so reading
+    /// it as `am_daemon` applies a daemon's confinement to a client's own local
+    /// destination - a shape upstream leaves on arm 1, and which the client
+    /// (unlike a daemon worker) can be running from anywhere on the filesystem.
+    /// `served_module_root()` is the fact that distinguishes them: `None` on the
+    /// client, `Some(root)` in the serving process.
+    ///
+    /// upstream: `clientserver.c:1093` - `am_daemon` is the serving process
+    /// only; `rsync-3.5.0/generator.c:979` reads that same global.
+    #[test]
+    fn an_rsync_client_is_not_a_daemon_receiver() {
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
+        let client = ConnectionConfig {
+            is_daemon_connection: true,
+            daemon_module_root: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            BasisTrust::for_connection(&client),
+            BasisTrust::LocalReceiver
+        );
+    }
+
+    /// Non-vacuity companion: the SERVING process, which differs from the
+    /// client above only by carrying the module root, does take the daemon arm.
+    /// Also pins that `for_connection` reads `am_chrooted` off the session.
+    #[test]
+    fn the_serving_daemon_takes_the_daemon_arm() {
+        let serving = ConnectionConfig {
+            is_daemon_connection: true,
+            daemon_module_root: Some(PathBuf::from("/srv/mod")),
+            ..Default::default()
+        };
+
+        let module = |chrooted: bool| ModuleState {
+            root: Some(PathBuf::from("/srv/mod")),
+            chrooted,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::from_module_config(false),
+        };
+
+        install_daemon_session(module(false));
+        let not_chrooted = BasisTrust::for_connection(&serving);
+        install_daemon_session(module(true));
+        let chrooted = BasisTrust::for_connection(&serving);
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
+
+        assert_eq!(not_chrooted, BasisTrust::NonChrootedDaemon);
+        assert_eq!(chrooted, BasisTrust::ChrootedDaemon);
     }
 }
 
@@ -350,30 +528,46 @@ mod basis_trust_tests {
 /// Any failure is reported as "no basis here", the same outcome upstream
 /// produces when `link_stat` fails: the file transfers normally.
 ///
-/// [`BasisTrust::PlainStat`] takes the path-based stat instead. That is not a
-/// weakening: it is the arm upstream itself takes for a daemon receiver, whose
-/// basis is confined by the module resolver rather than by ownership. Walking
-/// there would also be actively wrong - the walk opens every component starting
-/// at `/`, and a daemon worker is confined (chroot, or a Landlock ruleset rooted
-/// at the module) precisely so that the ancestors of the module are *not*
-/// openable, so the walk fails with `EACCES` and the basis silently disappears.
+/// [`BasisArm::ModuleConfinedWalk`] adds the module-root boundary to that walk.
+/// The ownership rule alone is not enough for a daemon: the module tree belongs
+/// to the daemon uid, so an in-module symlink whose target lands OUTSIDE the
+/// module is trusted-owned and would be followed. That is the
+/// `--compare-dest=/evil` read oracle - the daemon roots the peer's absolute
+/// basis under the module, so the escaping component is a PARENT of the basis
+/// leaf, and `fs::symlink_metadata` refuses to follow a symlink at the LEAF
+/// only. Confining the resolved leaf is what refuses it, and it is upstream's
+/// `operator_path_resolve = 1`.
+///
+/// [`BasisArm::PlainStat`] takes the path-based stat. That is not a weakening:
+/// it is upstream's own fall-through, taken for a dest-relative basis
+/// (`--link-dest=../01`), whose `../` `sanitize_path` has already clamped to
+/// the module root, and for a chrooted daemon, where the kernel chroot is the
+/// confinement.
+///
+/// The symlink opt-out (`insecure links = yes` / `--insecure-links`) is not
+/// tested here. Upstream tests it at each arm, but it reads the same global the
+/// walk itself reads: `ona_open()` short-circuits to a legacy symlink-following
+/// open before any root is consulted (`syscall.c:300-302`), which
+/// `fast_io::owner_walk` mirrors. Under an opt-out every walking arm therefore
+/// already degenerates to the plain resolution arm 4 performs, and restating
+/// the test here would be a second copy of one policy.
 ///
 /// # Upstream Reference
 ///
-/// - `rsync-3.5.0/generator.c:979-990` `basis_link_stat()` - the non-daemon
-///   receiver arm: `owner_walk_parent()` for the parent components, then
+/// - `rsync-3.5.0/generator.c:979-990` `basis_link_stat()` arm 1 - the
+///   non-daemon receiver: `owner_walk_parent()` for the parent components, then
 ///   `link_stat_at()` on the leaf through the returned descriptor.
-/// - `rsync-3.5.0/generator.c:1010` - the plain `link_stat()` fall-through a
-///   daemon receiver reaches for a dest-relative basis (`--link-dest=../01`),
-///   whose `../` `sanitize_path` has already clamped to the module root.
+/// - `rsync-3.5.0/generator.c:1004-1018` arm 2 - the same walk with
+///   `operator_path_resolve = 1`, for a non-chrooted daemon's ABSOLUTE basis.
+/// - `rsync-3.5.0/generator.c:1064` - the trailing plain `link_stat()`.
 /// - `rsync-3.5.0/syscall.c:558` `owner_walk_parent()` - the walk itself.
 #[cfg(unix)]
 fn basis_stat(path: &Path, trust: BasisTrust) -> Option<fs::Metadata> {
-    if trust == BasisTrust::PlainStat {
-        return fs::symlink_metadata(path).ok();
+    match trust.arm_for(path) {
+        BasisArm::OwnerWalk => fast_io::operator_symlink_metadata(path).ok(),
+        BasisArm::ModuleConfinedWalk => fast_io::operator_symlink_metadata_confined(path).ok(),
+        BasisArm::PlainStat => fs::symlink_metadata(path).ok(),
     }
-
-    fast_io::operator_symlink_metadata(path).ok()
 }
 
 /// Non-Unix fallback: the ownership walk is a dirfd construction with no
@@ -1074,7 +1268,7 @@ mod info_copy_emission_tests {
             &mut metadata_errors,
             None,
             None,
-            BasisTrust::OwnerWalk,
+            BasisTrust::LocalReceiver,
         );
 
         // Restore writable permissions so tempdir cleanup succeeds.
@@ -1132,7 +1326,7 @@ mod info_copy_emission_tests {
             &mut metadata_errors,
             None,
             None,
-            BasisTrust::OwnerWalk,
+            BasisTrust::LocalReceiver,
         );
 
         let mut restore = fs::metadata(&dest_dir).expect("dest meta").permissions();
@@ -1238,7 +1432,7 @@ mod symlink_basis_tests {
             &mut metadata_errors,
             None,
             None,
-            BasisTrust::OwnerWalk,
+            BasisTrust::LocalReceiver,
         )
     }
 
@@ -1385,6 +1579,200 @@ mod symlink_basis_tests {
         assert_eq!(
             fs::read(dest_dir.join("payload.bin")).expect("dest file"),
             b"basis payload"
+        );
+    }
+}
+
+/// Regression tests for upstream's SECOND `basis_link_stat()` arm: a daemon
+/// receiver serving a module WITHOUT chroot must resolve an ABSOLUTE alt-dest
+/// basis through the ownership walk with MODULE-ROOT confinement.
+///
+/// The mechanism this closes, in the shape the
+/// `daemon-symlink-escape-matrix` cell builds it: the daemon roots a peer's
+/// `--compare-dest=/evil` under the module, so the basis path is
+/// `<module>/evil/tgtfile` and the escaping symlink `evil` is a PARENT
+/// component. `fs::symlink_metadata` refuses to follow a symlink at the LEAF
+/// only, so the kernel resolves `evil` and the stat lands outside the module -
+/// a read oracle. The ownership walk alone does not close it either: the module
+/// tree belongs to the daemon uid, so `evil` is trusted-OWNED and is followed.
+/// Only the module-root judgement on the resolved leaf refuses it.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/generator.c:991-1003` - the comment naming this exact cell.
+/// - `rsync-3.5.0/generator.c:1004-1018` - the arm itself.
+#[cfg(unix)]
+#[cfg(test)]
+mod daemon_module_confined_basis_tests {
+    use std::fs;
+    use std::os::unix;
+    use std::path::{Path, PathBuf};
+
+    use fast_io::confinement::{
+        LocalInsecureLinks, ModuleInsecureLinks, ModuleState, install_daemon_session,
+        install_local_session,
+    };
+    use metadata::MetadataOptions;
+    use protocol::flist::FileEntry;
+
+    use super::{BasisTrust, ModifyWindow, try_reference_dest};
+    use crate::config::{ReferenceDirectory, ReferenceDirectoryKind};
+
+    const PAYLOAD: &[u8] = b"module payload";
+
+    /// Builds the module tree the daemon serves, publishes it as the session's
+    /// confinement root, and returns `(temp, module_root, dest_dir)`.
+    ///
+    /// Inside the module: `escape -> ../outside`, a symlink THIS test owns, so
+    /// the ownership rule trusts it. `outside/payload.bin` is the file that must
+    /// stay unreachable.
+    fn serve_module_with_an_escaping_symlink() -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        // The module root is published PHYSICAL (`install_session` canonicalises
+        // it), and the walk resolves physically too, so build the fixture from
+        // the canonical temp path or the two namespaces disagree on macOS,
+        // where `/var` is a symlink to `/private/var`.
+        let base = temp.path().canonicalize().expect("canonicalise tempdir");
+
+        let outside = base.join("outside");
+        fs::create_dir_all(&outside).expect("create outside dir");
+        fs::write(outside.join("payload.bin"), PAYLOAD).expect("write outside file");
+
+        let module_root = base.join("module");
+        fs::create_dir_all(&module_root).expect("create module root");
+        unix::fs::symlink("../outside", module_root.join("escape")).expect("create escape link");
+
+        let dest_dir = base.join("dest");
+        fs::create_dir_all(&dest_dir).expect("create dest dir");
+
+        install_daemon_session(ModuleState {
+            root: Some(module_root.clone()),
+            chrooted: false,
+            selected: true,
+            insecure_links: ModuleInsecureLinks::from_module_config(false),
+        });
+
+        (temp, module_root, dest_dir)
+    }
+
+    /// Restores the process default so a `cargo test` run (one process, many
+    /// threads) does not leave a module root installed for unrelated cells.
+    fn clear_session() {
+        install_local_session(LocalInsecureLinks::from_local_flag(false), None);
+    }
+
+    fn try_basis(basis: &Path, dest_dir: &Path, trust: BasisTrust) -> bool {
+        let entry = FileEntry::new_file(PathBuf::from("payload.bin"), PAYLOAD.len() as u64, 0o644);
+        let reference = ReferenceDirectory::new(ReferenceDirectoryKind::Copy, basis.to_path_buf());
+        let metadata_opts = MetadataOptions::default();
+        let mut metadata_errors = Vec::new();
+
+        try_reference_dest(
+            &entry,
+            dest_dir,
+            std::slice::from_ref(&reference),
+            false,
+            true,
+            None,
+            ModifyWindow::from_secs(0),
+            &metadata_opts,
+            &mut metadata_errors,
+            None,
+            None,
+            trust,
+        )
+    }
+
+    /// THE FIX: a non-chrooted daemon receiver must not reach a basis whose
+    /// parent component leaves the module. Asserted on the OBSERVED outcome -
+    /// the basis is not consumed and nothing is written to the destination -
+    /// not on any message.
+    #[test]
+    fn a_daemon_refuses_a_basis_whose_parent_escapes_the_module() {
+        let (_tmp, module_root, dest_dir) = serve_module_with_an_escaping_symlink();
+
+        let handled = try_basis(
+            &module_root.join("escape"),
+            &dest_dir,
+            BasisTrust::for_receiver(true, false),
+        );
+
+        clear_session();
+
+        assert!(
+            !handled,
+            "an escaping basis must look absent so the file transfers normally"
+        );
+        assert!(
+            !dest_dir.join("payload.bin").exists(),
+            "nothing may be copied through a basis parent that leaves the module"
+        );
+    }
+
+    /// Non-vacuity, and the reason arm 2 exists at all: on the SAME fixture the
+    /// non-daemon arm FOLLOWS the escaping link, because the ownership rule
+    /// trusts a symlink this uid owns. So the refusal above comes from the
+    /// module-root judgement and from nothing else - and the previous
+    /// `PlainStat` routing, which followed it via the kernel, was worse still.
+    #[test]
+    fn the_non_daemon_arm_still_follows_the_same_self_owned_link() {
+        let (_tmp, module_root, dest_dir) = serve_module_with_an_escaping_symlink();
+
+        let handled = try_basis(
+            &module_root.join("escape"),
+            &dest_dir,
+            BasisTrust::for_receiver(false, false),
+        );
+
+        clear_session();
+
+        assert!(
+            handled,
+            "the ownership walk alone trusts a self-owned symlink; arm 2's \
+             module-root judgement is what refuses it"
+        );
+    }
+
+    /// Non-vacuity: the confined arm is not "refuse everything". An absolute
+    /// basis that stays INSIDE the module is still consumed, byte for byte.
+    #[test]
+    fn a_daemon_still_consumes_a_basis_inside_the_module() {
+        let (_tmp, module_root, dest_dir) = serve_module_with_an_escaping_symlink();
+
+        let inside = module_root.join("inside");
+        fs::create_dir_all(&inside).expect("create in-module basis dir");
+        fs::write(inside.join("payload.bin"), PAYLOAD).expect("write in-module basis");
+
+        let handled = try_basis(&inside, &dest_dir, BasisTrust::for_receiver(true, false));
+
+        clear_session();
+
+        assert!(handled, "an in-module basis must still match");
+        assert_eq!(
+            fs::read(dest_dir.join("payload.bin")).expect("dest file"),
+            PAYLOAD
+        );
+    }
+
+    /// A CHROOTED daemon keeps upstream's fall-through on the same fixture:
+    /// arm 2 is guarded by `!am_chrooted`. Pins that `am_chrooted` is a real
+    /// input and not decoration.
+    #[test]
+    fn a_chrooted_daemon_keeps_the_fall_through_on_the_same_fixture() {
+        let (_tmp, module_root, dest_dir) = serve_module_with_an_escaping_symlink();
+
+        let handled = try_basis(
+            &module_root.join("escape"),
+            &dest_dir,
+            BasisTrust::for_receiver(true, true),
+        );
+
+        clear_session();
+
+        assert!(
+            handled,
+            "upstream's `!am_chrooted` guard leaves a chrooted daemon on the \
+             plain link_stat fall-through"
         );
     }
 }
@@ -1779,7 +2167,7 @@ mod alt_dest_match_level_tests {
             &mut errs,
             None,
             None,
-            BasisTrust::OwnerWalk,
+            BasisTrust::LocalReceiver,
         )
     }
 

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -296,7 +296,14 @@ pub(super) enum BasisTrust {
 ///
 /// Separate from [`BasisTrust`] because upstream's arm choice is not a pure
 /// session property: arm 2 additionally requires `path[0] == '/'`.
+///
+/// Unix-only, matching its sole consumer. Two of the three arms name the
+/// ownership walk, which is a dirfd construction with no Windows analogue, so
+/// the `cfg(not(unix))` `basis_stat` below takes the plain stat for every
+/// `BasisTrust` and never asks which arm applies. Selecting an arm is
+/// therefore not a question that can be posed off Unix.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg(unix)]
 pub(super) enum BasisArm {
     /// Resolve the parent through the ownership walk (arm 1).
     OwnerWalk,
@@ -366,6 +373,7 @@ impl BasisTrust {
     /// upstream: `generator.c:997-1001` - the comment that spells out exactly
     /// this split, and the `path[0] == '/'` term at `generator.c:1004`.
     #[must_use]
+    #[cfg(unix)]
     pub(super) fn arm_for(self, path: &Path) -> BasisArm {
         match self {
             Self::LocalReceiver => BasisArm::OwnerWalk,
@@ -375,6 +383,9 @@ impl BasisTrust {
     }
 }
 
+// Every case asserts an `arm_for` answer, so the module follows that method's
+// gate rather than carrying a second, weaker copy for Windows.
+#[cfg(unix)]
 #[cfg(test)]
 mod basis_trust_tests {
     use std::path::{Path, PathBuf};

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -504,7 +504,7 @@ impl ReceiverContext {
                         metadata_errors,
                         acl_cache,
                         acl_id_map,
-                        BasisTrust::for_receiver(self.config.connection.is_daemon_connection),
+                        BasisTrust::for_connection(&self.config.connection),
                     )
                 {
                     continue;


### PR DESCRIPTION
## The defect

Upstream `rsync-3.5.0/generator.c` `basis_link_stat()` has **four** arms; oc modelled two.

| | upstream | condition | resolver |
|---|---|---|---|
| arm 1 | `generator.c:979` | `!am_daemon && am_root >= 0 && !symlink_optout_allowed()` | ownership walk |
| **arm 2** | `generator.c:1004` | `am_daemon && !am_chrooted && path[0] == '/' && !symlink_optout_allowed()` | **ownership walk with `operator_path_resolve = 1`** |
| arm 3 | `generator.c:1046` | `am_daemon && am_chrooted && module_dirlen && path[0] != '/'` | `secure_relative_open()` |
| arm 4 | `generator.c:1064` | — | plain `link_stat()` |

`BasisTrust` was a two-valued enum keyed on one bool, so **every** daemon receiver fell straight to arm 4.

Arm 2 is not decoration. The ownership rule answers *who planted this symlink*; it does not answer *where following it lands*. A module tree belongs to the daemon uid, so an in-module symlink pointing **outside** the module is trusted-OWNED and the plain walk follows it. Only the module-root judgement on the resolved leaf refuses it — and that is exactly what upstream's `operator_path_resolve = 1` does.

Upstream's own comment at `generator.c:991-1003` names the `daemon-symlink-escape-matrix` cell and explains the `path[0] == '/'` term.

## The read oracle it closes

The daemon roots a peer's `--compare-dest=/evil` under the module (`clamp_basis_to_module`, mirroring upstream `sanitize_path`), so the basis path is `<module>/evil/tgtfile`. The escaping component `evil` is therefore a **parent**, and `fs::symlink_metadata` declines to follow a symlink at the **leaf only** — the kernel resolves every parent component, and the stat lands outside the module.

All four of arm 2's conditions hold in that cell: daemon, `use chroot: no`, absolute basis, `insecure links = no`.

## The change

- **`BasisTrust`** now carries the two session facts upstream branches on (`am_daemon`, `am_chrooted`). **`BasisTrust::arm_for(path)`** applies the per-path `path[0] == '/'` term and yields a `BasisArm`. One predicate owns the whole decision; the call site is a single `BasisTrust::for_connection(&connection)` and states no policy of its own.
- **`fast_io::operator_symlink_metadata_confined`** is arm 2's resolver: the same walk with `PathKind::Confined`, so the resolved leaf is judged against the session root. Both spellings share one body.
- **`fast_io::confinement`** publishes `am_chrooted` alongside the opt-out it already published. A `chroot()` changes the process root, so it belongs in process state; a module's `insecure links` directive does not, and stays on the connection where it already lives.
- **`am_daemon` is read as `served_module_root().is_some()`, not `is_daemon_connection`.** The latter is set on **both** ends of an `rsync://` transfer, so it was applying a daemon's confinement to an `rsync://` **client's** own local destination — a shape upstream leaves on arm 1. `ConnectionConfig::served_module_root()`'s own doc already designates it as oc's `am_daemon` spelling; this call site was not reading it.

### Deliberately not restated: the symlink opt-out

Upstream tests `!symlink_optout_allowed()` at each arm, but it reads the same global the walk reads: `ona_open()` short-circuits to a legacy symlink-following open before any root is consulted (`syscall.c:300-302`). `fast_io::owner_walk` mirrors that short-circuit, so under an opt-out every walking arm already degenerates to the resolution arm 4 performs. Restating the test at the predicate would be a second copy of one policy.

### The regression this must not re-open

A RELATIVE basis (`--link-dest=../01`) keeps the plain stat on both implementations. Its `../` is already clamped to the module root by `sanitize_path`, and confining it would break `link-dest-relative-basis` (#915/#930), whose manifest row passes on both pipe legs. That is pinned by `a_non_chrooted_daemon_keeps_the_plain_stat_for_a_relative_basis`, and mutation M3 below confirms the pin bites.

## Non-vacuity

The discriminating fixture is one module tree with `escape -> ../outside`, a symlink the test itself owns, so the ownership rule trusts it:

- `a_daemon_refuses_a_basis_whose_parent_escapes_the_module` — arm 2 refuses; nothing is written to the destination.
- `the_non_daemon_arm_still_follows_the_same_self_owned_link` — on the **same fixture**, arm 1 follows it. The refusal comes from the module-root judgement and from nothing else.
- `a_daemon_still_consumes_a_basis_inside_the_module` — the confined arm is not "refuse everything".
- `a_chrooted_daemon_keeps_the_fall_through_on_the_same_fixture` — `am_chrooted` is a real input.

All assert on the observed outcome (basis consumed or not, bytes present or not), never on a message string.

## Mutation kill list

Nine mutants, each run against `cargo nextest run -p fast_io -p transfer --lib --no-fail-fast` at the 1.88.0 pin. Every summary satisfies `passed + failed == run` (3489), so no list is truncated.

| # | mutation | killed by |
|---|---|---|
| M1 | arm 2 never selected (reverts the fix) | `a_non_chrooted_daemon_confines_an_absolute_basis_to_the_module`; `a_daemon_refuses_a_basis_whose_parent_escapes_the_module` |
| M2 | arm 2 selected, resolved by the UNCONFINED walk | `a_daemon_refuses_a_basis_whose_parent_escapes_the_module` |
| M3 | drop the `path[0] == '/'` term (confine a relative basis) | `a_non_chrooted_daemon_keeps_the_plain_stat_for_a_relative_basis` |
| M4 | `am_chrooted` ignored | `a_chrooted_daemon_falls_through_to_the_plain_stat`; `the_serving_daemon_takes_the_daemon_arm`; `a_chrooted_daemon_keeps_the_fall_through_on_the_same_fixture` |
| M5 | `am_daemon` ignored | `a_non_daemon_receiver_walks_the_basis_parent`; `an_rsync_client_is_not_a_daemon_receiver`; `the_non_daemon_arm_still_follows_the_same_self_owned_link` |
| M6 | the confined stat aliases the ancillary one | `owner_walk::tests::the_confined_stat_refuses_a_parent_that_leaves_the_module`; `a_daemon_refuses_a_basis_whose_parent_escapes_the_module` |
| M7 | the session never publishes `am_chrooted` | `confinement::tests::install_session_publishes_the_chroot_state`; `the_serving_daemon_takes_the_daemon_arm` |
| M8 | read `is_daemon_connection` as `am_daemon` | `an_rsync_client_is_not_a_daemon_receiver` |
| M9 | `for_connection` ignores the session chroot state | `the_serving_daemon_takes_the_daemon_arm` |

M8 initially **survived**: the derivation lived at the call site inside the receiver loop, which no test reaches. Folding it into `BasisTrust::for_connection` made it unit-reachable — a design change the mutation testing drove, not a test written to fit the code.

## Verification (pinned toolchain 1.88.0)

- `tools/ci/check_rustfmt_all.py` — clean, 3422 files at edition 2024.
- `cargo clippy -p transfer -p fast_io --all-targets -- -D warnings` — clean.
- `cargo nextest run -p fast_io -p transfer --no-fail-fast` — **4020 passed, 0 failed, 4 skipped**.

## Scope: what this does NOT claim

This closes the **compare-dest vector** of `daemon-symlink-escape-matrix`. The cell's other four vectors (read / write / read-plain / write-plain) are **unmeasured** — the cell needs a root + TCP leg, which was not run here, and only an executed root-TCP run enumerates the residual set. No `tools/ci/upstream-3.5.0-expect.*` manifest row was touched.

Two gaps are named rather than papered over:

- **upstream arm 3** (`generator.c:1046`) — a chrooted daemon with a `/./` inner module boundary resolving a RELATIVE basis through `secure_relative_open()` — has no oc counterpart. oc takes arm 4 there, as `BasisArm::PlainStat` documents.
- **`try_dests_non`** (`generator.c:1226`/`:1253`) reaches `basis_link_stat()` upstream, but oc's `try_reference_dest_non` uses a plain `symlink_metadata`. That is the same defect class for non-regular basis entries, and it is untouched here because the cell's transferred file is regular and a change there would ship unexercised by the failing cell.
