### PR TITLE
fix(ci): stop the legacy-oracle probe from deleting the binary it just built

### DIFF
--- a/tools/ci/build_old_rsync_oracle.sh
+++ b/tools/ci/build_old_rsync_oracle.sh
@@ -50,18 +50,44 @@ WORKDIR="${3:-${DEST_DIR}/.build}"
 TARGET_BIN="${DEST_DIR}/rsync_${VERSION}"
 TARBALL_BASE_URL="${RSYNC_TARBALL_BASE_URL:-https://rsync.samba.org/ftp/rsync/src}"
 
+# The banner's first line, or non-zero if the binary would not run at all.
+#
+# Captured in ONE command substitution rather than piped through `head -1`,
+# and that is a correctness requirement, not a style choice. This script runs
+# under `set -o pipefail` and rsync does not buffer its version banner: MEASURED
+# on 3.2.7, `--version` is 20 separate write(2) calls totalling 793 bytes. So
+# `head -1` can exit - closing the read end - while rsync is still writing, rsync
+# dies of SIGPIPE, and the pipeline reports 141 even though the text matched.
+#
+# The consequence was not a bad diagnostic, it was destruction: oracle_is_usable
+# then called a working, freshly built oracle unusable, and the tail of this
+# script `rm -f`s the binary and exits 1 - which ensure_legacy_oracles treats as
+# fatal, failing the whole leg. MEASURED 10/10 on an 8-core Linux host, and
+# MEASURED not to fire on the GitHub runner (nightly run 34031044215 installed
+# all three oracles), so it was a host-dependent failure, which is worse than a
+# constant one: CI stayed green while the same command could not be reproduced
+# locally. A command substitution reads to EOF, so there is no early close and
+# no race.
+oracle_version_line() {
+    local banner
+    banner=$("$TARGET_BIN" --version 2>/dev/null) || return 1
+    printf '%s\n' "${banner%%$'\n'*}"
+}
+
 # `--version` is the acceptance test, not `-x`: a binary that cannot run on
 # this host (wrong arch, missing shared library) is still present and
 # executable, and would be handed to the testsuite as a working oracle. The
 # consuming test runs the same probe for the same reason.
 oracle_is_usable() {
+    local line
     [[ -x "$TARGET_BIN" ]] || return 1
-    "$TARGET_BIN" --version 2>/dev/null | head -1 | grep -q "version ${VERSION}"
+    line=$(oracle_version_line) || return 1
+    [[ $line == *"version ${VERSION}"* ]]
 }
 
 if oracle_is_usable; then
     echo "==> rsync ${VERSION} oracle already present: ${TARGET_BIN}" >&2
-    "$TARGET_BIN" --version | head -1 >&2
+    oracle_version_line >&2
     exit 0
 fi
 
@@ -155,10 +181,14 @@ install -m 0755 "${srcdir}/rsync" "$TARGET_BIN"
 
 if ! oracle_is_usable; then
     echo "ERROR: built oracle at ${TARGET_BIN} does not report version ${VERSION}." >&2
-    "$TARGET_BIN" --version 2>&1 | head -1 >&2 || true
+    # stderr folded in, so a binary that fails with a message (missing shared
+    # library, wrong arch) names its own reason here. Same no-pipe shape as
+    # oracle_version_line, for the same reason.
+    diag=$("$TARGET_BIN" --version 2>&1) || true
+    printf '%s\n' "${diag%%$'\n'*}" >&2
     rm -f "$TARGET_BIN"
     exit 1
 fi
 
 echo "==> Installed rsync ${VERSION} oracle: ${TARGET_BIN}" >&2
-"$TARGET_BIN" --version | head -1 >&2
+oracle_version_line >&2

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -295,14 +295,21 @@ class BuildOldRsyncOracleTests(unittest.TestCase):
     def tearDown(self) -> None:
         self._tmp.cleanup()
 
-    def _plant_source(self, version: str, reports: str) -> None:
-        """A fake rsync-<version>.tar.gz whose build reports `reports`."""
+    def _plant_source(self, version: str, reports: str,
+                      banner: str | None = None) -> None:
+        """A fake rsync-<version>.tar.gz whose build reports `reports`.
+
+        `banner` overrides the whole shell body of the fake binary, for cases
+        that need the banner emitted in more than one write.
+        """
         src = self.tmp / "src" / f"rsync-{version}"
         src.mkdir(parents=True)
+        if banner is None:
+            banner = f'echo "rsync  version {reports}  protocol version 31"\n'
+        (src / "rsync.template").write_text("#!/bin/sh\n" + banner)
         (src / "configure").write_text(
             "#!/bin/sh\n"
-            "printf 'all:\\n\\tprintf \"#!/bin/sh\\\\necho \\\\\"rsync  version "
-            f"{reports}  protocol version 31\\\\\"\\\\n\" > rsync\\n"
+            "printf 'all:\\n\\tcp rsync.template rsync\\n"
             "\\tchmod +x rsync\\n' > Makefile\n"
             "touch configured.marker\n"
         )
@@ -335,6 +342,34 @@ class BuildOldRsyncOracleTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("does not report version 3.2.7", result.stderr)
         self.assertFalse((self.dest / "rsync_3.2.7").exists())
+
+    def test_a_binary_that_writes_its_banner_in_stages_is_still_accepted(self) -> None:
+        # REGRESSION. The usability probe used to read
+        #     "$TARGET_BIN" --version 2>/dev/null | head -1 | grep -q ...
+        # inside a script running under `set -o pipefail`. Real rsync does not
+        # buffer its banner - MEASURED on a 3.2.7 build, `--version` is 20
+        # separate write(2) calls - so `head -1` closes the read end while rsync
+        # is still writing, rsync dies of SIGPIPE, and the PIPELINE yields 141
+        # even though the version text matched. The script then treats the
+        # oracle it has just built as unusable, `rm -f`s it and exits 1, which
+        # ensure_legacy_oracles escalates to failing the whole leg.
+        #
+        # MEASURED 10/10 against a real 3.2.7 build on an 8-core Linux host, and
+        # MEASURED not to fire on the GitHub runner (nightly 34031044215
+        # installed all three oracles) - a host-dependent failure, so CI green
+        # was no evidence.
+        #
+        # The single-line stub the other cases use CANNOT show this: its writer
+        # is finished before `head -1` exits, so no close is ever early. Two
+        # writes with a pause between them reproduce it deterministically.
+        self._plant_source("3.2.7", "3.2.7", banner=(
+            'echo "rsync  version 3.2.7  protocol version 31"\n'
+            "sleep 1\n"
+            'echo "Copyright (C) 1996-2022 by Andrew Tridgell and others"\n'
+        ))
+        result = self._run("3.2.7")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((self.dest / "rsync_3.2.7").is_file())
 
     def test_an_unfetchable_version_fails(self) -> None:
         # No tarball planted and no network reachable for a version that does


### PR DESCRIPTION
`oracle_is_usable()` in `tools/ci/build_old_rsync_oracle.sh` probed the freshly
built binary with:

```sh
"$TARGET_BIN" --version 2>/dev/null | head -1 | grep -q "version ${VERSION}"
```

rsync does not buffer its version banner. Measured with `strace`: **20 separate
`write(1, …)` calls, 793 bytes total**. `head -1` takes its line and closes the
read end while rsync is still writing, rsync takes SIGPIPE, and under
`set -euo pipefail` the pipeline reports **141 even though `grep` matched**.

The consequence is destruction rather than a bad message. On that return the
script declares the oracle unusable, `rm -f`s the binary it just built, and
exits 1 - which `ensure_legacy_oracles` (`tools/ci/run_upstream_testsuite.sh`)
escalates into failing the whole testsuite leg. Two further success paths
carried the same pipeline shape, where `set -e` would abort with 141 after a
good install.

## Why CI never caught it

Measured 10/10 on a Linux host (gcc 16.1.1, 8 cores). Measured **not** to fire
on the GitHub runner - the nightly logs `==> Installed rsync 3.2.7 oracle: …`
and proceeds. The banner write pattern is timing-dependent, so the command was
green in CI while being unreproducible locally.

The existing unit tests were vacuous against it: their stub rsync is a one-line
`echo`, so the writer always finishes before `head -1` exits. No amount of
re-running them could have found this.

## The fix

Read the banner in one command substitution, which reads to EOF and never
closes the pipe early. Added a regression case whose stub emits a second line
after a pause - the shape the old probe could not survive.

Mutation-checked: reverting the probe to the piped form fails **exactly** the
new case and none of the other four.

## Verification

- `tools/tests/test_upstream_testsuite_oracle.py`: 5/5.
- Both `3.2.7` and `3.1.3` build, install and re-probe clean on Linux/gcc 16.1.1,
  and the idempotent path reports `already present`. The `-std=gnu17` era pin
  therefore holds one gcc generation past the 15.2.0 it was measured on.
- Not verified: no macOS measurement. Every macOS leg runs `legacy_oracles: off`,
  so this builder never executes there today.

## Scope note

No expect-manifest is touched. `daemon-symlink-escape-matrix` fails both with
and without the oracle - the `on`/`off` manifests differ on exactly one of 155
rows - so that cell is a pre-existing, already-recorded defect this change
neither causes nor hides.
