### PR TITLE
fix(transfer): keep the leading slash when the daemon module is rooted at /

### DIFF
--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -53,6 +53,9 @@
 //!   daemon server that has selected a module.
 //! - `clientserver.c:864,993` - `module_dirlen` is the length of the
 //!   normalized module path and the server `chdir()`s there before serving.
+//! - `clientserver.c:922-923` - `if (module_dirlen == 1) module_dirlen = 0;`.
+//!   A module rooted at `/` has length 0, so `p1` keeps `curr_dir`'s leading
+//!   slash and the rendered name stays absolute.
 
 use std::fmt::Write as _;
 use std::path::Path;
@@ -96,6 +99,17 @@ impl DaemonPaths<'_> {
             tail
         };
         if p1.is_empty() {
+            // upstream: `module_dirlen` is a BYTE COUNT into `curr_dir`, not a
+            // path, and `clientserver.c:922-923` forces it to 0 - never 1 - for
+            // a module whose `module_dir` is `/`. `p1 = curr_dir + 0` is then
+            // `curr_dir` itself, so a server whose `curr_dir` is `/` renders
+            // `"/" + fn`, keeping the leading slash. Stripping `/` as a *path*
+            // prefix loses that byte and silently turns the absolute name into
+            // a relative one. Every other module root leaves `p1` genuinely
+            // empty and the bare relative name is correct.
+            if self.module_root == Path::new("/") {
+                return Some(format!("/{tail}"));
+            }
             // upstream: p1 == "" and p2 == "" - the bare relative name.
             return Some(tail);
         }
@@ -236,6 +250,38 @@ mod tests {
                 Some(paths("/srv/mod", "/srv/mod"))
             ),
             "\"/etc/passwd\" (in mymod)"
+        );
+    }
+
+    /// Ground truth, MEASURED 2026-09-07 against rsync 3.5.0 serving a module
+    /// declared `path = /`, pulled with `-r -R` for a name that does not exist:
+    ///
+    /// ```text
+    /// rsync: [sender] link_stat "/tmp/t1141/msg/srv/mod/nope" (in root) failed: ...
+    /// ```
+    ///
+    /// The `--relative` walk base is the module root, so `curr_dir` is `/` and
+    /// upstream's `p1 = curr_dir + module_dirlen` is `/` - `module_dirlen` is
+    /// forced to 0, not 1, at `clientserver.c:922-923`. Treating `/` as a path
+    /// prefix instead of a byte count drops that slash and renders the name
+    /// relative, which is what oc emitted before this pin.
+    #[test]
+    fn module_rooted_at_slash_keeps_the_leading_slash() {
+        assert_eq!(
+            full_fname_path(Path::new("/tmp/srv/mod/nope"), Some(paths("/", "/"))),
+            "\"/tmp/srv/mod/nope\" (in mymod)"
+        );
+    }
+
+    /// The same module root one directory down: `p1` is non-empty here, so the
+    /// pre-existing `/{p1}/{tail}` arm already reproduced upstream. Negative
+    /// control for [`module_rooted_at_slash_keeps_the_leading_slash`] - it must
+    /// stay green when that pin's branch is mutated out.
+    #[test]
+    fn module_rooted_at_slash_below_the_root_is_unchanged() {
+        assert_eq!(
+            full_fname_path(Path::new("/tmp/srv/nope"), Some(paths("/", "/tmp/srv"))),
+            "\"/tmp/srv/nope\" (in mymod)"
         );
     }
 


### PR DESCRIPTION
Upstream's `full_fname()` renders the name as `p1 + p2 + fn`, where
`p1 = curr_dir + module_dirlen` (`util1.c:1448`) is a **byte offset** into
`curr_dir`, not a path prefix. `clientserver.c:922-923` forces `module_dirlen`
to `0` - never `1` - for a module whose `module_dir` is `/`, so a server whose
`curr_dir` is `/` renders `"/" + fn` and the name stays absolute.

`DaemonPaths::relativize` strips `module_root` as a **path prefix**. For every
other module root that reproduces upstream exactly, but for `path = /` it
consumes the one byte upstream deliberately leaves, and an absolute name is
rendered relative.

## Measured

`[root] path = /`, six pull shapes, oc-rsync at `f054c633b` vs a real rsync
3.5.0 daemon serving an identical module:

| flags | operand | oc (before) | upstream |
|---|---|---|---|
| `-r` | `/root/nope` | `"nope"` | `"/nope"` ✗ |
| `-r -R` | `/root/nope` | `"nope"` | `"/nope"` ✗ |
| `-r` | `/root/<abs>/sub/nope` | `"/tmp/…"` | same ✓ |
| `-r -R` | `/root/<abs>/sub/nope` | `"tmp/…"` | `"/tmp/…"` ✗ |
| `-r` | `/root/<abs>/sub` | `"/tmp/…/denied.txt"` | same ✓ |
| `-r -R` | `/root/<abs>/sub` | `"tmp/…/denied.txt"` | `"/tmp/…/denied.txt"` ✗ |

**4 of 6 diverged; 6/6 after.** Transferred trees were byte-identical on all
six before and after - this is diagnostic text only.

## Scope

`DaemonPaths::relativize` is a pure diagnostic string renderer. The change does
not touch `relative_walk_base`, `resolve_receiver_dest`, `resolve_sender_sources`,
`confine_basis_under_module` or `source_open`.

Confinement re-verified rather than assumed: a planted-symlink escape probe
(absolute symlink out of the module, relative `../../../`, `mod/../outside`, and
each again via a `/./` pivot), baseline and fixed, oc and upstream - **no
`SECRET` byte reached the destination in any of the 24 cells**, and oc's refusal
text matched upstream including the `-r` vs `-r -R` asymmetry.

## Mutation proof

`cargo test -p transfer --lib full_fname` - 11 run / 11 passed.

Deleting the `module_root == Path::new("/")` arm: **11 run / 10 passed / 1
failed** - `module_rooted_at_slash_keeps_the_leading_slash` goes red
(`"tmp/srv/mod/nope"` vs `"/tmp/srv/mod/nope"`), the negative control
`module_rooted_at_slash_below_the_root_is_unchanged` stays green, and the nine
pre-existing `full_fname` tests stay green.

## Two filed claims REFUTED while measuring this

Both were already fixed on master; recording so they are not re-investigated.

- **"daemon `--relative` sender leaks absolute module paths, 14 of 16 operand
  shapes"** - does not reproduce. 16/16 byte-identical destination trees against
  a real 3.5.0 daemon, with upstream as the client in both arms so only the
  daemon varies. Closed by `eff06c7d1` (#7700); the one shape it left open (the
  `SP_KEEP_DOT_DIRS` pivot) was closed by `e971b135c` (#7714).
- **"no module ⇒ no current-directory anchor"** - the named symptom is gone:
  `relative_walk_base` re-supplies the module root as the walk base. Daemon error
  text is byte-identical to upstream (`link_stat "nope" (in mod) failed`,
  `send_files failed to open "sub/denied.txt" (in mod)`).

What survives is the *structure*: `DaemonPaths` still fuses the module-name axis
and the module-root axis into one `Option`, and the `path = /` cell above is what
that fusion produces.

## Verification

Pinned toolchain (rustc/cargo **1.88.0**), `CARGO_BUILD_JOBS=1`:

- `tools/ci/check_rustfmt_all.py` clean (3422 files) - it caught two rustfmt
  diffs in the new test, fixed and re-run.
- `cargo clippy -p transfer --all-targets` - no warnings.
- `cargo test -p transfer --lib full_fname` - 11/11.

Stated plainly as **not** verified: the `use chroot = yes` path needs root and
was not measured. Under upstream chroot `module_dir` becomes `/` with
`module_dirlen` forced to 0 (`clientserver.c:912-913, 922-923`) - exactly the
cell fixed here - so whether oc's chrooted daemon sets its module root to `/` or
keeps the on-disk path is an open follow-up, not something this PR settles.
