### PR TITLE
fix(daemon): keep a module filter file's whitespace as pattern text

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -252,11 +252,27 @@ fn build_daemon_filter_rules(
     Ok(rules)
 }
 
-/// Reads patterns from a file, one per line.
+/// Reads patterns from a filter file, one per record.
 ///
-/// Skips empty lines and comment lines (starting with `#` or `;`).
-/// This matches upstream rsync's `parse_filter_file()` behavior for
-/// `exclude_from` and `include_from` daemon parameters.
+/// upstream: `exclude.c:1601 parse_filter_file()`, which is what
+/// `clientserver.c:938,947` calls for the `include from` and `exclude from`
+/// module parameters. Both templates are line-parsed - `rule_template(...)`
+/// carries no `FILTRULE_WORD_SPLIT` - so the two decisions this reader makes
+/// are exactly the ones the shared owners hold:
+///
+/// * where a record ends - [`filters::filter_file_records`]
+///   (`exclude.c:1774-1793`): `\n`, a lone `\r`, or `\r\n` as one terminator.
+/// * whether it carries a rule - [`filters::filter_file_line_is_rule`]
+///   (`exclude.c:1806`): the FIRST BYTE is tested, with no trimming.
+///
+/// Nothing is trimmed. The pattern length upstream takes is `strlen(s)`
+/// (`exclude.c:1465`), so trailing whitespace is pattern text.
+///
+/// MEASURED against rsync 3.5.0 with a module whose `exclude from` file holds
+/// the single line `a ` (trailing space), over a module directory holding `a`
+/// and `a `: upstream hides `a ` and serves `a`; oc trimmed the rule, hid `a`
+/// and served `a `. Both at exit 0, with no diagnostic - a silent divergence
+/// in which files the daemon exposes.
 fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
     let content = fs::read_to_string(path).map_err(|e| {
         io::Error::new(
@@ -265,11 +281,11 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
         )
     })?;
 
-    let patterns = content
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty() && !line.starts_with('#') && !line.starts_with(';'))
-        .map(str::to_string)
+    let patterns = filters::filter_file_records(&content)
+        // `true`: these two parameters are the non-word-split templates, so a
+        // leading `;`/`#` is a comment (`exclude.c:1806`, `word_split ||`).
+        .filter(|line| filters::filter_file_line_is_rule(line, true))
+        .map(str::to_owned)
         .collect();
 
     Ok(patterns)

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2125,6 +2125,33 @@ mod module_access_tests {
         assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Include);
     }
 
+    /// The whitespace reaches the RULE, not merely the reader.
+    ///
+    /// `read_patterns_from_file` is the reader; `build_pattern_rule` then
+    /// decides anchoring and the `DIR2WILD3` suffix from the pattern text. This
+    /// pins the composed result, so a later "tidy the pattern up" inside the
+    /// builder cannot silently undo the fix while the reader test stays green.
+    ///
+    /// MEASURED against a real rsync 3.5.0 daemon (module holding `a` and `a `,
+    /// `exclude from` file holding the one line `a `): upstream served `a` and
+    /// hid `a `; oc at f054c633b served `a ` and hid `a`.
+    #[test]
+    fn build_daemon_filter_rules_exclude_from_keeps_trailing_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let exclude_file = dir.path().join("excludes.txt");
+        fs::write(&exclude_file, "a \n  #kept\n").unwrap();
+
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude_from: Some(exclude_file),
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "a ");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[1].pattern, "  #kept");
+    }
+
     #[test]
     fn build_daemon_filter_rules_missing_file_returns_error() {
         let module = ModuleRuntime::from(ModuleDefinition {
@@ -2243,6 +2270,14 @@ mod module_access_tests {
         }
     }
 
+    /// Comments and EMPTY records are skipped - a whitespace-only record is
+    /// neither.
+    ///
+    /// upstream: `exclude.c:1806` tests `*line` and `line[0]` on the untrimmed
+    /// record, so `  ` is not empty and becomes a pattern matching a file
+    /// literally named `  `. MEASURED against an rsync 3.5.0 daemon whose
+    /// `exclude from` file holds the single line `   `: the module's file named
+    /// `   ` is hidden.
     #[test]
     fn build_daemon_filter_rules_from_file_skips_comments_and_blanks() {
         let dir = tempfile::tempdir().unwrap();
@@ -2258,9 +2293,10 @@ mod module_access_tests {
             ..Default::default()
         });
         let rules = build_daemon_filter_rules(&module).unwrap();
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[0].pattern, "*.tmp");
-        assert_eq!(rules[1].pattern, "*.bak");
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern, "  ");
+        assert_eq!(rules[1].pattern, "*.tmp");
+        assert_eq!(rules[2].pattern, "*.bak");
     }
 
     #[test]
@@ -2535,10 +2571,78 @@ mod module_access_tests {
     fn read_patterns_from_file_skips_empty_lines() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("patterns.txt");
-        fs::write(&file, "\n*.tmp\n  \n\n*.bak\n").unwrap();
+        fs::write(&file, "\n*.tmp\n\n*.bak\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
         assert_eq!(patterns, vec!["*.tmp", "*.bak"]);
+    }
+
+    /// A rule's trailing whitespace is PATTERN TEXT, not decoration.
+    ///
+    /// upstream: `clientserver.c:947` reads `exclude from` with
+    /// `parse_filter_file()`, whose reader stops at the terminator and hands the
+    /// record over verbatim (`exclude.c:1794-1808`); `parse_rule_tok` then takes
+    /// `len = strlen(s)` (`exclude.c:1465`). No end is trimmed.
+    ///
+    /// MEASURED against rsync 3.5.0: a module whose `exclude from` file holds
+    /// the single line `a ` over a directory holding `a` and `a ` serves `a` and
+    /// hides `a `. oc trimmed the rule, so it hid `a` and SERVED `a ` - a
+    /// different set of files, at exit 0, with no diagnostic.
+    #[test]
+    fn read_patterns_from_file_keeps_trailing_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("patterns.txt");
+        fs::write(&file, "a \nb\t\n *.log\n").unwrap();
+
+        let patterns = read_patterns_from_file(&file).unwrap();
+        assert_eq!(patterns, vec!["a ", "b\t", " *.log"]);
+    }
+
+    /// A whitespace-only record is a PATTERN, not a blank line.
+    ///
+    /// upstream: `exclude.c:1806` tests `*line` - the FIRST BYTE - so `   ` is
+    /// not empty and becomes a rule matching a file literally named `   `.
+    /// Trimming first collapsed it to `""` and dropped it.
+    #[test]
+    fn read_patterns_from_file_keeps_a_whitespace_only_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("patterns.txt");
+        fs::write(&file, "   \n*.tmp\n").unwrap();
+
+        let patterns = read_patterns_from_file(&file).unwrap();
+        assert_eq!(patterns, vec!["   ", "*.tmp"]);
+    }
+
+    /// `#`/`;` open a comment only in COLUMN ZERO.
+    ///
+    /// upstream: `exclude.c:1806` tests `*line != ';' && *line != '#'` on the
+    /// untrimmed record, so ` #a` is a pattern. oc trimmed before the test and
+    /// dropped it, which SERVED a file the operator had asked the daemon to
+    /// hide.
+    #[test]
+    fn read_patterns_from_file_comment_marker_counts_only_in_column_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("patterns.txt");
+        fs::write(&file, "#dropped\n  #kept\n ;kept\n;dropped\n").unwrap();
+
+        let patterns = read_patterns_from_file(&file).unwrap();
+        assert_eq!(patterns, vec!["  #kept", " ;kept"]);
+    }
+
+    /// A lone `\r` ends a record, and `\r\n` ends exactly one.
+    ///
+    /// upstream: `exclude.c:1774-1793`. `str::lines` breaks only on `\n`, so a
+    /// `\r`-separated filter file collapsed into ONE pattern carrying the `\r`
+    /// and every later rule as literal bytes - it matched nothing and the files
+    /// those rules named all transferred.
+    #[test]
+    fn read_patterns_from_file_splits_on_a_lone_carriage_return() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("patterns.txt");
+        fs::write(&file, "a \r*.tmp\r\n*.bak\n").unwrap();
+
+        let patterns = read_patterns_from_file(&file).unwrap();
+        assert_eq!(patterns, vec!["a ", "*.tmp", "*.bak"]);
     }
 
     #[test]

--- a/crates/filters/src/merge/records.rs
+++ b/crates/filters/src/merge/records.rs
@@ -25,10 +25,10 @@
 //! That is file selection, not formatting. MEASURED against rsync 3.5.0 over a
 //! source holding `a.txt` and `a.txt ` (trailing space), with a merge file
 //! holding `- a.txt \r`: upstream excluded `a.txt ` and oc transferred it, both
-//! at exit 0. The same divergence reproduced through `--exclude-from` and
-//! through a `.rsync-filter` dir-merge, because each of oc's four readers
-//! spelled the split for itself. Routing them all through one iterator is what
-//! stops the next reader from drifting again.
+//! at exit 0. The same divergence reproduced through `--exclude-from`, through
+//! a `.rsync-filter` dir-merge, and through a daemon module's `exclude from`,
+//! because each of oc's FIVE readers spelled the split for itself. Routing them
+//! all through one iterator is what stops the next reader from drifting again.
 
 /// Splits filter-file content into records the way upstream's reader does.
 ///

--- a/crates/filters/src/merge/skip.rs
+++ b/crates/filters/src/merge/skip.rs
@@ -19,10 +19,12 @@
 //!    are ordinary pattern bytes.
 //!
 //! Both matter to file selection, not to formatting: whatever survives this
-//! test becomes a pattern matched literally against names. oc had four readers
-//! spelling it four ways, and two of them trimmed, which changed which files
-//! transferred at exit 0. Routing them all through one predicate is what stops
-//! the next reader from drifting again.
+//! test becomes a pattern matched literally against names. oc had FIVE readers
+//! spelling it five ways, and three of them trimmed, which changed which files
+//! transferred at exit 0. The fifth - the daemon's `exclude from`/`include
+//! from` reader, which only a running daemon exercises - was still trimming
+//! after the other four were converged here. Routing them all through one
+//! predicate is what stops the next reader from drifting again.
 
 /// Reports whether a filter-file record should be handed to the rule parser.
 ///

--- a/tests/daemon_filter_file_whitespace_is_pattern_text.rs
+++ b/tests/daemon_filter_file_whitespace_is_pattern_text.rs
@@ -1,0 +1,254 @@
+//! A daemon `exclude from` / `include from` rule's whitespace is pattern text.
+//!
+//! upstream builds `daemon_filter_list` in `clientserver.c:rsync_module()`, and
+//! the two FILE-valued parameters go through `parse_filter_file()`:
+//!
+//! ```c
+//! /* clientserver.c:937-948 */
+//! p = lp_include_from(module_id);
+//! parse_filter_file(&daemon_filter_list, p, rule_template(FILTRULE_INCLUDE), ...);
+//! p = lp_exclude_from(module_id);
+//! parse_filter_file(&daemon_filter_list, p, rule_template(0), ...);
+//! ```
+//!
+//! Neither template carries `FILTRULE_WORD_SPLIT`, so both are line-parsed and
+//! the reader's two decisions are upstream's:
+//!
+//! * where a record ends (`exclude.c:1774-1793`): `\n`, a lone `\r`, or `\r\n`
+//!   as ONE terminator; and
+//! * whether it carries a rule (`exclude.c:1806`): `if (*line && (word_split ||
+//!   (*line != ';' && *line != '#')))` - the FIRST BYTE, with no trimming.
+//!
+//! `parse_rule_tok` then takes `len = strlen((char*)s)` (`exclude.c:1465`), so
+//! trailing whitespace is pattern text.
+//!
+//! oc's daemon reader was the one that never got the fix that `crates/filters`,
+//! the engine dir-merge loader and the CLI `--*clude-from` reader all received:
+//! it split with `str::lines` and then `.map(str::trim)`, testing for a blank
+//! and a comment AFTER the trim. All four consequences change WHICH FILES THE
+//! DAEMON SERVES, at exit 0, with no diagnostic.
+//!
+//! MEASURED against a real rsync 3.5.0 daemon on Linux, module holding `a` and
+//! `a ` (trailing space), `exclude from` file holding the single line `a `:
+//! upstream serves `a` and hides `a `; oc at f054c633b served `a ` and hid `a`.
+//! Every row below is asserted against that measured upstream behaviour.
+//!
+//! The assertion is the SET OF FILES THE CLIENT RECEIVES, not a parsed pattern
+//! string, because that set is the property that matters.
+//!
+//! Skip conditions (the test passes with a printed reason):
+//! - Loopback TCP is unavailable.
+//! - The cross-implementation cell additionally needs a built upstream 3.5.0
+//!   binary; without it it reports why it did not run.
+
+#![cfg(unix)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn oc_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+fn upstream_binary() -> Option<PathBuf> {
+    let path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("target/interop/upstream-src/rsync-3.5.0/rsync");
+    path.is_file().then_some(path)
+}
+
+fn free_port() -> Option<u16> {
+    TcpListener::bind("127.0.0.1:0")
+        .ok()
+        .and_then(|listener| listener.local_addr().ok())
+        .map(|addr| addr.port())
+}
+
+/// The module's contents. Every name is chosen so that ONE of the rules below
+/// selects it and the others do not, which is what makes each row
+/// discriminating rather than merely green.
+const PLANTED: &[&str] = &[
+    "a",     // the plain name
+    "a ",    // the same name with a trailing space
+    " #a",   // an INDENTED comment marker: a pattern, not a comment
+    "   ",   // a whitespace-only name: a pattern, not a blank line
+    "x.tmp", // reached only through the second record of the `\r` row
+    "keep",  // the control: no row here may hide it
+];
+
+/// One row of the reader's truth table.
+struct Case {
+    /// The `exclude from` file's exact bytes.
+    body: &'static str,
+    /// The names the daemon must still serve.
+    served: &'static [&'static str],
+    /// Why this row is in the table.
+    why: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        body: "a \n",
+        served: &["a", " #a", "   ", "x.tmp", "keep"],
+        why: "the trailing space is pattern text (exclude.c:1465, strlen), so \
+              the rule names `a ` and not `a`; trimming inverted the pair",
+    },
+    Case {
+        body: " #a\n",
+        served: &["a", "a ", "   ", "x.tmp", "keep"],
+        why: "exclude.c:1806 tests the FIRST byte, so ` #a` is a pattern, not \
+              a comment; trimming first dropped the rule and SERVED a file the \
+              operator asked the daemon to hide",
+    },
+    Case {
+        body: "   \n",
+        served: &["a", "a ", " #a", "x.tmp", "keep"],
+        why: "exclude.c:1806 tests `*line`, so a whitespace-only record is not \
+              empty and becomes a pattern",
+    },
+    Case {
+        body: "a \r*.tmp\r",
+        served: &["a", " #a", "   ", "keep"],
+        why: "a lone `\\r` ends a record (exclude.c:1774), so this file holds \
+              TWO rules; `str::lines` fused them into one pattern carrying the \
+              `\\r`, which matched nothing and served both files",
+    },
+    // CONTROL. Without it every row above is satisfied by a reader that drops
+    // its input entirely, and the first row is satisfied by one that trims -
+    // this is the row where the trimmed and untrimmed readings agree on the
+    // rule but disagree on which of `a` / `a ` it names.
+    Case {
+        body: "a\n",
+        served: &["a ", " #a", "   ", "x.tmp", "keep"],
+        why: "CONTROL: the same rule with NO trailing space names `a`, so the \
+              pair is selected the other way round and the filter is live",
+    },
+];
+
+struct Fixture {
+    root: tempfile::TempDir,
+    port: u16,
+}
+
+impl Fixture {
+    fn new(body: &str) -> Option<Self> {
+        let root = tempfile::tempdir().expect("temp dir");
+        let port = free_port()?;
+        let module = root.path().join("mod");
+        fs::create_dir_all(&module).expect("module dir");
+        for name in PLANTED {
+            fs::write(module.join(name), b"x\n").expect("plant module file");
+        }
+        fs::write(root.path().join("ef"), body.as_bytes()).expect("filter file");
+        let conf = format!(
+            "port = {port}\n\
+             use chroot = no\n\
+             \n\
+             [m]\n\
+             \tpath = {module}\n\
+             \tread only = yes\n\
+             \texclude from = {ef}\n",
+            module = module.display(),
+            ef = root.path().join("ef").display(),
+        );
+        fs::write(root.path().join("rsyncd.conf"), conf).expect("config");
+        Some(Self { root, port })
+    }
+
+    fn conf(&self) -> PathBuf {
+        self.root.path().join("rsyncd.conf")
+    }
+
+    /// Pulls the whole module and reports the names that arrived.
+    fn served(&self, daemon_bin: &Path, client_bin: &Path) -> BTreeSet<String> {
+        let mut daemon = spawn_daemon(daemon_bin, &self.conf(), self.port);
+        let dest = self.root.path().join("dest");
+        fs::create_dir_all(&dest).expect("dest dir");
+        let status = Command::new(client_bin)
+            .args([
+                "-r",
+                "-q",
+                &format!("rsync://127.0.0.1:{}/m/", self.port),
+                &format!("{}/", dest.display()),
+            ])
+            .stdin(Stdio::null())
+            .status()
+            .expect("run client");
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+        assert!(status.success(), "the pull itself must succeed: {status:?}");
+
+        fs::read_dir(&dest)
+            .expect("read dest")
+            .map(|entry| {
+                entry
+                    .expect("dest entry")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    }
+}
+
+/// Starts a daemon and waits until its port answers.
+///
+/// `stdin` is `/dev/null` deliberately: with an inherited terminal or pipe the
+/// daemon takes its single-connection path and never listens.
+fn spawn_daemon(binary: &Path, conf: &Path, port: u16) -> Child {
+    let child = Command::new(binary)
+        .arg("--daemon")
+        .arg("--no-detach")
+        .arg(format!("--config={}", conf.display()))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn daemon");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return child;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    child
+}
+
+fn assert_table(binary: &Path, label: &str) {
+    for case in CASES {
+        let Some(fixture) = Fixture::new(case.body) else {
+            println!("SKIP: no loopback port available");
+            return;
+        };
+        let served = fixture.served(binary, binary);
+        let expected: BTreeSet<String> = case.served.iter().map(|s| (*s).to_owned()).collect();
+        assert_eq!(
+            served, expected,
+            "{label}: `exclude from` holding {:?} must serve {:?} - {}",
+            case.body, case.served, case.why
+        );
+    }
+}
+
+#[test]
+fn oc_keeps_daemon_filter_file_whitespace_as_pattern_text() {
+    assert_table(&oc_binary(), "oc");
+}
+
+/// CROSS-IMPLEMENTATION: the expected column is upstream's behaviour, so assert
+/// it against upstream rather than trusting the transcription.
+#[test]
+fn upstream_keeps_daemon_filter_file_whitespace_as_pattern_text() {
+    let Some(upstream) = upstream_binary() else {
+        println!(
+            "SKIP: upstream 3.5.0 oracle not built \
+             (target/interop/upstream-src/rsync-3.5.0/rsync)"
+        );
+        return;
+    };
+    assert_table(&upstream, "upstream 3.5.0");
+}

--- a/tests/filter_rule_whitespace_is_pattern_text.rs
+++ b/tests/filter_rule_whitespace_is_pattern_text.rs
@@ -16,14 +16,20 @@
 //! or whitespace-only line reaches the prefix switch's `default:` arm and dies
 //! at `exclude.c:1363` with `Unknown filter rule`.
 //!
-//! TWO oc readers trimmed. The engine dir-merge parser trimmed both ends of
-//! every line, and the CLI `--exclude-from`/`--include-from` reader trimmed
-//! before testing for a blank or a comment. Because a filter pattern is
-//! matched literally, both changed WHICH FILES TRANSFER at exit 0 - silent
-//! data selection divergence, not cosmetics. The third reader, the CLI
-//! `--filter='merge FILE'` loop (`crates/cli/.../filter_rules/merge.rs`),
-//! already mirrored upstream, which is what made this a one-of-three lag
-//! rather than a uniform choice.
+//! THREE oc readers trimmed. The engine dir-merge parser trimmed both ends of
+//! every line; the CLI `--exclude-from`/`--include-from` reader trimmed before
+//! testing for a blank or a comment; and the DAEMON's `exclude from`/`include
+//! from` reader
+//! (`crates/daemon/.../module_access/helpers.rs::read_patterns_from_file`) did
+//! both, and was missed when the first two were fixed. Because a filter
+//! pattern is matched literally, all three changed WHICH FILES TRANSFER at
+//! exit 0 - silent data selection divergence, not cosmetics. The fourth
+//! reader, the CLI `--filter='merge FILE'` loop
+//! (`crates/cli/.../filter_rules/merge.rs`), already mirrored upstream, which
+//! is what made this a lag in some readers rather than a uniform choice.
+//!
+//! The daemon reader is pinned separately, because only a running daemon
+//! exercises it: `tests/daemon_filter_file_whitespace_is_pattern_text.rs`.
 //!
 //! MEASURED against rsync 3.5.0 with a source holding `a` and `a ` (trailing
 //! space) and a `.rsync-filter` of `- a `: upstream excludes `a ` and copies


### PR DESCRIPTION
The daemon's `exclude from` / `include from` reader
(`module_access/helpers.rs::read_patterns_from_file`) was the **fifth** filter-file
reader, and the one the earlier passes (#7699, #7705, #7708) missed. It split with
`str::lines` then `.map(str::trim)`, and tested blank-ness and comment-ness *after*
the trim.

Upstream reads both parameters with `parse_filter_file()` under a template carrying
**no `FILTRULE_WORD_SPLIT`** (`clientserver.c:938,947`), so nothing may be trimmed
at either end:

- record boundary — `exclude.c:1774-1793`: `\n`, a lone `\r`, or `\r\n` as ONE terminator
- carries-a-rule test — `exclude.c:1806`: `if (*line && (word_split || (*line != ';' && *line != '#')))`, on the **first byte**, untrimmed
- pattern length — `exclude.c:1465`: `len = strlen((char*)s)`, so trailing whitespace **is** pattern text

Upstream flags the hazard rather than removing it (`exclude.c:267`,
`" -- CAUTION: trailing whitespace!"`).

## Measured, real daemons on loopback

Module holds `a`, `a ` (trailing space), ` #a`, `   `, `x.tmp`, `keep`. Files **served**:

| `exclude from` body | rsync 3.5.0 | oc before | oc after |
|---|---|---|---|
| `a \n` | a, keep | **"a ", keep** | a, keep |
| ` #a\n` | keep | **" #a", keep** | keep |
| `   \n` | keep | **"   ", keep** | keep |
| `a \r*.tmp\r` | a, keep | **a, "a ", keep, x.tmp** | a, keep |
| `a\n` (control) | "a ", keep | "a ", keep | "a ", keep |

All at exit 0 with no diagnostic. **Rows 2 and 3 are exposures**: a file the operator
told the daemon to hide was served, silently. Row 4 is the lone-`\r` boundary, where
the old reader also lost the second rule entirely.

The expected column is asserted against the **real 3.5.0 binary**, so the table is
measured rather than transcribed.

## Scope — what deliberately did NOT change

The other four readers and every rule parser were already on the shared owners and are
untouched. `split_filter_tokens` and the `include`/`exclude` **string** parameters keep
their trimming, because upstream parses exactly those with `FILTRULE_WORD_SPLIT`
(`clientserver.c:934,942,951`), where whitespace *is* eaten at both ends — trimming
there is upstream-faithful. `config_parsing/include_merge.rs` is the rsyncd.conf
`include`/`&merge` directive (params.c), a different mechanism.

The reader now routes through `filters::filter_file_records` +
`filters::filter_file_line_is_rule` and keeps **no copy** of either rule, so the five
readers can no longer drift apart.

## Mutation proof

Mutation = restore the exact old body, rebuild, re-run.

- unit: fixed **27 run / 27 passed**; mutant **27 run / 21 passed / 6 failed** — the four
  new `read_patterns_from_file_*` cells, `build_daemon_filter_rules_exclude_from_keeps_trailing_whitespace`,
  and the corrected `..._skips_comments_and_blanks`. The 21 that stay green under the
  mutant are the negative controls.
- integration (new file): fixed **2/2**; mutant **2 run / 1 passed / 1 failed** — the oc
  cell reddens on row 1, while the cross-implementation upstream cell stays green, which
  is the right control for an oc-only mutation. Checked with `--nocapture` that neither
  cell was silently skipping (0.14s → 0.78s once the oracle was present).

## The filed task was REFUTED as written

Task 1144 named the dir-merge / `--*clude-from` / `--filter='merge FILE'` readers. Those
were fixed a day earlier by #7699/#7705/#7708. Measured 7 cells against the 3.5.0 oracle:
**oc HEAD identical on all 7.** The instrument is not blind — the same probe against a
stale oc binary (`4eb9e430a`, 19 Aug, predating the fixes) flips the two dir-merge cells.
So this PR is a *different* reader that the earlier sweep did not enumerate.

## Verification

lxhost, pinned toolchain **1.88.0**, `CARGO_BUILD_JOBS=1`:
`tools/ci/check_rustfmt_all.py` clean (3423 files) ·
`cargo clippy --release -p daemon -p filters --all-targets -- -D warnings` RC=0 ·
regression sweep over 4 root integration targets **22 passed / 0 failed**.

Three `-p daemon` cells fail under a full parallel run and **pass 3/3 in isolation**
(`refuse_if_at_capacity_emits_structured_warning`, `poll_ready_wakes_on_connection_while_parked`,
`goodbye_clone_reads_after_drain_stops`); they touch no filter code and a peer agent was
running `cargo test -p transfer` on the same host concurrently.

Not run: full-workspace nextest, macOS, Windows, upstream testsuite. The new integration
test is `#![cfg(unix)]` and prints a visible SKIP when the 3.5.0 oracle is absent.

## Separate finding, NOT fixed here

⚠ Both file parameters also carry **`XFLG_OLD_PREFIXES`** (`clientserver.c:937,944`), so
upstream strips a leading `- `/`+ ` as an action prefix (`exclude.c:1276-1284`) and treats
a bare `!` as a list-clear. oc's `build_pattern_rule` takes the whole record as the
pattern. Measured: module holding `foo`,`keep` with an `exclude from` file holding
`- foo` — **upstream serves only `keep`; oc serves `foo` AND `keep`.** A second exposure,
a different mechanism, filed separately rather than folded in here.
