### PR TITLE
docs(transfer): attribute the receiver INC_RECURSE deadlock to a measured side

### DIFF
--- a/crates/transfer/src/lib.rs
+++ b/crates/transfer/src/lib.rs
@@ -499,9 +499,41 @@ fn requires_multiplex_output(
 /// ⚠ That names the blocking sites; it does NOT say what makes the throttle
 /// safe. Removing this restriction is the INC_RECURSE-on-pull work: it needs an
 /// index-driven transfer walk over a growing list rather than the up-front
-/// drain, and it needs whatever releases the sender's backlog per consumed
-/// sub-list. Neither is a one-line change, and sufficiency is not settled by
+/// drain. Neither is a one-line change, and sufficiency is not settled by
 /// reading source - re-run the A/B above.
+///
+/// # The backlog release is NOT missing on the sender - measured
+///
+/// An earlier revision of this block also required "whatever releases the
+/// sender's backlog per consumed sub-list". Against an upstream peer that half
+/// already works, so do not build it again.
+///
+/// MEASURED 2026-09-07 (upstream rsync 3.4.4 protocol 32 as the peer, oc as the
+/// remote server-sender, INC_RECURSE confirmed negotiated by upstream's
+/// `receiving flist for dir N` debug line): a 50000-entry tree carried entirely
+/// in sub-lists - five times `MAX_FILECNT_LOOKAHEAD` - completes in 4s on an
+/// unpatched sender. `SegmentScheduler::retire_current_flist` releases the
+/// window on the peer's per-sub-list `NDX_DONE`, which upstream's generator
+/// emits from `check_for_finished_files` (`generator.c:2698`) inside its
+/// per-file loop (`generator.c:2820`).
+///
+/// A port of `rsync.c:394-402` into oc's sender was built, mutation-proved and
+/// then reverted: it would double-release against the path above, fixing
+/// nothing measurable while weakening a working throttle. What oc lacks is the
+/// RECEIVER half - it emits its per-segment `NDX_DONE`s only after the walk, in
+/// `exchange_phase_done` - so an oc receiver opposite an *oc* sender has
+/// neither release even though the upstream-peer case is covered.
+///
+/// # ⚠⚠ Removing the up-front drain DESTROYS DATA on its own
+///
+/// Both delete passes build their keep-set from a full `file_list` walk. With
+/// the drain removed the list is incomplete by construction, so every entry not
+/// yet materialised is classified extraneous and UNLINKED. The delete passes
+/// need a completeness predicate before the drain can go; `build_files_to_transfer`
+/// also hands back borrows of the whole context, so this is not a local edit.
+///
+/// Order: completeness predicate, then per-segment `NDX_DONE` during the walk,
+/// then the drain conversion, then re-run the A/B. Not a flag flip.
 ///
 /// upstream: compat.c:161-179 set_allow_inc_recurse,
 /// rsync.h:151-152 (`MIN_FILECNT_LOOKAHEAD` / `MAX_FILECNT_LOOKAHEAD`),


### PR DESCRIPTION
Comment-only. No behaviour change. Rebased onto #7723, which landed on this
same doc block while this was in flight.

#7723 attributed both blocking sites and did it well — this keeps all of that,
including its `send_flist_eof_if_exhausted` detail. Two things it could not have
known are now measured, and **one of them contradicts a requirement #7723
states**.

## The sender's backlog release is NOT missing

#7723 says removing the up-front drain "needs whatever releases the sender's
backlog per consumed sub-list". Against an upstream peer that half already works.

Measured with upstream rsync 3.4.4 (protocol 32) as the peer and oc as the remote
server-sender, INC_RECURSE confirmed negotiated by upstream's own `receiving
flist for dir N` line: a 50,000-entry tree carried entirely in sub-lists — **five
times `MAX_FILECNT_LOOKAHEAD`** — completes in **4s** on an unpatched sender.
`SegmentScheduler::retire_current_flist` releases the window on the peer's
per-sub-list `NDX_DONE`, which upstream's generator emits from
`check_for_finished_files` (`generator.c:2698`) inside its per-file loop
(`generator.c:2820`).

A port of `rsync.c:394-402` into oc's sender was built, mutation-proved, and then
**reverted** — it would double-release against the path that already works: no
measurable gain, and a weakened throttle.

⚠ A mutation-proven change is not thereby a correct change. The mutation shows
the new code is *reachable*; it never shows the behaviour it adds was *absent*.

What oc actually lacks is the **receiver** half — it emits its per-segment
`NDX_DONE`s only after the walk, in `exchange_phase_done` — so an oc receiver
opposite an **oc** sender has neither release, even though the upstream-peer case
is covered. The doc now draws that distinction instead of asserting the sender is
short.

## ⚠⚠ Removing the drain destroys data on its own

Not previously recorded anywhere. Both delete passes build their keep-set from a
full `file_list` walk, so with the drain removed the list is incomplete by
construction and every not-yet-materialised entry is classified extraneous and
**unlinked**. `build_files_to_transfer` also hands back borrows of the whole
context, so this is not a local edit either.

The block now states the order — completeness predicate, then per-segment
`NDX_DONE` during the walk, then the drain conversion, then re-run the A/B — so
the next reader does not take it for the flag flip the surrounding text could be
read to imply.

## Conflict resolution

`crates/transfer/src/lib.rs` conflicted with #7723. Resolved by **keeping both**:
#7723's attribution paragraphs are untouched, the single sentence refuted above
is corrected, and the two measured sections are added after it. The one thing
removed is the clause claiming the sender release is missing.
