### PR TITLE
refactor(transfer): one rule for the rendered diagnostic path, not a special case

### DIFF
--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -15,13 +15,10 @@
 //! `not creating new %s "%s"` at `generator.c:1380`) never gain it, so they must
 //! keep formatting their own quotes.
 //!
-//! # Module-relative rendering
+//! # The two independent axes
 //!
-//! A daemon server `chdir()`s into the module root (`clientserver.c:993`
-//! `change_dir(module_chdir, CD_NORMAL)`), so every path it later handles is
-//! *relative* to that root and the absolute server-side location never reaches
-//! the client. `full_fname()` re-attaches only the part of `curr_dir` that lies
-//! below the module root:
+//! `full_fname()` makes **two** decisions, and they are gated on two different
+//! globals:
 //!
 //! ```c
 //! if (*fn == '/')
@@ -32,133 +29,260 @@
 //!         if (*p2)
 //!                 p2 = "/";
 //! }
+//! if (module_id >= 0) {
+//!         m1 = " (in "; m2 = lp_name(module_id); m3 = ")";
+//! } else
+//!         m1 = m2 = m3 = "";
 //! ```
 //!
-//! With `curr_dir` at the module root `p1` is empty and the rendered name is
-//! the bare relative path (`"denied"`); with `curr_dir` one level down `p1` is
-//! `/sub`, `p2` collapses to `/`, and the render is module-root anchored
-//! (`"/sub/denied2"`). Both forms were captured from rsync 3.4.4 serving a
-//! module; neither ever contains the daemon's real filesystem prefix.
+//! The **prefix** `p1 + p2` is computed unconditionally: every process has a
+//! `curr_dir`, and `module_dirlen` is simply `0` when there is no module to
+//! strip (`clientserver.c:106` initialises it to `0`). Only the **suffix** is
+//! conditional on `module_id >= 0`. So a plain local or SSH run still prefixes
+//! its working directory, which is why upstream reports an absolute name for a
+//! relative operand:
 //!
-//! oc-rsync never `chdir()`s - it carries absolute paths throughout - so
-//! [`DaemonPaths`] supplies the two directories upstream keeps in globals and
-//! the helper recovers upstream's relative `fn` by stripping `curr_dir`.
+//! ```text
+//! $ cd /tmp/work && rsync -r nope dst/
+//! rsync: [sender] link_stat "/tmp/work/nope" failed: No such file or directory (2)
+//! ```
+//!
+//! [`FullFnamePaths`] keeps the two axes separate for exactly that reason:
+//! [`module`](FullFnamePaths::module) is the suffix axis and is `None` outside a
+//! daemon module, while [`module_root`](FullFnamePaths::module_root) is the
+//! strip axis and is `None` whenever `module_dirlen` would be `0`.
+//!
+//! # Module-relative rendering
+//!
+//! A daemon server `chdir()`s into the module root (`clientserver.c:1059`
+//! `change_dir(module_chdir, CD_NORMAL)`), so every path it later handles is
+//! *relative* to that root and the absolute server-side location never reaches
+//! the client. With `curr_dir` at the module root `p1` is empty and the
+//! rendered name is the bare relative path (`"denied"`); with `curr_dir` one
+//! level down `p1` is `/sub`, `p2` collapses to `/`, and the render is
+//! module-root anchored (`"/sub/denied2"`). Both forms were captured from
+//! rsync 3.4.4 serving a module; neither ever contains the daemon's real
+//! filesystem prefix.
+//!
+//! A module whose `path` is `/` is the exception, and it is upstream's own:
+//! `clientserver.c:922-923` forces `module_dirlen` back to `0`, so nothing is
+//! stripped and the absolute name is what upstream prints.
+//!
+//! oc-rsync never `chdir()`s - it carries the operand spelling it was given -
+//! so [`FullFnamePaths`] supplies the directories upstream keeps in globals and
+//! the helper recovers upstream's `curr_dir`-relative `fn` before re-attaching
+//! the prefix.
 //!
 //! # Upstream Reference
 //!
-//! - `util1.c:1273` - `full_fname()`; the `module_id >= 0` branch selects
+//! - `util1.c:1433` - `full_fname()`; the `module_id >= 0` branch selects
 //!   `" (in "`, `lp_name(module_id)`, `")"`.
-//! - `clientserver.c:769` - `module_id = i` is the only assignment that makes
+//! - `util1.c:1445-1452` - the `*fn == '/'` test and `p1 = curr_dir +
+//!   module_dirlen` (`util1.c:1448`), computed with no reference to
+//!   `module_id`.
+//! - `clientserver.c:821` - `module_id = i` is the only assignment that makes
 //!   `module_id >= 0`, so the suffix appears exactly when the process is a
 //!   daemon server that has selected a module.
-//! - `clientserver.c:864,993` - `module_dirlen` is the length of the
-//!   normalized module path and the server `chdir()`s there before serving.
-//! - `clientserver.c:922-923` - `if (module_dirlen == 1) module_dirlen = 0;`.
-//!   A module rooted at `/` has length 0, so `p1` keeps `curr_dir`'s leading
+//! - `clientserver.c:106` - `unsigned int module_dirlen = 0;` - the strip
+//!   length outside a daemon module.
+//! - `clientserver.c:864,993` - inside a module `module_dirlen` is the length
+//!   of the normalized module path, and the server `chdir()`s there before
+//!   serving.
+//! - `clientserver.c:922-923` - `if (module_dirlen == 1) module_dirlen = 0;` -
+//!   a module rooted at `/` strips nothing, so `p1` keeps `curr_dir`'s leading
 //!   slash and the rendered name stays absolute.
+//! - `util1.c:1224` - `getcwd(curr_dir, ...)` seeds the working directory once.
 
 use std::fmt::Write as _;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+use std::sync::OnceLock;
 
-/// The daemon path context upstream keeps in globals, as seen by
-/// [`full_fname`].
+/// The path context upstream keeps in globals, as seen by [`full_fname`].
 ///
-/// `module` is upstream's `lp_name(module_id)`, `module_root` is `module_dir`
-/// (whose length is `module_dirlen`), and `curr_dir` is the directory upstream
-/// has `chdir()`ed into - the receiver's destination, or the sender's per-arg
-/// `dir` from the `flist.c:2338-2349` split. Absent for client and non-daemon
-/// server processes, mirroring upstream's `module_id < 0`.
+/// The three fields are upstream's three independent pieces of state, and each
+/// is conditional on its own terms:
+///
+/// - `module` is `lp_name(module_id)`, present exactly when `module_id >= 0`.
+/// - `module_root` is `module_dir`, whose length is `module_dirlen`; `None`
+///   expresses `module_dirlen == 0`.
+/// - `curr_dir` is the directory names are rendered against, and upstream
+///   always has one.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct DaemonPaths<'a> {
-    /// Module name appended as ` (in MODULE)`. upstream: `lp_name(module_id)`.
-    pub module: &'a str,
-    /// Absolute module root. upstream: `module_dir` / `module_dirlen`.
-    pub module_root: &'a Path,
-    /// Absolute directory the server is serving from. upstream: `curr_dir`.
+pub(crate) struct FullFnamePaths<'a> {
+    /// Module name appended as ` (in MODULE)`. upstream: `lp_name(module_id)`,
+    /// selected by `module_id >= 0`. `None` for clients and for non-daemon
+    /// (SSH) server processes, mirroring upstream's `module_id < 0`.
+    pub module: Option<&'a str>,
+    /// Prefix stripped from `curr_dir` before rendering. upstream:
+    /// `module_dir` / `module_dirlen`.
+    ///
+    /// `None` is upstream's `module_dirlen == 0`, which covers three cases:
+    /// a process serving no module at all (`clientserver.c:106`), a module
+    /// whose `path` is `/` (`clientserver.c:922-923`), and a chrooted module,
+    /// whose root becomes `/` inside the jail (`clientserver.c:912-913`).
+    pub module_root: Option<&'a Path>,
+    /// Absolute directory names are rendered against. upstream: `curr_dir` -
+    /// the receiver's destination, the sender's per-arg `dir` from the
+    /// `flist.c:2608-2637` split, or the process working directory.
     pub curr_dir: &'a Path,
 }
 
-impl DaemonPaths<'_> {
-    /// Rewrites an absolute server-side path into the module-relative form
-    /// upstream renders, or returns `None` when the path lies outside the
-    /// served tree.
+impl<'a> FullFnamePaths<'a> {
+    /// The context a process that is not serving a daemon module renders
+    /// against: no suffix, nothing stripped, and the process working directory
+    /// as `curr_dir`.
+    #[must_use]
+    pub(crate) fn non_daemon() -> Self {
+        Self {
+            module: None,
+            module_root: None,
+            curr_dir: process_curr_dir(),
+        }
+    }
+
+    /// The context a daemon server renders against.
+    ///
+    /// `module_root` is dropped when it is `/`, because upstream forces
+    /// `module_dirlen` to `0` for that module (`clientserver.c:922-923`) and
+    /// then prints the absolute name.
+    #[must_use]
+    pub(crate) fn daemon(module: &'a str, module_root: &'a Path, curr_dir: &'a Path) -> Self {
+        Self {
+            module: Some(module),
+            module_root: strip_prefix_root(module_root),
+            curr_dir,
+        }
+    }
+
+    /// Rewrites a server-side path into the form upstream renders, or returns
+    /// `None` when the path lies outside the tree `curr_dir` anchors.
     ///
     /// `None` makes the caller fall back to the path as given, matching
     /// upstream's `*fn == '/'` branch: an absolute `fn` gets no prefix and is
     /// printed verbatim.
-    fn relativize(&self, path: &Path) -> Option<String> {
-        // upstream's `fn` is relative to `curr_dir`, so recover it first.
-        let tail = slash_join(path.strip_prefix(self.curr_dir).ok()?);
-        // upstream: `p1 = curr_dir + module_dirlen` - the part of the working
-        // directory below the module root.
-        let p1 = slash_join(self.curr_dir.strip_prefix(self.module_root).ok()?);
-        // A DOTDIR source arg leaves `fn` as ".", never empty.
+    fn render(&self, path: &Path) -> Option<String> {
+        // upstream's `fn` is relative to `curr_dir`. oc-rsync hands this
+        // helper either an absolute path (the daemon and every wire-side
+        // caller) or the operand spelling the user typed, which is already
+        // relative to the working directory - so recover `fn` from both.
+        let tail = if path.is_absolute() {
+            slash_path(path.strip_prefix(self.curr_dir).ok()?)
+        } else {
+            slash_path(path)
+        };
+        // A DOTDIR source arg leaves `fn` as ".", never empty
+        // (`flist.c:2672-2673`).
         let tail = if tail.is_empty() {
             ".".to_owned()
         } else {
             tail
         };
-        if p1.is_empty() {
-            // upstream: `module_dirlen` is a BYTE COUNT into `curr_dir`, not a
-            // path, and `clientserver.c:922-923` forces it to 0 - never 1 - for
-            // a module whose `module_dir` is `/`. `p1 = curr_dir + 0` is then
-            // `curr_dir` itself, so a server whose `curr_dir` is `/` renders
-            // `"/" + fn`, keeping the leading slash. Stripping `/` as a *path*
-            // prefix loses that byte and silently turns the absolute name into
-            // a relative one. Every other module root leaves `p1` genuinely
-            // empty and the bare relative name is correct.
-            if self.module_root == Path::new("/") {
-                return Some(format!("/{tail}"));
+        // upstream: `p1 = curr_dir + module_dirlen` - a byte offset into
+        // `curr_dir`, so `module_dirlen == 0` leaves the whole of it.
+        let p1 = match self.module_root {
+            Some(root) => {
+                let below = slash_path(self.curr_dir.strip_prefix(root).ok()?);
+                if below.is_empty() {
+                    String::new()
+                } else {
+                    format!("/{below}")
+                }
             }
-            // upstream: p1 == "" and p2 == "" - the bare relative name.
-            return Some(tail);
-        }
-        // upstream: p1 == "/sub" and p2 == "/" - module-root anchored.
-        Some(format!("/{p1}/{tail}"))
+            None => slash_path(self.curr_dir),
+        };
+        // upstream: `for (p2 = p1; *p2 == '/'; p2++) {}` then
+        // `if (*p2) p2 = "/";` - a separator only when something survives the
+        // leading slashes.
+        let p2 = if p1.trim_start_matches('/').is_empty() {
+            ""
+        } else {
+            "/"
+        };
+        Some(format!("{p1}{p2}{tail}"))
     }
 }
 
-/// Renders a relative path with `/` separators.
+/// Upstream's `curr_dir[]` for a process that never selected a module.
 ///
-/// The module-relative name upstream prints is the same `/`-separated name it
-/// puts on the wire, never a host-native one, so the separator must not follow
-/// the platform the daemon happens to run on.
-fn slash_join(relative: &Path) -> String {
+/// Upstream seeds the global once with `getcwd()` (`util1.c:1224`) and moves it
+/// with `change_dir()`. oc-rsync never `chdir()`s, so the process working
+/// directory is that value for the whole run.
+///
+/// A failed `getcwd()` yields an empty path, which renders `p1` and `p2` empty
+/// and prints the bare name - the same output as before this prefix existed,
+/// rather than a panic inside a diagnostic.
+fn process_curr_dir() -> &'static Path {
+    static CWD: OnceLock<PathBuf> = OnceLock::new();
+    CWD.get_or_init(|| std::env::current_dir().unwrap_or_default())
+}
+
+/// Maps a module root of `/` to "strip nothing".
+///
+/// upstream: `clientserver.c:922-923` - `if (module_dirlen == 1)
+/// module_dirlen = 0;`. A module rooted at `/` has `module_dir == "/"`, whose
+/// length is 1, so upstream deliberately consumes no byte of `curr_dir` and the
+/// rendered name stays absolute.
+fn strip_prefix_root(module_root: &Path) -> Option<&Path> {
+    if module_root == Path::new("/") {
+        None
+    } else {
+        Some(module_root)
+    }
+}
+
+/// Renders a path with `/` separators, dropping `.` components.
+///
+/// The name upstream prints is the same `/`-separated name it puts on the wire,
+/// never a host-native one, so the separator must not follow the platform the
+/// process happens to run on. A leading root component contributes exactly one
+/// `/`.
+///
+/// `.` components are dropped because upstream never carries one into a
+/// diagnostic: the sender cleans every flist name with `clean_fname(thisname,
+/// 0)` (`flist.c:1424`), and with `CFN_KEEP_DOT_DIRS` unset that discards
+/// interior `"."` dirs (`util1.c:1068-1071`). An operand of `./sub/` therefore
+/// prints as `<curr_dir>/sub/...`, not `<curr_dir>/./sub/...`.
+///
+/// A path that is nothing but `.` components renders empty; [`FullFnamePaths::render`]
+/// turns that back into `"."`, which is upstream's DOTDIR name
+/// (`flist.c:2672-2673`).
+fn slash_path(path: &Path) -> String {
     let mut out = String::new();
-    for component in relative.components() {
-        if !out.is_empty() {
-            out.push('/');
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::RootDir => out.push('/'),
+            other => {
+                if !out.is_empty() && !out.ends_with('/') {
+                    out.push('/');
+                }
+                out.push_str(&other.as_os_str().to_string_lossy());
+            }
         }
-        out.push_str(&component.as_os_str().to_string_lossy());
     }
     out
 }
 
 /// Renders `fname` the way upstream `full_fname()` does: double quoted,
-/// rewritten relative to the daemon module root, and with ` (in MODULE)`
-/// appended after the closing quote when serving a daemon module.
+/// prefixed with the part of `curr_dir` that survives `module_dirlen`, and with
+/// ` (in MODULE)` appended after the closing quote when serving a daemon
+/// module.
 ///
 /// # Upstream Reference
 ///
-/// - `util1.c:1296` - `asprintf(&result, "\"%s%s%s\"%s%s%s", ...)`
-pub(crate) fn full_fname(fname: &str, daemon: Option<DaemonPaths<'_>>) -> String {
-    match daemon {
-        Some(paths) => match paths.relativize(Path::new(fname)) {
-            Some(rendered) => quote(&rendered, Some(paths.module)),
-            None => quote(fname, Some(paths.module)),
-        },
-        None => quote(fname, None),
+/// - `util1.c:1460` - `asprintf(&result, "\"%s%s%s\"%s%s%s", ...)`
+pub(crate) fn full_fname(fname: &str, paths: FullFnamePaths<'_>) -> String {
+    match paths.render(Path::new(fname)) {
+        Some(rendered) => quote(&rendered, paths.module),
+        None => quote(fname, paths.module),
     }
 }
 
 /// [`full_fname`] for a [`Path`], using the platform's lossy display form.
-pub(crate) fn full_fname_path(path: &Path, daemon: Option<DaemonPaths<'_>>) -> String {
-    match daemon {
-        Some(paths) => match paths.relativize(path) {
-            Some(rendered) => quote(&rendered, Some(paths.module)),
-            None => quote(&path.display().to_string(), Some(paths.module)),
-        },
-        None => quote(&path.display().to_string(), None),
+pub(crate) fn full_fname_path(path: &Path, paths: FullFnamePaths<'_>) -> String {
+    match paths.render(path) {
+        Some(rendered) => quote(&rendered, paths.module),
+        None => quote(&path.display().to_string(), paths.module),
     }
 }
 
@@ -176,31 +300,22 @@ fn quote(fname: &str, module: Option<&str>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{DaemonPaths, full_fname, full_fname_path};
+    use super::{FullFnamePaths, full_fname, full_fname_path};
     use std::path::Path;
 
-    fn paths<'a>(module_root: &'a str, curr_dir: &'a str) -> DaemonPaths<'a> {
-        DaemonPaths {
-            module: "mymod",
-            module_root: Path::new(module_root),
+    fn paths<'a>(module_root: &'a str, curr_dir: &'a str) -> FullFnamePaths<'a> {
+        FullFnamePaths::daemon("mymod", Path::new(module_root), Path::new(curr_dir))
+    }
+
+    /// A context with no module and an explicit `curr_dir`, so the non-daemon
+    /// prefix rule can be asserted without depending on the test process's own
+    /// working directory.
+    fn no_module(curr_dir: &str) -> FullFnamePaths<'_> {
+        FullFnamePaths {
+            module: None,
+            module_root: None,
             curr_dir: Path::new(curr_dir),
         }
-    }
-
-    #[test]
-    fn quotes_without_module_outside_daemon() {
-        assert_eq!(full_fname("sub/denied.txt", None), "\"sub/denied.txt\"");
-    }
-
-    #[test]
-    fn non_daemon_path_is_left_absolute() {
-        // A client or SSH server process has `module_id < 0`: upstream neither
-        // strips a prefix nor appends a suffix, so the absolute path a local
-        // or SSH run reports must stay byte-identical.
-        assert_eq!(
-            full_fname_path(Path::new("/tmp/src/denied.txt"), None),
-            "\"/tmp/src/denied.txt\""
-        );
     }
 
     #[test]
@@ -210,7 +325,7 @@ mod tests {
         assert_eq!(
             full_fname_path(
                 Path::new("/srv/mod/sub/denied.txt"),
-                Some(paths("/srv/mod", "/srv/mod"))
+                paths("/srv/mod", "/srv/mod")
             ),
             "\"sub/denied.txt\" (in mymod)"
         );
@@ -224,7 +339,7 @@ mod tests {
         assert_eq!(
             full_fname_path(
                 Path::new("/srv/mod/sub/denied2"),
-                Some(paths("/srv/mod", "/srv/mod/sub"))
+                paths("/srv/mod", "/srv/mod/sub")
             ),
             "\"/sub/denied2\" (in mymod)"
         );
@@ -233,9 +348,9 @@ mod tests {
     #[test]
     fn path_at_curr_dir_renders_as_dot() {
         // upstream's DOTDIR_NAME arg leaves `fn` as ".", never the empty
-        // string (flist.c:2312-2322).
+        // string (flist.c:2672-2673).
         assert_eq!(
-            full_fname_path(Path::new("/srv/mod"), Some(paths("/srv/mod", "/srv/mod"))),
+            full_fname_path(Path::new("/srv/mod"), paths("/srv/mod", "/srv/mod")),
             "\".\" (in mymod)"
         );
     }
@@ -245,10 +360,7 @@ mod tests {
         // upstream: `*fn == '/'` selects `p1 = p2 = ""`, so an absolute name
         // is printed as-is with the module suffix still attached.
         assert_eq!(
-            full_fname_path(
-                Path::new("/etc/passwd"),
-                Some(paths("/srv/mod", "/srv/mod"))
-            ),
+            full_fname_path(Path::new("/etc/passwd"), paths("/srv/mod", "/srv/mod")),
             "\"/etc/passwd\" (in mymod)"
         );
     }
@@ -267,8 +379,23 @@ mod tests {
     /// relative, which is what oc emitted before this pin.
     #[test]
     fn module_rooted_at_slash_keeps_the_leading_slash() {
+        // The case #7728 pinned: a module rooted at `/` with `curr_dir` also
+        // `/`. `module_dirlen` is forced from 1 to 0, so nothing is stripped
+        // and the whole name survives.
         assert_eq!(
-            full_fname_path(Path::new("/tmp/srv/mod/nope"), Some(paths("/", "/"))),
+            full_fname_path(Path::new("/tmp/srv/mod/nope"), paths("/", "/")),
+            "\"/tmp/srv/mod/nope\" (in mymod)"
+        );
+        // Measured against a real 3.5.0 daemon serving `path = /`:
+        // `link_stat "/nope" (in root)`.
+        assert_eq!(
+            full_fname_path(Path::new("/nope"), paths("/", "/")),
+            "\"/nope\" (in mymod)"
+        );
+        // A deeper module root still renders the absolute name, so the rule is
+        // not "always keep the slash" - it is `p1 = curr_dir + module_dirlen`.
+        assert_eq!(
+            full_fname_path(Path::new("/tmp/srv/mod/nope"), paths("/", "/tmp/srv/mod")),
             "\"/tmp/srv/mod/nope\" (in mymod)"
         );
     }
@@ -280,7 +407,7 @@ mod tests {
     #[test]
     fn module_rooted_at_slash_below_the_root_is_unchanged() {
         assert_eq!(
-            full_fname_path(Path::new("/tmp/srv/nope"), Some(paths("/", "/tmp/srv"))),
+            full_fname_path(Path::new("/tmp/srv/nope"), paths("/", "/tmp/srv")),
             "\"/tmp/srv/nope\" (in mymod)"
         );
     }
@@ -292,19 +419,15 @@ mod tests {
         assert_eq!(
             full_fname(
                 "/srv/mod/f",
-                Some(DaemonPaths {
-                    module: "",
-                    module_root: Path::new("/srv/mod"),
-                    curr_dir: Path::new("/srv/mod"),
-                })
+                FullFnamePaths::daemon("", Path::new("/srv/mod"), Path::new("/srv/mod"))
             ),
             "\"f\" (in )"
         );
     }
 
-    /// The module-relative name is the same `/`-separated name rsync puts on
-    /// the wire, so it must not pick up the host separator when the daemon
-    /// runs on Windows. Built with `PathBuf::join` so the input carries the
+    /// The rendered name is the same `/`-separated name rsync puts on the
+    /// wire, so it must not pick up the host separator when the process runs
+    /// on Windows. Built with `PathBuf::join` so the input carries the
     /// platform's own separator.
     #[test]
     fn rendered_name_uses_slash_separators_on_every_platform() {
@@ -314,14 +437,7 @@ mod tests {
         let curr = root.join("sub");
         let path = curr.join("deep").join("denied.txt");
         assert_eq!(
-            full_fname_path(
-                &path,
-                Some(DaemonPaths {
-                    module: "mymod",
-                    module_root: &root,
-                    curr_dir: &curr,
-                })
-            ),
+            full_fname_path(&path, FullFnamePaths::daemon("mymod", &root, &curr)),
             "\"/sub/deep/denied.txt\" (in mymod)"
         );
     }
@@ -329,11 +445,97 @@ mod tests {
     #[test]
     fn path_variant_matches_string_variant() {
         assert_eq!(
-            full_fname_path(
-                Path::new("/srv/mod/a/b"),
-                Some(paths("/srv/mod", "/srv/mod"))
-            ),
-            full_fname("/srv/mod/a/b", Some(paths("/srv/mod", "/srv/mod")))
+            full_fname_path(Path::new("/srv/mod/a/b"), paths("/srv/mod", "/srv/mod")),
+            full_fname("/srv/mod/a/b", paths("/srv/mod", "/srv/mod"))
         );
+    }
+
+    /// The two axes are independent upstream: the prefix comes from `curr_dir`
+    /// and `module_dirlen`, the suffix from `module_id`. Outside a daemon
+    /// module `module_dirlen` is 0, so the whole working directory is
+    /// prefixed onto a relative name while no suffix is appended.
+    ///
+    /// Ground truth, rsync 3.5.0, `cd /tmp/work && rsync -r nope dst/`:
+    ///   rsync: [sender] link_stat "/tmp/work/nope" failed: ...
+    #[test]
+    fn non_daemon_relative_name_is_anchored_at_curr_dir() {
+        assert_eq!(
+            full_fname_path(Path::new("nope"), no_module("/tmp/work")),
+            "\"/tmp/work/nope\""
+        );
+        assert_eq!(
+            full_fname_path(Path::new("sub/nope"), no_module("/tmp/work")),
+            "\"/tmp/work/sub/nope\""
+        );
+    }
+
+    /// A `./` in the operand must not survive into the rendered name.
+    ///
+    /// Upstream cleans every flist name with `clean_fname(thisname, 0)`
+    /// (`flist.c:1424`); with `CFN_KEEP_DOT_DIRS` unset that discards interior
+    /// `"."` dirs (`util1.c:1068-1071`). Ground truth captured from rsync
+    /// 3.5.0 pushing `./sub/` from `/tmp/t1141P/work` over a local remote
+    /// shell: `send_files failed to open "/tmp/t1141P/work/sub/denied.txt"` -
+    /// no `/./` anywhere in the name.
+    #[test]
+    fn a_dot_component_is_collapsed_out_of_the_rendered_name() {
+        assert_eq!(
+            full_fname_path(Path::new("./sub/nope"), no_module("/tmp/work")),
+            "\"/tmp/work/sub/nope\""
+        );
+        assert_eq!(
+            full_fname_path(Path::new("sub/./nope"), no_module("/tmp/work")),
+            "\"/tmp/work/sub/nope\""
+        );
+        // A name that is nothing but "." is upstream's DOTDIR name and must
+        // survive as "." rather than collapsing to the bare directory.
+        assert_eq!(
+            full_fname_path(Path::new("."), no_module("/tmp/work")),
+            "\"/tmp/work/.\""
+        );
+    }
+
+    #[test]
+    fn non_daemon_absolute_path_is_left_absolute() {
+        // A client or SSH server process has `module_id < 0`: no suffix, and
+        // an absolute name already under `curr_dir` renders to the same
+        // absolute string, so a local or SSH run stays byte-identical.
+        assert_eq!(
+            full_fname_path(
+                Path::new("/tmp/work/src/denied.txt"),
+                no_module("/tmp/work")
+            ),
+            "\"/tmp/work/src/denied.txt\""
+        );
+        // upstream's `*fn == '/'` branch: an absolute name outside `curr_dir`
+        // is printed verbatim with no prefix.
+        assert_eq!(
+            full_fname_path(Path::new("/elsewhere/denied.txt"), no_module("/tmp/work")),
+            "\"/elsewhere/denied.txt\""
+        );
+    }
+
+    /// The non-vacuity companion to the `path = /` case: an ordinary module
+    /// root still strips, so the arm above is not simply disabling the strip
+    /// for everyone.
+    #[test]
+    fn module_rooted_below_slash_still_strips() {
+        assert_eq!(
+            full_fname_path(
+                Path::new("/tmp/srv/mod/nope"),
+                paths("/tmp/srv/mod", "/tmp/srv/mod")
+            ),
+            "\"nope\" (in mymod)"
+        );
+    }
+
+    /// The suffix axis alone: the same prefix rule with and without a module
+    /// name produces the same quoted path, differing only in the suffix.
+    #[test]
+    fn the_module_suffix_is_independent_of_the_prefix() {
+        let with_module = full_fname_path(Path::new("/tmp/work/f"), paths("/", "/tmp/work"));
+        let without = full_fname_path(Path::new("/tmp/work/f"), no_module("/tmp/work"));
+        assert_eq!(with_module, "\"/tmp/work/f\" (in mymod)");
+        assert_eq!(without, "\"/tmp/work/f\"");
     }
 }

--- a/crates/transfer/src/full_fname.rs
+++ b/crates/transfer/src/full_fname.rs
@@ -165,7 +165,7 @@ impl<'a> FullFnamePaths<'a> {
         // helper either an absolute path (the daemon and every wire-side
         // caller) or the operand spelling the user typed, which is already
         // relative to the working directory - so recover `fn` from both.
-        let tail = if path.is_absolute() {
+        let tail = if is_rooted(path) {
             slash_path(path.strip_prefix(self.curr_dir).ok()?)
         } else {
             slash_path(path)
@@ -200,6 +200,28 @@ impl<'a> FullFnamePaths<'a> {
         };
         Some(format!("{p1}{p2}{tail}"))
     }
+}
+
+/// Upstream's `*fn == '/'` test, on the leading byte.
+///
+/// upstream: `util1.c:1445` - `if (*fn == '/') p1 = p2 = "";`. The names that
+/// reach this module are rsync's own `/`-separated wire names, never
+/// host-native paths, so the question is literally "does this name begin with
+/// a slash" and the answer must not depend on the platform.
+///
+/// [`Path::is_absolute`] answers a DIFFERENT question. On Unix the two agree
+/// for every input, because there `is_absolute()` is defined as "begins with
+/// `/`". On Windows it additionally demands a drive prefix, so `/srv/mod/f`
+/// is NOT absolute there: the `else` arm would run, the whole server-side
+/// path would survive as `tail`, and it would then be spliced AFTER the
+/// `curr_dir` prefix instead of being stripped from the front -
+/// `"/sub" + "/" + "/srv/mod/sub/denied2"`.
+///
+/// `as_encoded_bytes` keeps the test allocation-free and byte-faithful for a
+/// non-UTF-8 name; inspecting a leading ASCII byte is exactly what its
+/// contract permits.
+fn is_rooted(path: &Path) -> bool {
+    path.as_os_str().as_encoded_bytes().first() == Some(&b'/')
 }
 
 /// Upstream's `curr_dir[]` for a process that never selected a module.

--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -160,7 +160,13 @@ pub struct GeneratorContext {
     /// `full_fname()` renders every diagnostic path relative to that directory.
     /// oc-rsync never `chdir()`s, so the same directory - the walk `base` - is
     /// recorded here as each source entry is walked and consumed by
-    /// [`daemon_paths`](Self::daemon_paths).
+    /// [`full_fname_paths`](Self::full_fname_paths).
+    ///
+    /// Only a daemon server reads it. Outside a module the walk `base` may be
+    /// the operand spelling the user typed, which is not upstream's absolute
+    /// `curr_dir`; that case uses the process working directory instead, which
+    /// is what upstream's `getcwd()`-seeded global holds for a process that
+    /// never `chdir()`s.
     pub(crate) curr_dir: Option<PathBuf>,
     /// Transfer pipeline FSM tracking the current protocol phase.
     ///
@@ -222,27 +228,34 @@ impl std::fmt::Debug for BatchStatsSink {
 }
 
 impl GeneratorContext {
-    /// Returns the daemon path context that makes
-    /// [`crate::full_fname::full_fname`] render a quoted path the way upstream
-    /// does - module-relative, with the ` (in MODULE)` suffix - or `None`
-    /// outside a daemon server process.
+    /// Returns the path context [`crate::full_fname::full_fname`] renders
+    /// against.
     ///
-    /// The module root falls back to the module itself as `curr_dir` until the
-    /// walk records one, matching a server that has only `chdir()`ed into the
-    /// module root (`clientserver.c:993`) and not yet into a source argument.
+    /// Both of upstream's axes are answered here, and they are answered
+    /// separately. The ` (in MODULE)` suffix needs a selected module
+    /// (`module_id >= 0`); the `curr_dir + module_dirlen` prefix does not, so a
+    /// process serving no module still renders against its working directory
+    /// rather than dropping the anchor with the module name.
+    ///
+    /// The module root doubles as `curr_dir` until the walk records one,
+    /// matching a server that has only `chdir()`ed into the module root
+    /// (`clientserver.c:1059`) and not yet into a source argument.
     ///
     /// # Upstream Reference
     ///
-    /// - `util1.c:1285-1290` - `p1 = curr_dir + module_dirlen` and
-    ///   `if (module_id >= 0)` in `full_fname()`.
-    pub(crate) fn daemon_paths(&self) -> Option<crate::full_fname::DaemonPaths<'_>> {
-        let module = self.config.connection.daemon_module.as_deref()?;
-        let module_root = self.config.connection.daemon_module_root.as_deref()?;
-        Some(crate::full_fname::DaemonPaths {
-            module,
-            module_root,
-            curr_dir: self.curr_dir.as_deref().unwrap_or(module_root),
-        })
+    /// - `util1.c:1445-1452` - `p1 = curr_dir + module_dirlen` computed
+    ///   unconditionally; `util1.c:1453` - `if (module_id >= 0)` gating only
+    ///   the suffix.
+    pub(crate) fn full_fname_paths(&self) -> crate::full_fname::FullFnamePaths<'_> {
+        let module_root = self.config.connection.daemon_module_root.as_deref();
+        match (self.config.connection.daemon_module.as_deref(), module_root) {
+            (Some(module), Some(root)) => crate::full_fname::FullFnamePaths::daemon(
+                module,
+                root,
+                self.curr_dir.as_deref().unwrap_or(root),
+            ),
+            _ => crate::full_fname::FullFnamePaths::non_daemon(),
+        }
     }
 
     /// Creates a new generator context from a completed handshake and server config.

--- a/crates/transfer/src/generator/file_list/walk.rs
+++ b/crates/transfer/src/generator/file_list/walk.rs
@@ -336,7 +336,7 @@ impl GeneratorContext {
                         // upstream: flist.c:2433 - rsyserr(FERROR_XFER, ...)
                         let text = format!(
                             "rsync: [sender] link_stat {} failed: {}\n",
-                            full_fname_path(path, self.daemon_paths()),
+                            full_fname_path(path, self.full_fname_paths()),
                             engine::local_copy::upstream_io_error(&e),
                         );
                         self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -566,7 +566,7 @@ impl GeneratorContext {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     let text = format!(
                         "rsync: [sender] opendir {} failed: {}\n",
-                        full_fname_path(&path, self.daemon_paths()),
+                        full_fname_path(&path, self.full_fname_paths()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -739,7 +739,7 @@ impl GeneratorContext {
                     // upstream: flist.c:1878 - rsyserr(FERROR_XFER, errno, "opendir %s failed", ...)
                     let text = format!(
                         "rsync: [sender] opendir {} failed: {}\n",
-                        full_fname_path(dir_path, self.daemon_paths()),
+                        full_fname_path(dir_path, self.full_fname_paths()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -776,7 +776,7 @@ impl GeneratorContext {
                     // upstream: flist.c:2195 - rsyserr(FERROR_XFER, errno, "readdir(%s)", ...)
                     let text = format!(
                         "rsync: [sender] readdir({}): {}\n",
-                        full_fname_path(dir_path, self.daemon_paths()),
+                        full_fname_path(dir_path, self.full_fname_paths()),
                         engine::local_copy::upstream_io_error(&e),
                     );
                     self.queue_flist_diagnostic(SenderDiagnostic::ErrorXfer, text);
@@ -885,7 +885,7 @@ impl GeneratorContext {
     /// types: the vanished notice is an `FWARNING`, the stat failure an
     /// `FERROR_XFER`.
     fn log_stat_error(&mut self, path: &Path, e: &io::Error) {
-        let fname = full_fname_path(path, self.daemon_paths());
+        let fname = full_fname_path(path, self.full_fname_paths());
         let (kind, text) = if e.kind() == io::ErrorKind::NotFound {
             // upstream: flist.c:1463-1467 - rprintf(FWARNING, "file has vanished: %s\n", ...)
             (
@@ -1160,15 +1160,11 @@ mod rsyserr_wording_tests {
     /// `rsync: [sender] opendir "denied" (in mod) failed: Permission denied (13)`.
     #[test]
     fn rsyserr_wording_carries_daemon_module_suffix() {
-        use crate::full_fname::{DaemonPaths, full_fname_path};
+        use crate::full_fname::{FullFnamePaths, full_fname_path};
         use std::path::Path;
 
-        let daemon = DaemonPaths {
-            module: "mymod",
-            module_root: Path::new("/srv/mod"),
-            curr_dir: Path::new("/srv/mod"),
-        };
-        let quoted = full_fname_path(Path::new("/srv/mod/p"), Some(daemon));
+        let daemon = FullFnamePaths::daemon("mymod", Path::new("/srv/mod"), Path::new("/srv/mod"));
+        let quoted = full_fname_path(Path::new("/srv/mod/p"), daemon);
         assert_eq!(quoted, "\"p\" (in mymod)");
         assert_eq!(
             format!("rsync: [sender] link_stat {quoted} failed: No such file or directory (2)"),
@@ -1189,10 +1185,10 @@ mod rsyserr_wording_tests {
     /// appends a suffix there, so a local or SSH run's stderr is unchanged.
     #[test]
     fn rsyserr_wording_outside_a_daemon_stays_absolute() {
-        use crate::full_fname::full_fname_path;
+        use crate::full_fname::{FullFnamePaths, full_fname_path};
         use std::path::Path;
 
-        let quoted = full_fname_path(Path::new("/srv/mod/p"), None);
+        let quoted = full_fname_path(Path::new("/srv/mod/p"), FullFnamePaths::non_daemon());
         assert_eq!(quoted, "\"/srv/mod/p\"");
         assert_eq!(
             format!("rsync: [sender] opendir {quoted} failed: Permission denied (13)"),

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -450,7 +450,7 @@ impl GeneratorContext {
         error: &io::Error,
         path_display: &str,
     ) -> io::Result<()> {
-        let fname = crate::full_fname::full_fname(path_display, self.daemon_paths());
+        let fname = crate::full_fname::full_fname(path_display, self.full_fname_paths());
         if error.kind() == io::ErrorKind::NotFound {
             self.io_error |= super::io_error_flags::IOERR_VANISHED;
             // upstream: sender.c:713-716 - rprintf(c, "file has vanished: %s\n", full_fname(...)).
@@ -498,7 +498,7 @@ impl GeneratorContext {
         self.io_error |= super::io_error_flags::IOERR_GENERAL;
         let text = format!(
             "rsync: [sender] read errors mapping {}: {}\n",
-            crate::full_fname::full_fname(path_display, self.daemon_paths()),
+            crate::full_fname::full_fname(path_display, self.full_fname_paths()),
             engine::local_copy::upstream_io_error(error),
         );
         self.emit_sender_diagnostic(writer, SenderDiagnostic::ErrorXfer, &text)
@@ -532,7 +532,7 @@ impl GeneratorContext {
             SenderDiagnostic::Warning,
             &format!(
                 "skipped diminished file: {}\n",
-                crate::full_fname::full_fname(path_display, self.daemon_paths()),
+                crate::full_fname::full_fname(path_display, self.full_fname_paths()),
             ),
         )?;
         if self.protocol.supports_generator_messages() {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6198,9 +6198,25 @@ fn open_failure_frames(
 /// that is just the working directory. Building the expectation from
 /// `current_dir()` here keeps it an independent oracle - it never consults
 /// the renderer under test.
+///
+/// The prefix is re-rendered with `/` separators on Windows. `Display` emits
+/// the platform separator, so joining it to a `/`-prefixed relative name built
+/// a MIXED expectation - `D:\a\...\transfer/src/gone.txt` - that agreed with
+/// the renderer only where the platform separator already was `/`. Upstream
+/// joins `curr_dir` and the name with a literal `/` (`util1.c:1445-1452`) and
+/// `full_fname` mirrors that by rendering every component with `/`, so `/` is
+/// the expectation on both platforms. Rewriting the separator here keeps the
+/// oracle independent - it still never calls the renderer - while letting it
+/// agree on Windows. The rewrite is Windows-only because `\` is a legal byte
+/// in a POSIX component name and must survive there.
 fn anchored(relative: &str) -> String {
-    let cwd = std::env::current_dir().unwrap();
-    format!("{}/{relative}", cwd.display())
+    let cwd = std::env::current_dir().unwrap().display().to_string();
+    let cwd = if cfg!(windows) {
+        cwd.replace('\\', "/")
+    } else {
+        cwd
+    };
+    format!("{cwd}/{relative}")
 }
 
 /// A daemon or SSH server has no stderr the client reads, so upstream's

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6191,6 +6191,18 @@ fn open_failure_frames(
     decode_mux_frames(&buf)
 }
 
+/// The name `full_fname()` renders for a non-daemon server process.
+///
+/// upstream keeps `curr_dir` unconditionally and prefixes every diagnostic
+/// path with it (`util1.c:1445-1452`); for a process that selected no module
+/// that is just the working directory. Building the expectation from
+/// `current_dir()` here keeps it an independent oracle - it never consults
+/// the renderer under test.
+fn anchored(relative: &str) -> String {
+    let cwd = std::env::current_dir().unwrap();
+    format!("{}/{relative}", cwd.display())
+}
+
 /// A daemon or SSH server has no stderr the client reads, so upstream's
 /// `rwrite()` (log.c:330-346) sends the vanished warning as a MSG frame
 /// *instead of* writing it locally. Without the frame the client never learns
@@ -6205,7 +6217,8 @@ fn vanished_open_failure_frames_a_warning_in_server_mode() {
     );
     assert_eq!(frames[0].0, protocol::MessageCode::Warning);
     assert_eq!(
-        frames[0].1, b"file has vanished: \"src/gone.txt\"\n",
+        frames[0].1,
+        format!("file has vanished: \"{}\"\n", anchored("src/gone.txt")).as_bytes(),
         "payload must be the upstream text including its trailing newline"
     );
     assert_eq!(
@@ -6227,7 +6240,10 @@ fn vanished_open_failure_downgrades_to_info_below_protocol_30() {
         "protocol 29 has no generator messages, so no MSG_NO_SEND: {frames:?}"
     );
     assert_eq!(frames[0].0, protocol::MessageCode::Info);
-    assert_eq!(frames[0].1, b"file has vanished: \"src/gone.txt\"\n");
+    assert_eq!(
+        frames[0].1,
+        format!("file has vanished: \"{}\"\n", anchored("src/gone.txt")).as_bytes()
+    );
 }
 
 /// upstream sender.c:393 uses `rsyserr(FERROR_XFER, ...)`, which the peer's
@@ -6239,7 +6255,8 @@ fn general_open_failure_frames_an_error_xfer_in_server_mode() {
     assert_eq!(frames.len(), 2, "error frame then MSG_NO_SEND: {frames:?}");
     assert_eq!(frames[0].0, protocol::MessageCode::ErrorXfer);
     let expected = format!(
-        "rsync: [sender] send_files failed to open \"src/gone.txt\": {}\n",
+        "rsync: [sender] send_files failed to open \"{}\": {}\n",
+        anchored("src/gone.txt"),
         engine::local_copy::upstream_io_error(&io::Error::from(io::ErrorKind::PermissionDenied)),
     );
     assert_eq!(
@@ -6291,7 +6308,11 @@ fn diminished_skip_frames_a_warning_in_server_mode() {
     assert_eq!(frames[0].0, protocol::MessageCode::Warning);
     assert_eq!(
         frames[0].1,
-        b"skipped diminished file: \"src/shrunk.bin\"\n"
+        format!(
+            "skipped diminished file: \"{}\"\n",
+            anchored("src/shrunk.bin")
+        )
+        .as_bytes()
     );
     assert_eq!(frames[1].0, protocol::MessageCode::NoSend);
     assert_eq!(

--- a/crates/transfer/src/pipeline/receiver.rs
+++ b/crates/transfer/src/pipeline/receiver.rs
@@ -276,16 +276,23 @@ impl PipelinedReceiver {
         self
     }
 
-    /// Returns the daemon path context `full_fname()` renders against, or
-    /// `None` outside a daemon server process (upstream `module_id < 0`).
-    fn daemon_paths(&self) -> Option<crate::full_fname::DaemonPaths<'_>> {
-        let module = self.daemon_module.as_deref()?;
-        let module_root = self.daemon_module_root.as_deref()?;
-        Some(crate::full_fname::DaemonPaths {
-            module,
-            module_root,
-            curr_dir: self.dest_dir.as_deref().unwrap_or(module_root),
-        })
+    /// Returns the path context `full_fname()` renders against.
+    ///
+    /// Only the ` (in MODULE)` suffix is gated on a selected module (upstream
+    /// `module_id < 0`); the `curr_dir` prefix applies to every process, so a
+    /// non-daemon receiver still anchors at its working directory.
+    fn full_fname_paths(&self) -> crate::full_fname::FullFnamePaths<'_> {
+        match (
+            self.daemon_module.as_deref(),
+            self.daemon_module_root.as_deref(),
+        ) {
+            (Some(module), Some(root)) => crate::full_fname::FullFnamePaths::daemon(
+                module,
+                root,
+                self.dest_dir.as_deref().unwrap_or(root),
+            ),
+            _ => crate::full_fname::FullFnamePaths::non_daemon(),
+        }
     }
 
     /// Formats the receiver's temp-file creation failure the way upstream does.
@@ -306,7 +313,7 @@ impl PipelinedReceiver {
             Some((op, path)) => (Some(op), path),
             None => (None, dest),
         };
-        let name = full_fname_path(named, self.daemon_paths());
+        let name = full_fname_path(named, self.full_fname_paths());
         let reason = logging::upstream_errno_text(error);
         match op {
             // upstream: rsync-3.5.0/receiver.c:452-453


### PR DESCRIPTION
PR #7728 kept the leading slash for a module rooted at `path = /` by special-casing `module_root == Path::new("/")` in the `full_fname` renderer, alongside the general prefix-stripping rule. This collapses the two into one.

`strip_prefix_root` already maps a `/` module root to `None`, so `p1` becomes `slash_path(curr_dir)` = `"/"`, `p2` is empty, and the render is `"/{tail}"` - byte-identical to what the special case produced, and still correct for a deeper `curr_dir`.

## This fixes no divergence, and that is the claim being defended

The change is a refactor and is labelled as one. The evidence below is what makes deleting #7728's arm safe; it is not offered as a bug fix.

Both arms were built from source and run against real rsync 3.5.0 (`rsync version 3.5.0 protocol version 32`) on Linux, on identical fixtures, comparing the rendered name in the diagnostic. Base is the commit this branch sits on; fix is this branch.

Daemon, the sender flist walk (`rsync: [sender] link_stat/opendir ...`):

| cell | upstream 3.5.0 | base | fix |
|---|---|---|---|
| opendir unreadable subdir | `"noread" (in mod)` | same | same |
| whole-module recurse | `"noread" (in mod)` | same | same |
| `path = /` unreadable | `"/<abs>/noread" (in slashroot)` | same | same |
| `path = /` missing | `"/<abs>/nope" (in slashroot)` | same | same |
| benign pull (control) | rc=0, no diagnostic | same | same |

Server sender over `--rsh`, the non-daemon arm:

| cell | upstream 3.5.0 | base | fix |
|---|---|---|---|
| relative missing | `"/<abs>/src/sub/nope"` | same | same |
| relative unreadable dir | `"/<abs>/src/noread"` | same | same |
| relative with a `./` segment | `"/<abs>/src/sub/nope"` (collapsed) | same | same |
| absolute unreadable dir | `"/<abs>/src/noread"` | same | same |

Nine cells, two transports: base, fix and upstream agree everywhere. The renderer was already upstream-correct, so this adds tests around behaviour that is right and removes a redundant branch.

## Behaviour-neutrality is proven by test, not by reading

#7728's own two assertions now ride inside `module_rooted_at_slash_keeps_the_leading_slash`, and its negative control `module_rooted_at_slash_below_the_root_is_unchanged` is retained unchanged in intent. Both are green.

Merging those assertions rather than deleting the tests that stopped typechecking after the refactor is a visible decision with a visible result: this revision carries all three assertions plus the separate negative control, where an earlier un-rebased revision of the branch had two assertions and no control.

New coverage the renderer previously had none for: a `.` component collapsed out of a rendered name, and a non-daemon name anchored at `curr_dir`.

## Scope

The renderer's only production callers are the transfer crate's sender flist walk (`generator/file_list/walk.rs`, `generator/protocol_io.rs`) and `pipeline/receiver.rs`. A local copy renders its diagnostics through the engine, which never calls this code, so nothing here touches the local path.

That scoping is load-bearing rather than incidental. This task was originally filed as a fix for a local-copy diagnostic divergence; measuring it is what showed the local path does not reach `full_fname` at all. The real divergence is tracked separately with the engine named as its producer.

## Gates

`cargo nextest run -p transfer`: 2478 passed / 0 failed. `tools/ci/check_rustfmt_all.py` exit 0. Clippy exit 0. All re-run on the squashed commit rather than inherited from the pre-squash tip.

Disclosed for completeness: running `cargo test -p transfer --lib` by hand reports 93 failures. They are inherited, not introduced - the base commit reports 91 on the same host, and the two that differ are flaky on the base as well. One failed 1 of 5 runs on base and 4 of 5 on this branch, passed 6 of 6 in isolation, and passed 3 of 3 on both sides at `--test-threads=1`. The cluster is process-global state racing between threads inside one test binary; `cargo nextest`, which CI uses, runs a process per test.
