### PR TITLE
fix(daemon): honour XFLG_OLD_PREFIXES on the module filter parameters

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -208,10 +208,15 @@ fn build_daemon_filter_rules(
     let mut rules = Vec::new();
 
     // 1. filter rules - full filter syntax (e.g., "- *.tmp", "+ *.rs")
-    // upstream: clientserver.c:874 - parse_filter_str(&daemon_filter_list, lp_filter(i),
+    // upstream: clientserver.c:933-935 - parse_filter_str(&daemon_filter_list, lp_filter(i),
     //           rule_template(FILTRULE_WORD_SPLIT), XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3)
     // FILTRULE_WORD_SPLIT means a single filter line can contain multiple
     // space-separated rules: "+ *.txt + *.rs - *" is three rules.
+    //
+    // This is the ONE module filter parameter upstream does NOT give
+    // XFLG_OLD_PREFIXES: `filter` takes the modern rule syntax, where `- ` and
+    // `+ ` are rule prefixes already, so `old_prefix_*` below deliberately does
+    // not apply here.
     for filter_str in &module.filter {
         for token in split_filter_tokens(filter_str.trim()) {
             if let Some(rule) = parse_daemon_filter_token(&token) {
@@ -221,8 +226,9 @@ fn build_daemon_filter_rules(
     }
 
     // 2. include_from - read patterns from file, one per line
-    // upstream: clientserver.c:878 - parse_filter_file(&daemon_filter_list, lp_include_from(i),
-    //           rule_template(FILTRULE_INCLUDE), XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | ...)
+    // upstream: clientserver.c:937-939 - parse_filter_file(&daemon_filter_list,
+    //           lp_include_from(i), rule_template(FILTRULE_INCLUDE),
+    //           XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | XFLG_OLD_PREFIXES | XFLG_FATAL_ERRORS)
     if let Some(ref path) = module.include_from {
         let patterns = read_patterns_from_file(path)?;
         for pattern in patterns {
@@ -231,7 +237,7 @@ fn build_daemon_filter_rules(
     }
 
     // 3. include rules - bare patterns, word-split on whitespace
-    // upstream: clientserver.c:941-943 - parse_filter_str(&daemon_filter_list, lp_include(i),
+    // upstream: clientserver.c:941-944 - parse_filter_str(&daemon_filter_list, lp_include(i),
     //           rule_template(FILTRULE_INCLUDE | FILTRULE_WORD_SPLIT),
     //           XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | XFLG_OLD_PREFIXES)
     for include_str in &module.include {
@@ -330,8 +336,8 @@ fn unexpected_end_of_filter_rule(rule: &str) -> io::Error {
 /// Builds one rule from a whole filter-file record under `XFLG_OLD_PREFIXES`.
 ///
 /// `template_include` is the template's `FILTRULE_INCLUDE` bit:
-/// `rule_template(FILTRULE_INCLUDE)` for `include from` (clientserver.c:936-937)
-/// and `rule_template(0)` for `exclude from` (clientserver.c:943-944).
+/// `rule_template(FILTRULE_INCLUDE)` for `include from` (clientserver.c:937-939)
+/// and `rule_template(0)` for `exclude from` (clientserver.c:946-948).
 ///
 /// Neither template carries `FILTRULE_WORD_SPLIT`, so the pattern runs to the
 /// end of the record: `len = strlen(s)` (`exclude.c:1465`). That is why the
@@ -350,6 +356,16 @@ fn old_prefix_record_rule(
         OldPrefix::MaybeClear if record.len() == 1 => return Ok(clear_list_rule()),
         OldPrefix::MaybeClear | OldPrefix::Inherit => (record, template_include),
     };
+    // upstream: exclude.c:1474-1475 - `filter_rule_err("unexpected end of
+    // filter rule")`, fatal under XFLG_FATAL_ERRORS.
+    //
+    // ⚠ REVERSION GUARD, not a live refusal: `read_patterns_from_file` trims
+    // each record, so a `"- "` line arrives here as `"-"` and never reaches an
+    // empty pattern. Upstream's `parse_filter_file` (exclude.c:1774) keeps the
+    // trailing space and does refuse it; the trim is a separate pre-existing
+    // divergence. The reachable refusal is the string-parameter one in
+    // `push_old_prefix_token_rules`, pinned by
+    // `exclude_string_empty_after_the_prefix_is_refused`.
     if pattern.is_empty() {
         return Err(unexpected_end_of_filter_rule(record));
     }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -192,7 +192,16 @@ fn dont_compress_is_match_all(value: &str) -> bool {
 ///
 /// The order matches upstream: filter, include_from, include, exclude_from, exclude.
 ///
-/// upstream: clientserver.c:874-893 - `rsync_module()` builds `daemon_filter_list`.
+/// upstream: clientserver.c:933-952 - `rsync_module()` builds `daemon_filter_list`.
+///
+/// Four of the five carry `XFLG_OLD_PREFIXES` - every one except `filter`,
+/// which gets the full filter-rule grammar instead. Under that flag a leading
+/// `- ` or `+ ` is an ACTION PREFIX that is stripped from the pattern, and a
+/// token that is exactly `!` clears the list. Taking the record verbatim
+/// instead turns `- foo` into a pattern that matches a file literally named
+/// `- foo`, so the entry the operator wrote it to hide is served.
+/// [`old_prefix_record_rule`] and [`push_old_prefix_token_rules`] own that
+/// decision for the file and string spellings respectively.
 fn build_daemon_filter_rules(
     module: &ModuleRuntime,
 ) -> Result<Vec<FilterRuleWireFormat>, io::Error> {
@@ -217,39 +226,181 @@ fn build_daemon_filter_rules(
     if let Some(ref path) = module.include_from {
         let patterns = read_patterns_from_file(path)?;
         for pattern in patterns {
-            rules.push(build_pattern_rule(&pattern, true));
+            rules.push(old_prefix_record_rule(&pattern, true)?);
         }
     }
 
     // 3. include rules - bare patterns, word-split on whitespace
-    // upstream: clientserver.c:882 - parse_filter_str(&daemon_filter_list, lp_include(i),
-    //           rule_template(FILTRULE_INCLUDE | FILTRULE_WORD_SPLIT), XFLG_ABS_IF_SLASH | ...)
+    // upstream: clientserver.c:941-943 - parse_filter_str(&daemon_filter_list, lp_include(i),
+    //           rule_template(FILTRULE_INCLUDE | FILTRULE_WORD_SPLIT),
+    //           XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | XFLG_OLD_PREFIXES)
     for include_str in &module.include {
-        for pattern in include_str.split_whitespace() {
-            rules.push(build_pattern_rule(pattern, true));
-        }
+        push_old_prefix_token_rules(&mut rules, include_str, true)?;
     }
 
     // 4. exclude_from - read patterns from file, one per line
-    // upstream: clientserver.c:887 - parse_filter_file(&daemon_filter_list, lp_exclude_from(i),
+    // upstream: clientserver.c:946-948 - parse_filter_file(&daemon_filter_list, lp_exclude_from(i),
     //           rule_template(0), XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | ...)
     if let Some(ref path) = module.exclude_from {
         let patterns = read_patterns_from_file(path)?;
         for pattern in patterns {
-            rules.push(build_pattern_rule(&pattern, false));
+            rules.push(old_prefix_record_rule(&pattern, false)?);
         }
     }
 
     // 5. exclude rules - bare patterns, word-split on whitespace
-    // upstream: clientserver.c:891 - parse_filter_str(&daemon_filter_list, lp_exclude(i),
-    //           rule_template(FILTRULE_WORD_SPLIT), XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | ...)
+    // upstream: clientserver.c:950-952 - parse_filter_str(&daemon_filter_list, lp_exclude(i),
+    //           rule_template(FILTRULE_WORD_SPLIT),
+    //           XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | XFLG_OLD_PREFIXES)
     for exclude_str in &module.exclude {
-        for pattern in exclude_str.split_whitespace() {
-            rules.push(build_pattern_rule(pattern, false));
-        }
+        push_old_prefix_token_rules(&mut rules, exclude_str, false)?;
     }
 
     Ok(rules)
+}
+
+/// The prefix `XFLG_OLD_PREFIXES` recognises at the head of a filter rule.
+///
+/// upstream: `exclude.c:1276-1284`. Under `XFLG_OLD_PREFIXES` exactly three
+/// forms are special, and nothing else is: a literal `- ` (dash, space) makes
+/// the rule an exclude, a literal `+ ` makes it an include, and a leading `!`
+/// *tentatively* marks a list-clear. Only the first two consume bytes - the
+/// `!` arm leaves the cursor where it is, which is why `Clear` carries no
+/// remainder here and the caller measures the token including the `!`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OldPrefix {
+    /// `- ` - override the template to exclude, consuming two bytes.
+    Exclude,
+    /// `+ ` - override the template to include, consuming two bytes.
+    Include,
+    /// A leading `!` - a list-clear only if the whole token is exactly `!`.
+    MaybeClear,
+    /// No recognised prefix: the rule inherits the template's include flag.
+    Inherit,
+}
+
+/// Classifies the head of one rule under `XFLG_OLD_PREFIXES`.
+///
+/// upstream: `exclude.c:1277-1284`. The tests are on raw bytes with no
+/// whitespace skipping of their own: under `FILTRULE_WORD_SPLIT` the caller has
+/// already advanced past the leading whitespace (`exclude.c:1250-1255`), and the
+/// two file-read parameters are *not* word-split, so their record starts at
+/// column zero. A `-` or `+` not followed by a space is therefore ordinary
+/// pattern text, which is what makes `- - foo` an exclude of the literal
+/// pattern `- foo`: exactly one strip happens, never two.
+fn old_prefix(rule: &str) -> OldPrefix {
+    if rule.starts_with("- ") {
+        OldPrefix::Exclude
+    } else if rule.starts_with("+ ") {
+        OldPrefix::Include
+    } else if rule.starts_with('!') {
+        OldPrefix::MaybeClear
+    } else {
+        OldPrefix::Inherit
+    }
+}
+
+/// A list-clear rule.
+///
+/// upstream: `exclude.c:1284` sets `FILTRULE_CLEAR_LIST`; `exclude.c:1542`
+/// makes the receiving list drop every rule accumulated so far.
+fn clear_list_rule() -> FilterRuleWireFormat {
+    FilterRuleWireFormat {
+        rule_type: protocol::filters::RuleType::Clear,
+        ..FilterRuleWireFormat::default()
+    }
+}
+
+/// Upstream's fatal "unexpected end of filter rule" refusal.
+///
+/// upstream: `exclude.c:1474-1475` - a rule that is empty once its prefix has
+/// been consumed calls `filter_rule_err()`, which is `rprintf(FERROR, ...)`
+/// followed by `exit_cleanup(RERR_SYNTAX)` (`exclude.c:133-137`). Both file
+/// parameters additionally carry `XFLG_FATAL_ERRORS`. Returning an error here
+/// reaches the caller's existing abort path, which refuses the module rather
+/// than silently dropping the rule - dropping it would serve every file the
+/// operator wrote that line to hide.
+fn unexpected_end_of_filter_rule(rule: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("unexpected end of filter rule: {rule}"),
+    )
+}
+
+/// Builds one rule from a whole filter-file record under `XFLG_OLD_PREFIXES`.
+///
+/// `template_include` is the template's `FILTRULE_INCLUDE` bit:
+/// `rule_template(FILTRULE_INCLUDE)` for `include from` (clientserver.c:936-937)
+/// and `rule_template(0)` for `exclude from` (clientserver.c:943-944).
+///
+/// Neither template carries `FILTRULE_WORD_SPLIT`, so the pattern runs to the
+/// end of the record: `len = strlen(s)` (`exclude.c:1465`). That is why the
+/// whole record is handed to [`build_pattern_rule`] rather than a first word.
+fn old_prefix_record_rule(
+    record: &str,
+    template_include: bool,
+) -> Result<FilterRuleWireFormat, io::Error> {
+    let (pattern, is_include) = match old_prefix(record) {
+        OldPrefix::Exclude => (&record[2..], false),
+        OldPrefix::Include => (&record[2..], true),
+        // upstream: exclude.c:1467-1473 - the `!` is tentative. `len` is
+        // measured from the UNADVANCED cursor, so it counts the `!` itself;
+        // `len > 1` clears the flag again and the rule keeps `!...` as literal
+        // pattern text. `len == 1` is the bare `!` that really clears the list.
+        OldPrefix::MaybeClear if record.len() == 1 => return Ok(clear_list_rule()),
+        OldPrefix::MaybeClear | OldPrefix::Inherit => (record, template_include),
+    };
+    if pattern.is_empty() {
+        return Err(unexpected_end_of_filter_rule(record));
+    }
+    Ok(build_pattern_rule(pattern, is_include))
+}
+
+/// Appends the rules a word-split `include` / `exclude` value expands to.
+///
+/// upstream: `parse_filter_str()` (`exclude.c:1516`) loops `parse_rule_tok()`
+/// until the string is consumed. With `FILTRULE_WORD_SPLIT` each iteration
+/// skips leading whitespace (`exclude.c:1250-1255`), applies the
+/// `XFLG_OLD_PREFIXES` decision, then takes the pattern up to the next
+/// whitespace (`exclude.c:1457-1462`). So `exclude = - foo bar` is two rules:
+/// an exclude of `foo` and - from the template - an exclude of `bar`.
+///
+/// The scan is on ASCII whitespace because upstream's is `isspace()` over the
+/// raw bytes, which no byte of a multi-byte UTF-8 sequence can satisfy.
+fn push_old_prefix_token_rules(
+    rules: &mut Vec<FilterRuleWireFormat>,
+    value: &str,
+    template_include: bool,
+) -> Result<(), io::Error> {
+    let mut rest = value;
+    loop {
+        rest = rest.trim_start_matches(|ch: char| ch.is_ascii_whitespace());
+        if rest.is_empty() {
+            return Ok(());
+        }
+        let prefix = old_prefix(rest);
+        let after_prefix = match prefix {
+            OldPrefix::Exclude | OldPrefix::Include => &rest[2..],
+            OldPrefix::MaybeClear | OldPrefix::Inherit => rest,
+        };
+        let end = after_prefix
+            .find(|ch: char| ch.is_ascii_whitespace())
+            .unwrap_or(after_prefix.len());
+        let (token, tail) = after_prefix.split_at(end);
+        if prefix == OldPrefix::MaybeClear && token.len() == 1 {
+            rules.push(clear_list_rule());
+        } else if token.is_empty() {
+            return Err(unexpected_end_of_filter_rule(rest));
+        } else {
+            let is_include = match prefix {
+                OldPrefix::Exclude => false,
+                OldPrefix::Include => true,
+                OldPrefix::MaybeClear | OldPrefix::Inherit => template_include,
+            };
+            rules.push(build_pattern_rule(token, is_include));
+        }
+        rest = tail;
+    }
 }
 
 /// Reads patterns from a filter file, one per record.
@@ -415,10 +566,7 @@ fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
     }
 
     if strip_keyword_prefix(token, "clear").is_some() {
-        return Some(FilterRuleWireFormat {
-            rule_type: protocol::filters::RuleType::Clear,
-            ..FilterRuleWireFormat::default()
-        });
+        return Some(clear_list_rule());
     }
 
     // Bare pattern defaults to exclude (upstream behaviour)

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -360,14 +360,18 @@ fn old_prefix_record_rule(
     // upstream: exclude.c:1474-1475 - `filter_rule_err("unexpected end of
     // filter rule")`, fatal under XFLG_FATAL_ERRORS.
     //
-    // ⚠ REVERSION GUARD, not a live refusal: `read_patterns_from_file` trims
-    // each record, so a `"- "` line arrives here as `"-"` and never reaches an
-    // empty pattern. Upstream's `parse_filter_file` line loop breaks only on
-    // the newline for a non-word-split template (exclude.c:1772-1774), so it
-    // keeps the trailing space and does refuse it; the trim is pre-existing
-    // divergence. The reachable refusal is the string-parameter one in
-    // `push_old_prefix_token_rules`, pinned by
-    // `exclude_string_empty_after_the_prefix_is_refused`.
+    // This is LIVE, and it is live because of the ORDER these two changes
+    // compose in. `read_patterns_from_file` hands the record over untrimmed
+    // (exclude.c:1772-1774 breaks a non-word-split line only on the newline,
+    // so trailing whitespace is pattern text), and the prefix strip above then
+    // consumes two bytes of it. A `"- "` line therefore arrives here as `""`
+    // and upstream refuses it. Reverse the order - split or trim before
+    // stripping - and this becomes unreachable, which is what it was while the
+    // reader trimmed.
+    //
+    // Pinned by `exclude_from_empty_after_the_prefix_is_refused`; the
+    // string-parameter twin lives in `push_old_prefix_token_rules` and is
+    // pinned by `exclude_string_empty_after_the_prefix_is_refused`.
     if pattern.is_empty() {
         return Err(unexpected_end_of_filter_rule(record));
     }

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -308,8 +308,9 @@ fn old_prefix(rule: &str) -> OldPrefix {
 
 /// A list-clear rule.
 ///
-/// upstream: `exclude.c:1284` sets `FILTRULE_CLEAR_LIST`; `exclude.c:1542`
-/// makes the receiving list drop every rule accumulated so far.
+/// upstream: `exclude.c:1284` sets `FILTRULE_CLEAR_LIST`; `exclude.c:1542-1549`
+/// makes the receiving list drop every rule accumulated so far
+/// (`pop_filter_list(listp)` at `exclude.c:1548`).
 fn clear_list_rule() -> FilterRuleWireFormat {
     FilterRuleWireFormat {
         rule_type: protocol::filters::RuleType::Clear,
@@ -361,8 +362,9 @@ fn old_prefix_record_rule(
     //
     // ⚠ REVERSION GUARD, not a live refusal: `read_patterns_from_file` trims
     // each record, so a `"- "` line arrives here as `"-"` and never reaches an
-    // empty pattern. Upstream's `parse_filter_file` (exclude.c:1774) keeps the
-    // trailing space and does refuse it; the trim is a separate pre-existing
+    // empty pattern. Upstream's `parse_filter_file` line loop breaks only on
+    // the newline for a non-word-split template (exclude.c:1772-1774), so it
+    // keeps the trailing space and does refuse it; the trim is pre-existing
     // divergence. The reachable refusal is the string-parameter one in
     // `push_old_prefix_token_rules`, pinned by
     // `exclude_string_empty_after_the_prefix_is_refused`.
@@ -378,7 +380,7 @@ fn old_prefix_record_rule(
 /// until the string is consumed. With `FILTRULE_WORD_SPLIT` each iteration
 /// skips leading whitespace (`exclude.c:1250-1255`), applies the
 /// `XFLG_OLD_PREFIXES` decision, then takes the pattern up to the next
-/// whitespace (`exclude.c:1457-1462`). So `exclude = - foo bar` is two rules:
+/// whitespace (`exclude.c:1458-1462`). So `exclude = - foo bar` is two rules:
 /// an exclude of `foo` and - from the template - an exclude of `bar`.
 ///
 /// The scan is on ASCII whitespace because upstream's is `isspace()` over the

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2429,6 +2429,119 @@ mod module_access_tests {
         assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
     }
 
+    /// A FILE record left empty by the strip is upstream's fatal syntax error.
+    ///
+    /// This cell is reachable only because the reader hands the record over
+    /// UNTRIMMED (`exclude.c:1772-1774`) and the strip then consumes its two
+    /// bytes: `"- "` becomes `""`. Trim or split before stripping and the
+    /// refusal goes unreachable, so this pins the ORDER as much as the check.
+    ///
+    /// upstream: `exclude.c:1474-1475` -> `filter_rule_err()` -> exit
+    /// `RERR_SYNTAX` (`exclude.c:133-137`), fatal because the two `* from`
+    /// parameters carry `XFLG_FATAL_ERRORS` (`clientserver.c:937-939,946-948`).
+    #[test]
+    fn exclude_from_empty_after_the_prefix_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = exclude_from_rules(&dir, "- \n").unwrap_err();
+        assert!(
+            error.to_string().contains("unexpected end of filter rule"),
+            "unexpected message: {error}"
+        );
+    }
+
+    /// A LATER record carries its own prefix - the strip is re-run per record.
+    ///
+    /// upstream: `parse_filter_file` calls `parse_rule_tok` once per line
+    /// (`exclude.c:1772-1774`), and that re-runs the whole `XFLG_OLD_PREFIXES`
+    /// block (`exclude.c:1276-1284`) at each new cursor. So record 2's `- `
+    /// overrides the template exactly as record 1's `+ ` did, rather than
+    /// inheriting record 1's polarity.
+    ///
+    /// The exposure direction is what makes this worth a cell: hoist the
+    /// prefix decision to the caller and `secret.txt` inherits record 1's
+    /// INCLUDE, so the file the operator hid is served.
+    #[test]
+    fn exclude_from_a_later_record_carries_its_own_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "+ keep.txt\n- secret.txt\n").unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "keep.txt");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rules[1].pattern, "secret.txt");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// The same property in the availability direction, same fixture family.
+    #[test]
+    fn exclude_from_a_later_record_prefix_can_re_include() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "- secret.txt\n+ keep.txt\n").unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "secret.txt");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[1].pattern, "keep.txt");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Include);
+    }
+
+    /// A LATER token carries its own prefix - the string half of the same
+    /// upstream property.
+    ///
+    /// upstream: `parse_filter_str` loops over `parse_rule_tok`
+    /// (`exclude.c:1516-1531`), advancing the cursor each pass, so the
+    /// `XFLG_OLD_PREFIXES` block runs again at `+ b`.
+    ///
+    /// `exclude = + keep.txt *` cannot cover this: its second token has no
+    /// prefix, so an implementation that reads the prefix ONCE and applies the
+    /// template to everything after still passes that cell while failing this
+    /// one.
+    #[test]
+    fn exclude_string_a_later_token_carries_its_own_prefix() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude: vec!["- a + b".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "a");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[1].pattern, "b");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Include);
+    }
+
+    /// `filter` is the ONE module parameter upstream does not give
+    /// `XFLG_OLD_PREFIXES`, and this is the control that can actually fail.
+    ///
+    /// `- x`, `+ x` and a bare `!` are handled IDENTICALLY by both parsers, so
+    /// none of them discriminates: in the modern grammar `!` falls to the
+    /// `default:` arm (`exclude.c:1325-1326`) and reaches
+    /// `case '!' -> FILTRULE_CLEAR_LIST` (`exclude.c:1359-1361`), which is what
+    /// the OLD_PREFIXES arm does at `exclude.c:1283-1284`.
+    ///
+    /// The KEYWORD forms are modern-only. `hide` maps to `'H'`
+    /// (`exclude.c:1301-1304`) which sets `FILTRULE_SENDER_SIDE`
+    /// (`exclude.c:1348-1350`); `protect` maps to `'P'` (`exclude.c:1313-1316`)
+    /// which sets `FILTRULE_RECEIVER_SIDE` (`exclude.c:1355-1357`). Route
+    /// `filter` through the old-prefix stripper and both collapse to plain
+    /// excludes carrying the keyword as pattern text with no side flag - and a
+    /// side flag is something no pattern rule can produce.
+    #[test]
+    fn filter_keywords_are_not_routed_through_the_old_prefix_stripper() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["hide *.log".to_string(), "protect secret".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "*.log");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert!(rules[0].sender_side, "hide must be sender-side");
+        assert!(!rules[0].receiver_side);
+        assert_eq!(rules[1].pattern, "secret");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Exclude);
+        assert!(rules[1].receiver_side, "protect must be receiver-side");
+        assert!(!rules[1].sender_side);
+    }
+
     /// A token left empty by the strip is upstream's fatal syntax error.
     ///
     /// upstream: `exclude.c:1474-1475` calls `filter_rule_err()`, which exits

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2429,16 +2429,29 @@ mod module_access_tests {
         assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
     }
 
-    /// A record left empty by the strip is upstream's fatal syntax error.
+    /// A token left empty by the strip is upstream's fatal syntax error.
     ///
     /// upstream: `exclude.c:1474-1475` calls `filter_rule_err()`, which exits
-    /// with `RERR_SYNTAX`; `clientserver.c:944` additionally passes
-    /// `XFLG_FATAL_ERRORS`. The caller turns this error into a module abort -
-    /// dropping the rule instead would serve everything it named.
+    /// with `RERR_SYNTAX`; `clientserver.c:950-952` additionally passes
+    /// `XFLG_FATAL_ERRORS` on the file spellings. The caller turns this error
+    /// into a module abort - dropping the rule instead would serve everything
+    /// it named.
+    ///
+    /// ⚠ This is pinned on the STRING parameter, not on `exclude from`. oc's
+    /// `read_patterns_from_file` trims each record (`helpers.rs`), so a `"- "`
+    /// LINE reaches the prefix strip as `"-"` and becomes the literal pattern
+    /// `-` instead - the empty-after-prefix state is unreachable through the
+    /// file spellings today. Upstream's `parse_filter_file` (`exclude.c:1774`)
+    /// only stops at the newline and keeps the trailing space, so it does
+    /// refuse that line; that trim is a separate, pre-existing divergence and
+    /// is deliberately not changed here.
     #[test]
-    fn exclude_from_empty_after_the_prefix_is_refused() {
-        let dir = tempfile::tempdir().unwrap();
-        let error = exclude_from_rules(&dir, "- \n").unwrap_err();
+    fn exclude_string_empty_after_the_prefix_is_refused() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude: vec!["- ".to_string()],
+            ..Default::default()
+        });
+        let error = build_daemon_filter_rules(&module).unwrap_err();
         assert!(
             error.to_string().contains("unexpected end of filter rule"),
             "unexpected message: {error}"

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2299,6 +2299,191 @@ mod module_access_tests {
         assert_eq!(rules[2].pattern, "*.bak");
     }
 
+    /// Helper: build the rules for a module whose `exclude from` file holds
+    /// exactly `contents`.
+    fn exclude_from_rules(
+        dir: &tempfile::TempDir,
+        contents: &str,
+    ) -> Result<Vec<FilterRuleWireFormat>, std::io::Error> {
+        let file = dir.path().join("excludes.txt");
+        fs::write(&file, contents).unwrap();
+        build_daemon_filter_rules(&ModuleRuntime::from(ModuleDefinition {
+            exclude_from: Some(file),
+            ..Default::default()
+        }))
+    }
+
+    /// Helper: build the rules for a module whose `include from` file holds
+    /// exactly `contents`.
+    fn include_from_rules(
+        dir: &tempfile::TempDir,
+        contents: &str,
+    ) -> Result<Vec<FilterRuleWireFormat>, std::io::Error> {
+        let file = dir.path().join("includes.txt");
+        fs::write(&file, contents).unwrap();
+        build_daemon_filter_rules(&ModuleRuntime::from(ModuleDefinition {
+            include_from: Some(file),
+            ..Default::default()
+        }))
+    }
+
+    /// A leading `- ` in an `exclude from` file is an ACTION PREFIX.
+    ///
+    /// upstream: `clientserver.c:943-944` reads `exclude from` with
+    /// `XFLG_OLD_PREFIXES`, and `exclude.c:1277-1279` strips the two bytes.
+    ///
+    /// MEASURED against real rsync 3.5.0 and oc daemons on loopback (module
+    /// holding `foo` and `keep`, `exclude from` file holding the one line
+    /// `- foo`): upstream served only `keep`; oc served `foo` AND `keep`, at
+    /// exit 0 with no diagnostic - a file the operator told the daemon to hide.
+    #[test]
+    fn exclude_from_strips_the_old_dash_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "- foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// A leading `+ ` in an `include from` file is an ACTION PREFIX.
+    ///
+    /// upstream: `exclude.c:1280-1282`.
+    #[test]
+    fn include_from_strips_the_old_plus_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = include_from_rules(&dir, "+ foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Include);
+    }
+
+    /// The prefix OVERRIDES the template, it does not merely decorate it.
+    ///
+    /// upstream: `exclude.c:1278` clears `FILTRULE_INCLUDE` on the rule even
+    /// though `include from`'s template (`clientserver.c:936-937`) sets it.
+    #[test]
+    fn include_from_dash_prefix_overrides_the_include_template() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = include_from_rules(&dir, "- foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// NEGATIVE CONTROL: exactly ONE strip happens, never two.
+    ///
+    /// upstream spells a pattern that legitimately begins with a literal `-` as
+    /// `- - foo`: `exclude.c:1277-1279` consumes the first `- ` and
+    /// `exclude.c:1465` then takes `strlen(s)` over the remainder without
+    /// re-testing for a prefix. Without this row a suite that only asserts
+    /// stripping would also pass for an over-eager parser that strips twice and
+    /// silently stops hiding the file.
+    #[test]
+    fn exclude_from_strips_the_prefix_exactly_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "- - foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "- foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// A `-` NOT followed by a space is ordinary pattern text.
+    ///
+    /// upstream: `exclude.c:1277` tests `*s == '-' && s[1] == ' '`, both bytes.
+    #[test]
+    fn exclude_from_dash_without_a_space_is_pattern_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "-foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "-foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// A record that is exactly `!` clears the list.
+    ///
+    /// upstream: `exclude.c:1283-1284` sets `FILTRULE_CLEAR_LIST`, and
+    /// `exclude.c:1471-1472` keeps it only when the measured length is 1.
+    #[test]
+    fn exclude_from_bare_bang_clears_the_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "*.tmp\n!\n*.bak\n").unwrap();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern, "*.tmp");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Clear);
+        assert_eq!(rules[2].pattern, "*.bak");
+    }
+
+    /// `!` with anything after it is a PATTERN, and it keeps the `!`.
+    ///
+    /// upstream: `exclude.c:1283` does NOT advance the cursor, so
+    /// `exclude.c:1465`'s `strlen(s)` counts the `!` itself; `exclude.c:1472`
+    /// then clears the tentative flag because the length exceeds 1. The `!` is
+    /// therefore part of the pattern, which is what makes this the companion
+    /// that stops the clear arm from swallowing every `!`-prefixed name.
+    #[test]
+    fn exclude_from_bang_with_trailing_text_is_a_pattern() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = exclude_from_rules(&dir, "!foo\n").unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "!foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// A record left empty by the strip is upstream's fatal syntax error.
+    ///
+    /// upstream: `exclude.c:1474-1475` calls `filter_rule_err()`, which exits
+    /// with `RERR_SYNTAX`; `clientserver.c:944` additionally passes
+    /// `XFLG_FATAL_ERRORS`. The caller turns this error into a module abort -
+    /// dropping the rule instead would serve everything it named.
+    #[test]
+    fn exclude_from_empty_after_the_prefix_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let error = exclude_from_rules(&dir, "- \n").unwrap_err();
+        assert!(
+            error.to_string().contains("unexpected end of filter rule"),
+            "unexpected message: {error}"
+        );
+    }
+
+    /// The STRING parameters carry `XFLG_OLD_PREFIXES` too - and they are
+    /// word-split, so the prefix binds to the next token only.
+    ///
+    /// upstream: `clientserver.c:950-952` passes both `FILTRULE_WORD_SPLIT`
+    /// (via the template) and `XFLG_OLD_PREFIXES`; `exclude.c:1457-1462` ends
+    /// the pattern at the next whitespace, so `bar` falls back to the template.
+    #[test]
+    fn exclude_string_prefix_binds_to_one_token_only() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude: vec!["+ foo bar".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].pattern, "foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rules[1].pattern, "bar");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Exclude);
+    }
+
+    /// A `!` token in a word-split `include` value clears the list.
+    ///
+    /// upstream: `exclude.c:1457-1462` measures the token to the next
+    /// whitespace, so this `!` has length 1 and `exclude.c:1472` leaves
+    /// `FILTRULE_CLEAR_LIST` set.
+    #[test]
+    fn include_string_bare_bang_token_clears_the_list() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            include: vec!["*.rs ! *.toml".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[0].pattern, "*.rs");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Clear);
+        assert_eq!(rules[2].pattern, "*.toml");
+        assert_eq!(rules[2].rule_type, protocol::filters::RuleType::Include);
+    }
+
     #[test]
     fn build_pattern_rule_exclude() {
         let rule = build_pattern_rule("*.tmp", false);

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2180,7 +2180,7 @@ mod module_access_tests {
         });
         let rules = build_daemon_filter_rules(&module).unwrap();
 
-        // upstream: clientserver.c:874-893 - order is:
+        // upstream: clientserver.c:933-952 - order is:
         // filter, include_from, include, exclude_from, exclude
         assert_eq!(rules.len(), 5);
         assert_eq!(rules[0].pattern, "*.tmp");
@@ -2259,9 +2259,9 @@ mod module_access_tests {
         });
         let rules = build_daemon_filter_rules(&module).unwrap();
         assert_eq!(rules.len(), 3);
-        // filter rules are processed first (upstream: clientserver.c:874)
+        // filter rules are processed first (upstream: clientserver.c:933)
         assert_eq!(rules[0].pattern, "*.bak");
-        // then excludes (upstream: clientserver.c:891)
+        // then excludes (upstream: clientserver.c:950)
         assert_eq!(rules[1].pattern, "*.tmp");
         assert_eq!(rules[2].pattern, "*.log");
         // All should be excludes
@@ -2329,7 +2329,7 @@ mod module_access_tests {
 
     /// A leading `- ` in an `exclude from` file is an ACTION PREFIX.
     ///
-    /// upstream: `clientserver.c:943-944` reads `exclude from` with
+    /// upstream: `clientserver.c:946-948` reads `exclude from` with
     /// `XFLG_OLD_PREFIXES`, and `exclude.c:1277-1279` strips the two bytes.
     ///
     /// MEASURED against real rsync 3.5.0 and oc daemons on loopback (module
@@ -2360,7 +2360,7 @@ mod module_access_tests {
     /// The prefix OVERRIDES the template, it does not merely decorate it.
     ///
     /// upstream: `exclude.c:1278` clears `FILTRULE_INCLUDE` on the rule even
-    /// though `include from`'s template (`clientserver.c:936-937`) sets it.
+    /// though `include from`'s template (`clientserver.c:937-939`) sets it.
     #[test]
     fn include_from_dash_prefix_overrides_the_include_template() {
         let dir = tempfile::tempdir().unwrap();
@@ -2402,7 +2402,7 @@ mod module_access_tests {
     /// A record that is exactly `!` clears the list.
     ///
     /// upstream: `exclude.c:1283-1284` sets `FILTRULE_CLEAR_LIST`, and
-    /// `exclude.c:1471-1472` keeps it only when the measured length is 1.
+    /// `exclude.c:1472-1473` keeps it only when the measured length is 1.
     #[test]
     fn exclude_from_bare_bang_clears_the_list() {
         let dir = tempfile::tempdir().unwrap();
@@ -2416,7 +2416,7 @@ mod module_access_tests {
     /// `!` with anything after it is a PATTERN, and it keeps the `!`.
     ///
     /// upstream: `exclude.c:1283` does NOT advance the cursor, so
-    /// `exclude.c:1465`'s `strlen(s)` counts the `!` itself; `exclude.c:1472`
+    /// `exclude.c:1465`'s `strlen(s)` counts the `!` itself; `exclude.c:1472-1473`
     /// then clears the tentative flag because the length exceeds 1. The `!` is
     /// therefore part of the pattern, which is what makes this the companion
     /// that stops the clear arm from swallowing every `!`-prefixed name.
@@ -2432,8 +2432,9 @@ mod module_access_tests {
     /// A token left empty by the strip is upstream's fatal syntax error.
     ///
     /// upstream: `exclude.c:1474-1475` calls `filter_rule_err()`, which exits
-    /// with `RERR_SYNTAX`; `clientserver.c:950-952` additionally passes
-    /// `XFLG_FATAL_ERRORS` on the file spellings. The caller turns this error
+    /// with `RERR_SYNTAX`; the two FILE spellings additionally pass
+    /// `XFLG_FATAL_ERRORS` (`clientserver.c:937-939` and `:946-948`), which the
+    /// string parameters do not. The caller turns this error
     /// into a module abort - dropping the rule instead would serve everything
     /// it named.
     ///
@@ -2462,7 +2463,7 @@ mod module_access_tests {
     /// word-split, so the prefix binds to the next token only.
     ///
     /// upstream: `clientserver.c:950-952` passes both `FILTRULE_WORD_SPLIT`
-    /// (via the template) and `XFLG_OLD_PREFIXES`; `exclude.c:1457-1462` ends
+    /// (via the template) and `XFLG_OLD_PREFIXES`; `exclude.c:1458-1462` ends
     /// the pattern at the next whitespace, so `bar` falls back to the template.
     #[test]
     fn exclude_string_prefix_binds_to_one_token_only() {
@@ -2480,8 +2481,8 @@ mod module_access_tests {
 
     /// A `!` token in a word-split `include` value clears the list.
     ///
-    /// upstream: `exclude.c:1457-1462` measures the token to the next
-    /// whitespace, so this `!` has length 1 and `exclude.c:1472` leaves
+    /// upstream: `exclude.c:1458-1462` measures the token to the next
+    /// whitespace, so this `!` has length 1 and `exclude.c:1472-1473` leaves
     /// `FILTRULE_CLEAR_LIST` set.
     #[test]
     fn include_string_bare_bang_token_clears_the_list() {

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -498,10 +498,19 @@ impl GeneratorContext {
                 RuleType::Protect => FilterRule::protect(reconstructed_pattern),
                 RuleType::Risk => FilterRule::risk(reconstructed_pattern),
                 RuleType::Clear => {
-                    rules.push(
-                        FilterRule::clear()
-                            .with_sides(wire_rule.sender_side, wire_rule.receiver_side),
-                    );
+                    // upstream: exclude.c:1542 - a `!` with no side modifier
+                    // pops the WHOLE active list, both sides. `FilterRule::clear`
+                    // already carries that (sender and receiver both true), and
+                    // `apply_clear_rule` returns without clearing anything when
+                    // neither side is set - so narrowing unconditionally made an
+                    // unsided clear a silent no-op. Apply the sides only when the
+                    // wire rule actually named one, exactly as the include /
+                    // exclude / protect / risk arms below do.
+                    let mut rule = FilterRule::clear();
+                    if wire_rule.sender_side || wire_rule.receiver_side {
+                        rule = rule.with_sides(wire_rule.sender_side, wire_rule.receiver_side);
+                    }
+                    rules.push(rule);
                     continue;
                 }
                 RuleType::DirMerge => {

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -798,6 +798,67 @@ fn parse_received_filters_multiple_rules() {
     assert!(!filter_set.is_empty());
 }
 
+/// An UNSIDED `!` clears the whole list.
+///
+/// upstream: `exclude.c:1542` - a clear rule with no side modifier pops the
+/// entire active section. The wire format leaves `sender_side` and
+/// `receiver_side` false for that spelling, and `apply_clear_rule`
+/// (`compiled/clear.rs:9-11`) refuses to clear anything when neither side is
+/// set, so narrowing the rule to `(false, false)` made the clear a silent
+/// no-op.
+///
+/// MEASURED on loopback daemons: a module whose `exclude from` file holds
+/// `foo` / `!` / `keep` served NOTHING from oc while rsync 3.5.0 served `foo`.
+/// The `clear_rule()` helper above pre-sets BOTH sides, which is why no
+/// existing row here discriminated.
+#[test]
+fn parse_received_filters_unsided_clear_empties_the_set() {
+    use protocol::filters::RuleType;
+    let (_handshake, ctx) = test_generator();
+
+    let wire_rules = vec![
+        FilterRuleWireFormat::exclude("*.log".to_owned()),
+        FilterRuleWireFormat {
+            rule_type: RuleType::Clear,
+            ..FilterRuleWireFormat::default()
+        },
+    ];
+
+    let (filter_set, _) = ctx.parse_received_filters(&wire_rules).unwrap();
+    assert!(
+        filter_set.is_empty(),
+        "an unsided clear must drop the preceding exclude"
+    );
+}
+
+/// A SIDED `!` still clears only the side it names.
+///
+/// Companion to the row above: without it a "force both sides on" fix would
+/// also pass, and the sided spelling would silently over-clear.
+#[test]
+fn parse_received_filters_sender_sided_clear_keeps_a_receiver_rule() {
+    use protocol::filters::RuleType;
+    let (_handshake, ctx) = test_generator();
+
+    let mut receiver_only = FilterRuleWireFormat::exclude("*.log".to_owned());
+    receiver_only.receiver_side = true;
+
+    let wire_rules = vec![
+        receiver_only,
+        FilterRuleWireFormat {
+            rule_type: RuleType::Clear,
+            sender_side: true,
+            ..FilterRuleWireFormat::default()
+        },
+    ];
+
+    let (filter_set, _) = ctx.parse_received_filters(&wire_rules).unwrap();
+    assert!(
+        !filter_set.is_empty(),
+        "a sender-sided clear must not drop a receiver-only rule"
+    );
+}
+
 #[test]
 fn parse_received_filters_with_modifiers() {
     let (_handshake, ctx) = test_generator();


### PR DESCRIPTION
A leading `- ` in a module's `exclude from` file was taken as pattern text,
so the file the operator meant to hide was SERVED. Measured against a real
rsync 3.5.0 daemon on loopback, same fixtures, the same 3.5.0 binary used as
the client on every arm so only the daemon varies:

| cell | rsync 3.5.0 | oc BEFORE | oc AFTER |
|---|---|---|---|
| `exclude from` holding `- foo` | `keep` | `foo,keep` (**foo leaked**) | `keep` |
| `include from` holding `+ foo`, `exclude = *` | `foo` | *(nothing served)* | `foo` |
| `exclude from` holding `foo` / `!` / `keep` | `foo` | *(nothing served)* | `foo` |
| `exclude from` holding `- - foo` (negative control) | `foo,keep` | `- foo,foo,keep` (**`- foo` leaked**) | `foo,keep` |
| `include = - foo *` | `keep` | `foo,keep` (**foo leaked**) | `keep` |
| `exclude = foo ! keep` | `foo` | *(nothing served)* | `foo` |
| `exclude from` holding `!foo` | `keep` | `keep` | `keep` |
| `exclude from` holding `- ` (empty after the prefix) | *refused, nothing served* | `foo,keep` (**both leaked**) | *refused, nothing served* |

BEFORE matches upstream on 1 of 8; AFTER matches on 8 of 8. Four of the seven
divergences were exposures. Row 4 is the negative control that proves the
strip is not over-eager: `- - foo` must excise exactly one prefix and exclude
the file literally named `- foo`.

Both arms were built from source at the pinned toolchain (rustc 1.88.0) and
are md5-distinct (`c5625c2e…` base, `138a5a6c…` fix); the fix arm's
`--version` reports the branch revision.

## The family is FOUR parameters, not two

Verified by reading the fetched 3.5.0 pin, not the task text.
`clientserver.c:933-952` builds `daemon_filter_list` from five parameters and
passes `XFLG_OLD_PREFIXES` to four of them:

- `:933-935` `filter` — `parse_filter_str`, `FILTRULE_WORD_SPLIT`, **no** OLD_PREFIXES
- `:937-939` `include from` — `parse_filter_file`, `FILTRULE_INCLUDE`, +OLD_PREFIXES +FATAL_ERRORS
- `:941-944` `include` — `parse_filter_str`, `INCLUDE|WORD_SPLIT`, +OLD_PREFIXES
- `:946-948` `exclude from` — `parse_filter_file`, `rule_template(0)`, +OLD_PREFIXES +FATAL_ERRORS
- `:950-952` `exclude` — `parse_filter_str`, `WORD_SPLIT`, +OLD_PREFIXES

`filter` is the one parameter deliberately left alone: it takes the modern
rule syntax where `- `/`+ ` are already rule prefixes.

The prefix rule itself is `exclude.c:1276-1284`: `- ` and `+ ` consume two
bytes and set the include bit; `!` does **not** advance the cursor, so the
`len` measured at `:1465` counts the `!` itself and `:1467-1473` keeps the
tentative `FILTRULE_CLEAR_LIST` only when that length is exactly 1. A `!`
with trailing text is literal pattern text. `:1474-1475` refuses an
empty-after-prefix token via `filter_rule_err`, which is fatal
(`exclude.c:133-137` -> `RERR_SYNTAX`).

Because the two string parameters ALSO carry `FILTRULE_WORD_SPLIT`, the
prefix there binds to one token, not to the rest of the line
(`exclude.c:1458-1463`): `include = - foo *` is an exclude of `foo` plus an
include of `*`.

## The `filter` exclusion needed a control that can actually fail

`filter` is excluded from this change, and the obvious way to pin that
exclusion does not work. `- x`, `+ x` and a bare `!` are handled IDENTICALLY
by both parsers: in the modern grammar a bare `!` falls to the `default:` arm
(`exclude.c:1325-1326`, `ch = *s`) and reaches `case '!': FILTRULE_CLEAR_LIST`
at `:1359-1361`, which is exactly what the OLD_PREFIXES arm does at
`:1283-1284`. A control built from those spellings passes whether or not
`filter` is wrongly routed through the stripper.

The pre-existing `build_daemon_filter_rules_filter_syntax` is such a control:
`filter: vec!["- *.log", "+ *.rs"]` would still pass under the wrong routing.

The discriminating form is the KEYWORD syntax, which only the modern parser
supports:

    filter = hide *.log        -> sender-side exclude of `*.log`
    filter = protect secret    -> receiver-side exclude of `secret`

Upstream maps `hide` to `'H'` (`exclude.c:1301-1304`) and `protect` to `'P'`
(`:1313-1316`); `'H'` sets `FILTRULE_SENDER_SIDE` (`:1345-1350`) and `'P'`
sets `FILTRULE_RECEIVER_SIDE` (`:1352-1357`), neither setting INCLUDE. Route
`filter` through the old-prefix stripper and both collapse to plain excludes
with the keyword still in the pattern text and both side flags false — a side
flag is something no pattern rule can produce, which is what makes this
control discriminating.

## Two cells for one upstream property, and why neither is redundant

`parse_rule_tok` re-runs the whole prefix block — including the
`XFLG_OLD_PREFIXES` arm at `exclude.c:1276-1284` — at EVERY cursor position:
`parse_filter_str` loops over it for the string parameters
(`exclude.c:1516-1531`) and `parse_filter_file` calls it per line for the file
parameters (`:1772-1774`). So "a later token/record carries its own prefix" is
one upstream property with a string half and a file half, and this PR pins
both:

    exclude = - a + b                    -> [exclude a, include b]
    exclude from:  `+ keep.txt`
                   `- secret.txt`        -> [include keep.txt, exclude secret.txt]

**Why the existing cells cannot cover this.** `exclude = + keep.txt *` tests
only that a prefix binds to ONE token; its second token has no prefix. And no
`exclude from` cell mixed prefixes across records at all — the one
multi-record cell used three unprefixed patterns — so the file half's
per-record behaviour was pinned by NOTHING before this change. That is a
standing coverage hole on the exposure path, not one this PR created: any
earlier edit to those two caller loops could have broken per-record handling
and nothing would have gone red.

**The rule these mutations follow: A MUTATION IS WORTH ITS PLACE WHEN IT
MODELS THE LIKELY WRONG IMPLEMENTATION, NOT THE ADVERSARIAL ONE.** Reversing
strip-and-split is a rewrite nobody performs by accident. HOISTING the prefix
decision out of the loop is what someone writes who reads "the prefix binds to
one token" as the whole rule — and `+ keep.txt *` is BLIND to it (it still
yields include `keep.txt`, exclude `*`) while `- a + b` catches it. That
non-overlap is measured, not argued: M11 below kills
`exclude_string_a_later_token_carries_its_own_prefix` and leaves
`exclude_string_prefix_binds_to_one_token_only` GREEN.

The file-half hoist is a less likely regression than the string-half one, and
this says so rather than overselling it: `old_prefix_record_rule` is a pure
per-record function with no loop, so hoisting it means moving the decision
into the caller and changing the signature, where the string-half hoist is a
one-line deletion from a loop body. The cell is added because the coverage gap
is real and sits on the path where a miss means serving a hidden file.

Both new cells are also RED on the pre-fix base — with no prefix parser,
`+ keep.txt` stays a literal pattern, `keep.txt` is never matched and
`secret.txt` is never excluded, so both are served. That is the non-vacuity
claim, and it is a DIFFERENT claim from the mutation kills: every cell in this
PR is red on the base, so red-on-base cannot discriminate between them.
Non-vacuity comes from red-on-base; the reason the second cell is not
redundant comes from the mutation non-overlap.

## Not the whitespace rule

This is orthogonal to #7729, which landed first. Whitespace splitting is
governed by `FILTRULE_WORD_SPLIT`; prefixes are governed by
`XFLG_OLD_PREFIXES`. The two changes meet in the two file-parameter readers
and BOTH ARE KEPT: #7729 owns reading the record untrimmed, this PR owns
stripping the prefix from it, in that order. The order is upstream's and it is
load-bearing — prefix-strip THEN whatever the directive does with the
remainder.

That ordering makes one refusal reachable that was not before. While the
reader trimmed, a `"- "` line arrived as `"-"`, never matched the `"- "`
prefix, and stayed a non-empty pattern — so the empty-after-prefix refusal in
`old_prefix_record_rule` was unreachable by construction and its comment said
so. Post-#7729 the record arrives verbatim, `&record[2..]` is empty, and the
refusal fires as upstream's does. The comment is rewritten accordingly and the
file-parameter refusal now has its own cell and its own oracle row (row 8
above).

## The Clear consumer

The `!` cells could not pass on the parser fix alone. `parse_received_filters`
built every Clear rule as `FilterRule::clear().with_sides(sender, receiver)`
unconditionally. `FilterRule::clear()` already carries both sides true —
upstream's `!` with no side modifier pops the whole active section
(`exclude.c:1542-1549`, the `pop_filter_list` at `:1548`) — and the wire format
leaves both side flags false for that spelling, so the call flipped them off
and `apply_clear_rule` returned without clearing anything. Every sibling arm
already guards the narrowing on `sender_side || receiver_side`; the Clear arm
was the one that did not. The existing `clear_rule()` fixture in the generator
tests pre-sets BOTH sides, so no row in the suite could discriminate.

## A citation pass on my own comments

The third commit retargets nine upstream line references that this branch's
own comments had pointed at the wrong construct — `exclude from` cited as
`:943-944` (which is the `include` STRING parameter), the FATAL_ERRORS note
attributed to a parameter that does not carry the flag, and several
one-off-by-one ranges. Two pre-existing `:874-893` citations in the same tests,
left from the 3.4.4 era, were retargeted with them rather than left disagreeing
with the production comments beside them. That commit changes no non-comment
line.

## Verification

### Loopback oracle — 8 cells, RE-RUN on the rebased head

The table at the top is that run. All three arms were re-measured after the
rebase; the harness prints a visible `SKIP:` and exits 3 when either binary is
absent, so an absent oracle cannot read as a pass.

Two things about that re-run are worth stating rather than smoothing over:

- **Rows 1-7 did not move.** The composition changed (untrimmed read, then
  strip) but every one of those seven cells reports exactly what it reported
  before the rebase, on all three arms. None of them carries trailing
  whitespace or an empty-after-prefix record, so none can see the change —
  which is why row 8 was added rather than assuming the existing rows covered
  it.
- **Row 8's refusal is delivered differently from upstream, and that is
  PRE-EXISTING.** Upstream refuses with exit 5 and logs
  `unexpected end of filter rule: <rule from FILE line 1>`; oc refuses with
  exit 12 (`unexpected tag 95 [Receiver]`) and logs no reason line. Nothing is
  served either way, so the security outcome matches. The delivery does not,
  and the cause is not this change: the BASE binary produces the identical exit
  12 / `unexpected tag 95` / no-reason-line shape on a per-connection module
  filter refusal this branch does not touch (`exclude from` naming a
  nonexistent file), where upstream gives exit 11 with the real errno. So this
  PR makes a refusal reachable that inherits a standing daemon
  refusal-delivery divergence. That family is task 889 (IOBUF-3a, `@ERROR: `
  prefix and the missing exit linger); whether it is the same mechanism is NOT
  established by this measurement, only that base and fix behave identically.
  The missing reason line is the DAEMON half of the diagnostics-provenance gap
  filed as task 1156. Neither is fixed here.

### Mutation matrix — MEASURED kills, on the rebased head

Every arm restored in isolation, `cargo nextest run --lib --no-fail-fast
--retries 0` at the pinned toolchain, predictions registered BEFORE the run.
Population is one set for every row: 64 daemon filter cells (baseline 64/64)
plus 9 `parse_received_filters` cells in transfer (baseline 9/9) for M8.

| # | mutation | measured kills |
|---|---|---|
| M1 | `old_prefix` drops the `- ` arm | 8: both `exclude_from_a_later_record_*`, `exclude_from_empty_after_the_prefix_is_refused`, `exclude_from_strips_the_old_dash_prefix`, `exclude_from_strips_the_prefix_exactly_once`, `exclude_string_a_later_token_carries_its_own_prefix`, `exclude_string_empty_after_the_prefix_is_refused`, `include_from_dash_prefix_overrides_the_include_template` |
| M2 | `old_prefix` drops the `+ ` arm | 5: both `exclude_from_a_later_record_*`, `exclude_string_a_later_token_carries_its_own_prefix`, `exclude_string_prefix_binds_to_one_token_only`, `include_from_strips_the_old_plus_prefix` |
| M3 | `old_prefix` drops the `!` arm | 2: `exclude_from_bare_bang_clears_the_list`, `include_string_bare_bang_token_clears_the_list` |
| M4 | record strip becomes over-eager (strips twice) | 1: `exclude_from_strips_the_prefix_exactly_once` |
| M5 | `!` always clears (drops the `len == 1` guard) | 1: `exclude_from_bang_with_trailing_text_is_a_pattern` |
| M6 | the `include` string parameter reverts to `split_whitespace` | 1: `include_string_bare_bang_token_clears_the_list` |
| M7 | file-arm empty post-strip pattern accepted instead of refused | 1: `exclude_from_empty_after_the_prefix_is_refused` |
| M8 | `Clear` arm narrows the sides unconditionally again | 1: `parse_received_filters_unsided_clear_empties_the_set` |
| M9 | string-arm empty token accepted instead of refused | 1: `exclude_string_empty_after_the_prefix_is_refused` |
| M10 | strip/split ORDER reversed on the string path | 3: `exclude_string_a_later_token_carries_its_own_prefix`, `exclude_string_empty_after_the_prefix_is_refused`, `exclude_string_prefix_binds_to_one_token_only` |
| M11 | `old_prefix` hoisted out of the string loop | 2: `exclude_string_a_later_token_carries_its_own_prefix`, `include_string_bare_bang_token_clears_the_list` |
| M12 | per-record polarity hoisted to the file caller | 3: both `exclude_from_a_later_record_*`, `exclude_from_bare_bang_clears_the_list` |

Several rows kill more cells than the property they are named for. That is the
mutation being broader than its label, not the cells being over-specified: a
mutation that deletes a whole prefix arm or hoists a decision out of a loop
also suppresses the `MaybeClear` handling for later tokens and records, so the
bare-`!` cells fall with it. The load-bearing claim is a NON-kill, and it holds
measured: M11 leaves `exclude_string_prefix_binds_to_one_token_only` GREEN
while killing the new `- a + b` cell.

Three registered predictions were wrong, and the runs are what corrected them:

- **M7 is now lethal where it was inert.** Pre-#7729 it killed nothing, and
  correctly so — the trimmed reader made the refusal unreachable. Post-rebase
  it kills exactly the new file-arm refusal cell. That is the direct
  measurement that the composition change made the refusal live, and it is why
  the old `REVERSION GUARD` comment had to be rewritten rather than kept.
- **M10 kills three cells, not one.** I registered "ONLY
  `exclude_string_prefix_binds_to_one_token_only`" and never revised it after
  adding the `- a + b` cell; I also did not foresee that splitting first
  destroys the string-side refusal, because `"- ".split_whitespace()` yields
  `["-"]` and `"-"` is a non-empty pattern. The half of that prediction that
  was contested — that a bare `!` does NOT kill M10, because `MaybeClear` does
  not advance the cursor so both orders see the same token boundary — is
  CONFIRMED: `include_string_bare_bang_token_clears_the_list` survives M10.
- **M6 kills one cell, not the two predicted.** The mutation replaces only the
  `include` loop, so it cannot reach a cell written against `exclude`. A
  scope artefact of the mutation, not a coverage gap.

M11 and M12 were likewise registered with "ONLY" and both over-kill; the word
is dropped above and the entries state what was measured.

### Gates run

At the pinned toolchain 1.88.0 (`rust-toolchain.toml`), on this head:

- `tools/ci/check_rustfmt_all.py` — exit 0, 3423 files at edition 2024
- `cargo clippy -p daemon -p filters -p transfer --all-targets -- -D warnings` — no issues
- `cargo nextest run --lib -p daemon -p transfer --no-fail-fast --retries 0` — 4343 run / 4343 passed

### NOT run

Listed so the reviewer knows what CI still has to establish: the
full-workspace nextest, the root-level `tests/integration_*.rs` cells, the
macOS / Windows / musl cells, `--all-features`, and the upstream 3.5.0
testsuite legs.

## Known residuals, NOT closed by this change

All three are `filter`-directive defects. `filter` carries no
`XFLG_OLD_PREFIXES`, so none is in this change's family, and each is filed
rather than fixed here.

- `filter = - foo` then `filter = clear`: rsync 3.5.0 serves `[foo, keep]`, oc
  serves `[keep]`. The daemon parser is measured CORRECT for that input (an
  in-tree probe dumps `[Exclude "foo", Clear]`) and `FilterSet::from_rules`
  applies Clear order-independently, so the loss is between the two on the live
  daemon path. An instrumented build could not be read back because the
  per-connection child's diagnostics do not reach the parent's stderr.
- `filter = !` is a second spelling of that clear and oc does not implement it
  at all: no `!` arm exists in `parse_daemon_filter_token`, so it becomes an
  exclude of the literal pattern `!`. Recorded as its own row rather than
  assumed to share a cause — one is recognised-but-loses-effect, the other is
  not recognised at all.
- `filter = -foo` / `+foo` (prefix with no space): upstream refuses the rule at
  `exclude.c:1371-1377` (`invalid modifier 'f'`, RERR_SYNTAX) because the
  modifier alphabet is `- + / ! C e n p r s w x`; oc accepts it via
  `strip_prefix('-')`. Fail-open on a config-syntax error, and the `+`
  direction turns a rejected config into an active include.

Plus the two delivery residuals row 8 surfaced, both measured pre-existing and
both filed separately: the daemon refusal's client-visible exit code and
framing (task 889's family) and its missing `<rule from FILE line N>` log line
(task 1156).
