### PR TITLE
fix(engine): name a failed link_stat operand by its absolute path

### DIFF
--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -746,8 +746,12 @@ fn process_single_source(
             // RERR_PARTIAL), and the transfer continues with the remaining
             // sources. Distinct from a file that vanishes mid-transfer (exit
             // 24, "file has vanished").
+            //
+            // The name upstream prints is the operand anchored to the working
+            // directory, not the operand as typed: `full_fname()` puts
+            // `curr_dir` in front of every relative `fn` (util1.c:1445-1452).
             return Err(LocalCopyError::link_stat_failed(
-                source_path.to_path_buf(),
+                crate::local_copy::operand_diagnostic_name(source_path),
                 error,
             ));
         }

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -238,6 +238,51 @@ pub(crate) fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf 
     filters::collapse_dot_dot_dirs(path)
 }
 
+/// Names a source operand the way upstream's sender diagnostics name it: with
+/// the working directory in front, so a relative operand is reported by its
+/// absolute path.
+///
+/// Upstream arrives at that string in two steps. `send_file_list()` splits each
+/// operand into a `dir`/`fn` pair and `push_dir()`s into `dir` before the
+/// `link_stat()` at `flist.c:2697`, which appends onto the `curr_dir` *string*
+/// and cleans it lexically - it never re-reads the path from the kernel, so a
+/// symlinked component keeps the spelling the operator typed. `full_fname()`
+/// then prefixes the surviving relative `fn` with `curr_dir` before quoting it:
+///
+/// ```text
+/// if (*fn == '/')
+///         p1 = p2 = "";
+/// else {
+///         p1 = curr_dir + module_dirlen;
+///         for (p2 = p1; *p2 == '/'; p2++) {}
+///         if (*p2)
+///                 p2 = "/";
+/// }
+/// ```
+///
+/// `fn` is a single component, so joining the working directory onto the whole
+/// operand and collapsing `.`/`..` lexically reproduces both steps at once. A
+/// local copy is never a daemon server, so `module_dirlen` is 0 and the prefix
+/// is the whole working directory.
+///
+/// An operand that is already absolute is left alone by the join, which is what
+/// upstream's `*fn == '/'` branch and its `p1`/`p2` branch both produce for it.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/util1.c:1433-1464` - `full_fname()`.
+/// - `rsync-3.5.0/flist.c:2688-2697` - the `dir`/`fn` split and the `push_dir()`
+///   that makes `curr_dir` the operand's parent before `link_stat()` runs.
+pub(crate) fn operand_diagnostic_name(path: &std::path::Path) -> std::path::PathBuf {
+    let Ok(working_dir) = std::env::current_dir() else {
+        // upstream keeps `curr_dir` in a global it can always read; with no
+        // working directory to anchor against, the operand as given is the only
+        // name left to report.
+        return path.to_path_buf();
+    };
+    lexically_normalize(&working_dir.join(path))
+}
+
 #[cfg(test)]
 pub(crate) fn with_hard_link_override<F, R>(override_fn: F, action: impl FnOnce() -> R) -> R
 where

--- a/crates/engine/src/local_copy/mod.rs
+++ b/crates/engine/src/local_copy/mod.rs
@@ -265,15 +265,34 @@ pub(crate) fn lexically_normalize(path: &std::path::Path) -> std::path::PathBuf 
 /// local copy is never a daemon server, so `module_dirlen` is 0 and the prefix
 /// is the whole working directory.
 ///
-/// An operand that is already absolute is left alone by the join, which is what
+/// An operand that already carries a root is returned unchanged, which is what
 /// upstream's `*fn == '/'` branch and its `p1`/`p2` branch both produce for it.
+///
+/// ⚠ That arm must be spelled explicitly and must use
+/// [`Path::has_root`](std::path::Path::has_root), NOT `Path::is_absolute` and
+/// NOT the join alone. Upstream tests a leading BYTE (`*fn == '/'`,
+/// `util1.c:1445`), a question about the spelling. `is_absolute()` asks a
+/// different question - "is this absolute on THIS host" - and on Windows a
+/// rooted but prefixless `/no/such/entry` has no drive, so it answers `false`.
+/// Relying on `join` to leave such an operand alone has the same defect from
+/// the other side: `Path::join` keeps the working directory's DRIVE and
+/// replaces only the root, yielding `D:\no\such\entry` for an operand upstream
+/// would have printed verbatim. `has_root()` is `is_absolute()` on Unix and is
+/// true for `/no/such/entry` on Windows, so it says only what the C says.
 ///
 /// # Upstream Reference
 ///
-/// - `rsync-3.5.0/util1.c:1433-1464` - `full_fname()`.
+/// - `rsync-3.5.0/util1.c:1433-1464` - `full_fname()`; `:1445` is the
+///   leading-slash test this arm mirrors.
 /// - `rsync-3.5.0/flist.c:2688-2697` - the `dir`/`fn` split and the `push_dir()`
 ///   that makes `curr_dir` the operand's parent before `link_stat()` runs.
 pub(crate) fn operand_diagnostic_name(path: &std::path::Path) -> std::path::PathBuf {
+    if path.has_root() {
+        // Still collapsed, never re-anchored. On Unix this is exactly what the
+        // join below already produced for a rooted operand, so the arm changes
+        // nothing there; it exists to keep Windows from prefixing a drive.
+        return lexically_normalize(path);
+    }
     let Ok(working_dir) = std::env::current_dir() else {
         // upstream keeps `curr_dir` in a global it can always read; with no
         // working directory to anchor against, the operand as given is the only

--- a/crates/engine/src/local_copy/tests/link_stat_operand_name.rs
+++ b/crates/engine/src/local_copy/tests/link_stat_operand_name.rs
@@ -1,0 +1,61 @@
+// The name a failed `link_stat` reports for a source operand.
+//
+// Upstream renders it through `full_fname()` (util1.c:1433-1464), which puts
+// `curr_dir` in front of every relative `fn`, so a missing relative operand is
+// reported by its absolute path. `curr_dir` is upstream's own *string* - built
+// by `push_dir()` appending the operand's `dir` half and cleaning it lexically -
+// so `..` and `.` collapse without the kernel being consulted and a symlinked
+// component keeps the spelling the operator typed.
+//
+// Measured against rsync 3.5.0 from `/tmp/t1158` (all `-a <operand> dst/`):
+//
+// ```text
+// nope        -> rsync: [sender] link_stat "/tmp/t1158/nope" failed: ...
+// sub/nope    -> rsync: [sender] link_stat "/tmp/t1158/sub/nope" failed: ...
+// ./nope      -> rsync: [sender] link_stat "/tmp/t1158/nope" failed: ...
+// ../nope     -> rsync: [sender] link_stat "/tmp/t1158/nope" failed: ...  (from sub/)
+// link/nope   -> rsync: [sender] link_stat "/tmp/t1158/link/nope" failed: ...
+// /tmp/t1158/nope -> rsync: [sender] link_stat "/tmp/t1158/nope" failed: ...
+// ```
+
+#[test]
+fn a_relative_operand_is_named_by_its_absolute_path() {
+    let working_dir = std::env::current_dir().expect("current dir");
+
+    assert_eq!(
+        operand_diagnostic_name(Path::new("nope")),
+        working_dir.join("nope"),
+        "upstream prefixes a relative `fn` with `curr_dir` (util1.c:1445-1452)"
+    );
+    assert_eq!(
+        operand_diagnostic_name(Path::new("sub/nope")),
+        working_dir.join("sub/nope"),
+        "the operand's `dir` half is pushed onto `curr_dir`, not dropped"
+    );
+}
+
+#[test]
+fn dot_and_dot_dot_collapse_the_way_push_dir_cleans_curr_dir() {
+    let working_dir = std::env::current_dir().expect("current dir");
+
+    assert_eq!(
+        operand_diagnostic_name(Path::new("./nope")),
+        working_dir.join("nope"),
+        "`push_dir(\".\")` leaves `curr_dir` where it was"
+    );
+    assert_eq!(
+        operand_diagnostic_name(Path::new("sub/../nope")),
+        working_dir.join("nope"),
+        "`clean_fname()` cancels the component before a `..`"
+    );
+}
+
+#[test]
+fn an_absolute_operand_is_named_unchanged() {
+    // Upstream's `*fn == '/'` branch adds no prefix, and the `dir`/`fn` split
+    // reaches the same string for an absolute operand. This is the arm that
+    // already matched upstream before the working directory was consulted, so
+    // it is the negative control for the two tests above.
+    let absolute = Path::new("/no/such/entry");
+    assert_eq!(operand_diagnostic_name(absolute), absolute.to_path_buf());
+}

--- a/crates/engine/src/local_copy/tests/mod.rs
+++ b/crates/engine/src/local_copy/tests/mod.rs
@@ -1059,3 +1059,4 @@ include!("execute_skip_compress.rs");
 include!("execute_direct_write.rs");
 include!("execute_dry_run.rs");
 include!("files_from_vanished.rs");
+include!("link_stat_operand_name.rs");

--- a/tests/link_stat_names_the_absolute_path.rs
+++ b/tests/link_stat_names_the_absolute_path.rs
@@ -1,0 +1,242 @@
+//! Regression: a local copy's `link_stat` diagnostic names the source operand
+//! by its absolute path, the way upstream's `full_fname()` does.
+//!
+//! Upstream renders every path inside a sender diagnostic through
+//! `full_fname()` (`util1.c:1433-1464`), which prefixes a relative `fn` with
+//! `curr_dir`:
+//!
+//! ```c
+//! if (*fn == '/')
+//!         p1 = p2 = "";
+//! else {
+//!         p1 = curr_dir + module_dirlen;
+//!         for (p2 = p1; *p2 == '/'; p2++) {}
+//!         if (*p2)
+//!                 p2 = "/";
+//! }
+//! ```
+//!
+//! `send_file_list()` has already split the operand into a `dir`/`fn` pair and
+//! `push_dir()`ed into `dir` before the `link_stat()` at `flist.c:2697`, so
+//! `curr_dir` is the operand's parent and the rendered name is absolute. From
+//! `/tmp/t1158`, rsync 3.5.0 reports `-a nope dst/` as:
+//!
+//! ```text
+//! rsync: [sender] link_stat "/tmp/t1158/nope" failed: No such file or directory (2)
+//! ```
+//!
+//! oc reported `link_stat "nope" failed` - the operand as typed - which is what
+//! this file pins. The name is built once, at the point the engine constructs
+//! `LocalCopyError::link_stat_failed`, and reaches stderr through two emitters
+//! (the engine's own `eprintln!` of the error and the `ClientError` the same
+//! error is mapped to), so both lines are asserted here rather than one.
+//!
+//! These are end-to-end runs of the shipped binary: the operand name is
+//! produced on the live local-copy path, and a unit test over the helper alone
+//! could not show that the path reaches the diagnostic.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+/// Upstream `RERR_PARTIAL`: some files were not transferred (`errcode.h`).
+const RERR_PARTIAL: i32 = 23;
+
+/// Path to the binary under test, resolved by Cargo at compile time.
+fn oc_rsync_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_oc-rsync")
+}
+
+/// A scratch tree plus the *canonical* spelling of its root.
+///
+/// `getcwd()` - which both upstream and oc read for `curr_dir` - returns the
+/// resolved path, and a temporary directory commonly sits under a symlinked
+/// ancestor (`/var` -> `/private/var` on macOS). Comparing against the
+/// unresolved `TempDir` path would fail there for a reason that has nothing to
+/// do with the diagnostic.
+struct Scratch {
+    _root: TempDir,
+    working_dir: PathBuf,
+}
+
+impl Scratch {
+    fn new() -> Self {
+        let root = TempDir::new().expect("tempdir");
+        let working_dir = fs::canonicalize(root.path()).expect("canonicalize tempdir");
+        fs::create_dir_all(working_dir.join("dst")).expect("create dst");
+        fs::create_dir_all(working_dir.join("sub")).expect("create sub");
+        Self {
+            _root: root,
+            working_dir,
+        }
+    }
+}
+
+/// Runs one local copy of `operand` from `working_dir` and returns the result.
+fn run_from(working_dir: &Path, operand: &str) -> Output {
+    Command::new(oc_rsync_binary())
+        .arg("-a")
+        .arg(operand)
+        .arg("dst/")
+        .current_dir(working_dir)
+        .output()
+        .expect("run oc-rsync")
+}
+
+/// Asserts the run reported the missing operand under `expected_name` and
+/// exited `RERR_PARTIAL`.
+///
+/// Every `link_stat` line is checked, not just the first: the error is rendered
+/// twice on this path, and asserting only that the text appears *somewhere*
+/// would stay green if one emitter kept the old name.
+fn assert_named(output: &Output, expected_name: &Path, label: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected = format!("link_stat \"{}\" failed", expected_name.display());
+
+    let reports: Vec<&str> = stderr
+        .lines()
+        .filter(|line| line.contains("link_stat"))
+        .collect();
+    assert!(
+        !reports.is_empty(),
+        "{label}: no link_stat diagnostic at all; stderr was:\n{stderr}"
+    );
+    for line in &reports {
+        assert!(
+            line.contains(&expected),
+            "{label}: expected a line containing `{expected}`, got `{line}`"
+        );
+    }
+
+    assert_eq!(
+        output.status.code(),
+        Some(RERR_PARTIAL),
+        "{label}: a missing source operand exits {RERR_PARTIAL}; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
+fn a_relative_operand_is_reported_by_its_absolute_path() {
+    let scratch = Scratch::new();
+    let output = run_from(&scratch.working_dir, "nope");
+    assert_named(&output, &scratch.working_dir.join("nope"), "bare relative");
+}
+
+#[test]
+fn a_relative_operand_with_a_parent_keeps_the_whole_tail() {
+    let scratch = Scratch::new();
+    let output = run_from(&scratch.working_dir, "sub/nope");
+    assert_named(
+        &output,
+        &scratch.working_dir.join("sub").join("nope"),
+        "relative with parent",
+    );
+}
+
+#[test]
+fn dot_and_dot_dot_components_collapse_lexically() {
+    let scratch = Scratch::new();
+
+    let output = run_from(&scratch.working_dir, "./nope");
+    assert_named(&output, &scratch.working_dir.join("nope"), "leading ./");
+
+    // `push_dir("..")` from `sub/` lands back at the scratch root, exactly as
+    // `clean_fname()` cancels the component before a `..`.
+    let output = run_from(&scratch.working_dir.join("sub"), "../nope");
+    assert_named(&output, &scratch.working_dir.join("nope"), "leading ../");
+}
+
+/// Negative control. An absolute operand already matched upstream before the
+/// working directory was consulted, so this leg must stay green under any
+/// mutation of the relative arm - it is what distinguishes "the name is now
+/// anchored" from "the name changed".
+#[test]
+fn an_absolute_operand_is_reported_unchanged() {
+    let scratch = Scratch::new();
+    let absolute = scratch.working_dir.join("nope");
+    let output = run_from(&scratch.working_dir, &absolute.display().to_string());
+    assert_named(&output, &absolute, "absolute operand");
+}
+
+/// Locates a real upstream rsync 3.x, either where the interop harness installs
+/// it or where it builds it, and verifies the `--version` banner so macOS's
+/// `openrsync` shim cannot stand in for it.
+fn upstream_rsync() -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(explicit) = std::env::var_os("OC_RSYNC_UPSTREAM_RSYNC") {
+        candidates.push(PathBuf::from(explicit));
+    }
+    for version in ["3.5.0", "3.4.4"] {
+        if let Some(installed) = test_support::upstream_install_bin(version) {
+            candidates.push(installed);
+        }
+        if let Some(root) = test_support::workspace_root() {
+            candidates.push(
+                root.join("target")
+                    .join("interop")
+                    .join("upstream-src")
+                    .join(format!("rsync-{version}"))
+                    .join("rsync"),
+            );
+        }
+    }
+
+    candidates.into_iter().find(|candidate| {
+        Command::new(candidate)
+            .arg("--version")
+            .output()
+            .ok()
+            .and_then(|out| String::from_utf8(out.stdout).ok())
+            .is_some_and(|text| {
+                text.lines()
+                    .next()
+                    .is_some_and(|line| line.starts_with("rsync") && line.contains(" version 3."))
+            })
+    })
+}
+
+/// Extracts the quoted name from the first `link_stat` line, if any.
+fn quoted_link_stat_name(output: &Output) -> Option<String> {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let line = stderr.lines().find(|line| line.contains("link_stat "))?;
+    let rest = line.split_once("link_stat \"")?.1;
+    let (name, _) = rest.split_once('"')?;
+    Some(name.to_owned())
+}
+
+/// Cross-implementation leg: the quoted name must be the one a real rsync
+/// prints for the same operand from the same directory. Skipped when no
+/// upstream binary is installed; the literal assertions above are what hold the
+/// behaviour in that case.
+#[test]
+fn the_quoted_name_matches_a_real_rsync() {
+    let Some(upstream) = upstream_rsync() else {
+        eprintln!("skip: no upstream rsync 3.x binary available");
+        return;
+    };
+
+    for operand in ["nope", "sub/nope", "./nope"] {
+        let scratch = Scratch::new();
+
+        let ours = run_from(&scratch.working_dir, operand);
+        let theirs = Command::new(&upstream)
+            .arg("-a")
+            .arg(operand)
+            .arg("dst/")
+            .current_dir(&scratch.working_dir)
+            .output()
+            .expect("run upstream rsync");
+
+        let expected = quoted_link_stat_name(&theirs)
+            .unwrap_or_else(|| panic!("upstream printed no link_stat line for `{operand}`"));
+        let actual = quoted_link_stat_name(&ours)
+            .unwrap_or_else(|| panic!("oc-rsync printed no link_stat line for `{operand}`"));
+
+        assert_eq!(
+            actual, expected,
+            "operand `{operand}`: oc must name the operand exactly as upstream does"
+        );
+    }
+}


### PR DESCRIPTION
## The oracle, measured first

Established by running the real binary, not by reading the C. `rsync version 3.5.0 protocol version 32`, from `/tmp/t1158`, each `-a <operand> dst/`:

```
nope                -> rsync: [sender] link_stat "/tmp/t1158/nope" failed: No such file or directory (2)
sub/nope            -> ... link_stat "/tmp/t1158/sub/nope" failed: ...
./nope              -> ... link_stat "/tmp/t1158/nope" failed: ...
../nope (from sub/) -> ... link_stat "/tmp/t1158/nope" failed: ...
link/nope           -> ... link_stat "/tmp/t1158/link/nope" failed: ...   <- symlink spelling KEPT
/tmp/t1158/nope     -> ... link_stat "/tmp/t1158/nope" failed: ...
nope/               -> a change_dir diagnostic, NOT link_stat
```

The decisive row is `link/nope`. `push_dir()` appends onto the `curr_dir` string and cleans it **lexically** — it never re-reads the path from the kernel — so the fix must join-and-collapse and must **not** `canonicalize()`. A canonicalising fix would have diverged on exactly that row.

## The oc text, measured on the BASE arm

Base arm built from source and run on the same fixture:

```
link_stat "nope" failed: No such file or directory (os error 2)
oc-rsync error: link_stat "nope" failed: ... (code 23) at error.rs(252) [sender=0.6.4]
```

The operand is reported as typed. Exit code 23 (RERR_PARTIAL) already matched.

## Producer confirmed by measurement, not by reading

The brief pointed at `crates/engine/src/.../error.rs:252`. That is **not** where it lives — oc's own `at error.rs(252)` suffix identifies `crates/core/src/client/error.rs:252`, the second *emitter*, not the producer.

The producer is the single construction site of `LocalCopyError::link_stat_failed`, in the `SourceMetadataResult::NotFoundError` arm of `crates/engine/src/local_copy/executor/sources/orchestration.rs`. Confirmed by changing that one site and re-running: **both** emitted lines moved together (the engine's `eprintln!("{error}")` at orchestration.rs:524 and the `ClientError` the same value is mapped to via `first_io_error`). A change anywhere else could not have moved both.

Fix-arm vs oracle, 5/5 quoted names MATCH exactly: `nope`, `sub/nope`, `./nope`, `/abs/nope`, `../nope`.

## The change

- New `operand_diagnostic_name()` in `crates/engine/src/local_copy/mod.rs`: joins the process working directory onto the whole operand and runs the existing `filters::collapse_dot_dot_dirs` port (`lexically_normalize`). Falls back to the operand as given if `current_dir()` fails. Cites `rsync-3.5.0/util1.c:1433-1464` and `rsync-3.5.0/flist.c:2688-2697` — both ranges verified by reading those files at the 3.5.0 pin, not copied from the brief.
- One call site changed in `orchestration.rs`.
- 3 engine unit tests over the helper + a 5-test root integration file that runs the shipped binary end to end, including a cross-implementation leg against the real 3.5.0.

## Mutation results (explicit counts; `run == passed + failed` in every arm)

**M1 — revert the call site to `source_path.to_path_buf()` (the exact pre-fix state):**

- e2e: **5 run / 1 passed / 4 failed.** Kills `a_relative_operand_is_reported_by_its_absolute_path`, `a_relative_operand_with_a_parent_keeps_the_whole_tail`, `dot_and_dot_dot_components_collapse_lexically`, `the_quoted_name_matches_a_real_rsync`. Survivor is `an_absolute_operand_is_reported_unchanged` — the negative control.
- engine lib: **58 run / 58 passed / 0 failed.** Stated plainly: the unit tests **cannot** see a call-site regression, because they exercise the helper directly. That is precisely why the end-to-end file exists and is the load-bearing pin.

**M2 — mutate the helper body to return the operand unchanged:**

- engine lib: **58 run / 56 passed / 2 failed.** Kills `a_relative_operand_is_named_by_its_absolute_path` and `dot_and_dot_dot_collapse_the_way_push_dir_cleans_curr_dir`; `an_absolute_operand_is_named_unchanged` survives.

Fix restored afterwards; both scopes re-run green (58/58 and 5/5), diff footprint byte-identical to pre-mutation.

## A vacuity trap hit and closed

The e2e run first reported `5 tests run: 5 passed` in **0.037 s**. Implausible for five process-spawning tests — and it was: that worktree has no `target/interop`, so `upstream_rsync()` returned `None` and `the_quoted_name_matches_a_real_rsync` **self-skipped silently**. Re-run with `OC_RSYNC_UPSTREAM_RSYNC` pointed at the real 3.5.0 binary: the cell takes 0.23 s against 0.03 s for its siblings, and passes. In CI the interop harness builds the oracle so the cell runs there; but the skip is silent, which is the same shape as the skip-as-pass class already on the ledger. Filed as a follow-up.

## Residual divergences — measured, NOT fixed, filed separately

1. oc line 1 lacks upstream's `rsync: [sender] ` prefix.
2. oc line 2 repeats the link_stat text; upstream prints the generic `rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1394)` summary instead.

Both are pre-existing and independent of this change.

## Verification

Run, at the pinned toolchain 1.88.0 (`rustc 1.88.0 (6b00bc388)`), on Linux:

- `python3 tools/ci/check_rustfmt_all.py` -> 3425 files at edition 2024, exit 0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` -> exit 0
- `cargo nextest run -p engine --lib --all-features` -> **4872 run / 4872 passed / 23 skipped**
- `cargo nextest run --test link_stat_names_the_absolute_path --all-features` -> **5 run / 5 passed**, with the upstream oracle wired in

NOT run, and why:

- **Full-workspace `--all-features` nextest.** Started, then stopped by PID when the build host fell to 3G free with ~41 of 106 root integration binaries still to link. Named rather than papered over. The host has since been reclaimed to 68G free, so this is re-runnable on request.
- macOS / Windows / musl cells, the 3.5.0 testsuite legs, interop.
