### PR TITLE
fix(receiver): honour a daemon filter clear on the receiving side

### DIFF
--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -125,7 +125,31 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
                 RuleType::Exclude => FilterRule::exclude(pat),
                 RuleType::Protect => FilterRule::protect(pat),
                 RuleType::Risk => FilterRule::risk(pat),
-                RuleType::Clear | RuleType::DirMerge | RuleType::Merge => return None,
+                // A clear pops the rules accumulated before it, so it must
+                // survive into the compiled set rather than being discarded
+                // here. `FilterSet::from_rules` already honours
+                // `FilterAction::Clear` on both chains, so this arm only has to
+                // stop dropping the rule.
+                //
+                // The sides are applied only when the wire rule names one:
+                // `FilterRule::clear()` pre-sets both, and `apply_clear_rule`
+                // returns without clearing anything when neither side is set,
+                // so narrowing an unsided clear to `with_sides(false, false)`
+                // would silently reinstate the drop.
+                //
+                // upstream: receiver.c:711-716 checks each file against
+                // `daemon_filter_list`, which `clientserver.c:874-893` builds
+                // from the module's filter directives - a `clear` among them
+                // pops the earlier rules for the receiver exactly as it does
+                // for the sender.
+                RuleType::Clear => {
+                    let mut rule = FilterRule::clear();
+                    if wire_rule.sender_side || wire_rule.receiver_side {
+                        rule = rule.with_sides(wire_rule.sender_side, wire_rule.receiver_side);
+                    }
+                    return Some(rule);
+                }
+                RuleType::DirMerge | RuleType::Merge => return None,
             };
 
             if wire_rule.sender_side || wire_rule.receiver_side {
@@ -178,4 +202,79 @@ pub(in crate::receiver) fn daemon_filter_refuses_ancestor(filters: &FilterSet, n
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compile_daemon_filter_set;
+    use protocol::filters::{FilterRuleWireFormat, RuleType};
+    use std::path::Path;
+
+    fn exclude(pattern: &str) -> FilterRuleWireFormat {
+        FilterRuleWireFormat::exclude(pattern)
+    }
+
+    /// An unsided `clear`, as a module's `filter = clear` directive produces.
+    fn clear() -> FilterRuleWireFormat {
+        FilterRuleWireFormat {
+            rule_type: RuleType::Clear,
+            ..FilterRuleWireFormat::default()
+        }
+    }
+
+    /// The discriminating cell.
+    ///
+    /// Ground truth, MEASURED 2026-09-07 against a real rsync 3.5.0 daemon on
+    /// loopback with `read only = no`, pushing `foo` and `keep` into a module
+    /// declaring `filter = - foo` then `filter = clear`: BOTH files land.
+    /// oc refused `foo` and exited 23, because the clear was dropped here and
+    /// the exclude survived.
+    #[test]
+    fn a_clear_pops_the_exclude_that_precedes_it() {
+        let filters = compile_daemon_filter_set(&[exclude("foo"), clear()])
+            .expect("two rules compile to a filter set");
+        assert!(
+            filters.allows(Path::new("foo"), false),
+            "the clear must pop the preceding exclude"
+        );
+    }
+
+    /// Non-vacuity companion for
+    /// [`a_clear_pops_the_exclude_that_precedes_it`].
+    ///
+    /// Without this, that test would also pass if the compiled set simply
+    /// allowed everything - which is exactly what a filter set built from zero
+    /// surviving rules does. This one proves the exclude bites when no clear
+    /// follows it, so the pin above is measuring the clear and not the absence
+    /// of a filter.
+    #[test]
+    fn an_exclude_alone_still_refuses() {
+        let filters = compile_daemon_filter_set(&[exclude("foo")])
+            .expect("one rule compiles to a filter set");
+        assert!(
+            !filters.allows(Path::new("foo"), false),
+            "an exclude with no clear after it must still refuse"
+        );
+    }
+
+    /// A clear pops what PRECEDED it and nothing more, so a rule written after
+    /// it still applies. Distinguishes "the clear emptied the list" from "the
+    /// clear disabled filtering", which the first two tests alone cannot tell
+    /// apart.
+    ///
+    /// Same fixture measured against rsync 3.5.0 with a third directive
+    /// `filter = - keep`: `foo` lands, `keep` is refused.
+    #[test]
+    fn a_rule_after_the_clear_still_applies() {
+        let filters = compile_daemon_filter_set(&[exclude("foo"), clear(), exclude("keep")])
+            .expect("three rules compile to a filter set");
+        assert!(
+            filters.allows(Path::new("foo"), false),
+            "the clear must pop the exclude written before it"
+        );
+        assert!(
+            !filters.allows(Path::new("keep"), false),
+            "a rule written after the clear must survive it"
+        );
+    }
 }


### PR DESCRIPTION
A module declaring `filter = - foo` followed by `filter = clear` refuses `foo`
on a push and exits 23, where rsync 3.5.0 accepts it. Add a later
`filter = - keep` and the module receives **nothing at all**. That is data
silently not landing on an ordinary `read only = no` module — a write-path
defect, not a diagnostic one.

`compile_daemon_filter_set` builds the set the receiver checks each file
against (upstream `receiver.c:711-716`, over the list `clientserver.c:874-893`
assembles from the module's directives). Its `filter_map` discarded
`RuleType::Clear` along with the merge kinds, so the rules the clear should
have popped survived it.

`FilterSet::from_rules` already honours `FilterAction::Clear` on both chains,
so the fix is **to stop dropping the rule**, not to implement clearing.

## Why the guard is four lines and not one

The sides are applied only when the wire rule names one. `FilterRule::clear()`
pre-sets both, and `apply_clear_rule` returns without clearing when neither is
set — so narrowing an unsided clear to `with_sides(false, false)` would
reinstate the drop by a different route. That is the same mechanism as #7732,
reappearing on the receiving side.

## Measured against a real rsync 3.5.0 daemon

Loopback, 3.5.0 held constant as the client, asserting on what landed on disk:

    cell                       upstream 3.5.0    before            after
    ctl-push-no-filter         foo,keep rc 0     foo,keep rc 0     foo,keep rc 0
    ctl-push-exclude-only      keep     rc 23    keep     rc 23    keep     rc 23
    push-clear-after-exclude   foo,keep rc 0     keep      rc 23   foo,keep rc 0
    push-clear-then-exclude    foo      rc 23    (nothing) rc 23   foo      rc 23

⚠ **Independence was re-measured on this base, not carried over.** The original
A/B ran on #7732's head; that establishes the claim about *that* tree. On a
master-base binary built from source the defect reproduces identically — same
two failures, both controls matching — and the fix alone takes it to 4/4.

**The two controls are what make this readable rather than merely green.**
`ctl-push-no-filter` proves the push works at all, so a missing `foo` is
falsifiable. `ctl-push-exclude-only` proves the daemon filter list is consulted
on this path — without it, a missing `foo` would be equally consistent with
"filters ignored entirely", and the honest report would have been
*inconclusive* rather than *confirmed*.

A `--list-only` pull cannot observe any of this: it makes the daemon the
sender, and the module's rules route through the generator instead.

## Mutations — both registered before running, both exact

Population: whole `transfer` lib, baseline 2476/2476.

- **M1** (revert — `Clear` back in the `return None` arm): predicted 2 kills,
  measured 2476 run / 2474 passed / 2 failed — `a_clear_pops_the_exclude_that_precedes_it`
  and `a_rule_after_the_clear_still_applies`; `an_exclude_alone_still_refuses` GREEN.
- **M2** (drop the side guard, always `with_sides(sender, receiver)`): same two
  kills, companion green. **M2 killing the same set as M1 is by design** — its
  claim is "the guard is load-bearing", not "a different cell covers it", since
  an unsided clear narrowed to `(false,false)` is inert in `apply_clear_rule`.

⚠ **Vacuity check that mattered:** the whole-lib count was 2476 both before and
after adding three tests, which on its own proves nothing. Running the three by
name gave `3 tests run, 2473 skipped` — so master's baseline was 2473 and the
new cells do execute.

## Gates

At the pinned toolchain 1.88.0: `tools/ci/check_rustfmt_all.py` 3424 files
clean; `clippy -p transfer -p filters --all-targets -D warnings` clean;
`nextest -p transfer --lib` 2476/2476. One file, +100/−1.

⚠ Both gates failed on the first run and both failures were the author's:
`items_after_test_module` plus a rustfmt rewrite, from inserting `mod tests`
before a remaining item. Placement, not logic — but worth naming, because the
gates caught something a green test run would not have.

**NOT run**, listed rather than implied: full-workspace nextest,
`--all-features`, root `tests/integration_*.rs`, macOS/Windows/musl cells, the
3.5.0 testsuite legs, interop.

**Residuals, filed not fixed and not softened:** SSH-transport push (only
rsync:// loopback was measured); `use chroot = yes`; and whether any non-daemon
receiver reaches the same `filter_map`. All three unmeasured; none claimed
harmless.
