### PR TITLE
fix(daemon): refuse a malformed `filter` rule instead of silently skipping it

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -217,9 +217,17 @@ fn build_daemon_filter_rules(
     // XFLG_OLD_PREFIXES: `filter` takes the modern rule syntax, where `- ` and
     // `+ ` are rule prefixes already, so `old_prefix_*` below deliberately does
     // not apply here.
+    //
+    // A malformed rule is REFUSED, not skipped: upstream's `parse_rule_tok`
+    // exits `RERR_SYNTAX` (`exclude.c:1130`), so the module is never served.
+    // This function already returns `Result`, and its caller already refuses
+    // the connection on the file-reading arms below - the refusal PATH is
+    // unchanged here; only which tokens enter it is new.
     for filter_str in &module.filter {
         for token in split_filter_tokens(filter_str.trim()) {
-            if let Some(rule) = parse_daemon_filter_token(&token) {
+            if let Some(rule) =
+                parse_daemon_filter_token(&token).map_err(MalformedRule::into_io_error)?
+            {
                 rules.push(rule);
             }
         }
@@ -548,19 +556,82 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
 /// `clear`, `dir-merge`, `merge`). The pattern follows the prefix after
 /// optional whitespace.
 ///
-/// Returns `None` for unrecognised tokens (silently skipped, matching
-/// upstream's lenient parsing of daemon filter strings).
+/// `Ok(None)` is an EMPTY token - nothing to add, no error. `Err` is a
+/// MALFORMED rule, which upstream refuses: `parse_rule_tok` calls
+/// `rprintf(FERROR, "Invalid... rule: %s\n", ..)` then
+/// `exit_cleanup(RERR_SYNTAX)` (`exclude.c:1130`, `:1170`).
+///
+/// ⚠ This doc block previously claimed the opposite - *"Returns `None` for
+/// unrecognised tokens (silently skipped, matching upstream's lenient parsing
+/// of daemon filter strings)"*. There is no lenient parsing to match.
+/// MEASURED against rsync 3.5.0: a module with `filter = -foo` is refused with
+/// exit 5, while oc served the module and silently excluded `foo`. The comment
+/// is what made the fallback below read as deliberate.
 ///
 /// # Upstream Reference
 ///
+/// - `exclude.c:1096-1131` - the modifier scan that rejects `-foo` on `f`
 /// - `exclude.c:1134-1178` - long-form keyword to short-form char mapping
-fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
-    // Short-form prefixes: +, -
-    if let Some(pattern) = token.strip_prefix("+ ").or_else(|| token.strip_prefix('+')) {
-        return non_empty_pattern_rule(pattern, true);
+fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
+    // Short-form prefixes: `+` and `-` are RULE CHARACTERS, and upstream's
+    // parser requires a separator after them. `parse_rule_tok` reads the
+    // prefix, then `while (*s && *s != ' ')` scans modifier characters and
+    // rejects any byte that is not a known modifier (exclude.c:1096-1131) -
+    // so `-foo` refuses on `f`, it does not silently become an exclude of
+    // `foo`.
+    //
+    // ⚠ The `.or_else(|| strip_prefix('+'))` fallback this replaces accepted
+    // the separator-less spelling and, for `-foo`, SILENTLY EXCLUDED `foo`
+    // from a module whose config upstream refuses to serve at all.
+    if let Some(pattern) = token.strip_prefix("+ ") {
+        return Ok(non_empty_pattern_rule(pattern, true));
     }
-    if let Some(pattern) = token.strip_prefix("- ").or_else(|| token.strip_prefix('-')) {
-        return non_empty_pattern_rule(pattern, false);
+    if let Some(pattern) = token.strip_prefix("- ") {
+        return Ok(non_empty_pattern_rule(pattern, false));
+    }
+    // The `+ `/`- ` arms above consumed the separator spelling, so a `+`/`-`
+    // reaching here is one upstream does NOT read as a bare include/exclude.
+    // Two upstream arms split on what follows it.
+    if let Some(rest) = token.strip_prefix(['+', '-']) {
+        return Err(match rest.chars().next() {
+            // `-foo`: upstream reads the rule character, then scans MODIFIER
+            // characters up to the first space and rejects any byte that is
+            // not a known modifier (exclude.c:1364-1379). `f` is not one, so
+            // it refuses at position 1.
+            //
+            // ⚠ oc accepted this spelling and SILENTLY EXCLUDED `foo` from a
+            // module upstream refuses to serve at all.
+            Some(c) => MalformedRule::InvalidModifier {
+                modifier: c,
+                position: 1,
+                token: token.to_owned(),
+            },
+            // A BARE `-` or `+`: the modifier scan ends immediately, leaving
+            // an empty pattern, and upstream's `else if (!len ...)` arm
+            // refuses (exclude.c:1474-1476).
+            None => MalformedRule::UnexpectedEnd {
+                token: token.to_owned(),
+            },
+        });
+    }
+
+    // `!` is upstream's clear rule. It takes no pattern, and because a daemon
+    // `filter` directive carries neither FILTRULE_NO_PREFIXES nor
+    // XFLG_OLD_PREFIXES, both conjuncts of the guard at exclude.c:1468-1470
+    // hold and a non-empty remainder refuses.
+    //
+    // ⚠ Upstream's modifier scan is `while (ch != '!' && ...)`, so it is
+    // SKIPPED for `!` - this refusal comes from the trailing-characters check
+    // AFTER the loop, not from the modifier arm above. The two arms report
+    // different things and are not interchangeable.
+    //
+    // ⚠ A BARE `!` is deliberately left on its existing path: oc does not
+    // implement it as a clear at all, so no cell measured here can
+    // discriminate what oc does with it. That is task 1155's question.
+    if token.len() > 1 && token.starts_with('!') {
+        return Err(MalformedRule::ClearWithTrailingCharacters {
+            token: token.to_owned(),
+        });
     }
 
     // upstream: exclude.c:1134-1178 - keyword-to-short-form mapping.
@@ -578,24 +649,96 @@ fn parse_daemon_filter_token(token: &str) -> Option<FilterRuleWireFormat> {
         if let Some(pattern) = strip_keyword_prefix(token, keyword) {
             let pattern = pattern.trim();
             if pattern.is_empty() {
-                return None;
+                return Ok(None);
             }
             let mut rule = build_pattern_rule(pattern, is_include);
             rule.sender_side = sender;
             rule.receiver_side = receiver;
-            return Some(rule);
+            return Ok(Some(rule));
         }
     }
 
     if strip_keyword_prefix(token, "clear").is_some() {
-        return Some(clear_list_rule());
+        return Ok(Some(clear_list_rule()));
     }
 
     // Bare pattern defaults to exclude (upstream behaviour)
     if token.is_empty() {
-        return None;
+        return Ok(None);
     }
-    Some(build_pattern_rule(token, false))
+    Ok(Some(build_pattern_rule(token, false)))
+}
+
+/// A daemon filter token upstream's parser refuses.
+///
+/// Carries the offending token so the refusal names it, as upstream's
+/// `"Invalid filter rule: %s"` does (`exclude.c:1130`).
+/// A daemon filter token upstream's parser refuses.
+///
+/// ⚠ THREE variants, not one, because upstream reports three DIFFERENT things
+/// and reaches them by three different routes. Collapsing them to a single
+/// "invalid rule" message would lose the distinction upstream draws.
+#[derive(Debug)]
+enum MalformedRule {
+    /// A rule character followed by a byte that is not a known modifier.
+    ///
+    /// upstream: `exclude.c:1373-1378` - the `default: invalid` arm of the
+    /// modifier scan.
+    InvalidModifier {
+        modifier: char,
+        position: usize,
+        token: String,
+    },
+    /// A rule character with no pattern after it.
+    ///
+    /// upstream: `exclude.c:1474-1476` - `else if (!len && !CVS_IGNORE)`.
+    UnexpectedEnd { token: String },
+    /// A `!` clear rule carrying a pattern it cannot take.
+    ///
+    /// upstream: `exclude.c:1468-1470`.
+    ClearWithTrailingCharacters { token: String },
+}
+
+impl MalformedRule {
+    fn into_io_error(self) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, self.to_string())
+    }
+}
+
+/// Renders upstream's diagnostic text.
+///
+/// `Display` is the SINGLE owner of the wording so the message a test reads
+/// and the message [`MalformedRule::into_io_error`] delivers cannot drift
+/// apart.
+///
+/// Two of the three go through upstream's `filter_rule_err`, which renders
+/// `"{msg}: {rule text}"` and then `exit_cleanup(RERR_SYNTAX)`
+/// (`exclude.c:133-137`); the modifier arm builds its own line at
+/// `exclude.c:1373-1378`.
+///
+/// ⚠ SCOPE: what this change was measured on is the REFUSAL - whether the
+/// module is served - not the wording. The daemon's filter diagnostics also
+/// lack upstream's `<rule from FILE line N>` provenance envelope, which is
+/// task 1156 and deliberately NOT attempted here.
+impl std::fmt::Display for MalformedRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidModifier {
+                modifier,
+                position,
+                token,
+            } => write!(
+                f,
+                "invalid modifier '{modifier}' at position {position} in filter rule: {token}"
+            ),
+            Self::UnexpectedEnd { token } => {
+                write!(f, "unexpected end of filter rule: {token}")
+            }
+            Self::ClearWithTrailingCharacters { token } => {
+                write!(f, "'!' rule has trailing characters: {token}")
+            }
+        }
+    }
 }
 
 /// Returns a rule if the trimmed pattern is non-empty, `None` otherwise.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2712,41 +2712,73 @@ mod module_access_tests {
         assert!(rule.anchored);
     }
 
+    /// A token the parser accepts and turns into a rule.
+    ///
+    /// Panics on a refusal AND on an empty token, so a cell using this can
+    /// never pass by silently skipping the token it means to assert about.
+    fn accepted_rule(token: &str) -> FilterRuleWireFormat {
+        parse_daemon_filter_token(token)
+            .expect("token refused")
+            .expect("token produced no rule")
+    }
+
+    /// A token the parser accepts and skips - `Ok(None)`, not a refusal.
+    fn is_skipped(token: &str) -> bool {
+        matches!(parse_daemon_filter_token(token), Ok(None))
+    }
+
     #[test]
     fn parse_daemon_filter_token_exclude() {
-        let rule = parse_daemon_filter_token("- *.tmp").unwrap();
+        let rule = accepted_rule("- *.tmp");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.tmp");
     }
 
     #[test]
     fn parse_daemon_filter_token_include() {
-        let rule = parse_daemon_filter_token("+ *.rs").unwrap();
+        let rule = accepted_rule("+ *.rs");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.rs");
     }
 
     #[test]
     fn parse_daemon_filter_token_bare_pattern_defaults_to_exclude() {
-        let rule = parse_daemon_filter_token("*.bak").unwrap();
+        let rule = accepted_rule("*.bak");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.bak");
     }
 
     #[test]
     fn parse_daemon_filter_token_empty_returns_none() {
-        assert!(parse_daemon_filter_token("").is_none());
+        assert!(is_skipped(""));
     }
 
     #[test]
-    fn parse_daemon_filter_token_prefix_only_returns_none() {
-        assert!(parse_daemon_filter_token("-").is_none());
-        assert!(parse_daemon_filter_token("+").is_none());
+    fn a_bare_rule_character_with_no_pattern_is_refused() {
+        // RENAMED from `parse_daemon_filter_token_prefix_only_returns_none`,
+        // which pinned oc's old `Ok(None)`. That was NOT upstream's behaviour:
+        // the modifier scan ends immediately on an empty remainder, leaving
+        // `len == 0`, and `else if (!len && !CVS_IGNORE)` refuses
+        // (exclude.c:1474-1476).
+        //
+        // ⚠ This row is read from the C, not from the differential oracle -
+        // the oracle for this change covered `-foo`, `+foo` and `!name`. It is
+        // in scope anyway because removing the separator-less fallback moved
+        // this token off its old path regardless; leaving it would have made
+        // a bare `-` an EXCLUDE OF THE LITERAL STRING `-`, which is neither
+        // the old behaviour nor upstream's.
+        for token in ["-", "+"] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert!(
+                err.to_string().starts_with("unexpected end of filter rule"),
+                "{token}: {err}"
+            );
+        }
     }
 
     #[test]
     fn parse_daemon_filter_token_exclude_keyword() {
-        let rule = parse_daemon_filter_token("exclude *.bak").unwrap();
+        let rule = accepted_rule("exclude *.bak");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.bak");
     }
@@ -2754,14 +2786,14 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_exclude_keyword_comma_sep() {
         // upstream: RULE_STRCMP accepts comma as separator
-        let rule = parse_daemon_filter_token("exclude,*.bak").unwrap();
+        let rule = accepted_rule("exclude,*.bak");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.bak");
     }
 
     #[test]
     fn parse_daemon_filter_token_include_keyword() {
-        let rule = parse_daemon_filter_token("include *.rs").unwrap();
+        let rule = accepted_rule("include *.rs");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.rs");
     }
@@ -2769,7 +2801,7 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_hide_keyword() {
         // upstream: hide -> sender-side exclude
-        let rule = parse_daemon_filter_token("hide *.secret").unwrap();
+        let rule = accepted_rule("hide *.secret");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.secret");
         assert!(rule.sender_side);
@@ -2779,7 +2811,7 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_show_keyword() {
         // upstream: show -> sender-side include
-        let rule = parse_daemon_filter_token("show *.pub").unwrap();
+        let rule = accepted_rule("show *.pub");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.pub");
         assert!(rule.sender_side);
@@ -2789,7 +2821,7 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_protect_keyword() {
         // upstream: protect -> receiver-side exclude
-        let rule = parse_daemon_filter_token("protect *.conf").unwrap();
+        let rule = accepted_rule("protect *.conf");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.conf");
         assert!(!rule.sender_side);
@@ -2799,7 +2831,7 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_risk_keyword() {
         // upstream: risk -> receiver-side include
-        let rule = parse_daemon_filter_token("risk *.tmp").unwrap();
+        let rule = accepted_rule("risk *.tmp");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.tmp");
         assert!(!rule.sender_side);
@@ -2808,7 +2840,7 @@ mod module_access_tests {
 
     #[test]
     fn parse_daemon_filter_token_clear_keyword() {
-        let rule = parse_daemon_filter_token("clear").unwrap();
+        let rule = accepted_rule("clear");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
         assert!(rule.pattern.is_empty());
     }
@@ -2816,15 +2848,123 @@ mod module_access_tests {
     #[test]
     fn parse_daemon_filter_token_keyword_not_partial_match() {
         // "excluder" should NOT match "exclude" keyword - treated as bare pattern
-        let rule = parse_daemon_filter_token("excluder *.tmp").unwrap();
+        let rule = accepted_rule("excluder *.tmp");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "excluder *.tmp");
     }
 
     #[test]
     fn parse_daemon_filter_token_keyword_empty_pattern_returns_none() {
-        assert!(parse_daemon_filter_token("exclude").is_none());
-        assert!(parse_daemon_filter_token("include ").is_none());
+        assert!(is_skipped("exclude"));
+        assert!(is_skipped("include "));
+    }
+
+    // ---------------------------------------------------------------------
+    // Separator-less rule prefixes. Upstream's `parse_rule_tok` reads the
+    // rule character, then scans MODIFIER characters up to the first space
+    // and refuses any byte that is not a known modifier
+    // (`exclude.c:1096-1131`), so `-foo` refuses on `f`.
+    //
+    // MEASURED against the real rsync 3.5.0 binary, oc's daemon serving the
+    // same module against the same client: upstream exits 5 and serves
+    // nothing; oc exited 0, served the module, and silently applied the rule.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn a_minus_prefix_without_a_separator_is_refused() {
+        // The severe row: oc SILENTLY EXCLUDED `foo` from a module that
+        // upstream refuses to serve at all, so the operator saw a successful
+        // transfer with a file missing from it.
+        //
+        // The message names the offending BYTE and its offset, as upstream's
+        // modifier arm does - a bare "invalid rule" would not tell an
+        // operator which character of their config is wrong.
+        let err = parse_daemon_filter_token("-foo").expect_err("must refuse");
+        assert_eq!(
+            err.to_string(),
+            "invalid modifier 'f' at position 1 in filter rule: -foo"
+        );
+    }
+
+    #[test]
+    fn a_plus_prefix_without_a_separator_is_refused() {
+        let err = parse_daemon_filter_token("+foo").expect_err("must refuse");
+        assert_eq!(
+            err.to_string(),
+            "invalid modifier 'f' at position 1 in filter rule: +foo"
+        );
+    }
+
+    #[test]
+    fn a_bang_carrying_a_pattern_is_refused() {
+        // `!` takes no pattern. oc fell through to the bare-pattern arm, so
+        // `!name` became an exclude of `name` and the module was served.
+        //
+        // ⚠ This reports the TRAILING-CHARACTERS text, not the modifier text:
+        // upstream's modifier scan is `while (ch != '!' && ...)` and so never
+        // runs for `!`. The two arms are distinct, and asserting the wrong
+        // one here would pin a message upstream cannot produce for this token.
+        let err = parse_daemon_filter_token("!name").expect_err("must refuse");
+        assert_eq!(err.to_string(), "'!' rule has trailing characters: !name");
+    }
+
+    #[test]
+    fn a_bare_bang_keeps_its_existing_behaviour() {
+        // SCOPE BOUNDARY, pinned rather than asserted as correct.
+        //
+        // The guard above fires only past length 1, so a bare `!` still
+        // reaches the bare-pattern arm and becomes an exclude of the literal
+        // `!`. Upstream instead treats it as a CLEAR rule.
+        //
+        // ⚠ That divergence is REAL and is task 1155's, deliberately NOT
+        // fixed here - oc has no clear-rule implementation on this path at
+        // all, so "fixing" it would mean building one, well outside a change
+        // scoped to three measured refusal rows.
+        //
+        // ⚠ This cell exists because the `token.len() > 1` term was otherwise
+        // UNPROTECTED: mutating it away killed nothing, so the comment
+        // claiming bare `!` is untouched had no evidence behind it. Dropping
+        // the term now reddens this cell.
+        let rule = accepted_rule("!");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "!");
+    }
+
+    #[test]
+    fn the_separator_spelling_is_still_accepted() {
+        // The non-vacuity companion for the three cells above: without it
+        // they would also pass if the parser refused EVERY `+`/`-`/`!` token.
+        assert_eq!(accepted_rule("- foo").pattern, "foo");
+        assert_eq!(accepted_rule("+ foo").pattern, "foo");
+    }
+
+    #[test]
+    fn a_malformed_filter_rule_refuses_the_whole_module() {
+        // The refusal has to reach the CALLER to matter - a rule the parser
+        // rejects while `build_daemon_filter_rules` returns `Ok` would leave
+        // the module served with the rule merely dropped, which is the
+        // pre-fix behaviour wearing a new error type.
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["-foo".to_string()],
+            ..Default::default()
+        });
+        let err = build_daemon_filter_rules(&module).expect_err("must refuse");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(
+            err.to_string(),
+            "invalid modifier 'f' at position 1 in filter rule: -foo"
+        );
+    }
+
+    #[test]
+    fn a_well_formed_filter_rule_still_builds() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["- *.tmp".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).expect("must accept");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "*.tmp");
     }
 
     #[test]


### PR DESCRIPTION
fix(daemon): refuse a malformed `filter` rule instead of silently skipping it

A `-`/`+` prefix in a daemon filter rule REQUIRES a separating space, in
both of upstream's parse modes. The old-prefix mode tests it explicitly -
`*s == '-' && s[1] == ' '` (exclude.c:1277-1282) - and the modern mode
consumes the separator through the same `if (*s) s++` (exclude.c:1444).
What differs between the modes is only what happens when the separator
is ABSENT:

  - `exclude`/`include` carry `XFLG_OLD_PREFIXES` (clientserver.c:939-952),
    no arm matches, and the whole token becomes a literal pattern;
  - `filter` does NOT carry it, so the token enters the rule-character
    switch and `parse_rule_tok` refuses it, exiting `RERR_SYNTAX`
    (exclude.c:1130) without serving the module.

oc's parser returned `None` for such a token and the caller dropped it,
so the module was served with the rule missing. Measured against the
real 3.5.0 binary as a differential oracle, with the same 3.5.0 client
held constant and only the daemon varying:

    directive/value    upstream          oc before         oc after
    exclude = -foo     rc 0, both        rc 0, both        rc 0, both
    filter  = - foo    rc 0, foo hidden  rc 0, foo hidden  rc 0, foo hidden
    filter  = -foo     refuse            rc 0, foo HIDDEN  refuse
    filter  = +foo     refuse            rc 0, both        refuse
    filter  = !name    refuse            rc 0, both        refuse
    filter  = -        refuse            rc 0, both        refuse
    filter  = +        refuse            rc 0, both        refuse

The first two rows are the controls. `exclude = -foo` serves BOTH files
on every arm: `-foo` is a literal pattern there, matching nothing, and
this change leaves that path untouched. `filter = - foo` is the
well-formed spelling and is unaffected.

`filter = -foo` is the severe row, and it is a reading upstream has
nowhere: oc excluded `foo` outright, applying a filter the operator
never wrote and hiding a file with no diagnostic.

The refusal PATH already existed - `build_daemon_filter_rules` returns
`Result` and its caller already refuses the connection on the
file-reading arms. Only the membership test changes: which tokens enter
that path.

Upstream reports three different things by three different routes, so
the error type has three variants rather than one message:

  - a rule character followed by a non-modifier byte is
    `invalid modifier` (exclude.c:1364-1379);
  - a bare rule character is `unexpected end of filter rule`
    (exclude.c:1474-1476), reached through the post-loop length check;
  - `!` carrying a pattern is `'!' rule has trailing characters`
    (exclude.c:1468-1470). Two things keep these apart: the modifier
    scan is `while (ch != '!' && ...)`, so it is skipped entirely for
    `!`, and the trailing-characters check is itself conditioned on
    `!(xflags & XFLG_OLD_PREFIXES)` (exclude.c:1469) - which is why
    `!name` refuses under `filter` and not under `exclude`.

`Display` is the single owner of the wording so the delivered text and
the asserted text cannot drift apart.

Also corrects the doc block on `parse_daemon_filter_token`, which
claimed the fallback matched "upstream's lenient parsing of daemon
filter strings". There is no lenient parsing to match; that comment is
what made the skip read as deliberate.

The exit code oc delivers for a refused module (12, from the tag-95
frame) differs from upstream's 5. That is pre-existing and untouched
here: an A/B on a refusal this change does not reach - `exclude from`
naming a file that does not exist - gives rc 12 on both arms.

## Scope note

Bare `-` and `+` now refuse as well, which changes two previously-passing
test expectations. That was not optional: the membership change moves those
tokens off their old path regardless, and leaving them would have made each
an exclude of the literal string `-`, which is neither the old behaviour nor
upstream's. Upstream was measured on both (rc 5) before the scope widened -
the widening rests on an executed oracle row, not on a reading.

## Verification

Mutation matrix M1-M5, predictions registered in a file before running.
M1/M2 predictions were WRONG (predicted 2 and 1, measured 3 and 2) because
one cell loops over both `-` and `+`; recorded as measured rather than
re-engineered. M4 is the load-bearing non-overlap: swallowing the refusal at
the caller kills only the caller cell while all three parser cells stay
green - i.e. exactly the pre-fix behaviour wearing a new error type, which
is what shows the caller cell is not redundant. M5 as first registered no
longer applied; re-aimed at the `!` arm with the revised prediction
("kills nothing") registered first, it killed nothing - a real coverage gap
on the unprotected `len() > 1` term, now closed by a dedicated cell and
lethal on re-run.

Run at the pinned toolchain (1.88.0, not stable):

- `tools/ci/check_rustfmt_all.py` - 3424 files, exit 0
- `cargo clippy -p daemon --all-targets -- -D warnings` - clean
- `cargo nextest run -p daemon --lib --no-fail-fast` -
  `1860 tests run: 1860 passed (5 slow, 10 leaky), 0 skipped`

NOT run, and CI is the first place these execute: full-workspace nextest,
root `tests/integration_*.rs`, macOS / Windows / musl, `--all-features`,
the upstream-3.5.0 testsuite legs, interop.
