### PR TITLE
fix(daemon): a repeated exclude/include/filter directive replaces the previous value

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -538,9 +538,16 @@ fn apply_global_directive(
         // When bInGlobalSection is true, parm_ptr = def_ptr, so the value
         // written becomes the default for all subsequent module sections
         // (via init_section -> copy_section).
+        //
+        // Last-wins here too: `do_parameter()` resolves the same parameter
+        // pointer whether the section is global or a module and assigns it
+        // through `string_set()` (loadparm.c:379-470), so a repeated global
+        // `exclude` REPLACES the default rather than extending it. These three
+        // are the only `Vec`-shaped fields on `GlobalModuleDefaults`; every
+        // other field is an `Option`, which is last-wins by construction.
         "exclude" => {
             if !value.is_empty() {
-                state.module_defaults.exclude.push(value.to_owned());
+                state.module_defaults.exclude = vec![value.to_owned()];
             }
         }
         // upstream: daemon-parm.txt `Locals:` `include` is P_STRING/P_LOCAL
@@ -550,12 +557,12 @@ fn apply_global_directive(
         // default, mirroring `exclude` above.
         "include" => {
             if !value.is_empty() {
-                state.module_defaults.include.push(value.to_owned());
+                state.module_defaults.include = vec![value.to_owned()];
             }
         }
         "filter" => {
             if !value.is_empty() {
-                state.module_defaults.filter.push(value.to_owned());
+                state.module_defaults.filter = vec![value.to_owned()];
             }
         }
         "maxverbosity" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -364,23 +364,27 @@ fn apply_module_directive(
             let resolved = resolve_config_relative_path(canonical, value);
             builder.set_include_from(resolved);
         }
-        // upstream: daemon-parm.h - `filter` STRING, P_LOCAL.
-        // Repeatable: multiple directives accumulate rules.
+        // upstream: daemon-parm.h - `filter` STRING, P_LOCAL. Last-wins like
+        // every other directive: `do_parameter()` reaches `string_set()`, which
+        // frees the previous value before storing the new one
+        // (loadparm.c:379-470), so a second `filter` line REPLACES the first.
+        // It does not extend it - a value carrying several rules says so with
+        // whitespace inside that one value.
         "filter" => {
             if !value.is_empty() {
-                builder.filter.push(value.to_owned());
+                builder.set_filter(vec![value.to_owned()]);
             }
         }
         // upstream: daemon-parm.h - `exclude` STRING, P_LOCAL.
         "exclude" => {
             if !value.is_empty() {
-                builder.exclude.push(value.to_owned());
+                builder.set_exclude(vec![value.to_owned()]);
             }
         }
         // upstream: daemon-parm.h - `include` STRING, P_LOCAL.
         "include" => {
             if !value.is_empty() {
-                builder.include.push(value.to_owned());
+                builder.set_include(vec![value.to_owned()]);
             }
         }
         // upstream: daemon-parm.h:78 `reverse_lookup` BOOL, P_LOCAL. Consumed

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -2666,8 +2666,15 @@ mod config_parsing_tests {
         assert_eq!(result.modules[0].filter, vec!["- *.tmp"]);
     }
 
+    /// A repeated `filter` directive REPLACES the earlier one.
+    ///
+    /// upstream: loadparm.c:379-470 do_parameter() assigns every P_STRING
+    /// through `string_set()`, which frees the old value first, so the last
+    /// occurrence is the one that survives. Measured against the real 3.5.0
+    /// daemon: with `filter = - foo` then `filter = - bar`, upstream serves
+    /// `foo` and hides only `bar`.
     #[test]
-    fn parse_module_filter_multiple_rules_accumulate() {
+    fn parse_module_filter_last_directive_wins() {
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
@@ -2678,7 +2685,26 @@ mod config_parsing_tests {
         );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(result.modules[0].filter, vec!["- *.tmp", "+ *.rs"]);
+        assert_eq!(result.modules[0].filter, vec!["+ *.rs"]);
+    }
+
+    /// The non-vacuity companion to the last-wins cells: several rules inside
+    /// ONE directive value are all kept. Without this, "last wins" could be
+    /// satisfied by a parser that simply dropped rules, and the two cells
+    /// would not distinguish replacement from loss.
+    #[test]
+    fn parse_module_filter_one_directive_keeps_its_whole_value() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nfilter = - *.tmp + *.rs\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].filter, vec!["- *.tmp + *.rs"]);
     }
 
     #[test]
@@ -2705,8 +2731,10 @@ mod config_parsing_tests {
         assert_eq!(result.modules[0].include, vec!["*.rs"]);
     }
 
+    /// Three `exclude` directives leave only the third, for the same
+    /// `string_set()` reason as the `filter` cell above.
     #[test]
-    fn parse_module_exclude_multiple_rules_accumulate() {
+    fn parse_module_exclude_last_directive_wins() {
         let dir = TempDir::new().expect("create temp dir");
         let path = dir.path().join("data");
         fs::create_dir(&path).expect("create dir");
@@ -2717,7 +2745,130 @@ mod config_parsing_tests {
         );
         let file = write_config(&config);
         let result = parse_config_modules(file.path()).expect("parse succeeds");
-        assert_eq!(result.modules[0].exclude, vec!["*.log", "*.tmp", "/cache/"]);
+        assert_eq!(result.modules[0].exclude, vec!["/cache/"]);
+    }
+
+    /// `include` takes the same rule; kept separate because the three
+    /// directives are three independent arms and a fix to one need not reach
+    /// the others.
+    #[test]
+    fn parse_module_include_last_directive_wins() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\ninclude = *.rs\ninclude = *.toml\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].include, vec!["*.toml"]);
+    }
+
+    /// The GLOBAL-section arms are a separate three, in a separate file
+    /// (`global_directives/dispatch.rs`), and they had the same defect. A
+    /// module that overrides nothing inherits the default, so the last global
+    /// `exclude` is the one every module sees.
+    ///
+    /// upstream: loadparm.c - a P_LOCAL parameter in the global section writes
+    /// the default that `init_section()`/`copy_section()` hand to every module.
+    /// The assignment is the same `string_set()`, so repeats replace here too.
+    #[test]
+    fn parse_global_exclude_last_directive_wins() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "exclude = *.log\nexclude = *.tmp\n[mod]\npath = {}\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].exclude, vec!["*.tmp"]);
+    }
+
+    #[test]
+    fn parse_global_filter_last_directive_wins() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "filter = - *.log\nfilter = - *.tmp\n[mod]\npath = {}\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].filter, vec!["- *.tmp"]);
+    }
+
+    #[test]
+    fn parse_global_include_last_directive_wins() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "include = *.rs\ninclude = *.toml\n[mod]\npath = {}\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].include, vec!["*.toml"]);
+    }
+
+    /// SCOPE BOUNDARY, and a negative control for the whole change: a module's
+    /// own value REPLACES the inherited global default, and that was already
+    /// correct before this fix. Measured against the real 3.5.0 daemon with
+    /// `exclude = foo` global + `exclude = bar` in the module: both upstream
+    /// and oc serve `foo` and hide only `bar`.
+    ///
+    /// If a future edit made the module arm extend the inherited default
+    /// instead of replacing it, this cell fails while the last-wins cells above
+    /// stay green - which is the distinction they cannot draw on their own.
+    #[test]
+    fn parse_module_exclude_replaces_the_inherited_global_default() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "exclude = *.log\n[mod]\npath = {}\nexclude = *.tmp\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].exclude, vec!["*.tmp"]);
+    }
+
+    /// The SECOND negative control: last-wins binds PER DIRECTIVE NAME. One
+    /// name does not clear another's slot.
+    ///
+    /// Every last-wins cell above repeats the SAME directive, so none of them
+    /// can see a cross-name effect. If `filter` overwrote what `exclude` had
+    /// stored, a per-arm assignment would be wrong in a way the rest of the
+    /// table is blind to - so this is measured, not assumed.
+    ///
+    /// Measured against the real 3.5.0 daemon, both orders and in the global
+    /// section too: with `exclude = foo` and `filter = - bar` on one module,
+    /// upstream hides BOTH and serves only the third file. `string_set()` keys
+    /// on the parameter (loadparm.c:379-470), so each name owns its own slot.
+    #[test]
+    fn parse_module_directives_of_different_names_keep_separate_slots() {
+        let dir = TempDir::new().expect("create temp dir");
+        let path = dir.path().join("data");
+        fs::create_dir(&path).expect("create dir");
+
+        let config = format!(
+            "[mod]\npath = {}\nexclude = *.log\nfilter = - *.tmp\n",
+            path.display()
+        );
+        let file = write_config(&config);
+        let result = parse_config_modules(file.path()).expect("parse succeeds");
+        assert_eq!(result.modules[0].exclude, vec!["*.log"]);
+        assert_eq!(result.modules[0].filter, vec!["- *.tmp"]);
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_definition/setters.rs
+++ b/crates/daemon/src/daemon/sections/module_definition/setters.rs
@@ -85,6 +85,49 @@ last_wins_setters! {
     set_syslog_facility => syslog_facility: String,
 }
 
+/// Generates the setters for the filter-rule slots, which hold `Vec<String>`
+/// rather than `Option<String>`.
+///
+/// These three are the only P_LOCAL slots on the builder that are not
+/// `Option`-shaped, so they are the only ones whose type can express
+/// accumulation at all. That is exactly why they need saying out loud: for
+/// every `Option` field above, "a repeat replaces" is true by construction
+/// and no code has to enforce it, while here it has to be written down.
+///
+/// The `Vec` holds ONE entry, the directive's whole value with its whitespace
+/// intact, rather than one entry per directive occurrence. Upstream keeps a
+/// single string per slot and `string_set()` frees the previous one
+/// (loadparm.c:379-470), so a second occurrence replaces the first rather than
+/// extending it. Splitting a value into individual rules happens later, at
+/// rule-parse time, not here.
+macro_rules! last_wins_rule_setters {
+    ($( $(#[$attr:meta])* $setter:ident => $field:ident ),+ $(,)?) => {
+        impl ModuleDefinitionBuilder {
+            $(
+                $(#[$attr])*
+                fn $setter(&mut self, value: Vec<String>) {
+                    self.$field = value;
+                }
+            )+
+        }
+    };
+}
+
+last_wins_rule_setters! {
+    /// Sets the module's `filter` rules.
+    ///
+    /// upstream: daemon-parm.h - `filter` STRING, P_LOCAL.
+    set_filter => filter,
+    /// Sets the module's `exclude` rules.
+    ///
+    /// upstream: daemon-parm.h - `exclude` STRING, P_LOCAL.
+    set_exclude => exclude,
+    /// Sets the module's `include` rules.
+    ///
+    /// upstream: daemon-parm.h - `include` STRING, P_LOCAL.
+    set_include => include,
+}
+
 impl ModuleDefinitionBuilder {
     /// Stores the module `comment`, where an empty directive value means "no
     /// comment" and is represented by `None` rather than by an unset field.

--- a/tools/ci/run_interop.sh
+++ b/tools/ci/run_interop.sh
@@ -9275,8 +9275,7 @@ path = ${sf_src}
 comment = server-side filter test
 read only = true
 numeric ids = yes
-exclude = *.tmp
-exclude = *.log
+exclude = *.tmp *.log
 filter = exclude *.bak
 CONF
 
@@ -9330,8 +9329,7 @@ path = ${sf_dest_push}
 comment = server-side filter push test
 read only = false
 numeric ids = yes
-exclude = *.tmp
-exclude = *.log
+exclude = *.tmp *.log
 filter = exclude *.bak
 CONF
 


### PR DESCRIPTION
A daemon config that names the same filter directive twice kept BOTH values.
Upstream keeps the last one and discards the first.

    [mod]
    exclude = *.log
    exclude = *.tmp

Upstream serves `a.log` and hides only `*.tmp`. oc hid both. Measured with a
real rsync 3.5.0 binary held constant as the client and only the daemon
varying: all six affected arms diverge on the base and match upstream after
the fix.

The rule is `do_parameter()` reaching `string_set()` (loadparm.c:379-470),
which frees the previous value before storing the new one. There is no
seen-set and no duplicate check anywhere in that path: a second occurrence of
a parameter simply overwrites the first. That holds for the global section
too, where a P_LOCAL parameter writes the default `init_section()` /
`copy_section()` hand to every module.

WHY EXACTLY THESE THREE DIRECTIVES

`GlobalModuleDefaults` has 40 fields. 37 are `Option<T>`; exactly three are
`Vec<String>`, and they are `exclude`, `include` and `filter`. An `Option`
field can only be assigned, so "does a repeat replace?" is true by
construction and no code has to enforce it - the question cannot even be
asked. The three `Vec` fields are the only ones whose type can express
accumulation, and they are precisely the three that got it wrong. That is the
survival mechanism: for 37 of 40 fields there was nothing for a reviewer to
check.

The same shape appears on the module builder, where `last_wins_setters!`
(module_definition/setters.rs) states the convention in its own header -
"Every directive is last-wins ... The single expansion below is the one place
that assignment happens" - and the three filter slots sat outside the macro
because their type is not `Option`. The convention was written down and these
three escaped it.

SCOPE - six arms across two files

Three module arms in `config_parsing/module_directives.rs` and three global
arms in `config_parsing/global_directives/dispatch.rs`. Each now assigns a
one-element `Vec` holding the directive's whole value. The module arms go
through new named setters (`last_wins_rule_setters!`, a sibling of the
existing macro) so the three slots are inside the convention rather than
beside it; one edit to that macro body reaches all three, which the mutation
matrix confirms.

The `Vec` is deliberately NOT collapsed to a `String`. It stays a `Vec` with
one entry because the inheritance path depends on the shape, and that path was
already correct - see the negative control below.

DELETED IN THIS COMMIT: `module_directives.rs` carried the comment
"Repeatable: multiple directives accumulate rules." It is false, it is the
statement this change refutes, and it is why the behaviour read as intended.

WHAT DID NOT CHANGE, AND IS PINNED AS SUCH

A module's own value replacing an inherited global default was ALREADY
correct on both implementations (`exclude = foo` globally plus
`exclude = bar` in the module serves `foo`, hides `bar`). The defect is
repeats within one section only. `parse_module_exclude_replaces_the_inherited
_global_default` pins that boundary: if a future edit made the module arm
extend the inherited default, it fails while every last-wins cell stays green
- a distinction those cells cannot draw alone.

`parse_module_filter_one_directive_keeps_its_whole_value` is the non-vacuity
companion: several rules inside ONE directive value are all kept. Without it,
"last wins" would also be satisfied by a parser that simply dropped rules.

The two other `.push(` sites in the global file are untouched and correct by
intent: `refuse options` clears then pushes and documents "The list is not
additive", and `motd` documents having no upstream counterpart.

TWO EXISTING TESTS ASSERTED THE DEFECT
`parse_module_filter_multiple_rules_accumulate` and its `exclude` sibling
encoded the accumulating behaviour by name. They are converted, not deleted -
same fixture, corrected expectation, renamed to `_last_directive_wins` to
match the ten sibling cells.

MUTATION MATRIX - 8 mutations, all lethal, predictions registered first
Population 15 cells, baseline 15/15 at pinned 1.88.0.

  M1-M3  each module arm back to `push`   -> kills exactly its own cell
  M4-M6  each global arm back to `push`   -> kills exactly its own cell
  M7     setter macro body to `.extend()` -> kills all THREE module cells at
         once and leaves the three global cells green: the single-owner proof
  M8     module filter arm splits the value on whitespace -> kills the
         non-vacuity companion

One registered prediction was WRONG: M8 was predicted to kill 2 cells and
killed 3. It also reddens `parse_module_filter_single_rule`, whose value
`- *.tmp` splits into two tokens. Reported as measured; the mutation is not
re-scoped to fit the prediction.
