### PR TITLE
fix(daemon): a filter keyword ends at any separator upstream accepts

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -464,6 +464,51 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
     Ok(patterns)
 }
 
+/// Every long-form filter keyword the daemon `filter` directive recognises.
+///
+/// upstream: `exclude.c:1134-1178` maps each of these to a short-form rule
+/// character. The list is shared by the tokenizer and, through
+/// [`is_rule_keyword`], uses one terminator rule rather than a second copy.
+///
+/// ⚠ `merge`/`dir-merge` open a token here but `parse_daemon_filter_token` has
+/// no arm for them, so such a token falls through to its bare-pattern arm. That
+/// is a separate defect, tracked on its own; this list deliberately keeps them
+/// so the tokenizer's behaviour on them is unchanged by this commit.
+const RULE_KEYWORDS: &[&str] = &[
+    "include",
+    "exclude",
+    "hide",
+    "show",
+    "protect",
+    "risk",
+    "clear",
+    "merge",
+    "dir-merge",
+];
+
+/// The bytes that terminate a filter-rule keyword.
+///
+/// upstream: `exclude.c:1218-1227` `rule_strcmp` - a keyword matches only when
+/// the byte after it is whitespace, `_`, `,`, or the end of the string. Any
+/// other byte makes the token not that keyword at all.
+///
+/// oc's CLI parser states the same rule in
+/// `crates/cli/src/frontend/filter_rules/parsing/helpers.rs`, whose
+/// `is_rule_separator` records why oc treats the whole ASCII whitespace class
+/// as a separator where upstream's `rule_strcmp` calls `isspace`. This is the
+/// daemon-side statement of that one convention, not a second one.
+fn is_keyword_terminator(ch: char) -> bool {
+    ch == '_' || ch == ',' || ch.is_ascii_whitespace()
+}
+
+/// Returns true when `s` opens with `keyword` AND the keyword is terminated.
+fn is_rule_keyword(s: &str, keyword: &str) -> bool {
+    match s.strip_prefix(keyword) {
+        Some(rest) => rest.chars().next().is_none_or(is_keyword_terminator),
+        None => false,
+    }
+}
+
 /// Splits a filter string with `FILTRULE_WORD_SPLIT` semantics into individual
 /// rule tokens.
 ///
@@ -484,31 +529,18 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
 
     // Prefixes that start a new rule token when found after whitespace.
     const SHORT_PREFIXES: &[&str] = &["+ ", "- ", "+/", "-/"];
-    const KEYWORD_PREFIXES: &[&str] = &[
-        "include ",
-        "exclude ",
-        "hide ",
-        "show ",
-        "protect ",
-        "risk ",
-        "clear ",
-        "merge ",
-        "dir-merge ",
-    ];
 
     /// Returns true if `s` starts with a filter rule prefix.
+    ///
+    /// The keyword arm asks `is_rule_keyword`, so a keyword terminated by any
+    /// separator upstream accepts opens a new token. The table this replaced
+    /// carried a MANDATORY TRAILING SPACE on every entry, so `hide_bar` and a
+    /// line-final `clear` matched nothing, no token boundary opened, and the
+    /// whole remainder collapsed into one rule whose pattern was the literal
+    /// compound string.
     fn starts_with_rule_prefix(s: &str) -> bool {
-        for &p in SHORT_PREFIXES {
-            if s.starts_with(p) {
-                return true;
-            }
-        }
-        for &kw in KEYWORD_PREFIXES {
-            if s.starts_with(kw) {
-                return true;
-            }
-        }
-        false
+        SHORT_PREFIXES.iter().any(|p| s.starts_with(p))
+            || RULE_KEYWORDS.iter().any(|kw| is_rule_keyword(s, kw))
     }
 
     let mut tokens = Vec::new();
@@ -609,21 +641,45 @@ fn non_empty_pattern_rule(pattern: &str, is_include: bool) -> Option<FilterRuleW
 
 /// Strips a keyword prefix from a token, returning the remainder.
 ///
-/// The keyword must be followed by whitespace or a comma separator.
-/// Returns `None` if the token doesn't start with the keyword.
+/// Returns `None` when the token does not start with the keyword, or starts
+/// with it but is not TERMINATED by it - `hideout` is not a `hide` rule.
 ///
-/// upstream: exclude.c:1134 - RULE_STRCMP advances past the keyword and
-/// any following separator (space, comma).
+/// upstream: `exclude.c:1218-1227` `rule_strcmp`, via [`is_keyword_terminator`].
+/// The set this replaced was `' '` or `','` alone, so `_` and tab - both
+/// separators upstream accepts - made the token not-a-keyword and it fell
+/// through to the bare-pattern arm.
+///
+/// ⚠ The trailing `trim_start` consumes a whole RUN of whitespace, where
+/// upstream consumes exactly ONE separator (`if (*s) s++`,
+/// `exclude.c:1444-1445`) and takes the remainder verbatim - a rule oc's CLI
+/// parser measured against rsync 3.5.0 for the NON-word-split `--filter`.
+///
+/// MEASURED for THIS directive against a real rsync 3.5.0 daemon, and the
+/// question turns out to be UNASKABLE here rather than answered either way:
+///
+/// - `filter = exclude bar` (ONE space) builds the pattern `bar`, NOT ` bar`.
+///   Discriminated with a module holding both `bar` and ` bar`: upstream hides
+///   `bar` and serves ` bar`, and oc agrees. So on the only shape where the
+///   two readings differ observably, oc is faithful.
+/// - `filter = exclude  bar` (TWO spaces) and `filter = exclude\tbar` make
+///   upstream REFUSE the module - `unexpected end of filter rule` - because
+///   the word-split loop (`exclude.c:1250-1255`) splits on the whitespace RUN
+///   first, leaving the keyword with no pattern at all. Neither candidate
+///   pattern is ever built.
+///
+/// So a doubled separator cannot produce a divergent PATTERN in this mode; it
+/// produces a refusal upstream and an accepted rule in oc. That gap belongs to
+/// the daemon's broader accept-where-upstream-refuses class, which is tracked
+/// separately, not to this function's run-vs-one-separator behaviour. The
+/// `trim_start` is therefore left as it is, now on measurement rather than on
+/// the absence of one.
 fn strip_keyword_prefix<'a>(token: &'a str, keyword: &str) -> Option<&'a str> {
     let rest = token.strip_prefix(keyword)?;
-    if rest.is_empty() {
-        return Some(rest);
-    }
-    let first = rest.as_bytes()[0];
-    if first == b' ' || first == b',' {
-        Some(rest[1..].trim_start())
-    } else {
-        None
+    let mut chars = rest.chars();
+    match chars.next() {
+        None => Some(rest),
+        Some(ch) if is_keyword_terminator(ch) => Some(chars.as_str().trim_start()),
+        Some(_) => None,
     }
 }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2859,6 +2859,37 @@ mod module_access_tests {
         assert_eq!(strip_keyword_prefix("include *.tmp", "exclude"), None);
     }
 
+    /// upstream: `exclude.c:1222` - `rule_strcmp` accepts `_` as a keyword
+    /// separator. The set this replaced was `' '` or `','` alone, so `_` made
+    /// the token not-a-keyword and it fell through to the bare-pattern arm.
+    #[test]
+    fn strip_keyword_prefix_underscore_separator() {
+        assert_eq!(strip_keyword_prefix("hide_bar", "hide"), Some("bar"));
+    }
+
+    /// upstream: `exclude.c:1222` - `rule_strcmp` tests `isspace`, so a TAB is
+    /// in the terminator set this function shares with the tokenizer. Keeping
+    /// one terminator set with one owner is why the arm exists.
+    ///
+    /// ⚠ THE PREMISE IS UPSTREAM'S, THE CONCLUSION IS NOT UPSTREAM'S FOR THIS
+    /// DIRECTIVE, and the distinction is measured rather than reasoned. Against
+    /// a real rsync 3.5.0 daemon, `filter = exclude\tbar` REFUSES the module
+    /// (`unexpected end of filter rule`), because the word-split loop
+    /// (`exclude.c:1250-1255`) consumes the tab BEFORE `rule_strcmp` is ever
+    /// reached, leaving the keyword patternless. Upstream therefore never
+    /// exercises its own tab branch here; `_` behaves differently and IS
+    /// faithful, since it is not whitespace and survives the split.
+    ///
+    /// So this cell pins oc's terminator set, NOT a shape upstream accepts.
+    /// oc builds a rule where upstream refuses the module - the same
+    /// accept-where-upstream-refuses class the doubled-separator shapes fall
+    /// into, tracked separately. Do NOT read it as "upstream parses
+    /// `exclude\tbar` as an exclude of `bar`" - it does not.
+    #[test]
+    fn strip_keyword_prefix_tab_separator() {
+        assert_eq!(strip_keyword_prefix("hide\tbar", "hide"), Some("bar"));
+    }
+
     #[test]
     fn read_patterns_from_file_basic() {
         let dir = tempfile::tempdir().unwrap();
@@ -3161,6 +3192,76 @@ mod module_access_tests {
     fn split_filter_tokens_bare_pattern() {
         let tokens = split_filter_tokens("*.bak");
         assert_eq!(tokens, vec!["*.bak"]);
+    }
+
+    /// A keyword at END OF STRING terminates and opens its own token.
+    ///
+    /// upstream: `exclude.c:1218-1227` `rule_strcmp` accepts the end of the
+    /// string as a terminator. The prefix table this replaced required a
+    /// trailing SPACE on every keyword, so a line-final `clear` matched
+    /// nothing, no boundary opened, and the whole line collapsed into ONE rule
+    /// whose pattern was the literal text `foo clear`.
+    #[test]
+    fn split_filter_tokens_line_final_keyword_opens_its_own_token() {
+        let tokens = split_filter_tokens("- foo clear");
+        assert_eq!(tokens, vec!["- foo", "clear"]);
+    }
+
+    /// `_` terminates a keyword exactly as whitespace does.
+    ///
+    /// upstream: `exclude.c:1222` - `rule_strcmp` accepts `_` as a separator.
+    #[test]
+    fn split_filter_tokens_underscore_terminated_keyword_opens_its_own_token() {
+        let tokens = split_filter_tokens("- foo hide_bar");
+        assert_eq!(tokens, vec!["- foo", "hide_bar"]);
+    }
+
+    /// NON-VACUITY COMPANION for the two cells above.
+    ///
+    /// Without this, both would also pass if the split had been loosened to
+    /// "any token STARTING WITH a keyword", which is the obvious wrong fix and
+    /// is what upstream's terminator rule exists to prevent: `hideout` is NOT a
+    /// `hide` rule, because `o` is not a separator - `rule_strcmp`
+    /// (`exclude.c:1218-1227`) returns NULL and no keyword matches.
+    ///
+    /// ⚠ THIS CELL PINS THE TOKENIZER ONLY, AND UPSTREAM AND oc PART COMPANY
+    /// IMMEDIATELY AFTER IT. MEASURED against a real rsync 3.5.0 daemon:
+    /// `filter = hideout` and `filter = - foo hideout` both make upstream
+    /// REFUSE the module - `Unknown filter rule: hideout`, exit 1 at
+    /// `exclude.c:136` - because a token matching no keyword falls to
+    /// upstream's `default:` arm. oc instead falls through to its bare-pattern
+    /// arm and builds an exclude of the literal text, so it serves where
+    /// upstream refuses.
+    ///
+    /// That over-acceptance is a SEPARATE defect from this commit's terminator
+    /// rule and is tracked on its own; the same measurement shows `mergeX`
+    /// refused identically, so it is the whole unrecognised-word class, not one
+    /// spelling. Do NOT read this assertion as "upstream treats `hideout` as a
+    /// pattern" - it does not.
+    #[test]
+    fn split_filter_tokens_unterminated_keyword_opens_no_token() {
+        let tokens = split_filter_tokens("- foo hideout");
+        assert_eq!(tokens, vec!["- foo hideout"]);
+    }
+
+    /// The END-TO-END cell: a line-final `clear` must reach the rule list as a
+    /// CLEAR rule, not as pattern text.
+    ///
+    /// The tokenizer cells above cannot show this on their own - splitting the
+    /// token is necessary but not sufficient, since the token still has to
+    /// parse into a rule. This is the assertion that would have caught the
+    /// defect from the outside.
+    #[test]
+    fn build_daemon_filter_rules_line_final_clear_builds_a_clear_rule() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["- foo clear".to_string()],
+            ..Default::default()
+        });
+        let rules = build_daemon_filter_rules(&module).unwrap();
+        assert_eq!(rules.len(), 2, "expected an exclude and a clear: {rules:?}");
+        assert_eq!(rules[0].pattern, "foo");
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Clear);
     }
 
     #[test]


### PR DESCRIPTION
## What

`split_filter_tokens` decided where a daemon `filter` token started from a table of keyword prefixes each carrying a mandatory trailing space, and `strip_keyword_prefix` accepted only `' '` or `','` between keyword and pattern. Upstream's `rule_strcmp` (exclude.c:1218-1227) matches a keyword when the byte after it is whitespace, `_`, `,`, or end-of-string. So a line-final `clear`, a `hide,keep` and a `hide_bar` opened no token at all: the whole remainder collapsed into one rule whose pattern was the literal compound string, and the file the operator's filter named was served.

The terminator set is now stated once, in `is_keyword_terminator`, shared by the tokenizer and the stripper. oc's CLI parser already ports the same `rule_strcmp` rule for `--filter` (measured against rsync 3.5.0); this is the daemon-side statement of that one convention, not a second one.

## Axis 3 - separator-run consumption, measured in the daemon context

Upstream consumes exactly ONE separator (exclude.c:1444-1445) where this code consumes a whitespace run. That rule was measured on the non-word-split `--filter`; the daemon directive carries FILTRULE_WORD_SPLIT. Measured against the pinned rsync 3.5.0 binary (`--version` asserted), module holding both `bar` and ` bar` so the two readings hide different files:

| `filter =` | upstream 3.5.0 | oc base | oc fix |
|---|---|---|---|
| `exclude bar` (one space) | pattern `bar` - hides `bar`, serves ` bar` | same | same |
| `exclude  bar` (two spaces) | refuse: `unexpected end of filter rule` | serves | serves |
| `exclude<TAB>bar` | refuse, same message | serves (inert junk) | excludes `bar` |
| `- foo  bar` | refuse: `Unknown filter rule: bar` | serves all | serves all |

The question is unaskable in word-split mode: the caller loop (exclude.c:1250-1255) splits on the whitespace run before `rule_strcmp` is reached, so at a doubled separator the keyword is left patternless and upstream refuses - neither candidate pattern is ever built. On the only shape where the readings differ observably (one space), oc already agrees with upstream exactly. `trim_start` therefore stays, now on measurement. The gap the measurement does expose - upstream refuses those shapes, oc accepts them - belongs to the daemon's broader accept-where-upstream-refuses class (tracked separately), not to this function.

## Testsuite rows, stated before CI says it

- The three configurations this makes tokenise correctly (`clear` line-final, `hide,keep`, `hide_bar`) still fail their cells: upstream refuses those modules outright, and that refusal is tracked separately.
- One cell, `hide_foo`, moves AWAY from upstream by this change, predictably: it now tokenises correctly, and oc then applies a daemon-list `hide` that upstream drops. That is the separately-tracked `hide` semantics defect being unmasked, and the divergence direction is over-hiding, not disclosure.

## Instrument notes

- The axis-3 discriminator is a filename with a leading space. The first harness rebuilt names from whitespace-split awk fields, which destroys the leading space and makes ` bar` indistinguishable from `bar` - the probe would have run green while structurally unable to see its own subject. Caught before running; the harness cuts the fixed `--list-only` columns with `sed` and prints a leading space visibly, with a control row proving the instrument can see it.
- The first keyword choice for the cell was `hide` - the one keyword upstream drops on a daemon list, so no `hide` cell could ever discriminate pattern content. Switched to `exclude`, which is honoured; caught by the control row.
- Measured while writing the non-vacuity companion: an unrecognised bare word makes upstream refuse the module (`Unknown filter rule: hideout`, exit 1, exclude.c:136) where oc builds a bare exclude from the literal text. The companion's doc block records that so the test is not read as claiming upstream treats such a token as a pattern.

## Verification

- Oracle runs against the pinned `target/interop/upstream-src/rsync-3.5.0/rsync` (version asserted per run), daemon context, only the daemon binary varying.
- `cargo nextest run -p daemon` 1874/1874; clippy and whole-tree rustfmt clean at the pinned 1.88.0 toolchain.
- Not run here: full-workspace nextest, macOS/Windows/musl cells, the 3.5.0 testsuite legs - CI carries those.
