### PR TITLE
fix(filters,daemon): implied-include backslash matching per upstream wildmatch

### DIFF
--- a/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
+++ b/crates/core/src/client/remote/daemon_transfer/orchestration/transfer.rs
@@ -280,6 +280,18 @@ fn map_server_transfer_error(error: std::io::Error, role: Role) -> ClientError {
         let exit = ExitCode::from_i32(code).unwrap_or(ExitCode::PartialTransfer);
         return remote_exit_error(exit, role);
     }
+    // upstream: flist.c:1140-1146 - the receiver's own file-list validation
+    // (excluded / unrequested name, offset overflow) exits
+    // RERR_UNSUPPORTED, not the generic partial-transfer code. Those local
+    // rejects surface here as `ErrorKind::Unsupported` (filter_recheck.rs,
+    // sanitize.rs, restrictions.rs all mirror an upstream
+    // `exit_cleanup(RERR_UNSUPPORTED)` site), so keep upstream's exit code.
+    if error.kind() == std::io::ErrorKind::Unsupported {
+        return invalid_argument_error(
+            &format!("transfer failed: {error}"),
+            ExitCode::Unsupported.as_i32(),
+        );
+    }
     invalid_argument_error(&format!("transfer failed: {error}"), 23)
 }
 
@@ -456,6 +468,25 @@ mod map_server_transfer_error_tests {
         let err = map_server_transfer_error(remote_exit_io(1), Role::Receiver);
         assert_eq!(err.exit_code(), 1);
         assert!(err.to_string().contains("[receiver="), "{err}");
+    }
+
+    /// A receiver-side file-list validation rejection (implied-include or
+    /// daemon-filter recheck, offset overflow) mirrors upstream
+    /// `exit_cleanup(RERR_UNSUPPORTED)` (flist.c:1141,1145): the client exits
+    /// 4, not the generic 23. Measured against upstream 3.5.0: pulling
+    /// `mod/a\b*` from a daemon whose glob serves `ab.txt` prints "rejecting
+    /// unrequested file-list name: ab.txt" and exits 4.
+    #[test]
+    fn maps_unsupported_rejection_to_rerr_unsupported() {
+        let err = map_server_transfer_error(
+            std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "ERROR: rejecting unrequested file-list name: ab.txt",
+            ),
+            Role::Receiver,
+        );
+        assert_eq!(err.exit_code(), 4);
+        assert_eq!(err.code(), ExitCode::Unsupported);
     }
 
     /// Failures with no embedded remote code keep the prior generic

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -432,11 +432,11 @@ fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<st
                 for entry in entries.flatten() {
                     let name = entry.file_name();
                     if let Some(name_str) = name.to_str() {
-                        // Skip dotfiles unless the pattern starts with `.`,
-                        // matching POSIX glob default behaviour.
-                        if name_str.starts_with('.') && !pattern.starts_with('.') {
-                            continue;
-                        }
+                        // upstream: util1.c:760-764 - the readdir() loop skips
+                        // only `.` and `..`; other dotfiles are matched like
+                        // any name (this is wildmatch, not POSIX glob(3), so
+                        // there is no leading-dot special case). read_dir()
+                        // never yields `.`/`..`, so no explicit skip is needed.
                         if glob_match_segment(pattern, name_str) {
                             next.push(dir.join(&name));
                         }

--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -457,80 +457,18 @@ fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<st
     current
 }
 
-/// Single-segment glob matcher: `*` matches any run, `?` matches one byte,
-/// `[abc]` / `[!abc]` matches a character class. Mirrors `glob(3)` for the
-/// subset of patterns rsync emits.
+/// Single-segment glob matcher, delegated to the same `wildmatch()` port the
+/// filter engine uses.
+///
+/// upstream: `util1.c:765` - the daemon glob matches each dirent with
+/// `wildmatch(arg, dname)`, NOT with POSIX `glob(3)`. That gives the segment
+/// upstream's full pattern grammar: `\` escapes the next char both outside
+/// and inside a `[...]` class (lib/wildmatch.c:86, 154-161), so `a\*` matches
+/// only the literal name `a*` and `[\]]` is a class holding `]`. A segment
+/// never contains `/`, so wildmatch's slash-restricted `*`/`?` semantics
+/// reduce to plain single-segment globbing here.
 fn glob_match_segment(pattern: &str, name: &str) -> bool {
-    let pat = pattern.as_bytes();
-    let s = name.as_bytes();
-    fn go(p: &[u8], s: &[u8]) -> bool {
-        let mut pi = 0;
-        let mut si = 0;
-        let mut star: Option<(usize, usize)> = None;
-        while si < s.len() {
-            if pi < p.len() {
-                match p[pi] {
-                    b'?' => {
-                        pi += 1;
-                        si += 1;
-                        continue;
-                    }
-                    b'*' => {
-                        star = Some((pi + 1, si));
-                        pi += 1;
-                        continue;
-                    }
-                    b'[' => {
-                        // Find matching `]`.
-                        let mut end = pi + 1;
-                        let negate = end < p.len() && p[end] == b'!';
-                        if negate {
-                            end += 1;
-                        }
-                        let class_start = end;
-                        while end < p.len() && p[end] != b']' {
-                            end += 1;
-                        }
-                        if end >= p.len() {
-                            // Malformed class - treat `[` as literal.
-                            if p[pi] == s[si] {
-                                pi += 1;
-                                si += 1;
-                                continue;
-                            }
-                        } else {
-                            let class = &p[class_start..end];
-                            let matched = class.contains(&s[si]);
-                            if matched != negate {
-                                pi = end + 1;
-                                si += 1;
-                                continue;
-                            }
-                        }
-                    }
-                    c => {
-                        if c == s[si] {
-                            pi += 1;
-                            si += 1;
-                            continue;
-                        }
-                    }
-                }
-            }
-            if let Some((ps, ss)) = star {
-                pi = ps;
-                si = ss + 1;
-                star = Some((ps, ss + 1));
-            } else {
-                return false;
-            }
-        }
-        while pi < p.len() && p[pi] == b'*' {
-            pi += 1;
-        }
-        pi == p.len()
-    }
-    go(pat, s)
+    filters::wildmatch(pattern.as_bytes(), name.as_bytes())
 }
 
 /// Collapses `.` and `..` in a module-relative tail, the `Path`-typed

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -4153,9 +4153,11 @@ mod module_access_tests {
     }
 
     #[test]
-    fn resolve_sender_sources_glob_skips_dotfiles_by_default() {
-        // POSIX glob default: a leading `.` is only matched when the pattern
-        // itself starts with `.`. `*` must not match `.hidden`.
+    fn resolve_sender_sources_glob_matches_dotfiles_like_upstream() {
+        // upstream: util1.c:760-766 - the daemon glob is wildmatch() over a
+        // readdir() loop that skips ONLY `.` and `..`, never other dotfiles
+        // (it is not POSIX glob(3)). Measured against upstream 3.5.0: a
+        // daemon pull of `mod/*` serves `.hidden` alongside `visible`.
         let tmp = tempfile::tempdir().expect("tempdir");
         let module_path = tmp.path();
         std::fs::write(module_path.join(".hidden"), b"hidden").expect(".hidden");
@@ -4163,7 +4165,10 @@ mod module_access_tests {
 
         let args = vec![".".to_owned(), "mod/*".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod", false);
-        assert_eq!(sources, vec![module_path.join("visible")]);
+        assert_eq!(
+            sources,
+            vec![module_path.join(".hidden"), module_path.join("visible")]
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -4171,6 +4171,9 @@ mod module_access_tests {
         );
     }
 
+    // Unix-only: the fixture name `a*` is unrepresentable on Windows
+    // filesystems, so the scenario cannot arise on a Windows-hosted module.
+    #[cfg(unix)]
     #[test]
     fn resolve_sender_sources_glob_backslash_escapes_star() {
         // upstream: util1.c:765 - the daemon glob matches each dirent with
@@ -4188,6 +4191,9 @@ mod module_access_tests {
         assert_eq!(sources, vec![module_path.join("a*")]);
     }
 
+    // Unix-only: a Windows filename cannot contain `\`, so the
+    // literal-backslash fixture `a\b.txt` is unrepresentable there.
+    #[cfg(unix)]
     #[test]
     fn resolve_sender_sources_glob_backslash_escapes_literal_char() {
         // upstream: lib/wildmatch.c:86-91 - `\b` in a pattern means a literal
@@ -4206,6 +4212,12 @@ mod module_access_tests {
         assert_eq!(sources, vec![module_path.join("ab.txt")]);
     }
 
+    // Unix-only: the fixture `]x` is representable on Windows, but there the
+    // pattern's `\` escape collides with std::path treating `\` as a
+    // separator in the resolve pipeline, so `[\]]*` never reaches the
+    // matcher intact (same class as the peer-dest separator fix in
+    // module_access; the Windows arm is a pre-existing platform gap).
+    #[cfg(unix)]
     #[test]
     fn resolve_sender_sources_glob_class_with_escaped_bracket() {
         // upstream: lib/wildmatch.c:154-161 - inside a `[...]` class a `\`

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -4167,6 +4167,57 @@ mod module_access_tests {
     }
 
     #[test]
+    fn resolve_sender_sources_glob_backslash_escapes_star() {
+        // upstream: util1.c:765 - the daemon glob matches each dirent with
+        // wildmatch(), where a pattern `\` escapes the next char
+        // (lib/wildmatch.c:86). `a\*` must match only the literal name `a*`.
+        // Measured against upstream 3.5.0: a daemon pull of `mod/a\*` serves
+        // the file literally named `a*` and nothing else.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join("a*"), b"star").expect("a*");
+        std::fs::write(module_path.join("ab.txt"), b"ab").expect("ab.txt");
+
+        let args = vec![".".to_owned(), "mod/a\\*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
+        assert_eq!(sources, vec![module_path.join("a*")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_backslash_escapes_literal_char() {
+        // upstream: lib/wildmatch.c:86-91 - `\b` in a pattern means a literal
+        // `b`, NOT a literal backslash. `a\b*` therefore matches `ab.txt` and
+        // must NOT match the literal-backslash name `a\b.txt`. Measured
+        // against upstream 3.5.0: the daemon serves `ab.txt` for `mod/a\b*`
+        // (the client's own implied-include rule then rejects it - that side
+        // is pinned in the filters crate).
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join("a\\b.txt"), b"bs").expect("a\\b.txt");
+        std::fs::write(module_path.join("ab.txt"), b"ab").expect("ab.txt");
+
+        let args = vec![".".to_owned(), "mod/a\\b*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
+        assert_eq!(sources, vec![module_path.join("ab.txt")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_class_with_escaped_bracket() {
+        // upstream: lib/wildmatch.c:154-161 - inside a `[...]` class a `\`
+        // escapes the next char, so `[\]]*` is a class holding `]`. Measured
+        // against upstream 3.5.0: a daemon pull of `mod/[\]]*` serves the
+        // file named `]x`.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::write(module_path.join("]x"), b"bracket").expect("]x");
+        std::fs::write(module_path.join("ax"), b"ax").expect("ax");
+
+        let args = vec![".".to_owned(), "mod/[\\]]*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
+        assert_eq!(sources, vec![module_path.join("]x")]);
+    }
+
+    #[test]
     fn resolve_sender_sources_non_glob_paths_bypass_expansion() {
         // Plain paths without glob metachars must fall through unchanged,
         // even when the file does not exist on disk - upstream defers the

--- a/crates/filters/src/implied.rs
+++ b/crates/filters/src/implied.rs
@@ -129,6 +129,11 @@ impl ImpliedIncludes {
             arg = "";
         }
 
+        // upstream: exclude.c:509-516 - `strpbrk(arg, "*[?")` decides whether
+        // the arg builds FILTRULE_WILD rules; the check runs on the arg AFTER
+        // the module/basename strip and BEFORE the escaping transform.
+        let saw_wild = arg.contains(['*', '[', '?']);
+
         // upstream: exclude.c:412-491 - normalise the arg into an anchored
         // pattern, collapsing "//", "/./" and trailing "/" the way the C loop
         // does. Empty and "." segments are dropped.
@@ -138,26 +143,58 @@ impl ImpliedIncludes {
             .collect();
 
         if !segments.is_empty() {
-            let base = format!("/{}", segments.join("/"));
+            let joined = segments.join("/");
+            // upstream: exclude.c:521-533 - the char loop rewrites backslashes:
+            // in a wild arg, a `\` that does not escape a wildcard char is
+            // doubled so wildmatch keeps it literal; in a non-wild arg, a `\]`
+            // drops the `\` ("a \] in a non-wild filter causes a problem").
+            // Rules whose text carries no live wildcard are matched literally
+            // (FILTRULE_WILD unset upstream, compile-time literalisation here),
+            // so the raw single-backslash spelling is the literal form.
+            let base = if saw_wild {
+                format!("/{}", escape_backslashes_for_wild(&joined))
+            } else {
+                format!("/{}", drop_nonwild_bracket_escapes(&joined))
+            };
             self.push_rule(&base, false)?;
 
-            // upstream: exclude.c:497-527 - with --relative every parent
+            // upstream: exclude.c:592-624 - with --relative every parent
             // directory of the arg is implied as a directory-only include.
+            // A parent rule is FILTRULE_WILD only for a wild arg whose
+            // sub-path holds `*[?\` (exclude.c:612); a parent without a live
+            // wildcard is matched literally either way, and its literal name
+            // keeps single backslashes (with `\]` reduced to `]`).
             if self.opts.relative {
                 for depth in 1..segments.len() {
-                    let parent = format!("/{}/", segments[..depth].join("/"));
+                    let raw = segments[..depth].join("/");
+                    let parent = if saw_wild && raw.contains(['*', '[', '?']) {
+                        format!("/{}/", escape_backslashes_for_wild(&raw))
+                    } else {
+                        format!("/{}/", drop_nonwild_bracket_escapes(&raw))
+                    };
                     self.push_rule(&parent, true)?;
                 }
             }
         }
 
-        // upstream: exclude.c:531-567 - --recursive adds "arg/**" and --dirs
+        // upstream: exclude.c:633-667 - --recursive adds "arg/**" and --dirs
         // adds "arg/*" (an empty arg yields "/**" or "/*", accepting the tree).
+        // Appending the wildcard suffix makes the rule wild, so a non-wild
+        // base's backslashes are doubled first (exclude.c:640-647) to stay
+        // literal under wildmatch.
         if self.opts.recurse || self.opts.dirs {
             let base = if segments.is_empty() {
                 String::new()
             } else {
-                format!("/{}", segments.join("/"))
+                let joined = segments.join("/");
+                if saw_wild {
+                    format!("/{}", escape_backslashes_for_wild(&joined))
+                } else {
+                    format!(
+                        "/{}",
+                        drop_nonwild_bracket_escapes(&joined).replace('\\', "\\\\")
+                    )
+                }
             };
             let suffix = if self.opts.recurse { "**" } else { "*" };
             let pattern = format!("{base}/{suffix}");
@@ -263,6 +300,59 @@ impl ImpliedIncludes {
         }
         Ok(())
     }
+}
+
+/// Rewrites a wild arg's backslashes the way upstream's implied-include char
+/// loop does: a `\` escaping a wildcard char (`*`, `[`, `?`) is kept as the
+/// escape, a `\]` pair is kept verbatim, and every other `\` (including a
+/// trailing one) is doubled so wildmatch treats it as a literal backslash.
+///
+/// upstream: `exclude.c:521-533` - `case '\\'` inside `add_implied_include()`
+/// with `saw_wild` set.
+fn escape_backslashes_for_wild(arg: &str) -> String {
+    let bytes = arg.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() + 4);
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            match bytes.get(i + 1) {
+                Some(b']') => {
+                    out.extend_from_slice(b"\\]");
+                    i += 2;
+                    continue;
+                }
+                Some(b'*' | b'[' | b'?') => out.push(b'\\'),
+                _ => out.extend_from_slice(b"\\\\"),
+            }
+        } else {
+            out.push(bytes[i]);
+        }
+        i += 1;
+    }
+    debug_assert!(std::str::from_utf8(&out).is_ok());
+    String::from_utf8(out).unwrap_or_else(|_| arg.to_owned())
+}
+
+/// Reduces every `\]` pair in a non-wild arg to a bare `]`.
+///
+/// upstream: `exclude.c:524-526` - "A `\]` in a non-wild filter causes a
+/// problem, so drop the `\`". All other backslashes stay single: a non-wild
+/// rule is matched literally, so they mean themselves.
+fn drop_nonwild_bracket_escapes(arg: &str) -> String {
+    let bytes = arg.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && bytes.get(i + 1) == Some(&b']') {
+            out.push(b']');
+            i += 2;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    debug_assert!(std::str::from_utf8(&out).is_ok());
+    String::from_utf8(out).unwrap_or_else(|_| arg.to_owned())
 }
 
 /// Escapes every live (unescaped) `[` in `pattern` as `\[`, returning `None`
@@ -545,6 +635,93 @@ mod tests {
         // The literal-backslash rule stays anchored: it must not admit an
         // unrelated injected name (CVE-2022-29154 teeth preserved).
         assert!(!covers(&implied, "evil", false));
+    }
+
+    #[test]
+    fn wild_arg_backslash_is_doubled_to_stay_literal() {
+        // upstream: exclude.c:527-530 - in a wildcard arg, a `\` that does not
+        // escape a wildcard char is DOUBLED (`a\b*` -> `/a\\b*`), so wildmatch
+        // treats it as a literal backslash. The rule therefore matches the
+        // literal-backslash name and rejects the escape-interpreted one -
+        // measured against upstream 3.5.0: a daemon pull of `mod/a\b*` where
+        // the daemon serves `ab.txt` exits 4 with "rejecting unrequested
+        // file-list name: ab.txt".
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a\\b*"]).unwrap();
+        assert!(covers(&implied, "a\\b.txt", false));
+        assert!(!covers(&implied, "ab.txt", false));
+        // The doubled backslash also reaches the trailing `/**` rule.
+        assert!(covers(&implied, "a\\bdir/inner", false));
+        assert!(!covers(&implied, "abdir/inner", false));
+    }
+
+    #[test]
+    fn wild_arg_backslash_before_wildcard_keeps_escape() {
+        // upstream: exclude.c:527 - a `\` that escapes a wildcard char
+        // (`*`, `[`, `?`) is NOT doubled: `a\*` stays `/a\*`, matching only
+        // the literal name `a*`.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a\\*"]).unwrap();
+        assert!(covers(&implied, "a*", false));
+        assert!(!covers(&implied, "ab.txt", false));
+        assert!(!covers(&implied, "a\\b.txt", false));
+    }
+
+    #[test]
+    fn nonwild_arg_backslash_bracket_drops_the_backslash() {
+        // upstream: exclude.c:524-526 - "A \] in a non-wild filter causes a
+        // problem, so drop the \". The non-wild rule text becomes `/a]b`,
+        // matched literally.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a\\]b"]).unwrap();
+        assert!(covers(&implied, "a]b", true));
+        assert!(!covers(&implied, "a\\]b", true));
+    }
+
+    #[test]
+    fn nonwild_backslash_arg_recurse_rule_stays_literal() {
+        // upstream: exclude.c:640-647 - appending `/**` to a non-wild arg
+        // that contains backslashes doubles them first, so the wild rule
+        // still means a LITERAL backslash.
+        let opts = ImpliedIncludeOptions {
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["a\\b"]).unwrap();
+        assert!(covers(&implied, "a\\b", true));
+        assert!(covers(&implied, "a\\b/inner", false));
+        assert!(!covers(&implied, "ab", true));
+        assert!(!covers(&implied, "ab/inner", false));
+    }
+
+    #[test]
+    fn relative_wild_arg_parent_with_bracket_escape_matches_literal_bracket() {
+        // upstream: exclude.c:592-624 - parent-dir rules derive from the
+        // TRANSFORMED pattern and are FILTRULE_WILD when the sub-path holds
+        // `*[?\` (exclude.c:612), so `\]` in a wild arg's parent matches the
+        // literal `]` name.
+        let opts = ImpliedIncludeOptions {
+            relative: true,
+            recurse: true,
+            ..Default::default()
+        };
+        let implied = ImpliedIncludes::from_args(opts, ["p\\]q/leaf*"]).unwrap();
+        assert!(covers(&implied, "p]q", true));
+        assert!(covers(&implied, "p]q/leafy", true));
+        assert!(!covers(&implied, "p\\]q", true));
+        // Parent with a plain backslash stays a literal backslash.
+        let implied = ImpliedIncludes::from_args(opts, ["dir\\x/leaf*"]).unwrap();
+        assert!(covers(&implied, "dir\\x", true));
+        assert!(!covers(&implied, "dirx", true));
     }
 
     #[test]


### PR DESCRIPTION
## What

Implied-include handling of backslashes in daemon path arguments diverged from upstream 3.5.0 in three places, plus one exit-code mismatch. Measured first, on the full 4-combo loopback-daemon matrix ({upstream,oc} client x {upstream,oc} daemon) against the pinned rsync 3.5.0 oracle (version asserted), every cell carrying a live target, a bait file the wrong reading would serve, and a control.

Where the population could not show a defect, oc already matched upstream: non-wild args holding a literal backslash, and wildcards ranging over backslash *text*, are identical on all arms. The divergences live only where a backslash appears in the *pattern* alongside a wildcard:

| Arg | Upstream 3.5.0 | oc before | oc after |
|---|---|---|---|
| `modesc/a\*` (module holds literal `a*`, bait `ab.txt`) | rc 0, serves `a*` | rc 23, serves nothing | matches |
| `moddot/*` (module holds `.hid.txt`, `vis.txt`) | rc 0, serves both | rc 0, serves only `vis.txt` | matches |
| `modF/a\b*` (module holds `a\b.txt`, `ab.txt`) | rc 4, rejects unrequested `ab.txt` | rc 23, rejects the OPPOSITE spelling `a\b.txt` | matches |
| `modG/[\]]*` (module holds `]x`, `ax`) | rc 0, serves `]x` | rc 23, serves nothing | matches |

## Root causes, one commit each

1. **Daemon glob treated a pattern backslash as a literal byte** (`path_resolution.rs`): upstream matches each dirent with `wildmatch()` (util1.c:765), where `\` escapes the next character (wildmatch.c:86, 154-161). The ad-hoc matcher is replaced by delegation to the existing faithful `filters::wildmatch` port - one owner of the convention, not a second implementation.
2. **Daemon glob skipped dotfiles**: upstream's readdir loop skips only `.` and `..` (util1.c:760-764); oc skipped all dotfiles "per POSIX glob". The old test pinning the wrong behaviour is inverted and now carries the upstream anchor.
3. **Client implied-include construction missed upstream's backslash rewrites** (`filters/src/implied.rs`): doubling in wild args (exclude.c:521-533), the `\]` drop in non-wild args (:524-526), doubling before the appended `/**` rule (:640-647), and transformed-prefix parent rules under `-R` (:592-624). This is why cell F's oc client rejected the opposite spelling from upstream.
4. **Exit code**: an implied-include rejection exited 23 where upstream exits RERR_UNSUPPORTED = 4 (flist.c:1140-1146). `ErrorKind::Unsupported` now maps to 4 in `map_server_transfer_error`; a remote MSG_ERROR_EXIT still takes precedence.

## Verification

- 9 unit tests on the filters/daemon fix, 8 measured RED before the fix; the dotfile test inverted from the wrong pin and RED before; the exit-code guard mutation-checked (neutralised guard gives 23 instead of 4, killed).
- Live matrix after the fix: all 24 cells identical to upstream in served set, rejected name, and exit code.
- filters 523/523; daemon lib full pass; clippy `-D warnings` clean; whole-tree rustfmt clean (3424 files) at the pinned toolchain.
- core lib 2505/2508 locally: the 3 fails are `fd_limit` tests self-reporting the host cannot exercise them (macOS hard limit 256, untouched files) plus one pre-existing `draining_reader` timing flake under parallel load only (3/3 in isolation; no touched file in its module). CI carries the authoritative full-workspace and cross-platform runs.
