### PR TITLE
fix(daemon): read a filter file through the ownership walk

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -433,6 +433,55 @@ fn push_old_prefix_token_rules(
     }
 }
 
+/// Reads a daemon filter file through the ownership walk.
+///
+/// upstream: `exclude.c:1680-1684` calls `open_no_attacker_symlinks()`
+/// UNCONDITIONALLY for every filter file and toggles only
+/// `operator_path_resolve` around it:
+///
+/// ```text
+/// int save_opr = operator_path_resolve;
+/// if (!daemon_config_filter_file)
+///         operator_path_resolve = 1;
+/// fd = open_no_attacker_symlinks(open_path, O_RDONLY, 0);
+/// operator_path_resolve = save_opr;
+/// ```
+///
+/// ⚠ THE EXEMPTION UPSTREAM GRANTS `filter` / `include from` / `exclude from`
+/// IS FROM MODULE CONFINEMENT, NOT FROM THE WALK. Its comment
+/// (`exclude.c:1677-1679`) says those parameters "are operator-configured and
+/// legitimately live outside the module (/etc/rsync/excludes and the like)" -
+/// which is why this takes the OPERATOR arm rather than the confined one, and
+/// why confining these reads to the module root would refuse configurations
+/// upstream serves. It is NOT a statement that the path is trusted: the walk
+/// still runs. Reading the plain [`fs::read_to_string`] this replaced as
+/// "operator files are trusted" is exactly the misreading that left the hole.
+///
+/// The content becomes filter rules, and a rule the parser cannot read comes
+/// back to the peer in the refusal text, so a redirected read both reshapes
+/// the transfer and can disclose the target file.
+///
+/// MEASURED on Linux as root (module `mod` holding `bar` + `keep`;
+/// `exclude from` naming a symlink owned by a NON-root uid whose target holds
+/// the pattern `keep`): upstream REFUSES the module at exit 5, oc FOLLOWED the
+/// link and applied the planted rule, serving only `bar`. With the same
+/// symlink owned by ROOT both implementations follow it - that companion is
+/// what makes the refusal a statement about OWNERSHIP rather than about
+/// symlinks in general.
+///
+/// Windows has no ownership-walk equivalent, so it keeps the plain read - the
+/// same split [`open_log_file`] makes.
+fn read_filter_file_contents(path: &Path) -> io::Result<String> {
+    #[cfg(unix)]
+    {
+        fast_io::operator_read_to_string(path)
+    }
+    #[cfg(not(unix))]
+    {
+        fs::read_to_string(path)
+    }
+}
+
 /// Reads patterns from a filter file, one per record.
 ///
 /// upstream: `exclude.c:1601 parse_filter_file()`, which is what
@@ -455,7 +504,7 @@ fn push_old_prefix_token_rules(
 /// and served `a `. Both at exit 0, with no diagnostic - a silent divergence
 /// in which files the daemon exposes.
 fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
-    let content = fs::read_to_string(path).map_err(|e| {
+    let content = read_filter_file_contents(path).map_err(|e| {
         io::Error::new(
             e.kind(),
             format!("failed to read filter file '{}': {e}", path.display()),

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3105,6 +3105,51 @@ mod module_access_tests {
         assert!(err.to_string().contains("failed to read filter file"));
     }
 
+    /// The reader takes the OPERATOR arm of the ownership walk, not the
+    /// CONFINED one, so an operator file reached through a symlink this uid
+    /// owns is still read.
+    ///
+    /// ⚠ THIS IS THE NON-VACUITY COMPANION FOR THE OWNERSHIP-WALK ROUTING, AND
+    /// IT IS THE ONLY HALF THAT IS PORTABLE. The walk refuses a symlink
+    /// component owned by neither uid 0 nor the euid, so the ESCAPE it now
+    /// blocks needs root plus a second uid and cannot be reproduced in a
+    /// single-uid test process - a `#[test]` that planted its own symlink would
+    /// own it, the walk would trust it, and the cell would pass while being
+    /// structurally unable to observe the defect. The escape is measured
+    /// instead by `probe_1170_red.sh` on a Linux host as root (recorded on task
+    /// 1170); what this cell pins is the half that a single uid CAN decide:
+    /// that routing through the walk did NOT become a blanket symlink refusal,
+    /// which is the realistic regression the change could introduce.
+    #[cfg(unix)]
+    #[test]
+    fn read_patterns_from_file_follows_a_trusted_owner_symlink() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("real-excludes");
+        std::fs::write(&target, "keep\n").expect("write target");
+
+        let link = dir.path().join("link-excludes");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+
+        let patterns = read_patterns_from_file(&link).expect("trusted-owner symlink is followed");
+        assert_eq!(patterns, vec!["keep".to_string()]);
+    }
+
+    /// A plain file still reads identically after the routing change.
+    ///
+    /// Guards the happy path the swap could have broken: `operator_read_to_string`
+    /// resolves per component where `fs::read_to_string` did not, so a
+    /// regression here would be a total outage of both `include from` and
+    /// `exclude from` rather than a subtle one.
+    #[test]
+    fn read_patterns_from_file_reads_a_plain_file_unchanged() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("excludes");
+        std::fs::write(&file, "first\n; comment\nsecond\n").expect("write");
+
+        let patterns = read_patterns_from_file(&file).expect("plain file reads");
+        assert_eq!(patterns, vec!["first".to_string(), "second".to_string()]);
+    }
+
     #[test]
     fn secluded_args_flag_standalone() {
         let args: Vec<String> = vec!["--server", "-s", "."]


### PR DESCRIPTION
## What

`exclude from` and `include from` share one reader, `read_patterns_from_file` (module_access/helpers.rs), and it opened the operator's file with a plain `fs::read_to_string`. It is now routed onto `fast_io::operator_read_to_string` — the ownership walk's operator arm — behind the same `#[cfg(unix)]` split `open_log_file` already uses in this file.

## Why the OPERATOR arm, not the confined one

Upstream calls `open_no_attacker_symlinks()` UNCONDITIONALLY for every filter file and toggles only `operator_path_resolve` around it (`exclude.c:1680-1684`). The exemption upstream grants `filter` / `include from` / `exclude from` is from MODULE CONFINEMENT, not from the walk — its own comment (`exclude.c:1677-1679`) says these parameters "are operator-configured and legitimately live outside the module (/etc/rsync/excludes and the like)". Confining these reads to the module root would refuse configurations upstream serves. `daemon_config_filter_file` already makes the same choice, and `operator_read_to_string_confined`'s rustdoc (owner_walk.rs:1210) already cites this exact distinction — the API pair was built for it; this call site was simply never wired onto it.

## Measured escape (Linux, root)

Module `mod` holds `bar` + `keep`; `exclude from` names a symlink whose target holds the pattern `keep`:

| symlink owner | upstream 3.5.0 | oc (before) |
|---|---|---|
| non-root uid | refuses, exit 5 | FOLLOWS, serves only `bar` |
| root | follows | follows |

The root-owned row is the companion that makes the first a statement about OWNERSHIP rather than about symlinks in general. The redirected content becomes filter rules, so it both reshapes what the module serves and can surface the target file's text to the peer in a refusal message.

## Test honesty

The two committed cells are REGRESSION GUARDS, not witnesses — and that is measured, not assumed: reverting the one-line change leaves all 10 tests green. The walk refuses a symlink component owned by neither uid 0 nor the euid, so a single-uid test process owns every symlink it plants and the walk trusts it; the escape needs root plus a second uid and is measured by a host probe instead. What the cells do pin is the half a single uid CAN decide: a trusted-owner symlink is still followed and a plain file still reads — i.e. routing through the walk did not become a blanket symlink refusal, the realistic regression this change could introduce.

## Gates

At the pinned 1.88.0 toolchain: `tools/ci/check_rustfmt_all.py` exit 0 (3427 files); `cargo clippy -p daemon --all-targets -D warnings` clean; `cargo nextest run -p daemon --lib -E 'test(read_patterns_from_file)'` 10/10.

Not run locally (CI covers them): full-workspace nextest, `--all-features`, macOS/Windows/musl cells, the 3.5.0 testsuite legs, interop.
