### PR TITLE
fix(daemon): parse the module filter rules before the chroot and privilege drop

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
+++ b/crates/daemon/src/daemon/sections/module_access/transfer/orchestration.rs
@@ -261,14 +261,76 @@ fn process_approved_module(
         }
     }
 
-    // upstream: clientserver.c:983-1053 - chroot + setgid + setuid run BEFORE
-    // `@RSYNCD: OK` (1071), so their `@ERROR: chroot/setgid/setuid failed`
+    // upstream: clientserver.c:930-951 - the five daemon filter parameters
+    // (`filter`, `include from`, `include`, `exclude from`, `exclude`) are
+    // parsed HERE, and the ordering is the substance of this placement:
+    //
+    //   :934-951  parse_filter_str / parse_filter_file  <- the reads
+    //   :1050     chroot(module_chdir)
+    //   :1059     change_dir(module_chdir)
+    //   :1098     setgid
+    //   :1123     setuid
+    //   :1152     `@RSYNCD: OK`
+    //
+    // ⚠ ALL THREE OF chroot, THE UID DROP AND THE CWD CHANGE LAND AFTER THE
+    // PARSE UPSTREAM, AND EACH ONE BREAKS A DIFFERENT CONFIGURATION IF THE
+    // PARSE IS MOVED BELOW IT:
+    //
+    // - after `chroot`, an absolute path outside the module - the documented
+    //   `exclude from = /etc/rsync/excludes` shape - no longer names a file
+    //   this process can reach, so the whole connection is refused on a
+    //   DEFAULT config (`use chroot` defaults on);
+    // - after `setuid`, an operator file readable only by root (mode 0600)
+    //   becomes unreadable, which breaks it with no chroot involved at all;
+    // - after `change_dir`, a RELATIVE path resolves against the module root
+    //   rather than the daemon's launch directory, which is where upstream
+    //   resolves it because :1059 has not run yet.
+    //
+    // Reading them here reproduces all three. The rules are enforced
+    // server-side regardless of what filters the client later sends.
+    //
+    // ⚠ The parse is SPLIT from its assignment deliberately: `config` does not
+    // exist until the client's argv has been read, which is necessarily after
+    // `@RSYNCD: OK` and therefore after the privilege drop. Only the READ has
+    // to happen early, so only the read moves; the rules are parked in this
+    // local and installed into `config` at its construction site below. Upstream
+    // has no analogue of that assignment - it parses straight into the global
+    // `daemon_filter_list` - so the split is an oc structural artefact, not a
+    // behavioural difference.
+    //
+    // Client args are not available yet (the client blocks on OK before
+    // sending its argv), so a refusal here hooks post-xfer-exec with an empty
+    // arg list, exactly as the sibling pre-OK refusals below do.
+    let daemon_filter_rules = match build_daemon_filter_rules(module) {
+        Ok(rules) => rules,
+        Err(err) => {
+            let error = AtError::message(format!("failed to load module filter rules: {err}"));
+            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
+            let host_owned = ctx.host_display().to_owned();
+            run_post_xfer_finalizer(
+                ctx,
+                module,
+                &host_owned,
+                auth_user.as_deref(),
+                &[],
+                MODULE_ABORT_EXIT_CODE,
+            );
+            return Ok(());
+        }
+    };
+
+    // upstream: clientserver.c:1050-1123 - chroot + setgid + setuid run BEFORE
+    // `@RSYNCD: OK` (:1152), so their `@ERROR: chroot/setgid/setuid failed`
     // replies are raw pre-OK lines the client reads before it switches to the
     // multiplexed input stream. Run them here, then emit OK, so a failure can
     // never desync the client's multiplex decoder. Client args are not yet
     // available (the client blocks on OK before sending its argv), so the
     // post-xfer-exec hook fires with an empty arg list - matching upstream's
     // pre-read_args fork position (clientserver.c:908).
+    //
+    // ⚠ The daemon filter parameters are read ABOVE this point, not below it -
+    // see the ordering table there for why each of the three steps in this
+    // block would break a different working configuration.
     if !validate_module_path(ctx, module)? {
         // upstream: clientserver.c:992-993 - the change_dir() into the module
         // path is post-fork, so a missing/unreachable path still hooks.
@@ -548,26 +610,11 @@ fn process_approved_module(
             }
         };
 
-    // upstream: clientserver.c:rsync_module() - build daemon_filter_list from
-    // module filter/exclude/include/exclude_from/include_from parameters.
-    // These rules are enforced server-side regardless of client-sent filters.
-    match build_daemon_filter_rules(module) {
-        Ok(rules) => config.daemon_filter_rules = rules,
-        Err(err) => {
-            let error = AtError::message(format!("failed to load module filter rules: {err}"));
-            send_error(ctx.reader.get_mut(), ctx.limiter, &error)?;
-            let host_owned = ctx.host_display().to_owned();
-            run_post_xfer_finalizer(
-                ctx,
-                module,
-                &host_owned,
-                auth_user.as_deref(),
-                &client_args,
-                MODULE_ABORT_EXIT_CODE,
-            );
-            return Ok(());
-        }
-    }
+    // Install the rules parsed before the chroot and the privilege drop. This
+    // is the assignment half of the split described at the parse site; no file
+    // is read here, so nothing in this statement depends on paths the chroot
+    // or the uid drop has since taken away.
+    config.daemon_filter_rules = daemon_filter_rules;
 
     // LSM-CAP.3: drop every Linux capability not required by this module
     // before Landlock engages. The worker process inherits the resulting
@@ -580,8 +627,16 @@ fn process_approved_module(
     // SEC-1.p: engage the Landlock LSM allowlist now that chroot, the
     // uid/gid drop, and daemon-config filter-rule loading have completed.
     // Filter rules referencing files outside module.path (e.g.
-    // `exclude from = <abs-path>`) are read into memory above; once
-    // Landlock engages, those external paths become unreadable. Stub on
+    // `exclude from = <abs-path>`) are read into memory well above this point;
+    // once Landlock engages, those external paths become unreadable.
+    //
+    // ⚠ LANDLOCK IS NOT WHAT DECIDES WHERE THE PARSE GOES, and reading this
+    // comment as if it were is how the parse came to sit below the chroot.
+    // Landlock is only the LAST of four steps that each independently require
+    // the read to have already happened - chroot, the cwd change and the uid
+    // drop all land earlier and each breaks a different working config. The
+    // ordering constraint is stated in full at the parse site; this block is
+    // downstream of it, not the reason for it. Stub on
     // non-Linux short-circuits to `Unavailable`. Failure to engage is
     // logged but does not abort the connection: SEC-1 *at* helpers still
     // provide the primary defense. The validated client-supplied paths


### PR DESCRIPTION
## What

The daemon read its five filter parameters (`filter`, `include from`, `include`, `exclude from`, `exclude`) AFTER applying chroot, setgid and setuid. Upstream parses them first (clientserver.c:934-951) and only then runs chroot (:1050), change_dir (:1059), setgid (:1098) and setuid (:1123). This moves the read above the privilege step, where upstream's sits. Only the read moves: `config` is not constructed until the client's argv arrives (necessarily after `@RSYNCD: OK`, hence after the drop), so the rules are parked in a local and installed at config construction — upstream parses into the global `daemon_filter_list` and has no analogue of that assignment.

## Three independently observable failures, one late read

- **(a) chroot ordering, DEFAULT config**: with `use chroot = yes` (upstream's default), an absolute `exclude from = /etc/rsync/excludes` — the exact idiom upstream's own comment names at exclude.c:1677-1679 — no longer names a reachable file, and the whole connection is refused (rc 12).
- **(b) uid-drop ordering, no chroot involved**: with `use chroot = no`, a root-owned 0600 exclude file becomes unreadable after the drop to the module uid.
- **(c) relative base**: upstream resolves a relative path against the daemon's launch cwd (change_dir has not run yet); oc refuses.

## Measured A/B (Linux, root; both arms source-built, md5-distinct; real rsync 3.5.0 as oracle and constant client)

Module holds `bar` + `keep`; exclude file holds the bare pattern `keep`:

| cell | upstream | base | fix |
|---|---|---|---|
| chroot=yes, abs outside module | serves+applies | rc 12 OUTAGE | serves+applies |
| chroot=no, abs, root-only 0600 | serves+applies | rc 12 OUTAGE | serves+applies |
| chroot=yes, RELATIVE | serves+applies | rc 12 | rc 5 REFUSES |
| chroot=yes, abs INSIDE module | serves+applies | rc 12 OUTAGE | serves+applies |
| control: no filter directive | serves both | serves both | serves both |

The no-filter control pins non-vacuity in both directions: all three arms serve both files with no directive, and the relative row still refuses on the fix arm, so the fix is not a blanket "everything succeeds". An earlier discriminator run pins the ordering itself: a file planted ONLY at the spelling reachable after a chroot to the module root was applied by unfixed oc (read provably post-chroot) and refused by upstream (read provably pre-chroot).

## Deliberately out of scope

- **The relative row is NOT fixed** — the move only shifts its refusal from rc 12 to rc 5; something else anchors oc's relative resolution away from the launch cwd. Shipped here as an oracle row; the residual is tracked separately (task 1173). Widening this PR to "make relative work" would be a different change with an untraced mechanism.
- The abs-inside-module row was the intended control and is NOT one: post-chroot the module root becomes `/`, so even that spelling moves with the fix — which is why the no-filter row exists.

## Comments corrected in the same change

The stale `:983-1053` privilege citation (now `:1050-1123`); the full ordering table now lives at the parse site; and the Landlock block's reasoning is demoted — it named only Landlock as the ordering constraint, which is how the parse came to sit below the chroot in the first place.

`filter` and `include from` are covered by construction, not measured: same function, same moved call site. A parse refusal hooks post-xfer-exec with an empty arg list, matching the sibling pre-OK refusals (upstream's pre-read_args fork position, clientserver.c:908).

## Gates

Pinned 1.88.0, on the rebased head (master 67589df0b, which carries #7737's same-crate change): whole-tree rustfmt clean, `clippy -p daemon --all-targets -D warnings` clean, `nextest -p daemon --lib` 1888/1888. Not run locally (CI covers them): full-workspace nextest, `--all-features`, macOS/Windows/musl, 3.5.0 testsuite legs, interop.
