### PR TITLE
fix(daemon): store a relative filter-file path verbatim instead of rebasing it onto the config directory

### DIFF
--- a/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/global_directives/dispatch.rs
@@ -733,16 +733,18 @@ fn apply_global_directive(
                 state.module_defaults.open_noatime = Some(parsed);
             }
         }
+        // Same storage rule as the module-scoped arms in module_directives.rs:
+        // parse_filter_file() (clientserver.c:934-951) opens the stored value
+        // as given, so a relative path resolves against the daemon's cwd at
+        // read time - never against the config file's directory.
         "excludefrom" => {
             if !value.is_empty() {
-                let resolved = resolve_config_relative_path(canonical, value);
-                state.module_defaults.exclude_from = Some(resolved);
+                state.module_defaults.exclude_from = Some(daemon_parameter_path(value));
             }
         }
         "includefrom" => {
             if !value.is_empty() {
-                let resolved = resolve_config_relative_path(canonical, value);
-                state.module_defaults.include_from = Some(resolved);
+                state.module_defaults.include_from = Some(daemon_parameter_path(value));
             }
         }
         "comment" => {

--- a/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/module_directives.rs
@@ -339,7 +339,11 @@ fn apply_module_directive(
             }
         }
         // upstream: daemon-parm.txt - `exclude_from` STRING, default NULL.
-        // Loaded via parse_filter_file() in clientserver.c.
+        // Loaded via parse_filter_file() in clientserver.c:934-951, which opens
+        // the stored value as given: a relative path resolves against the
+        // daemon's working directory at read time (pre-change_dir, so the
+        // launch cwd), never against the config file's directory. See
+        // `daemon_parameter_path` for the storage rule.
         "excludefrom" => {
             if value.is_empty() {
                 return Err(config_parse_error(
@@ -348,11 +352,11 @@ fn apply_module_directive(
                     "'exclude from' directive must not be empty",
                 ));
             }
-            let resolved = resolve_config_relative_path(canonical, value);
-            builder.set_exclude_from(resolved);
+            builder.set_exclude_from(daemon_parameter_path(value));
         }
         // upstream: daemon-parm.txt - `include_from` STRING, default NULL.
-        // Loaded via parse_filter_file() in clientserver.c.
+        // Same storage rule as `exclude from` above: the value is kept
+        // verbatim and resolved at read time against the daemon's cwd.
         "includefrom" => {
             if value.is_empty() {
                 return Err(config_parse_error(
@@ -361,8 +365,7 @@ fn apply_module_directive(
                     "'include from' directive must not be empty",
                 ));
             }
-            let resolved = resolve_config_relative_path(canonical, value);
-            builder.set_include_from(resolved);
+            builder.set_include_from(daemon_parameter_path(value));
         }
         // upstream: daemon-parm.h - `filter` STRING, P_LOCAL. Last-wins like
         // every other directive: `do_parameter()` reaches `string_set()`, which

--- a/crates/daemon/src/daemon/sections/config_parsing/parser.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/parser.rs
@@ -413,8 +413,11 @@ fn continuation_offset(line: &str) -> Option<usize> {
 ///   to `open_no_attacker_symlinks()`.
 /// - `pid file`: clientserver.c:1584 `create_pid_file()` opens
 ///   `lp_pid_file()`'s value directly.
+/// - `exclude from` / `include from`: clientserver.c:934-951
+///   `parse_filter_file()` opens the stored value before change_dir runs, so
+///   a relative path resolves against the daemon's launch cwd.
 ///
-/// The three sites share this function because they must agree. `log file`'s
+/// These sites share this function because they must agree. `log file`'s
 /// module and global halves are read through one `lp_log_file()` accessor, so
 /// a rule applied to one and not the other would open two different files for
 /// one config line; `pid file` obeys the same storage rule, and rebasing it

--- a/crates/daemon/src/daemon/sections/config_parsing/tests.rs
+++ b/crates/daemon/src/daemon/sections/config_parsing/tests.rs
@@ -2015,8 +2015,14 @@ mod config_parsing_tests {
         );
     }
 
+    /// upstream: loadparm.c stores every parameter value verbatim, and
+    /// parse_filter_file() (clientserver.c:934-951) opens the stored string as
+    /// given - so a relative value must survive parsing UNCHANGED, resolving
+    /// against the daemon's cwd only at read time. Rebasing it onto the config
+    /// file's directory here would point the later read at a file the
+    /// operator never named.
     #[test]
-    fn exclude_from_relative_path_resolved_against_config_dir() {
+    fn exclude_from_relative_path_is_stored_verbatim() {
         let dir = TempDir::new().expect("create temp dir");
         let module_path = dir.path().join("data");
         fs::create_dir(&module_path).expect("create dir");
@@ -2033,13 +2039,12 @@ mod config_parsing_tests {
             .exclude_from
             .as_ref()
             .expect("exclude_from set");
-        let config_dir = file.path().canonicalize().unwrap();
-        let expected = config_dir.parent().unwrap().join("excludes.txt");
-        assert_eq!(*exclude_from, expected);
+        assert_eq!(*exclude_from, PathBuf::from("excludes.txt"));
     }
 
+    /// Same storage rule as `exclude_from_relative_path_is_stored_verbatim`.
     #[test]
-    fn include_from_relative_path_resolved_against_config_dir() {
+    fn include_from_relative_path_is_stored_verbatim() {
         let dir = TempDir::new().expect("create temp dir");
         let module_path = dir.path().join("data");
         fs::create_dir(&module_path).expect("create dir");
@@ -2056,9 +2061,7 @@ mod config_parsing_tests {
             .include_from
             .as_ref()
             .expect("include_from set");
-        let config_dir = file.path().canonicalize().unwrap();
-        let expected = config_dir.parent().unwrap().join("includes.txt");
-        assert_eq!(*include_from, expected);
+        assert_eq!(*include_from, PathBuf::from("includes.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`exclude from` and `include from` resolved a RELATIVE value against the CONFIG FILE'S directory (`resolve_config_relative_path`), at both the module arms and the global-default arms. Upstream stores every parameter value verbatim (loadparm.c string storage) and each consumer opens the string as given — `parse_filter_file()` (clientserver.c:934-951) runs before `change_dir` (:1059), so a relative path resolves against the daemon's LAUNCH cwd at read time. oc's rebase pointed the later read at a file the operator never named, so every relative value refused the module in all four chroot/uid regimes — the residual cell C of #7741's ordering table.

The sharpest part: the repo already documents upstream's rule. The `daemon_parameter_path` doc (parser.rs) states "a relative value is resolved against the daemon's working directory - never against the config file's directory", citing loadparm storage plus the `log file` and `pid file` consumers, which follow it. These two directives were wired to the other resolver. The fix routes all four arms through `daemon_parameter_path` and adds the filter parameters to that doc's consumer list — one owner for the storage rule, no new mechanism.

## Measured A/B (Linux, root; real 3.5.0 as oracle and constant client)

The fix arm for measurement is this branch + #7741's commit cherry-picked (the read must be pre-chroot to reach the launch cwd; the two changes are textually independent — config_parsing vs module_access — but only their combination completes the relative cell). Module holds `bar` + `keep`; `exclude from = excl-rel.txt` holds `keep`; the file sits in the daemon's launch cwd:

| cell | upstream | base | fix |
|---|---|---|---|
| present, chroot=yes | rc 0, serves `bar`, hides `keep` | rc 12 refuse | rc 0, serves `bar`, hides `keep` |
| present, chroot=no | rc 0, serves `bar`, hides `keep` | rc 12 refuse | rc 0, serves `bar`, hides `keep` |
| ABSENT, chroot=yes (negative control) | rc 5 refuse | rc 12 | rc 5 refuse, `@ERROR: failed to load module filter rules: failed to read filter file 'excl-rel.txt'` |

The negative control pins non-vacuity in the other direction: the fix does not blanket-serve, and its refusal delivery (rc 5 + reason line) now matches upstream where base gave rc 12 with no reason.

## Tests

The two tests that pinned the config-relative behaviour now pin verbatim storage (`exclude_from_relative_path_is_stored_verbatim` + include twin), with the upstream rationale in their doc comment. Mutation-proven: restoring `resolve_config_relative_path` on the exclude arm fails the exclude test (`left:` the joined path, `right: "excludes.txt"`); reverting restores 2/2.

## Deliberately out of scope

The six other `resolve_config_relative_path` consumers (motd file, module log file, and four global arms) each need their own upstream verbatim-vs-config-relative verdict before moving; `&include` is config-file composition, not a runtime open, and stays config-relative.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p daemon --all-targets -D warnings` clean, `nextest -p daemon --lib` 1891/1891. Not run locally (CI covers them): full-workspace nextest, `--all-features`, macOS/Windows/musl, 3.5.0 testsuite legs, interop.
