### PR TITLE
fix(daemon): report <rule from FILE line N> provenance when a filter-file rule is refused

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -238,9 +238,10 @@ fn build_daemon_filter_rules(
     //           lp_include_from(i), rule_template(FILTRULE_INCLUDE),
     //           XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | XFLG_OLD_PREFIXES | XFLG_FATAL_ERRORS)
     if let Some(ref path) = module.include_from {
-        let patterns = read_patterns_from_file(path)?;
-        for pattern in patterns {
-            rules.push(old_prefix_record_rule(&pattern, true)?);
+        let name = path.display().to_string();
+        for (pattern, line) in read_patterns_from_file(path)? {
+            let source = filters::RuleSource::File { name: &name, line };
+            rules.push(old_prefix_record_rule(&pattern, true, &source)?);
         }
     }
 
@@ -256,9 +257,10 @@ fn build_daemon_filter_rules(
     // upstream: clientserver.c:946-948 - parse_filter_file(&daemon_filter_list, lp_exclude_from(i),
     //           rule_template(0), XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3 | ...)
     if let Some(ref path) = module.exclude_from {
-        let patterns = read_patterns_from_file(path)?;
-        for pattern in patterns {
-            rules.push(old_prefix_record_rule(&pattern, false)?);
+        let name = path.display().to_string();
+        for (pattern, line) in read_patterns_from_file(path)? {
+            let source = filters::RuleSource::File { name: &name, line };
+            rules.push(old_prefix_record_rule(&pattern, false, &source)?);
         }
     }
 
@@ -335,10 +337,19 @@ fn clear_list_rule() -> FilterRuleWireFormat {
 /// reaches the caller's existing abort path, which refuses the module rather
 /// than silently dropping the rule - dropping it would serve every file the
 /// operator wrote that line to hide.
-fn unexpected_end_of_filter_rule(rule: &str) -> io::Error {
+///
+/// The rule text goes through [`filters::RuleSource::rule_text`], upstream's
+/// `rule_text()` chokepoint (`exclude.c:134`): text from a STRING parameter is
+/// the operator's own and stays verbatim (`rule_src_in_file == 0` while
+/// `parse_filter_str` runs on `lp_filter`/`lp_include`/`lp_exclude`,
+/// clientserver.c:933-952), while a record read out of an `include from` /
+/// `exclude from` FILE is replaced by `<rule from FILE line N>`
+/// (`exclude.c:1749-1754` sets `rule_src_file`/`rule_src_line`;
+/// `exclude.c:71-86` renders the description).
+fn unexpected_end_of_filter_rule(rule: &str, source: &filters::RuleSource<'_>) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("unexpected end of filter rule: {rule}"),
+        format!("unexpected end of filter rule: {}", source.rule_text(rule)),
     )
 }
 
@@ -354,6 +365,7 @@ fn unexpected_end_of_filter_rule(rule: &str) -> io::Error {
 fn old_prefix_record_rule(
     record: &str,
     template_include: bool,
+    source: &filters::RuleSource<'_>,
 ) -> Result<FilterRuleWireFormat, io::Error> {
     let (pattern, is_include) = match old_prefix(record) {
         OldPrefix::Exclude => (&record[2..], false),
@@ -381,7 +393,7 @@ fn old_prefix_record_rule(
     // string-parameter twin lives in `push_old_prefix_token_rules` and is
     // pinned by `exclude_string_empty_after_the_prefix_is_refused`.
     if pattern.is_empty() {
-        return Err(unexpected_end_of_filter_rule(record));
+        return Err(unexpected_end_of_filter_rule(record, source));
     }
     Ok(build_pattern_rule(pattern, is_include))
 }
@@ -420,7 +432,12 @@ fn push_old_prefix_token_rules(
         if prefix == OldPrefix::MaybeClear && token.len() == 1 {
             rules.push(clear_list_rule());
         } else if token.is_empty() {
-            return Err(unexpected_end_of_filter_rule(rest));
+            // A STRING parameter is the operator's own text: upstream shows it
+            // verbatim (`TEXT_FROM_FILE` is false, `exclude.c:67-69,110-117`).
+            return Err(unexpected_end_of_filter_rule(
+                rest,
+                &filters::RuleSource::Argument,
+            ));
         } else {
             let is_include = match prefix {
                 OldPrefix::Exclude => false,
@@ -503,7 +520,12 @@ fn read_filter_file_contents(path: &Path) -> io::Result<String> {
 /// and `a `: upstream hides `a ` and serves `a`; oc trimmed the rule, hid `a`
 /// and served `a `. Both at exit 0, with no diagnostic - a silent divergence
 /// in which files the daemon exposes.
-fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
+/// Each pattern is paired with its 1-indexed PHYSICAL line: upstream's
+/// `rule_src_line` increments once per record read (`exclude.c:1760-1761`),
+/// before the comment/blank test, so comments and blank lines keep their slot
+/// and a bad rule after them is reported at the line the operator sees in an
+/// editor. That number feeds the `<rule from FILE line N>` provenance.
+fn read_patterns_from_file(path: &Path) -> Result<Vec<(String, usize)>, io::Error> {
     let content = read_filter_file_contents(path).map_err(|e| {
         io::Error::new(
             e.kind(),
@@ -512,10 +534,11 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<String>, io::Error> {
     })?;
 
     let patterns = filters::filter_file_records(&content)
+        .enumerate()
         // `true`: these two parameters are the non-word-split templates, so a
         // leading `;`/`#` is a comment (`exclude.c:1806`, `word_split ||`).
-        .filter(|line| filters::filter_file_line_is_rule(line, true))
-        .map(str::to_owned)
+        .filter(|(_, line)| filters::filter_file_line_is_rule(line, true))
+        .map(|(index, line)| (line.to_owned(), index + 1))
         .collect();
 
     Ok(patterns)
@@ -797,10 +820,14 @@ impl MalformedRule {
 /// (`exclude.c:133-137`); the modifier arm builds its own line at
 /// `exclude.c:1373-1378`.
 ///
-/// ⚠ SCOPE: what this change was measured on is the REFUSAL - whether the
-/// module is served - not the wording. The daemon's filter diagnostics also
-/// lack upstream's `<rule from FILE line N>` provenance envelope, which is
-/// task 1156 and deliberately NOT attempted here.
+/// These variants render the token VERBATIM, and that matches upstream: they
+/// are reached only from the `filter` STRING parameter, whose text is the
+/// operator's own configuration. Upstream's `rule_text()` chokepoint redacts
+/// only text that came out of a file's contents (`TEXT_FROM_FILE`,
+/// `exclude.c:67-69`), and `rule_src_in_file` is 0 while `parse_filter_str`
+/// runs on `lp_filter` (clientserver.c:933-935) - so no `<rule from ...>`
+/// envelope applies here. The FILE parameters' provenance lives in
+/// `unexpected_end_of_filter_rule` via [`filters::RuleSource`].
 impl std::fmt::Display for MalformedRule {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2449,6 +2449,66 @@ mod module_access_tests {
         );
     }
 
+    /// A FILE refusal carries upstream's provenance envelope, not the rule.
+    ///
+    /// upstream: `filter_rule_err` renders through the `rule_text()` chokepoint
+    /// (`exclude.c:133-136`), and while `parse_filter_file` reads an
+    /// `exclude from` file `rule_src_file` is the file's GIVEN name and
+    /// `rule_src_line` counts PHYSICAL lines, comments and blanks included
+    /// (`exclude.c:1749-1761`). MEASURED against rsync 3.5.0 (task 1153): a
+    /// module whose `exclude from` file holds `- ` is refused with
+    /// `unexpected end of filter rule: <rule from FILE line 1>` at
+    /// `RERR_SYNTAX`. Only the TEXT is in scope here; the delivery shape
+    /// (@ERROR framing, exit 5 vs 12) is the iobuf work, tracked separately.
+    ///
+    /// The comment and blank line ahead of the bad rule are the counter's
+    /// probe: number the KEPT rules instead of the records and this reports
+    /// line 2, so the operator opens the wrong line of the file.
+    #[test]
+    fn exclude_from_refusal_names_the_file_and_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("excludes.txt");
+        fs::write(&file, "# comment\n\n+ good\n- \n").unwrap();
+        let error = build_daemon_filter_rules(&ModuleRuntime::from(ModuleDefinition {
+            exclude_from: Some(file.clone()),
+            ..Default::default()
+        }))
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "unexpected end of filter rule: <rule from {} line 4>",
+                file.display()
+            ),
+        );
+    }
+
+    /// The `include from` twin: both file parameters share the one provenance
+    /// path, and the envelope replaces the rule's text entirely.
+    #[test]
+    fn include_from_refusal_names_the_file_and_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("includes.txt");
+        fs::write(&file, "+ \n").unwrap();
+        let error = build_daemon_filter_rules(&ModuleRuntime::from(ModuleDefinition {
+            include_from: Some(file.clone()),
+            ..Default::default()
+        }))
+        .unwrap_err();
+        let message = error.to_string();
+        assert_eq!(
+            message,
+            format!(
+                "unexpected end of filter rule: <rule from {} line 1>",
+                file.display()
+            ),
+        );
+        assert!(
+            !message.contains("+ "),
+            "a file's contents must not be echoed: {message}"
+        );
+    }
+
     /// A LATER record carries its own prefix - the strip is re-run per record.
     ///
     /// upstream: `parse_filter_file` calls `parse_rule_tok` once per line
@@ -2570,6 +2630,38 @@ mod module_access_tests {
             error.to_string().contains("unexpected end of filter rule"),
             "unexpected message: {error}"
         );
+    }
+
+    /// A STRING parameter's refusal shows the operator's own text VERBATIM.
+    ///
+    /// upstream: `rule_text()` redacts only text that came out of a file's
+    /// contents (`TEXT_FROM_FILE`, `exclude.c:67-69,110-117`);
+    /// `rule_src_in_file` is 0 while `parse_filter_str` runs on the daemon's
+    /// string parameters (clientserver.c:933-952), so a bad `filter =` value
+    /// is echoed as typed with no `<rule from ...>` envelope. This is the
+    /// non-vacuity companion to the file cells above: a blanket "wrap
+    /// everything" implementation passes those and fails here.
+    #[test]
+    fn filter_string_refusal_shows_the_rule_verbatim() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            filter: vec!["-".to_string()],
+            ..Default::default()
+        });
+        let error = build_daemon_filter_rules(&module).unwrap_err();
+        assert_eq!(error.to_string(), "unexpected end of filter rule: -");
+    }
+
+    /// The same property on the old-prefix string path, which shares
+    /// `unexpected_end_of_filter_rule` with the file readers: its
+    /// [`filters::RuleSource::Argument`] arm is what keeps this verbatim.
+    #[test]
+    fn exclude_string_refusal_shows_the_token_verbatim() {
+        let module = ModuleRuntime::from(ModuleDefinition {
+            exclude: vec!["- ".to_string()],
+            ..Default::default()
+        });
+        let error = build_daemon_filter_rules(&module).unwrap_err();
+        assert_eq!(error.to_string(), "unexpected end of filter rule: - ");
     }
 
     /// The STRING parameters carry `XFLG_OLD_PREFIXES` too - and they are
@@ -3037,7 +3129,10 @@ mod module_access_tests {
         fs::write(&file, "*.tmp\n*.bak\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["*.tmp", "*.bak"]);
+        assert_eq!(
+            patterns,
+            vec![("*.tmp".to_owned(), 1), ("*.bak".to_owned(), 2)]
+        );
     }
 
     #[test]
@@ -3046,8 +3141,13 @@ mod module_access_tests {
         let file = dir.path().join("patterns.txt");
         fs::write(&file, "# comment\n*.tmp\n; another\n*.bak\n").unwrap();
 
+        // Comments keep their line slot: `rule_src_line` counts every record
+        // read (`exclude.c:1760-1761`), not every rule kept.
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["*.tmp", "*.bak"]);
+        assert_eq!(
+            patterns,
+            vec![("*.tmp".to_owned(), 2), ("*.bak".to_owned(), 4)]
+        );
     }
 
     #[test]
@@ -3057,7 +3157,10 @@ mod module_access_tests {
         fs::write(&file, "\n*.tmp\n\n*.bak\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["*.tmp", "*.bak"]);
+        assert_eq!(
+            patterns,
+            vec![("*.tmp".to_owned(), 2), ("*.bak".to_owned(), 4)]
+        );
     }
 
     /// A rule's trailing whitespace is PATTERN TEXT, not decoration.
@@ -3078,7 +3181,14 @@ mod module_access_tests {
         fs::write(&file, "a \nb\t\n *.log\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["a ", "b\t", " *.log"]);
+        assert_eq!(
+            patterns,
+            vec![
+                ("a ".to_owned(), 1),
+                ("b\t".to_owned(), 2),
+                (" *.log".to_owned(), 3)
+            ]
+        );
     }
 
     /// A whitespace-only record is a PATTERN, not a blank line.
@@ -3093,7 +3203,10 @@ mod module_access_tests {
         fs::write(&file, "   \n*.tmp\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["   ", "*.tmp"]);
+        assert_eq!(
+            patterns,
+            vec![("   ".to_owned(), 1), ("*.tmp".to_owned(), 2)]
+        );
     }
 
     /// `#`/`;` open a comment only in COLUMN ZERO.
@@ -3109,7 +3222,10 @@ mod module_access_tests {
         fs::write(&file, "#dropped\n  #kept\n ;kept\n;dropped\n").unwrap();
 
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["  #kept", " ;kept"]);
+        assert_eq!(
+            patterns,
+            vec![("  #kept".to_owned(), 2), (" ;kept".to_owned(), 3)]
+        );
     }
 
     /// A lone `\r` ends a record, and `\r\n` ends exactly one.
@@ -3124,8 +3240,18 @@ mod module_access_tests {
         let file = dir.path().join("patterns.txt");
         fs::write(&file, "a \r*.tmp\r\n*.bak\n").unwrap();
 
+        // Every terminator ends one record and one LINE: upstream bumps
+        // `rule_src_line` per record read, and a lone `\r` ends a record
+        // (`exclude.c:1760-1761,1774-1793`).
         let patterns = read_patterns_from_file(&file).unwrap();
-        assert_eq!(patterns, vec!["a ", "*.tmp", "*.bak"]);
+        assert_eq!(
+            patterns,
+            vec![
+                ("a ".to_owned(), 1),
+                ("*.tmp".to_owned(), 2),
+                ("*.bak".to_owned(), 3)
+            ]
+        );
     }
 
     #[test]
@@ -3162,7 +3288,7 @@ mod module_access_tests {
         std::os::unix::fs::symlink(&target, &link).expect("symlink");
 
         let patterns = read_patterns_from_file(&link).expect("trusted-owner symlink is followed");
-        assert_eq!(patterns, vec!["keep".to_string()]);
+        assert_eq!(patterns, vec![("keep".to_string(), 1)]);
     }
 
     /// A plain file still reads identically after the routing change.
@@ -3178,7 +3304,10 @@ mod module_access_tests {
         std::fs::write(&file, "first\n; comment\nsecond\n").expect("write");
 
         let patterns = read_patterns_from_file(&file).expect("plain file reads");
-        assert_eq!(patterns, vec!["first".to_string(), "second".to_string()]);
+        assert_eq!(
+            patterns,
+            vec![("first".to_string(), 1), ("second".to_string(), 3)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

A bad rule read from a daemon `exclude from`/`include from` file was refused with the raw record text and no provenance. Upstream's refusal goes through the `rule_text()` chokepoint (exclude.c:133-136 `filter_rule_err`): text read out of a FILE is redacted to `<rule from FILE line N>` (exclude.c:67-69, 110-123; `rule_src_where` at :71-86 renders the location), where FILE is the config-given name and N counts PHYSICAL records — `rule_src_line` increments once per record read (exclude.c:1760-1761), before the comment/blank test, so the number matches what the operator sees in an editor.

This routes the daemon refusals through the SAME provenance owner the CLI half already uses (`filters::RuleSource`, landed in #7384) — no second representation. `read_patterns_from_file` now yields `(pattern, physical line)`, and both refusal constructors take a `&RuleSource`.

## Correction to the original brief, measured from source

The task notes claimed upstream's string-parameter provenance "names the parameter". It does not: `rule_src_in_file` is 0 while `parse_filter_str` runs on `lp_filter`/`lp_include`/`lp_exclude` (clientserver.c:933-952), so `TEXT_FROM_FILE` is false and the operator's own text is echoed VERBATIM. oc already matched that; the string arm is unchanged except for routing through the shared owner, and the verbatim behaviour is pinned as the non-vacuity companion.

## Provenance produced vs upstream

- File params: `unexpected end of filter rule: <rule from FILE line N>` — byte-identical wording to upstream's `filter_rule_err` + `rule_src_where`.
- String params: `unexpected end of filter rule: <verbatim text>` — matches upstream's non-file arm.

## Tests + mutations (each run, kill confirmed, reverted)

- `exclude_from_refusal_names_the_file_and_line` (bad rule at line 4 behind a comment + blank line) kills the enumerate-after-filtering mutation: the mutant reports `line 2`. `include_from_refusal_names_the_file_and_line` is the twin and also asserts the file's text is NOT echoed.
- `exclude_string_refusal_shows_the_token_verbatim` kills the blanket-wrap mutation (`Argument` -> file-sourced): mutant produced `<rule from a file read earlier>`.
- `filter_string_refusal_shows_the_rule_verbatim` kills wrapping the Display arm.
- The seven existing `read_patterns_from_file` pins carry the new line numbers.

## Deliberately scoped out

The rc/delivery shape (oc rc 12 vs upstream rc 5, `@ERROR` framing) is task 889's iobuf work, untouched here. The `discarding over-long filter` and file-open-failure paths already match upstream (verbatim + errno; daemon config files are non-file-sourced for those arms).

## Gates

Pinned 1.88.0 on the master base: whole-tree rustfmt clean (3426 files), `clippy -p daemon --all-targets -D warnings` clean, `nextest -p daemon --lib` 1895/1895. Footprint note: `helpers.rs` overlaps #7740's diff (same function); whichever merges second gets rebased.
