### PR TITLE
fix(transfer): refuse an ITEM_TRANSFER request for a non-regular file per rsync.c:436-444

### DIFF
--- a/crates/transfer/src/generator/transfer/goodbye.rs
+++ b/crates/transfer/src/generator/transfer/goodbye.rs
@@ -72,6 +72,18 @@ impl FlistMarkerSink for GoodbyeNdxSink<'_> {
             .is_none_or(protocol::flist::FileEntry::is_active)
     }
 
+    fn ndx_is_regular_file(&self, ndx: i32) -> bool {
+        // upstream: rsync.c:436-444 - unreachable through the goodbye read
+        // (`read_marker_aware_ndx` decodes no attribute tail, so ITEM_TRANSFER
+        // is never seen here), but answered faithfully from the sender's own
+        // list, mirroring `ndx_is_active` above. Out of range defers to the
+        // guard that owns range faults.
+        usize::try_from(ndx)
+            .ok()
+            .and_then(|flat| self.0.file_list().get(flat))
+            .is_none_or(protocol::flist::FileEntry::is_file)
+    }
+
     fn begin_frame(&mut self) {}
 
     fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -728,6 +728,27 @@ impl GeneratorContext {
             // exact wire bytes consumed so this count never drifts from the wire.
             self.timing.total_bytes_read += trailing_bytes;
 
+            // upstream: rsync.c:436-444 - read_ndx_and_attrs() refuses an
+            // ITEM_TRANSFER frame whose index does not name a regular file
+            // ("received request to transfer non-regular file") with
+            // exit_cleanup(RERR_PROTOCOL), on the sender as much as on the
+            // receiver, before send_files() ever sees the request. The `i < 0`
+            // half of upstream's test is a gap NDX, which resolve_itemize_ndx
+            // maps to the owning *directory* entry, so the S_ISREG half below
+            // refuses it identically. An index past the end of the list is a
+            // different fault owned by validate_file_index (upstream's
+            // flist_for_ndx abort, which runs first), so it is deferred, not
+            // claimed with this diagnostic.
+            if iflags.needs_transfer()
+                && ndx < self.file_list.len()
+                && !self.file_list[ndx].is_file()
+            {
+                return Err(crate::receiver::ndx_stream::non_regular_transfer_request(
+                    wire_ndx,
+                    crate::receiver::ndx_stream::StreamRole::Sender,
+                ));
+            }
+
             // upstream: sender.c:286-290 - drain the generator's xattr request
             // when preserve_xattrs && ITEM_REPORT_XATTR is set. The generator
             // always emits at least a 0 terminator (varint) under this gate, so
@@ -2481,6 +2502,144 @@ mod phase2_guard_tests {
         ndx.write_ndx_done(&mut wire).unwrap();
 
         drive(&mut ctx, wire).expect("clean phase completion");
+    }
+}
+
+#[cfg(test)]
+mod non_regular_request_guard_tests {
+    //! The sender's half of upstream's `ITEM_TRANSFER` non-regular guard.
+    //!
+    //! upstream: rsync.c:436-444 - inside `read_ndx_and_attrs()`, once the
+    //! attribute tail has decoded `ITEM_TRANSFER`, an index that does not name
+    //! a regular file (`i < 0 || !S_ISREG(cur_flist->files[i]->mode)`) prints
+    //! `received request to transfer non-regular file: %d [%s]` and aborts with
+    //! `exit_cleanup(RERR_PROTOCOL)`. The guard runs on BOTH ends that read a
+    //! request/echo; these tests pin the sender's request-read site, whose
+    //! pre-fix behaviour would have serviced the frame up to the silent
+    //! `!file_entry.is_file()` skip - no diagnostic, no exit code.
+
+    use std::ffi::OsString;
+    use std::io::{self, Cursor};
+    use std::path::PathBuf;
+
+    use protocol::ProtocolVersion;
+    use protocol::codec::{MonotonicNdxWriter, NdxCodec};
+
+    use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::SumHead;
+    use crate::role::ServerRole;
+    use crate::writer::ServerWriter;
+
+    /// `ITEM_TRANSFER` (0x8000) as its 2-byte little-endian wire encoding.
+    const ITEM_TRANSFER_LE: [u8; 2] = [0x00, 0x80];
+
+    fn test_handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    /// Builds a sender over a single source file so wire NDX 0 is a valid,
+    /// in-range request.
+    fn generator_with_one_file() -> (tempfile::TempDir, GeneratorContext) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file = dir.path().join("only.txt");
+        std::fs::write(&file, b"payload").expect("write source");
+
+        let handshake = test_handshake();
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(&file)],
+            ..Default::default()
+        };
+        let mut ctx = GeneratorContext::new_for_test(&handshake, config);
+        ctx.build_file_list(&[PathBuf::from(&file)])
+            .expect("build file list");
+        (dir, ctx)
+    }
+
+    /// Drives the sender loop over a crafted receiver stream.
+    fn drive(ctx: &mut GeneratorContext, incoming: Vec<u8>) -> io::Result<usize> {
+        let mut reader = Cursor::new(incoming);
+        let mut writer = ServerWriter::new_plain(Vec::new());
+        let mut progress: Option<&mut dyn crate::TransferProgressCallback> = None;
+        let mut itemize: Option<&mut dyn crate::ItemizeCallback> = None;
+        ctx.run_transfer_loop(&mut reader, &mut writer, &mut progress, &mut itemize)
+            .map(|result| result.files_transferred)
+    }
+
+    /// An `ITEM_TRANSFER` request naming an entry whose mode is `S_IFLNK` (or
+    /// any other non-`S_IFREG` type) must abort with upstream's diagnostic and
+    /// `RERR_PROTOCOL` - never fall through to the silent skip.
+    fn assert_sender_refuses_mode(mode: u32, case: &str) {
+        let (_dir, mut ctx) = generator_with_one_file();
+        ctx.file_list[0].set_mode(mode);
+
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        ndx.write_ndx(&mut wire, 0).expect("write request ndx");
+        wire.extend_from_slice(&ITEM_TRANSFER_LE);
+
+        let err = drive(&mut ctx, wire).expect_err(case);
+        assert!(
+            err.to_string()
+                .contains("received request to transfer non-regular file: 0"),
+            "{case}: expected upstream's rejection text, got {err}"
+        );
+        assert!(
+            err.to_string().contains("[sender="),
+            "{case}: the who_am_i() tag must name the sender: {err}"
+        );
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+            "{case}: the abort must map to RERR_PROTOCOL"
+        );
+    }
+
+    #[test]
+    fn sender_refuses_transfer_request_for_a_symlink_entry() {
+        assert_sender_refuses_mode(0o120777, "a symlink is not transferable");
+    }
+
+    #[test]
+    fn sender_refuses_transfer_request_for_a_directory_entry() {
+        assert_sender_refuses_mode(0o040755, "a directory is not transferable");
+    }
+
+    /// NON-VACUITY COMPANION: the same request against the entry's real
+    /// regular-file mode passes the guard and completes a whole-file transfer.
+    ///
+    /// Without this, the guard could be written to refuse every ITEM_TRANSFER
+    /// frame and the refusal tests above would still pass.
+    #[test]
+    fn regular_entry_request_passes_the_guard_and_transfers() {
+        let (_dir, mut ctx) = generator_with_one_file();
+
+        let mut ndx = MonotonicNdxWriter::new(32);
+        let mut wire = Vec::new();
+        ndx.write_ndx(&mut wire, 0).expect("write request ndx");
+        wire.extend_from_slice(&ITEM_TRANSFER_LE);
+        // An empty sum_head: no basis, whole-file send.
+        SumHead::new(0, 0, 0, 0).write(&mut wire).expect("sum_head");
+        // Three NDX_DONEs drain phases 0 -> 1 -> 2 -> break past max_phase.
+        ndx.write_ndx_done(&mut wire).expect("done");
+        ndx.write_ndx_done(&mut wire).expect("done");
+        ndx.write_ndx_done(&mut wire).expect("done");
+
+        let files = drive(&mut ctx, wire).expect("a regular file must still transfer");
+        assert_eq!(files, 1, "the guard must not swallow a legitimate request");
     }
 }
 

--- a/crates/transfer/src/receiver/ndx_stream.rs
+++ b/crates/transfer/src/receiver/ndx_stream.rs
@@ -57,8 +57,14 @@
 //!   negotiates down to protocol 28, so the frame is reachable. Because the
 //!   branch re-enters the loop *after* `iflags` is decoded, [`read_ndx_and_attrs`]
 //!   keeps the attribute read inside its loop and marks the insertion point.
-//! - **The non-regular-file guard** (`rsync.c:420-428`) and the xname
-//!   `sanitize_path()` pass (`rsync.c:407-417`) stay with their current owners.
+//! - **The xname `sanitize_path()` pass** (`rsync.c:408-429`) stays with its
+//!   current owner, [`SenderAttrs::read_attrs_after_ndx`]'s basis-xname
+//!   sanitizer. The non-regular-file guard (`rsync.c:436-444`) is **not** an
+//!   omission: it lives in [`read_ndx_and_attrs`] via
+//!   [`FlistMarkerSink::ndx_is_regular_file`], and the sender's open-coded
+//!   request loop applies the same guard at its own attrs read
+//!   (`generator/transfer/transfer_loop.rs`), sharing
+//!   [`non_regular_transfer_request`] so the diagnostic has one owner.
 
 use std::io::{self, Read};
 
@@ -133,6 +139,24 @@ pub(crate) trait FlistMarkerSink {
     /// - `receiver.c:871-881` - `recv_files()` refuses the inactive entry.
     /// - `sender.c:558-563` - `send_files()` refuses it identically.
     fn ndx_is_active(&self, ndx: i32) -> bool;
+
+    /// Whether `ndx` names a *regular file* - upstream's `S_ISREG` term in the
+    /// `ITEM_TRANSFER` guard.
+    ///
+    /// Consulted by [`read_ndx_and_attrs`] only once the attribute tail has
+    /// decoded `ITEM_TRANSFER`; a frame that fails it is a hard protocol error
+    /// ([`non_regular_transfer_request`]), never a skip. Like
+    /// [`Self::ndx_is_active`], this is deliberately **not** defaulted so a
+    /// future sink cannot silently carry the guard past a list it owns. A sink
+    /// that cannot resolve the entry - no list of its own, or an index outside
+    /// every segment - reports `true`, deferring to the guard that owns range
+    /// faults rather than claiming them with the non-regular diagnostic.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `rsync.c:436-444` - `if (iflags & ITEM_TRANSFER)` refuses
+    ///   `i < 0 || !S_ISREG(cur_flist->files[i]->mode)`.
+    fn ndx_is_regular_file(&self, ndx: i32) -> bool;
 
     /// Captures [`Self::FrameMark`] before the NDX is read.
     fn begin_frame(&mut self) -> Self::FrameMark;
@@ -226,6 +250,12 @@ impl FlistMarkerSink for NoLazyFlist {
         true
     }
 
+    fn ndx_is_regular_file(&self, _ndx: i32) -> bool {
+        // Same as `ndx_is_active`: with no list there is no mode to test, so
+        // the guard defers to the owners of what this sink can see.
+        true
+    }
+
     fn begin_frame(&mut self) {}
 
     fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
@@ -291,6 +321,26 @@ pub(crate) fn invalid_file_index(ndx: i32, last: i32, role: StreamRole) -> io::E
 pub(crate) fn cleared_file_index(ndx: i32, role: StreamRole) -> io::Error {
     protocol::protocol_violation(format!(
         "rsync: refusing transfer of cleared file index {ndx} {}{}",
+        crate::role_trailer::error_location!(),
+        role.trailer()
+    ))
+}
+
+/// Builds upstream's `rsync.c:439-441` rejection of an `ITEM_TRANSFER` frame
+/// that does not name a regular file.
+///
+/// Keeps upstream's wording - `received request to transfer non-regular file:
+/// %d` - and appends oc's source location plus the `[role=VERSION]` trailer
+/// that stands in for `who_am_i()`, as every other diagnostic in this module
+/// does. Tagged as a protocol violation so the exit-code mapper yields
+/// `RERR_PROTOCOL` (2), matching `exit_cleanup(RERR_PROTOCOL)` at
+/// `rsync.c:442`.
+///
+/// Shared by [`read_ndx_and_attrs`] and the sender's open-coded request read
+/// (`generator/transfer/transfer_loop.rs`) so the message has a single owner.
+pub(crate) fn non_regular_transfer_request(ndx: i32, role: StreamRole) -> io::Error {
+    protocol::protocol_violation(format!(
+        "received request to transfer non-regular file: {ndx} {}{}",
         crate::role_trailer::error_location!(),
         role.trailer()
     ))
@@ -447,6 +497,17 @@ where
         // A `continue` here re-enters the loop above. Deliberately absent; see
         // the module docs for why it is tracked separately.
 
+        // upstream: rsync.c:436-444 - an ITEM_TRANSFER frame must name a
+        // regular file: `i = ndx - cur_flist->ndx_start; if (i < 0 ||
+        // !S_ISREG(cur_flist->files[i]->mode))` is a hard protocol error on
+        // whichever end read the frame, never a skip. The `i < 0` half is a
+        // gap/stale index, which no sink resolves to a regular entry; a range
+        // fault the sink cannot resolve at all is deferred to the guard that
+        // owns it (see `FlistMarkerSink::ndx_is_regular_file`).
+        if attrs.iflags & SenderAttrs::ITEM_TRANSFER != 0 && !sink.ndx_is_regular_file(ndx) {
+            return Err(non_regular_transfer_request(ndx, sink.role()));
+        }
+
         return Ok(Some((ndx, attrs)));
     }
 }
@@ -483,6 +544,16 @@ impl FlistMarkerSink for ReceiverContext {
         self.wire_to_flat_ndx(ndx)
             .and_then(|flat| self.file_list.get(flat))
             .is_none_or(protocol::flist::FileEntry::is_active)
+    }
+
+    fn ndx_is_regular_file(&self, ndx: i32) -> bool {
+        // upstream: rsync.c:436-444 - the receiver's half of the ITEM_TRANSFER
+        // guard. An index outside every segment is a range fault owned by the
+        // caller's echo-ordering check, so only an entry that resolves and is
+        // not S_ISREG is reported through the non-regular diagnostic.
+        self.wire_to_flat_ndx(ndx)
+            .and_then(|flat| self.file_list.get(flat))
+            .is_none_or(protocol::flist::FileEntry::is_file)
     }
 
     fn begin_frame(&mut self) -> u64 {

--- a/crates/transfer/src/receiver/ndx_stream/tests.rs
+++ b/crates/transfer/src/receiver/ndx_stream/tests.rs
@@ -271,6 +271,12 @@ fn sender_drains_del_stats_and_receives_the_counters() {
             true
         }
 
+        fn ndx_is_regular_file(&self, _ndx: i32) -> bool {
+            // No file list here; the non-regular guard is exercised by the
+            // sinks that own one.
+            true
+        }
+
         fn begin_frame(&mut self) {}
 
         fn on_del_stats(&mut self, stats: &DeleteStats) -> io::Result<()> {
@@ -394,6 +400,12 @@ fn marker_rejected_by_sender_with_upstream_text() {
             true
         }
 
+        fn ndx_is_regular_file(&self, _ndx: i32) -> bool {
+            // No file list here; the non-regular guard is exercised by the
+            // sinks that own one.
+            true
+        }
+
         fn begin_frame(&mut self) {}
 
         fn on_del_stats(&mut self, _stats: &DeleteStats) -> io::Result<()> {
@@ -510,4 +522,98 @@ fn receiver_without_negotiated_inc_recurse_rejects_markers() {
     );
     assert!(err.to_string().contains("[receiver="), "message: {err}");
     assert!(ctx.file_list().is_empty(), "no segment may be absorbed");
+}
+
+/// An INC_RECURSE receiver whose file list holds one symlink (wire NDX 1) and
+/// one regular file (wire NDX 2).
+fn receiver_with_symlink_then_file() -> ReceiverContext {
+    let mut ctx = inc_recurse_receiver(&["d0"]);
+    ctx.file_list.push(FileEntry::new_symlink(
+        PathBuf::from("link"),
+        PathBuf::from("target"),
+    ));
+    ctx.file_list
+        .push(FileEntry::new_file(PathBuf::from("f.txt"), 1, 0o100644));
+    ctx
+}
+
+/// An `ITEM_TRANSFER` frame naming a non-regular entry is a hard protocol
+/// error with upstream's wording.
+///
+/// WHY: upstream `rsync.c:436-444` - once the attribute tail has decoded
+/// `ITEM_TRANSFER`, `i < 0 || !S_ISREG(cur_flist->files[i]->mode)` prints
+/// `received request to transfer non-regular file: %d [%s]` and aborts with
+/// `exit_cleanup(RERR_PROTOCOL)`. A reader that surfaced the frame instead
+/// would let a hostile sender steer the transfer machinery at a symlink or
+/// directory entry.
+#[test]
+fn item_transfer_frame_for_non_regular_entry_is_refused_with_upstream_wording() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_file_echo(&mut wire, &mut codec, 1, SenderAttrs::ITEM_TRANSFER);
+
+    let mut ctx = receiver_with_symlink_then_file();
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let err = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect_err("an ITEM_TRANSFER frame naming a symlink must be refused");
+    assert!(
+        err.to_string()
+            .starts_with("received request to transfer non-regular file: 1"),
+        "unexpected message: {err}"
+    );
+    assert!(
+        err.to_string().contains("[receiver="),
+        "the who_am_i() tag must name the receiver: {err}"
+    );
+    assert!(
+        err.get_ref()
+            .and_then(|e| e.downcast_ref::<protocol::ProtocolViolation>())
+            .is_some(),
+        "rejection must map to RERR_PROTOCOL, got {err:?}"
+    );
+}
+
+/// NON-VACUITY COMPANION: the same frame naming the REGULAR entry passes the
+/// guard and surfaces normally.
+#[test]
+fn item_transfer_frame_for_regular_entry_passes_the_guard() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_file_echo(&mut wire, &mut codec, 2, SenderAttrs::ITEM_TRANSFER);
+
+    let mut ctx = receiver_with_symlink_then_file();
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let (ndx, attrs) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect("a regular-file frame decodes")
+        .expect("a per-file index, not NDX_DONE");
+    assert_eq!(ndx, 2);
+    assert_eq!(attrs.iflags, SenderAttrs::ITEM_TRANSFER);
+}
+
+/// The guard is gated on `ITEM_TRANSFER`: an itemize-only frame naming the
+/// symlink is NOT refused.
+///
+/// WHY: upstream's `rsync.c:436` predicate is `iflags & ITEM_TRANSFER`.
+/// Non-transfer echoes legitimately name directories and symlinks (attribute
+/// rows, hardlink followers); refusing them would abort every `-i` run over a
+/// tree with non-regular entries.
+#[test]
+fn non_transfer_frame_for_non_regular_entry_is_not_refused() {
+    let mut wire = Vec::new();
+    let mut codec = create_ndx_codec(PROTOCOL);
+    push_file_echo(&mut wire, &mut codec, 1, 0);
+
+    let mut ctx = receiver_with_symlink_then_file();
+    let mut reader = Cursor::new(wire);
+    let mut read_codec = create_ndx_codec(PROTOCOL);
+
+    let (ndx, attrs) = read_ndx_and_attrs(&mut reader, &mut read_codec, &mut ctx, false, false)
+        .expect("an itemize-only frame naming a symlink decodes")
+        .expect("a per-file index, not NDX_DONE");
+    assert_eq!(ndx, 1);
+    assert_eq!(attrs.iflags, 0);
 }

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -803,9 +803,25 @@ mod tests {
         names: &[&str],
         cleared_ndx: Option<usize>,
     ) -> crate::receiver::ReceiverContext {
+        use protocol::flist::FileEntry;
+
+        let mut entries: Vec<FileEntry> = names
+            .iter()
+            .map(|name| FileEntry::new_file(std::path::PathBuf::from(*name), 0, 0o100644))
+            .collect();
+        if let Some(ndx) = cleared_ndx {
+            entries[ndx].tombstone();
+        }
+        receiver_with_entries(entries)
+    }
+
+    /// Builds a protocol-31 receiver over an arbitrary pre-built file list, for
+    /// fixtures that need non-regular entry modes.
+    fn receiver_with_entries(
+        entries: Vec<protocol::flist::FileEntry>,
+    ) -> crate::receiver::ReceiverContext {
         use crate::config::ServerConfig;
         use crate::handshake::HandshakeResult;
-        use protocol::flist::FileEntry;
 
         let protocol = ProtocolVersion::from_supported(31).expect("31 is supported");
         let handshake = HandshakeResult {
@@ -825,30 +841,28 @@ mod tests {
             args: vec![std::ffi::OsString::from(".")],
             ..Default::default()
         };
-        let mut entries: Vec<FileEntry> = names
-            .iter()
-            .map(|name| FileEntry::new_file(std::path::PathBuf::from(*name), 0, 0o100644))
-            .collect();
-        if let Some(ndx) = cleared_ndx {
-            entries[ndx].tombstone();
-        }
         let mut ctx = crate::receiver::ReceiverContext::new_for_test(&handshake, config);
         ctx.set_file_list_for_test(entries);
         ctx
     }
 
-    /// Encodes one per-file echo (NDX + iflags + an all-zero `sum_head`) as the
-    /// sender writes it, so `read_response_header` reads a complete frame.
-    fn echo_bytes(ndx: i32) -> Vec<u8> {
+    /// Encodes one per-file echo (NDX + `iflags` + an all-zero `sum_head`) as
+    /// the sender writes it, so `read_response_header` reads a complete frame.
+    fn echo_bytes_with_iflags(ndx: i32, iflags: u16) -> Vec<u8> {
         use protocol::codec::{MonotonicNdxWriter, NdxCodec};
         let mut wire = Vec::new();
         let mut codec = MonotonicNdxWriter::new(31);
         codec.write_ndx(&mut wire, ndx).expect("ndx encodes");
-        wire.extend_from_slice(&0x8000_u16.to_le_bytes());
+        wire.extend_from_slice(&iflags.to_le_bytes());
         crate::receiver::SumHead::new(0, 0, 0, 0)
             .write(&mut wire)
             .expect("sum_head encodes");
         wire
+    }
+
+    /// [`echo_bytes_with_iflags`] carrying `ITEM_TRANSFER`, the common case.
+    fn echo_bytes(ndx: i32) -> Vec<u8> {
+        echo_bytes_with_iflags(ndx, SenderAttrs::ITEM_TRANSFER)
     }
 
     /// Drives `read_response_header` over `wire` with `expected_ndx` outstanding.
@@ -891,11 +905,18 @@ mod tests {
     /// point: it isolates the new guard from the pre-existing ordering check, so
     /// a pass cannot be produced by the wrong error.
     ///
+    /// The frame deliberately carries NO `ITEM_TRANSFER`: a cleared slot's
+    /// zeroed mode is not `S_ISREG`, so an ITEM_TRANSFER frame naming it is
+    /// refused earlier, by `read_ndx_and_attrs()`'s non-regular guard
+    /// (`rsync.c:436-444`) - exactly as upstream, where that guard runs before
+    /// `recv_files()` ever tests `F_IS_ACTIVE`. The cleared-entry diagnostic
+    /// therefore owns the non-transfer frames.
+    ///
     /// upstream: receiver.c:871-881 - `recv_files()` `!F_IS_ACTIVE(file)`.
     #[test]
     fn cleared_file_index_is_refused_with_upstream_wording() {
         let mut receiver = receiver_with_file_list(&["a.txt", "dup.txt"], Some(1));
-        let Err(err) = read_header_for(&mut receiver, echo_bytes(1), 1) else {
+        let Err(err) = read_header_for(&mut receiver, echo_bytes_with_iflags(1, 0), 1) else {
             panic!("a cleared slot must be refused");
         };
         assert!(
@@ -903,6 +924,79 @@ mod tests {
                 .contains("refusing transfer of cleared file index 1"),
             "unexpected diagnostic: {err}"
         );
+    }
+
+    /// An ITEM_TRANSFER frame naming the same cleared slot is refused by the
+    /// EARLIER guard, with the non-regular diagnostic.
+    ///
+    /// upstream ordering: `read_ndx_and_attrs()`'s `rsync.c:436-444` guard runs
+    /// inside the attrs read, before `recv_files()`'s `F_IS_ACTIVE` test - and a
+    /// cleared slot's zeroed mode fails `S_ISREG`. Pinning the ordering keeps
+    /// the two refusals from swapping owners.
+    #[test]
+    fn cleared_slot_under_item_transfer_reports_the_non_regular_guard() {
+        let mut receiver = receiver_with_file_list(&["a.txt", "dup.txt"], Some(1));
+        let Err(err) = read_header_for(&mut receiver, echo_bytes(1), 1) else {
+            panic!("a cleared slot under ITEM_TRANSFER must be refused");
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("received request to transfer non-regular file: 1"),
+            "unexpected diagnostic: {text}"
+        );
+        assert!(
+            !text.contains("cleared file index"),
+            "the earlier guard owns the ITEM_TRANSFER frame: {text}"
+        );
+    }
+
+    /// A sender that echoes ITEM_TRANSFER for an entry whose mode is not
+    /// `S_IFREG` is refused with upstream's diagnostic, even though the echo
+    /// arrives in the expected order.
+    ///
+    /// upstream: rsync.c:436-444 - `read_ndx_and_attrs()` refuses
+    /// `!S_ISREG(cur_flist->files[i]->mode)` under `ITEM_TRANSFER` with
+    /// `received request to transfer non-regular file: %d [%s]` and
+    /// `exit_cleanup(RERR_PROTOCOL)`, on the receiving end of the echo as much
+    /// as on the sender's request read. Keeping `echoed_ndx == expected_ndx`
+    /// isolates the guard from the pre-existing ordering check, so a pass
+    /// cannot be produced by the wrong error.
+    #[test]
+    fn non_regular_transfer_echo_is_refused_with_upstream_wording() {
+        use protocol::flist::FileEntry;
+        let mut receiver = receiver_with_entries(vec![
+            FileEntry::new_file(std::path::PathBuf::from("a.txt"), 0, 0o100644),
+            FileEntry::new_symlink(
+                std::path::PathBuf::from("link"),
+                std::path::PathBuf::from("a.txt"),
+            ),
+        ]);
+        let Err(err) = read_header_for(&mut receiver, echo_bytes(1), 1) else {
+            panic!("a non-regular ITEM_TRANSFER echo must be refused");
+        };
+        let text = err.to_string();
+        assert!(
+            text.contains("received request to transfer non-regular file: 1"),
+            "unexpected diagnostic: {text}"
+        );
+        assert!(
+            text.contains("[receiver="),
+            "the who_am_i() tag must name the receiver: {text}"
+        );
+        assert!(
+            err.get_ref()
+                .is_some_and(|e| e.is::<protocol::ProtocolViolation>()),
+            "the refusal must map to RERR_PROTOCOL"
+        );
+    }
+
+    /// NON-VACUITY COMPANION: the same echo for a REGULAR entry passes the
+    /// non-regular guard and yields a parsed response header.
+    #[test]
+    fn regular_file_echo_passes_the_non_regular_guard() {
+        let mut receiver = receiver_with_file_list(&["a.txt", "b.txt"], None);
+        read_header_for(&mut receiver, echo_bytes(0), 0)
+            .expect("a regular-file echo must not trip the non-regular guard");
     }
 
     /// NON-VACUITY COMPANION: a LIVE entry echoed out of order still produces the


### PR DESCRIPTION
## What

Upstream refuses an `ITEM_TRANSFER` frame that does not name a regular file, on BOTH ends that read a request/echo: rsync.c:436-444 — `if (iflags & ITEM_TRANSFER)` with `i < 0 || !S_ISREG(cur_flist->files[i]->mode)` prints `received request to transfer non-regular file: %d [%s]` (:439-441) and exits `RERR_PROTOCOL` (:442). oc had NO read-side analogue: the only look-alike was the REQUESTING side's polite `is_file()` skip in the generator, which cannot defend against a peer's frame, and the ndx_stream module doc claimed the guard "stays with its current owner" while no read-side owner existed (and cited drifted lines :420-428). Severity was capped by open-time defences (O_NOFOLLOW + post-open fstat/IS_DEVICE), so this is defence-in-depth plus diagnostic parity — the guard now refuses at protocol time, where upstream does.

## Placement

Hybrid single-owner. The sender's request read never routes through the shared NDX primitive (it open-codes NDX+iflags in `run_transfer_loop`), so a purely in-primitive guard could cover only one of the two sites without a wide signature refactor. Instead:

- ONE diagnostic owner: `ndx_stream::non_regular_transfer_request(ndx, role)` — upstream wording + oc's location/role-trailer convention, protocol-violation-tagged so the exit-code mapper yields RERR_PROTOCOL (2), same as sibling gates.
- Receiver side: the predicate lives inside `read_ndx_and_attrs` via a new non-defaulted `FlistMarkerSink::ndx_is_regular_file` (mirroring `ndx_is_active`, so a future sink cannot silently carry the guard past a list it owns). Resolution reuses the existing resolvers only (`wire_to_flat_ndx` / `NdxMap`) — no third NDX->entry resolver.
- Sender side: a 9-line guard at its own attrs read, calling the shared diagnostic.

The `:913` requester-side skip is untouched (now unreachable for ITEM_TRANSFER frames, matching upstream where send_files never sees such a frame). The module doc's misleading line and the drifted citation are fixed in the same commit.

## Overlap with existing gates, stated precisely

#7365 (negative NDX) and #7630 (overflow) fire BEFORE upstream's guard would — zero overlap. Upstream's `i < 0` residual is the INC_RECURSE gap NDX, which oc's `resolve_itemize_ndx` maps to the owning DIRECTORY, so the S_ISREG half refuses it exactly where upstream refuses `i < 0`. Past-end indexes stay with `validate_file_index` / the echo-ordering check; this guard never claims range faults — a sink that cannot resolve an entry reports regular and defers to the owners of range faults rather than mislabeling them with the non-regular diagnostic. The NEW substance is the S_ISREG check on both sites.

## One behavioural ordering fix

An ITEM_TRANSFER frame naming a CLEARED slot is now refused by this guard (a zeroed mode fails S_ISREG) — faithful to upstream, where :436-444 runs before recv_files' `F_IS_ACTIVE` check (receiver.c:871-881). The existing cleared-entry test moved to a non-transfer frame (which the cleared diagnostic genuinely owns) and a new test pins the ordering.

## Tests + mutations (measured)

Nine new tests across the primitive, the receiver wiring witness, and the sender site — each refusal test paired with a regular-entry non-vacuity companion. Mutation A (primitive guard disabled): exactly the 3 primitive-site refusal tests fail, 16 siblings green. Mutation B (sender guard disabled): exactly the 2 sender refusal tests fail, 17 green. Both reverted.

## Scoped out

`receiver/transfer/sync.rs:264` and three `pipeline.rs` echo drains read via `SenderAttrs::read_with_codec_xattr`, bypassing the primitive — outside the two sites this change targets (flagged; sync.rs's `run_sync` is the known-unreachable staged path). oc deliberately keeps reclaimed INC_RECURSE segments indexable (NdxMap totality), so upstream's freed-flist abort for a stale-but-in-range index has no direct analogue here.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p transfer --all-targets -D warnings` clean, `nextest -p transfer --lib` 2494/2494.
