### PR TITLE
fix(metadata): apply the new-file dest_mode rule when the pre-transfer destination is not a regular file

### DIFF
--- a/crates/engine/src/local_copy/tests/execute_basic.rs
+++ b/crates/engine/src/local_copy/tests/execute_basic.rs
@@ -1089,6 +1089,93 @@ fn execute_does_not_preserve_permissions_by_default() {
     );
 }
 
+// upstream: generator.c:2148-2153 deletes a non-regular obstacle and sets
+// statret = -1, and receiver.c:1176-1191 opens the basis O_NOFOLLOW and drops
+// any non-regular fd, so a symlink obstacle takes the exists == 0 dest_mode()
+// rule: the new file lands `source_mode & ~umask`, never the symlink's own
+// lstat mode (0o755/0o777 depending on platform).
+#[cfg(unix)]
+#[test]
+fn execute_symlink_obstacle_takes_new_file_mode_without_perms() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = create_tempdir();
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    let target = temp.path().join("target.txt");
+
+    fs::write(&source, b"fresh").expect("write source");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).expect("set source perms");
+    fs::write(&target, b"unrelated").expect("write target");
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).expect("set target perms");
+    std::os::unix::fs::symlink(&target, &destination).expect("create obstacle symlink");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(LocalCopyExecution::Apply, LocalCopyOptions::default())
+        .expect("copy succeeds");
+    assert_eq!(summary.files_copied(), 1);
+
+    let dest_meta = fs::symlink_metadata(&destination).expect("dest metadata");
+    assert!(
+        dest_meta.file_type().is_file(),
+        "the symlink obstacle must be replaced by a regular file"
+    );
+    assert_eq!(
+        dest_meta.permissions().mode() & 0o7777,
+        ::test_support::umask_masked(0o644),
+        "a symlink obstacle must not donate its lstat mode to the new file"
+    );
+
+    // The symlink was replaced, not followed: its target keeps mode and content.
+    let target_meta = fs::metadata(&target).expect("target metadata");
+    assert_eq!(target_meta.permissions().mode() & 0o7777, 0o755);
+    assert_eq!(fs::read(&target).expect("read target"), b"unrelated");
+}
+
+// Non-vacuity companion: with --perms the same obstacle yields the exact
+// source mode, proving the fixture reaches the transfer path and that the
+// no-perms pin above is asserting the dest_mode() rule rather than a mode
+// both arms would produce.
+#[cfg(unix)]
+#[test]
+fn execute_symlink_obstacle_takes_source_mode_with_perms() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = create_tempdir();
+    let source = temp.path().join("source.txt");
+    let destination = temp.path().join("dest.txt");
+    let target = temp.path().join("target.txt");
+
+    fs::write(&source, b"fresh").expect("write source");
+    fs::set_permissions(&source, fs::Permissions::from_mode(0o707)).expect("set source perms");
+    fs::write(&target, b"unrelated").expect("write target");
+    std::os::unix::fs::symlink(&target, &destination).expect("create obstacle symlink");
+
+    let operands = vec![
+        source.into_os_string(),
+        destination.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().permissions(true),
+        )
+        .expect("copy succeeds");
+    assert_eq!(summary.files_copied(), 1);
+
+    let dest_meta = fs::symlink_metadata(&destination).expect("dest metadata");
+    assert!(dest_meta.file_type().is_file());
+    assert_eq!(dest_meta.permissions().mode() & 0o7777, 0o707);
+}
+
 #[cfg(unix)]
 #[test]
 fn execute_preserves_executable_bit() {

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -262,6 +262,12 @@ pub fn apply_dest_mode_pre_transfer(
     }
 
     let source_mode = source_metadata.permissions().mode();
+    // upstream: receiver.c:1176-1191 - the basis file is opened with O_NOFOLLOW
+    // and the fd is dropped again unless it is a regular file, so a symlink /
+    // fifo / device obstacle leaves `exists = fd1 != -1` false and the incoming
+    // file takes the new-destination rule (its lstat mode - 0o755 for a symlink
+    // on some platforms - must never become the file's permissions).
+    let pre_transfer_meta = pre_transfer_meta.filter(|existing| existing.file_type().is_file());
     let base_mode = if let Some(existing) = pre_transfer_meta {
         // Existing destination: keep its prior permission bits.
         let stat_mode = existing.permissions().mode();


### PR DESCRIPTION
## What

Replacing a destination SYMLINK with a regular file without `--perms` gave the new file the symlink's own lstat mode (0o755 on macOS, 0o777 on Linux) instead of the source-derived mode. Measured 12-cell obstacle x flags matrix vs the real 3.5.0 binary (umask 022): fresh-dest and `-a` cells all match; both symlink-obstacle `-r` cells diverge (oc 755, upstream 644). Post-fix the whole matrix matches on the in-scope cells.

## Upstream rule

Upstream never lets a non-regular obstacle's mode reach `dest_mode()`:

- generator.c:2148-2153 — a non-regular obstacle is deleted and the entry proceeds with `statret = -1` (missing).
- receiver.c:1176-1191 — the basis is opened `O_NOFOLLOW` and the fd is dropped unless it is a regular file, so `exists = fd1 != -1` is false and `dest_mode()` (rsync.c:470-484) takes the new-destination arm: `flist_mode & (~CHMOD_BITS | dflt_perms)`.

oc's `apply_dest_mode_pre_transfer` (crates/metadata/src/apply/permissions.rs) received the raw `symlink_metadata` of the obstacle and took the "existing destination: keep prior permission bits" branch with the symlink's lstat mode.

## Fix

Filter `pre_transfer_meta` down to regular files before the exists split — one line mirroring receiver.c's fd-drop, with the citation at the site. Filtering at the capture site was deliberately rejected: `existing_metadata` also feeds `--update`/`--ignore-existing`/backup decisions, which upstream keys on the raw lstat. Directory obstacles were already cleared to `None` upstream-faithfully at the capture site.

## Tests + mutation (measured)

- `execute_symlink_obstacle_takes_new_file_mode_without_perms` — discriminating pin: symlink obstacle to a 755 target, no `--perms` -> umask-masked 0o644; symlink replaced, target untouched.
- `execute_symlink_obstacle_takes_source_mode_with_perms` — non-vacuity companion: same obstacle + `--perms` -> exact 0o707.

Mutation (filter line removed): exactly the new pin fails (0o755 vs 0o644), companion + existing fresh-dest control stay green (3 run: 2 passed, 1 failed). Reverted.

## Scoped out (found while measuring, filed separately)

- Existing regular file 600 + `-r --chmod=F604` (no `--perms`): oc 604, upstream 600 — upstream's `dest_mode()` exists-branch discards `--chmod` permission bits for existing files; separate root cause in the chmod early-return.
- Whether the network-receiver analogue `dest_mode_for_existing_or_new` receives the same unfiltered non-regular `pre_transfer_meta` is unverified.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p engine`/`-p metadata --all-targets -D warnings` clean, `nextest -p engine --lib` 4748 passed / 23 skipped, `-p metadata --lib` 467 passed.
