### PR TITLE
fix(daemon): resolve filter side modifiers at add time and keep the recheck on the client's rules

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -738,27 +738,50 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         });
     }
 
-    // upstream: exclude.c:1134-1178 - keyword-to-short-form mapping.
-    // (keyword, is_include, sender_side, receiver_side)
-    const KEYWORDS: &[(&str, bool, bool, bool)] = &[
-        ("exclude", false, false, false),
-        ("include", true, false, false),
-        ("hide", false, true, false),    // sender-side exclude
-        ("show", true, true, false),     // sender-side include
-        ("protect", false, false, true), // receiver-side exclude
-        ("risk", true, false, true),     // receiver-side include
+    // upstream: exclude.c:1134-1178 - keyword-to-short-form mapping;
+    // `hide`/`show` set FILTRULE_SENDER_SIDE (exclude.c:1345-1350),
+    // `protect`/`risk` FILTRULE_RECEIVER_SIDE (exclude.c:1351-1357).
+    // (keyword, is_include, sender_side)
+    const KEYWORDS: &[(&str, bool, bool)] = &[
+        ("exclude", false, false),
+        ("include", true, false),
+        ("hide", false, true),
+        ("show", true, true),
+        ("protect", false, false), // receiver-side upstream; see the drop below
+        ("risk", true, false),     // receiver-side upstream; see the drop below
     ];
 
-    for &(keyword, is_include, sender, receiver) in KEYWORDS {
+    for &(keyword, is_include, sender_side) in KEYWORDS {
         if let Some(pattern) = strip_keyword_prefix(token, keyword) {
             let pattern = pattern.trim();
             if pattern.is_empty() {
                 return Ok(None);
             }
-            let mut rule = build_pattern_rule(pattern, is_include);
-            rule.sender_side = sender;
-            rule.receiver_side = receiver;
-            return Ok(Some(rule));
+            // The side test happens HERE, at add time, never at match time.
+            // upstream: `add_rule` drops a rule whose side flags equal
+            // `am_sender ? FILTRULE_RECEIVER_SIDE : FILTRULE_SENDER_SIDE` when
+            // the parse passes XFLG_ANCHORED2ABS/XFLG_ABS_IF_SLASH
+            // (exclude.c:279-285), and every daemon module directive passes
+            // XFLG_ABS_IF_SLASH (clientserver.c:933-952). Those directives
+            // parse before `parse_arguments` runs (clientserver.c:933 vs
+            // :1160), so `am_sender` is still its static 0 (options.c:97)
+            // WHATEVER role the transfer later takes: `hide`/`show` are
+            // dropped, `protect`/`risk` are kept.
+            //
+            // The kept rules then match SIDE-BLIND. The only match-time side
+            // mechanism upstream has is `elide` (exclude.c:1010), and it is
+            // armed exclusively by `send_rules` (exclude.c:1912) - the daemon
+            // list is never transmitted, so its rules keep `elide = 0`
+            // (exclude.c:324) forever. A kept `protect` therefore hides files
+            // from a pulling client and refuses incoming writes alike, which
+            // is why no side flag goes on the wire rule here: copying the
+            // receiver-side bit made the match-time DecisionContext test skip
+            // the rule wherever the role disagreed, serving what upstream
+            // hides.
+            if sender_side {
+                return Ok(None);
+            }
+            return Ok(Some(build_pattern_rule(pattern, is_include)));
         }
     }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2591,15 +2591,17 @@ mod module_access_tests {
             ..Default::default()
         });
         let rules = build_daemon_filter_rules(&module).unwrap();
-        assert_eq!(rules.len(), 2);
-        assert_eq!(rules[0].pattern, "*.log");
+        // Mis-routed through the old-prefix stripper, BOTH lines would survive
+        // as literal excludes of `hide *.log` / `protect secret`. Parsed as
+        // keywords, `hide` is dropped at add time (exclude.c:279-285 with
+        // am_sender still 0) and `protect` is kept side-blind.
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].pattern, "secret");
         assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
-        assert!(rules[0].sender_side, "hide must be sender-side");
-        assert!(!rules[0].receiver_side);
-        assert_eq!(rules[1].pattern, "secret");
-        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Exclude);
-        assert!(rules[1].receiver_side, "protect must be receiver-side");
-        assert!(!rules[1].sender_side);
+        assert!(
+            !rules[0].sender_side && !rules[0].receiver_side,
+            "a kept daemon rule matches side-blind"
+        );
     }
 
     /// A token left empty by the strip is upstream's fatal syntax error.
@@ -2890,44 +2892,53 @@ mod module_access_tests {
         assert_eq!(rule.pattern, "*.rs");
     }
 
+    /// `hide`/`show` are dropped when the daemon list is BUILT, not kept for a
+    /// match-time side test: `add_rule` frees a sender-side rule under
+    /// XFLG_ABS_IF_SLASH with `am_sender` still 0 (exclude.c:279-285;
+    /// clientserver.c:933 parses the directives 227 lines before
+    /// parse_arguments at :1160 can set `am_sender`).
+    ///
+    /// MEASURED against rsync 3.5.0: `filter = hide bar` on a module holding
+    /// `bar` + `keep` serves BOTH files upstream; oc served only `keep` while
+    /// it kept the rule and applied it at match time.
     #[test]
-    fn parse_daemon_filter_token_hide_keyword() {
-        // upstream: hide -> sender-side exclude
-        let rule = accepted_rule("hide *.secret");
-        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
-        assert_eq!(rule.pattern, "*.secret");
-        assert!(rule.sender_side);
-        assert!(!rule.receiver_side);
+    fn parse_daemon_filter_token_hide_keyword_dropped_at_add_time() {
+        assert!(is_skipped("hide *.secret"));
     }
 
     #[test]
-    fn parse_daemon_filter_token_show_keyword() {
-        // upstream: show -> sender-side include
-        let rule = accepted_rule("show *.pub");
-        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
-        assert_eq!(rule.pattern, "*.pub");
-        assert!(rule.sender_side);
-        assert!(!rule.receiver_side);
+    fn parse_daemon_filter_token_show_keyword_dropped_at_add_time() {
+        assert!(is_skipped("show *.pub"));
     }
 
+    /// `protect`/`risk` are KEPT and side-BLIND. upstream keeps a
+    /// receiver-side rule at add time (exclude.c:279-285 drops only the
+    /// sender side) and never side-tests the daemon list at match time - the
+    /// only match-time side mechanism, `elide` (exclude.c:1010), is armed
+    /// exclusively by `send_rules` (exclude.c:1912) and the daemon list is
+    /// never transmitted.
+    ///
+    /// MEASURED against rsync 3.5.0: `filter = protect bar` HIDES `bar` from
+    /// a pulling client's listing - a receiver-side rule enforced while the
+    /// daemon is the SENDER. Copying the receiver-side bit onto the wire rule
+    /// made oc's match-time DecisionContext skip it there and serve the file
+    /// the operator wrote the rule to protect.
     #[test]
-    fn parse_daemon_filter_token_protect_keyword() {
-        // upstream: protect -> receiver-side exclude
+    fn parse_daemon_filter_token_protect_keyword_is_side_blind() {
         let rule = accepted_rule("protect *.conf");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.conf");
         assert!(!rule.sender_side);
-        assert!(rule.receiver_side);
+        assert!(!rule.receiver_side);
     }
 
     #[test]
-    fn parse_daemon_filter_token_risk_keyword() {
-        // upstream: risk -> receiver-side include
+    fn parse_daemon_filter_token_risk_keyword_is_side_blind() {
         let rule = accepted_rule("risk *.tmp");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.tmp");
         assert!(!rule.sender_side);
-        assert!(rule.receiver_side);
+        assert!(!rule.receiver_side);
     }
 
     #[test]

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -124,6 +124,22 @@ pub struct ReceiverContext {
     /// - `flist.c:266-284` - `path_is_daemon_excluded()` checks each path
     ///   component against the daemon filter list
     pub(in crate::receiver) daemon_filter_set: Option<FilterSet>,
+    /// Client-only view of the wire filter rules for the file-list re-check.
+    ///
+    /// `Some` only on a server-receiver whose `filter_chain` had daemon rules
+    /// prepended: the re-check must evaluate the CLIENT's rules alone, so the
+    /// view is compiled from the wire list before the merge. `None` means the
+    /// chain carries nothing but the client's own rules and the re-check may
+    /// read it directly.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1019-1024` - `check_server_filter(&filter_list, ...)`
+    ///   consults only the client-transferred list; `daemon_filter_list` is
+    ///   enforced by its own consumers (`generator.c:1662-1670` per-file
+    ///   refusal, `exclude.c:1111` deletion, the option screens) and never
+    ///   aborts the session here.
+    pub(in crate::receiver) recheck_client_filter: Option<FilterSet>,
     /// Per-directory scoped filter chain for deletion protection.
     ///
     /// Used by `delete_extraneous_files()` to check `allows_deletion()` before
@@ -498,6 +514,7 @@ impl ReceiverContext {
             uid_list: IdList::new(),
             gid_list: IdList::new(),
             daemon_filter_set,
+            recheck_client_filter: None,
             filter_chain: FilterChain::empty(),
             deletion_filter_chain: FilterChain::empty(),
             hardlink_tracker,

--- a/crates/transfer/src/receiver/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/file_list/filter_recheck.rs
@@ -87,7 +87,16 @@ impl ReceiverContext {
             if self.filter_chain.has_per_dir_merge() {
                 return Ok(());
             }
-            self.filter_chain.global()
+            // upstream: flist.c:1022 - `check_server_filter(&filter_list, ...)`
+            // consults the CLIENT's rules only. A server-receiver whose chain
+            // had daemon rules prepended re-checks against the client-only
+            // view captured before that merge; the daemon rules keep their own
+            // per-file refusal (`ERROR: daemon refused to receive file`,
+            // generator.c:1662-1670) instead of aborting the session here.
+            match &self.recheck_client_filter {
+                Some(client_set) => client_set,
+                None => self.filter_chain.global(),
+            }
         } else if self.config.connection.client_mode
             && !self.config.connection.filter_rules.is_empty()
         {

--- a/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
+++ b/crates/transfer/src/receiver/tests/file_list/filter_recheck.rs
@@ -225,6 +225,82 @@ fn directory_only_wire_rule_still_rejects_a_smuggled_directory() {
 }
 
 #[test]
+fn daemon_rules_merged_into_the_chain_are_screened_out_of_the_recheck() {
+    // upstream: flist.c:1022 - `check_server_filter(&filter_list, ...)` runs
+    // the CLIENT's rules only; `daemon_filter_list` never joins that list. oc
+    // prepends the daemon rules to `filter_chain`, so the re-check must use
+    // the client-only view captured before the merge.
+    //
+    // MEASURED against rsync 3.5.0 (task 1167, p-risk-protect): a module with
+    // `filter = risk bar protect *` receiving a push of `src1` refuses that
+    // one file (`ERROR: daemon refused to receive file "src1"`, exit 23).
+    // Re-checking the merged chain instead aborted the whole session with
+    // RERR_UNSUPPORTED (exit 4) and skipped the deletion pass.
+    use protocol::filters::RuleType;
+
+    let mut config = test_config();
+    config.daemon_filter_rules = vec![
+        FilterRuleWireFormat {
+            rule_type: RuleType::Include,
+            pattern: "bar".into(),
+            ..FilterRuleWireFormat::default()
+        },
+        FilterRuleWireFormat {
+            rule_type: RuleType::Exclude,
+            pattern: "*".into(),
+            ..FilterRuleWireFormat::default()
+        },
+    ];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.apply_received_filter_rules(Vec::new())
+        .expect("daemon-only rules compile");
+    assert!(
+        !ctx.filter_chain.is_empty(),
+        "fixture must exercise the merged-chain branch, or the pin is vacuous"
+    );
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("src1".into(), 10, 0o644));
+
+    ctx.recheck_received_filter().expect(
+        "a daemon rule must not reject a received name here - its refusal is \
+         the per-file `daemon refused to receive file` check, not a session abort",
+    );
+}
+
+#[test]
+fn client_rules_still_reject_alongside_daemon_rules() {
+    // Non-vacuity companion: the client-only view is a real rule set, not a
+    // disabled re-check. With daemon rules present AND a client exclude, a
+    // smuggled client-excluded name still aborts.
+    use protocol::filters::RuleType;
+
+    let mut config = test_config();
+    config.daemon_filter_rules = vec![FilterRuleWireFormat {
+        rule_type: RuleType::Exclude,
+        pattern: "keepout".into(),
+        ..FilterRuleWireFormat::default()
+    }];
+    let mut ctx = ReceiverContext::new_for_test(&test_handshake(), config);
+    ctx.apply_received_filter_rules(vec![FilterRuleWireFormat::exclude("*.log".to_owned())])
+        .expect("combined rules compile");
+
+    ctx.file_list
+        .push(FileEntry::new_directory(".".into(), 0o755));
+    ctx.file_list
+        .push(FileEntry::new_file("debug.log".into(), 20, 0o644));
+
+    let err = ctx.recheck_received_filter().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    assert_eq!(
+        err.to_string(),
+        "ERROR: rejecting excluded file-list name: debug.log"
+    );
+}
+
+#[test]
 fn transfer_root_never_rejected() {
     // upstream: flist.c:1019 - the transfer root (`.`) is exempt from the
     // re-check even when a catch-all exclude would otherwise match it.

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -846,11 +846,27 @@ impl ReceiverContext {
     ///
     /// upstream: clientserver.c:rsync_module() - daemon_filter_list is applied
     /// on top of client filters. Daemon rules take precedence (prepended).
-    fn apply_received_filter_rules(
+    pub(in crate::receiver) fn apply_received_filter_rules(
         &mut self,
         wire_rules: Vec<FilterRuleWireFormat>,
     ) -> io::Result<()> {
         let daemon_rules = &self.config.daemon_filter_rules;
+        // upstream: flist.c:1019-1024 - the received-name re-check runs
+        // `check_server_filter(&filter_list, ...)` against the CLIENT's rules
+        // only; `daemon_filter_list` never joins that list and is enforced by
+        // its own consumers (`generator.c:1662-1670` refuses the one file at
+        // FERROR_XFER, `exclude.c:1111` screens deletions). oc prepends the
+        // daemon rules to the same chain, so the re-check's client-only view
+        // must be captured BEFORE the merge - re-checking the merged chain
+        // aborted the whole session with RERR_UNSUPPORTED for any pushed name
+        // a daemon rule excludes, where upstream refuses that file alone and
+        // exits 23.
+        self.recheck_client_filter = if daemon_rules.is_empty() {
+            None
+        } else {
+            let (client_set, _merge_configs) = parse_wire_filters_for_receiver(&wire_rules)?;
+            Some(client_set)
+        };
         let combined = if daemon_rules.is_empty() {
             wire_rules
         } else if wire_rules.is_empty() {


### PR DESCRIPTION
## What

Daemon filter side modifiers (`hide`/`show`/`protect`/`risk`) were resolved at MATCH time against the transfer's actual role, where upstream resolves them at ADD time against `am_sender == 0`. Two consequences, both measured end-to-end against a real 3.5.0 client with only the daemon varying:

- **Disclosure**: `filter = protect bar` served `bar` to a pulling client (upstream hides it) — the match-time side test skipped the rule because the daemon was the sender.
- **Unauthorized write**: a push into a module whose `risk`/`protect` pair excludes the incoming name SUCCEEDED (rc 0) where upstream refuses per-file (`ERROR: daemon refused to receive file "src1"`, rc 23).

12-cell matrix (list-only x push, 6 rule shapes each): oc-master diverges on 5 cells; oc-fix matches upstream on all 12, byte-identical refusal text on the push-refusal cell.

## Upstream rule (cited at the sites)

- `add_rule` drops a rule whose side flags equal `am_sender ? FILTRULE_RECEIVER_SIDE : FILTRULE_SENDER_SIDE` under XFLG_ABS_IF_SLASH (exclude.c:279-285); every daemon module directive passes XFLG_ABS_IF_SLASH (clientserver.c:933-952) and parses before `parse_arguments` (:933 vs :1160), so `am_sender` is still its static 0 whatever role the transfer later takes: `hide`/`show` are dropped, `protect`/`risk` kept.
- The kept rules then match SIDE-BLIND: upstream's only match-time side mechanism is `elide` (exclude.c:1010), armed exclusively by `send_rules` (exclude.c:1912) — the daemon list is never transmitted, so its rules keep `elide = 0` forever.

## Two oc sites

1. `module_access/helpers.rs` — the sole producer of side flags on the daemon path copied all four sides onto the wire rule, deferring the decision to the match-time DecisionContext. Now: `hide`/`show` dropped at add time, `protect`/`risk` built side-blind.
2. A LATENT recheck bug this unmasked: the receiver's file-list re-check read the merged chain (client + prepended daemon rules), so a side-blind daemon exclude turned upstream's per-file refusal into a whole-session RERR_UNSUPPORTED abort. Upstream's `check_server_filter` (flist.c:1019-1024) consults the CLIENT list only; the daemon list is enforced by its own consumers (generator.c:1662-1670 per-file refusal, exclude.c:1111 deletion, the option screens). New `recheck_client_filter` captures the client-only view before the merge; the deletion chain and `daemon_filter_set` consumers are untouched.

## Behaviour change worth calling out

A push into a module whose filter excludes the incoming name now exits 23 with upstream's per-file refusal instead of accepting the write — oc previously honoured neither the hide nor the refusal on that shape.

## Tests + mutations (measured)

Five daemon parser pins (`*_dropped_at_add_time`, `*_is_side_blind`, plus the updated prefix-stripper pin) and a transfer recheck pin (`daemon_rules_merged_into_the_chain_are_screened_out_of_the_recheck`) with its non-vacuity companion (`client_rules_still_reject_alongside_daemon_rules`). Mutation A (restore match-time sides): exactly the 5 daemon pins fail, 10 siblings green. Mutation B (recheck reads the merged chain): exactly the recheck pin fails, companion green. Both reverted.

## Testsuite

Local daemon TCP leg (`USE_TCP=yes DAEMON_TESTS_ONLY=yes`) against the fix: 116 pass / 4 fail / 35 skip, identical to the committed macOS nonroot manifest — the 4 fails are the pre-existing proto-* rows. No expect-manifest row flipped; none edited.

## Scoped out

The report-only short forms (`P bar`, `S bar H *`) remain divergent on both arms — oc tokenizes them as inert bare patterns; that is the task-1166 bare-word refusal class, untouched here. One 1166 comma-form cell moved wrong-to-differently-wrong (`- foo hide,keep`: was serve-nothing, now serves `keep`; upstream refuses) — still a refusal-class row, not this mechanism.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p daemon -p transfer --all-targets -D warnings` clean, `nextest --lib -p daemon -p transfer` 4393/4393.
