### PR TITLE
fix(metadata): compose --chmod with dest_mode() as tweak-first, collapse-second

### DIFF
--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -266,9 +266,10 @@ impl<'a> CopyContext<'a> {
         // transfer; `set_file_attrs()` then chmods the freshly-renamed
         // temp file to that mode. Reproduce that chmod here so a re-
         // transferred regular file holds its pre-transfer permission bits
-        // and a new regular file lands at `source_mode & dflt_perms`. The
-        // call short-circuits when `-p`/`--chmod` are active so the
-        // existing chmod chain owns the syscall.
+        // and a new regular file lands at `source_mode & dflt_perms`. A
+        // `--chmod` without `--perms` rides this call too (the tweak feeds
+        // the exists split, per flist.c:1741-1742 + rsync.c:464-486); only
+        // `-p` short-circuits, since that path owns the chmod outright.
         #[cfg(unix)]
         ::metadata::apply_dest_mode_pre_transfer(
             destination,
@@ -303,6 +304,20 @@ impl<'a> CopyContext<'a> {
                     )
                     .map_err(map_metadata_error)?;
                 }
+            } else if let Ok(existing) = std::fs::metadata(destination) {
+                // Mirror the fd branch: hand the chain the destination's
+                // current stat. The `--chmod` dest_mode() composition (which
+                // `apply_dest_mode_pre_transfer` above already stamped) then
+                // takes its exists arm and keeps those bits, where a `None`
+                // would re-run the fresh-destination arm against a
+                // pre-existing file.
+                ::metadata::apply_file_metadata_if_changed(
+                    destination,
+                    metadata,
+                    &existing,
+                    &metadata_options,
+                )
+                .map_err(map_metadata_error)?;
             } else {
                 apply_file_metadata_with_options(destination, metadata, &metadata_options)
                     .map_err(map_metadata_error)?;

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -22,25 +22,32 @@ use crate::local_copy::sync_xattrs_if_requested;
 use crate::local_copy::{CopyContext, LocalCopyError, LocalCopyRecord, map_metadata_error};
 use ::metadata::apply_directory_metadata_with_options;
 
+/// The directory frame being finalized, with the stats the metadata apply reads.
+pub(super) struct DirectoryFinalize<'a> {
+    /// Source directory supplying the metadata to propagate.
+    pub source: &'a Path,
+    /// Destination directory receiving it.
+    pub destination: &'a Path,
+    /// Source stat carrying mode, ownership and timestamps.
+    pub metadata: &'a fs::Metadata,
+    /// `--relative` path when the operand materialized implied parents.
+    pub relative: Option<&'a Path>,
+    /// The destination's stat from BEFORE this transfer materialised it (`None`
+    /// when this run created it), feeding the `dest_mode()` exists split -
+    /// upstream generator.c:1856 judges `exists` by the pre-mkdir `statret`.
+    pub pre_transfer_meta: Option<&'a fs::Metadata>,
+}
+
 /// Applies final metadata to a directory after all contents have been processed.
 ///
 /// This includes permissions, timestamps (unless omit_dir_times is enabled),
-/// extended attributes, and ACLs. When `relative` covers more than one
+/// extended attributes, and ACLs. When `dir.relative` covers more than one
 /// component, propagates the source's directory mtime onto each intermediate
 /// component materialized by `--relative` so they do not carry wall-clock
 /// timestamps from `create_dir_all`.
-///
-/// `pre_transfer_meta` is the destination directory's stat from BEFORE this
-/// transfer materialised it (`None` when this run created it), feeding the
-/// `dest_mode()` exists split - upstream generator.c:1856 judges `exists` by
-/// the pre-mkdir `statret`.
 pub(super) fn apply_final_directory_metadata(
     context: &mut CopyContext,
-    source: &Path,
-    destination: &Path,
-    metadata: &fs::Metadata,
-    relative: Option<&Path>,
-    pre_transfer_meta: Option<&fs::Metadata>,
+    dir: &DirectoryFinalize<'_>,
     #[cfg(any(
         all(unix, any(feature = "acl", feature = "xattr")),
         all(windows, feature = "acl")
@@ -49,6 +56,13 @@ pub(super) fn apply_final_directory_metadata(
     #[cfg(all(unix, feature = "xattr"))] preserve_xattrs: bool,
     #[cfg(all(any(unix, windows), feature = "acl"))] preserve_acls: bool,
 ) -> Result<(), LocalCopyError> {
+    let &DirectoryFinalize {
+        source,
+        destination,
+        metadata,
+        relative,
+        pre_transfer_meta,
+    } = dir;
     let metadata_options = if context.omit_dir_times_enabled() {
         context.metadata_options().preserve_times(false)
     } else {

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -29,12 +29,18 @@ use ::metadata::apply_directory_metadata_with_options;
 /// component, propagates the source's directory mtime onto each intermediate
 /// component materialized by `--relative` so they do not carry wall-clock
 /// timestamps from `create_dir_all`.
+///
+/// `pre_transfer_meta` is the destination directory's stat from BEFORE this
+/// transfer materialised it (`None` when this run created it), feeding the
+/// `dest_mode()` exists split - upstream generator.c:1856 judges `exists` by
+/// the pre-mkdir `statret`.
 pub(super) fn apply_final_directory_metadata(
     context: &mut CopyContext,
     source: &Path,
     destination: &Path,
     metadata: &fs::Metadata,
     relative: Option<&Path>,
+    pre_transfer_meta: Option<&fs::Metadata>,
     #[cfg(any(
         all(unix, any(feature = "acl", feature = "xattr")),
         all(windows, feature = "acl")
@@ -48,8 +54,13 @@ pub(super) fn apply_final_directory_metadata(
     } else {
         context.metadata_options()
     };
-    apply_directory_metadata_with_options(destination, metadata, metadata_options.clone())
-        .map_err(map_metadata_error)?;
+    apply_directory_metadata_with_options(
+        destination,
+        metadata,
+        metadata_options.clone(),
+        pre_transfer_meta,
+    )
+    .map_err(map_metadata_error)?;
 
     // upstream: generator.c:1508-1521 - a directory whose real mode lacks owner
     // rwx is kept writable during the transfer so its contents, and the deferred
@@ -175,11 +186,17 @@ fn keep_directory_writable(
 /// skips the root's contents and its metadata finalization. Returns `Ok(None)`
 /// when no `--chmod` is active, the tweak keeps owner execute, or the root has
 /// not been materialised yet.
+///
+/// `pre_transfer_meta` is the root's stat from BEFORE this transfer
+/// materialised it (`None` when this run created it): without `--perms`,
+/// `dest_mode()` (rsync.c:470-471) keeps an existing root's own bits, so only
+/// a fresh root (or a `--perms` transfer) can self-lock on the tweaked mode.
 #[cfg(unix)]
 pub(super) fn enforce_transfer_root_self_lock(
     context: &mut CopyContext,
     destination: &Path,
     metadata: &fs::Metadata,
+    pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<Option<LocalCopyError>, LocalCopyError> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -194,17 +211,21 @@ pub(super) fn enforce_transfer_root_self_lock(
         return Ok(None);
     }
 
+    // Materialisation gate only: the strict-mode chmod below needs a root
+    // directory on disk. The `dest_mode()` exists split runs on the caller's
+    // PRE-transfer stat instead - this post-mkdir stat would make a root this
+    // run just created look pre-existing and mask the fresh-root self-lock.
     let existing = fs::symlink_metadata(destination).ok();
-    let Some(existing_meta) = existing.as_ref().filter(|meta| meta.is_dir()) else {
+    if !existing.as_ref().is_some_and(|meta| meta.is_dir()) {
         return Ok(None);
-    };
+    }
 
     let options = context.metadata_options();
     let Some((tweaked, self_locks)) = ::metadata::transfer_root_chmod_self_lock(
         destination,
         metadata,
         &options,
-        Some(existing_meta),
+        pre_transfer_meta,
     )
     .map_err(map_metadata_error)?
     else {
@@ -242,6 +263,7 @@ pub(super) fn enforce_transfer_root_self_lock(
     _context: &mut CopyContext,
     _destination: &Path,
     _metadata: &fs::Metadata,
+    _pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<Option<LocalCopyError>, LocalCopyError> {
     Ok(None)
 }
@@ -305,12 +327,24 @@ fn apply_relative_intermediate_dir_mtimes(
             _ => continue,
         };
 
-        if !dst_dir.is_dir() {
+        let Ok(dst_meta) = fs::symlink_metadata(&dst_dir) else {
+            continue;
+        };
+        if !dst_meta.file_type().is_dir() {
             continue;
         }
 
-        apply_directory_metadata_with_options(&dst_dir, &src_meta, metadata_options.clone())
-            .map_err(map_metadata_error)?;
+        // The intermediate already exists on disk here (whether pre-existing
+        // or just materialized by `create_dir_all`), so its current stat is
+        // the best available `dest_mode()` exists input: a `--chmod` without
+        // `--perms` keeps its bits rather than rewriting them.
+        apply_directory_metadata_with_options(
+            &dst_dir,
+            &src_meta,
+            metadata_options.clone(),
+            Some(&dst_meta),
+        )
+        .map_err(map_metadata_error)?;
     }
 
     Ok(())

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -32,7 +32,8 @@ use deletion::{
 };
 use destination::{check_destination_state, record_skipped_missing_destination};
 use dir_metadata::{
-    apply_final_directory_metadata, enforce_transfer_root_self_lock, record_directory_completion,
+    DirectoryFinalize, apply_final_directory_metadata, enforce_transfer_root_self_lock,
+    record_directory_completion,
 };
 use entry::process_planned_entry;
 
@@ -511,11 +512,13 @@ fn copy_directory_recursive_inner(
         if !context.mode().is_dry_run() {
             apply_final_directory_metadata(
                 context,
-                source,
-                destination,
-                metadata,
-                relative,
-                dir_pre_transfer,
+                &DirectoryFinalize {
+                    source,
+                    destination,
+                    metadata,
+                    relative,
+                    pre_transfer_meta: dir_pre_transfer,
+                },
                 #[cfg(any(
                     all(unix, any(feature = "acl", feature = "xattr")),
                     all(windows, feature = "acl")
@@ -697,11 +700,13 @@ fn copy_directory_recursive_inner(
     if !context.mode().is_dry_run() {
         apply_final_directory_metadata(
             context,
-            source,
-            destination,
-            metadata,
-            relative,
-            dir_pre_transfer,
+            &DirectoryFinalize {
+                source,
+                destination,
+                metadata,
+                relative,
+                pre_transfer_meta: dir_pre_transfer,
+            },
             #[cfg(any(
                 all(unix, any(feature = "acl", feature = "xattr")),
                 all(windows, feature = "acl")

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -199,6 +199,19 @@ fn copy_directory_recursive_inner(
         return Ok(false);
     }
 
+    // The `dest_mode()` exists input for this directory: its stat from before
+    // the transfer materialised it. A root the orchestrator just created
+    // (`root_just_created`) and a replaced non-directory obstacle both count
+    // as fresh - upstream generator.c:1841-1856 resets `statret` to -1 for a
+    // deleted obstacle and judges `exists` before its own mkdir.
+    let dir_pre_transfer: Option<&fs::Metadata> = if root_just_created {
+        None
+    } else {
+        existing_destination_metadata
+            .as_deref()
+            .filter(|meta| meta.file_type().is_dir())
+    };
+
     let list_start = Instant::now();
     let (readdir_buf, source_anchor) = context.readdir_buf_with_confined_anchor();
     // Seeded here rather than at the entry loop so a failed enumeration can
@@ -502,6 +515,7 @@ fn copy_directory_recursive_inner(
                 destination,
                 metadata,
                 relative,
+                dir_pre_transfer,
                 #[cfg(any(
                     all(unix, any(feature = "acl", feature = "xattr")),
                     all(windows, feature = "acl")
@@ -538,7 +552,8 @@ fn copy_directory_recursive_inner(
     // are addressed by name and never take this path.
     if relative.is_none()
         && !context.mode().is_dry_run()
-        && let Some(error) = enforce_transfer_root_self_lock(context, destination, metadata)?
+        && let Some(error) =
+            enforce_transfer_root_self_lock(context, destination, metadata, dir_pre_transfer)?
     {
         return Err(error);
     }
@@ -686,6 +701,7 @@ fn copy_directory_recursive_inner(
             destination,
             metadata,
             relative,
+            dir_pre_transfer,
             #[cfg(any(
                 all(unix, any(feature = "acl", feature = "xattr")),
                 all(windows, feature = "acl")

--- a/crates/engine/src/local_copy/executor/sources/orchestration.rs
+++ b/crates/engine/src/local_copy/executor/sources/orchestration.rs
@@ -1252,14 +1252,18 @@ fn stamp_directory_from_source(
         Ok(meta) if meta.file_type().is_dir() => meta,
         _ => return Ok(()),
     };
-    match fs::symlink_metadata(dest_dir) {
-        Ok(meta) if meta.file_type().is_dir() => {}
+    let dest_meta = match fs::symlink_metadata(dest_dir) {
+        Ok(meta) if meta.file_type().is_dir() => meta,
         _ => return Ok(()),
-    }
+    };
+    // The implied parent already exists on disk here, so its current stat is
+    // the `dest_mode()` exists input: a `--chmod` without `--perms` keeps
+    // its bits rather than rewriting them.
     ::metadata::apply_directory_metadata_with_options(
         dest_dir,
         &source_meta,
         metadata_options.clone(),
+        Some(&dest_meta),
     )
     .map_err(crate::local_copy::map_metadata_error)?;
     Ok(())

--- a/crates/engine/src/local_copy/tests/execute_metadata.rs
+++ b/crates/engine/src/local_copy/tests/execute_metadata.rs
@@ -228,6 +228,77 @@ fn execute_applies_chmod_modifiers() {
     assert_eq!(summary.files_copied(), 1);
 }
 
+/// The octal-all escalation cell: `--chmod=644 -r` into an EXISTING
+/// destination root must succeed. Upstream tweaks the flist mode first
+/// (flist.c:1741-1742) and `dest_mode()` (rsync.c:470-471) then keeps every
+/// existing entry's own bits - the root directory is never rewritten to
+/// 0o644, so it never self-locks. A directory this transfer creates lands
+/// the composed 0o644 plus the during-transfer owner-`rwx` grant
+/// (generator.c:1904-1905), which persists because 0o644 keeps owner write.
+// upstream: rsync.c:464-486 dest_mode() + generator.c:1904-1920.
+#[cfg(unix)]
+#[test]
+fn execute_octal_chmod_without_perms_keeps_existing_dirs_and_succeeds() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Pin the umask; the metadata crate caches it on first read and nextest
+    // runs each test in its own process.
+    let prev = rustix::process::umask(rustix::fs::Mode::from_bits_truncate(0o022));
+
+    let temp = tempdir().expect("tempdir");
+    let source_root = temp.path().join("source");
+    fs::create_dir_all(source_root.join("sub")).expect("create source tree");
+    fs::write(source_root.join("f"), b"new content").expect("write f");
+    fs::set_permissions(source_root.join("f"), PermissionsExt::from_mode(0o644)).expect("chmod f");
+    fs::write(source_root.join("sub").join("g"), b"nested").expect("write g");
+    fs::set_permissions(
+        source_root.join("sub").join("g"),
+        PermissionsExt::from_mode(0o644),
+    )
+    .expect("chmod g");
+    fs::set_permissions(source_root.join("sub"), PermissionsExt::from_mode(0o755))
+        .expect("chmod sub");
+
+    // Existing destination root with an existing file at a different mode.
+    let dest_root = temp.path().join("dest");
+    fs::create_dir(&dest_root).expect("create dest root");
+    fs::set_permissions(&dest_root, PermissionsExt::from_mode(0o755)).expect("chmod dest root");
+    fs::write(dest_root.join("f"), b"old content!").expect("write dest f");
+    fs::set_permissions(dest_root.join("f"), PermissionsExt::from_mode(0o600))
+        .expect("chmod dest f");
+
+    let mut source_operand = source_root.into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest_root.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let modifiers = ChmodModifiers::parse("644").expect("chmod parses");
+    let options = LocalCopyOptions::default().with_chmod(Some(modifiers));
+    let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
+
+    let mode_of = |p: &std::path::Path| fs::metadata(p).map(|m| m.permissions().mode() & 0o7777);
+    let root_mode = mode_of(&dest_root);
+    let f_mode = mode_of(&dest_root.join("f"));
+    let sub_mode = mode_of(&dest_root.join("sub"));
+    let g_mode = mode_of(&dest_root.join("sub").join("g"));
+    rustix::process::umask(prev);
+
+    result.expect("octal --chmod without --perms must not self-lock an existing root");
+    assert_eq!(root_mode.expect("root"), 0o755, "existing root untouched");
+    assert_eq!(f_mode.expect("f"), 0o600, "existing file keeps its bits");
+    let sub_want = if rustix::process::geteuid().is_root() {
+        0o644
+    } else {
+        0o744 // 0o644 | owner-rwx grant, kept because owner write is present
+    };
+    assert_eq!(sub_mode.expect("sub"), sub_want, "fresh dir composed mode");
+    assert_eq!(g_mode.expect("g"), 0o644, "fresh file masked tweak");
+    assert_eq!(
+        fs::read(dest_root.join("f")).expect("read f"),
+        b"new content",
+        "the transfer must actually copy into the existing root"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn execute_preserves_ownership_when_requested() {

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -35,21 +35,29 @@ pub fn apply_directory_metadata(
     destination: &Path,
     metadata: &fs::Metadata,
 ) -> Result<(), MetadataError> {
-    apply_directory_metadata_with_options(destination, metadata, MetadataOptions::default())
+    apply_directory_metadata_with_options(destination, metadata, MetadataOptions::default(), None)
 }
 
 /// Applies metadata from `metadata` to the destination directory using explicit options.
 ///
 /// Applies ownership, permissions, and timestamps in the same order as
 /// upstream rsync's `set_file_attrs()`: chown, chmod, then utimensat.
+///
+/// `pre_transfer_meta` is the directory's stat from BEFORE this transfer
+/// materialised it - `dest_mode()`'s `stat_mode`/`exists` inputs
+/// (generator.c:1856 judges `exists` by the pre-mkdir `statret`). `None`
+/// means the directory is new to this transfer, so a `--chmod` without
+/// `--perms` takes the fresh-destination arm instead of rewriting bits an
+/// existing directory would keep.
 /// upstream: rsync.c:set_file_attrs() - order: chown → chmod → utimensat
 pub fn apply_directory_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
     options: MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, true, &options, None)?;
-    permissions::apply_permissions_with_chmod(destination, metadata, &options, None)?;
+    permissions::apply_permissions_with_chmod(destination, metadata, &options, pre_transfer_meta)?;
     if options.times() {
         timestamps::set_timestamp_like(metadata, destination, true, None, Some(&options))?;
     }
@@ -463,20 +471,19 @@ pub fn metadata_unchanged(
         }
     }
 
-    // upstream: generator.c:495-502 - chmod modifiers applied on top of the
-    // entry's mode. Evaluate the modifier against the current stat and only
-    // fall through to the full apply path when the result would differ.
+    // upstream: flist.c:996-997 - the `--chmod` tweak rides the flist mode,
+    // and dest_mode() (rsync.c:470-471) then keeps an EXISTING destination's
+    // own permission bits when `!preserve_perms`. On this quick-check path
+    // the destination exists by definition, so only the `--perms` compare
+    // can report a chmod-driven difference.
     #[cfg(unix)]
     if let Some(chmod) = options.chmod() {
         use std::os::unix::fs::MetadataExt;
-        let base_mode = if options.permissions() {
-            entry.permissions()
-        } else {
-            cached_meta.mode()
-        };
-        let new_mode = chmod.apply(base_mode, cached_meta.is_dir());
-        if (cached_meta.mode() & 0o7777) != (new_mode & 0o7777) {
-            return false;
+        if options.permissions() {
+            let new_mode = chmod.apply(entry.permissions(), cached_meta.is_dir());
+            if (cached_meta.mode() & 0o7777) != (new_mode & 0o7777) {
+                return false;
+            }
         }
     }
     #[cfg(not(unix))]

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -239,9 +239,12 @@ fn compute_dest_mode(
 /// destination would silently inherit the temp file's `0o600`/umask-default
 /// permissions instead of upstream's `dest_mode()` result.
 ///
-/// Returns without acting when `-p`/`--chmod` are in effect: those paths
-/// already drive the chmod through `metadata.permissions().mode()` or the
-/// chmod modifier chain.
+/// Returns without acting when `-p` is in effect: that path drives the
+/// chmod through `metadata.permissions().mode()` directly. A `--chmod`
+/// without `--perms` stays on this path: upstream tweaks the flist mode at
+/// build time (flist.c:1741-1742) and `dest_mode()` then still collapses it
+/// against the pre-transfer destination, so the tweak must feed the exists
+/// split here rather than bypass it.
 ///
 /// upstream: receiver.c:964 (`dest_mode()` invocation) + rsync.c:449-472
 /// (`dest_mode()` body)
@@ -257,38 +260,25 @@ pub fn apply_dest_mode_pre_transfer(
     if !source_metadata.file_type().is_file() {
         return Ok(());
     }
-    if options.permissions() || options.chmod().is_some() {
+    if options.permissions() {
         return Ok(());
     }
 
-    let source_mode = source_metadata.permissions().mode();
     // upstream: receiver.c:1176-1191 - the basis file is opened with O_NOFOLLOW
     // and the fd is dropped again unless it is a regular file, so a symlink /
     // fifo / device obstacle leaves `exists = fd1 != -1` false and the incoming
     // file takes the new-destination rule (its lstat mode - 0o755 for a symlink
     // on some platforms - must never become the file's permissions).
     let pre_transfer_meta = pre_transfer_meta.filter(|existing| existing.file_type().is_file());
-    let base_mode = if let Some(existing) = pre_transfer_meta {
-        // Existing destination: keep its prior permission bits.
-        let stat_mode = existing.permissions().mode();
-        (source_mode & !0o7777) | (stat_mode & 0o7777)
-    } else {
-        // New destination: source mode masked by default permissions.
-        let dflt_perms = 0o777 & !cached_umask();
-        source_mode & (!0o7777 | dflt_perms)
-    };
-
-    let mut target_perms = base_mode & 0o7777;
-    if options.executability() {
-        // upstream: rsync.c:457-465 - layer `-E` executability on top of the
-        // dest_mode() base.
-        if source_mode & 0o111 == 0 {
-            target_perms &= !0o111;
-        } else if target_perms & 0o111 == 0 {
-            target_perms |= (target_perms & 0o444) >> 2;
-        }
-    }
-    let new_mode = (base_mode & !0o7777) | target_perms;
+    let new_mode = chmod_tweaked_dest_mode(
+        options.chmod(),
+        destination,
+        source_metadata.permissions().mode(),
+        false,
+        true,
+        options,
+        pre_transfer_meta,
+    );
 
     // Compare against the file's CURRENT (post-rename) mode. If the temp
     // file already happens to match the target we skip the chmod syscall.
@@ -522,8 +512,16 @@ pub(super) fn apply_permissions_with_chmod(
     #[cfg(unix)]
     {
         if let Some(modifiers) = options.chmod() {
-            let mut mode = base_mode_for_permissions(destination, metadata, options, existing)?;
-            mode = modifiers.apply(mode, metadata.is_dir());
+            use std::os::unix::fs::PermissionsExt;
+            let mut mode = chmod_tweaked_dest_mode(
+                Some(modifiers),
+                destination,
+                metadata.permissions().mode(),
+                metadata.is_dir(),
+                metadata.file_type().is_file(),
+                options,
+                existing,
+            );
             mode = tweak_directory_transfer_mode(mode, metadata.file_type());
 
             if let Some(existing) = existing {
@@ -606,8 +604,15 @@ pub(super) fn apply_permissions_with_chmod_fd(
     }
 
     if let Some(modifiers) = options.chmod() {
-        let mut mode = base_mode_for_permissions(destination, metadata, options, existing)?;
-        mode = modifiers.apply(mode, metadata.is_dir());
+        let mut mode = chmod_tweaked_dest_mode(
+            Some(modifiers),
+            destination,
+            metadata.permissions().mode(),
+            metadata.is_dir(),
+            metadata.file_type().is_file(),
+            options,
+            existing,
+        );
         mode = tweak_directory_transfer_mode(mode, metadata.file_type());
 
         if let Some(existing) = existing {
@@ -820,12 +825,11 @@ pub(super) fn apply_symlink_permissions_like(
 /// `set_file_attrs()` would chmod a non-fake-super destination to.
 ///
 /// This is the `new_mode` fed to `set_stat_xattr()` under `am_root < 0`: the
-/// `dest_mode()` result with any `--chmod` / daemon-chmod tweak applied on top.
-/// When `--perms` is active the source mode passes through; otherwise the
-/// umask/exec `dest_mode()` reduction (via [`base_mode_for_permissions`] and
-/// [`compute_dest_mode`]) supplies the baseline. Chmod modifiers, when present,
-/// are layered last so the recorded xattr reflects the same mode a privileged
-/// transfer would have applied on disk.
+/// `--chmod` tweak composed with the `dest_mode()` collapse (tweak first,
+/// per [`chmod_tweaked_dest_mode`]). When `--perms` is active the (tweaked)
+/// source mode passes through; without `--perms` or `--chmod` the plain
+/// [`compute_dest_mode`] reduction supplies the mode, so the recorded xattr
+/// reflects the same mode a privileged transfer would have applied on disk.
 /// upstream: rsync.c:495-519 set_file_attrs() new_mode / dest_mode + tweak_mode
 #[cfg(unix)]
 fn intended_fake_super_mode(
@@ -836,8 +840,16 @@ fn intended_fake_super_mode(
 ) -> Result<u32, MetadataError> {
     use std::os::unix::fs::PermissionsExt;
 
-    let base = if options.permissions() || options.chmod().is_some() {
-        base_mode_for_permissions(destination, metadata, options, existing)?
+    let mode = if options.permissions() || options.chmod().is_some() {
+        chmod_tweaked_dest_mode(
+            options.chmod(),
+            destination,
+            metadata.permissions().mode(),
+            metadata.is_dir(),
+            metadata.file_type().is_file(),
+            options,
+            existing,
+        )
     } else {
         let source_mode = metadata.permissions().mode();
         compute_dest_mode(
@@ -848,16 +860,17 @@ fn intended_fake_super_mode(
         )
         .unwrap_or(source_mode)
     };
-
-    let mode = match options.chmod() {
-        Some(modifiers) => modifiers.apply(base, metadata.is_dir()),
-        None => base,
-    };
     Ok(mode)
 }
 
-/// Computes the `--chmod`-tweaked permission bits (`0o7777`) a directory would
-/// receive, BEFORE upstream's during-transfer owner-`rwx` fixup.
+/// Computes the permission bits (`0o7777`) a directory would receive under
+/// `--chmod` - the tweak composed with the `dest_mode()` collapse when
+/// `!preserve_perms` - BEFORE upstream's during-transfer owner-`rwx` fixup.
+///
+/// `existing` is the directory's PRE-transfer stat: an existing destination
+/// directory keeps its own bits when `--perms` is off (rsync.c:470-471), so
+/// only a fresh directory (or a `--perms` transfer) can self-lock on the
+/// tweaked mode.
 ///
 /// Returns `None` when no `--chmod` modifiers are configured. The local-copy
 /// executor uses this to detect a transfer-root directory whose tweaked mode
@@ -874,67 +887,84 @@ pub(super) fn chmod_directory_target_mode(
     let Some(modifiers) = options.chmod() else {
         return Ok(None);
     };
-    let base = base_mode_for_permissions(destination, metadata, options, existing)?;
-    Ok(Some(modifiers.apply(base, metadata.is_dir()) & 0o7777))
+    use std::os::unix::fs::PermissionsExt;
+    let mode = chmod_tweaked_dest_mode(
+        Some(modifiers),
+        destination,
+        metadata.permissions().mode(),
+        metadata.is_dir(),
+        metadata.file_type().is_file(),
+        options,
+        existing,
+    );
+    Ok(Some(mode & 0o7777))
 }
 
-/// Determines the base mode before chmod modifiers are applied.
+/// Composes the `--chmod` tweak with upstream's `dest_mode()` collapse:
+/// tweak FIRST, collapse SECOND.
 ///
-/// When `--perms` is active, returns the source mode directly. Otherwise
-/// mirrors upstream `rsync.c:447-472 dest_mode()`: the chmod tweak (CLI
-/// `--chmod` or daemon `incoming chmod = ...`) runs on top of the
-/// source mode collapsed via `dest_mode()`, not on top of whatever the
-/// destination tempfile happens to carry. Without this, a freshly-renamed
-/// `O_TMPFILE` 0o600 leaks through as the chmod baseline and a daemon
-/// upload with `--no-perms` lands a file at 0o600 instead of the
-/// umask-default the testsuite `chmod-option` test pins.
+/// Upstream applies `--chmod` (CLI or daemon `incoming chmod = ...`) to the
+/// flist mode when the list is built (flist.c:1741-1742 sender,
+/// flist.c:996-997 `recv_file_entry`). Only then, when `!preserve_perms`,
+/// does `dest_mode()` (rsync.c:464-486) collapse the result: an existing
+/// destination keeps its own permission bits - the tweak is discarded -
+/// while a fresh one masks the tweaked mode by `dflt_perms` and drops the
+/// special bits. Inverting the order would apply the tweak to the
+/// destination's bits, which upstream never does. The destination tempfile
+/// mode is never the baseline either: reading it back would feed the
+/// `O_TMPFILE` 0o600 default into the chmod chain (testsuite `chmod-option`
+/// daemon upload).
+///
+/// `pre_transfer` is the destination's PRE-transfer stat - `dest_mode()`'s
+/// `stat_mode`/`exists` inputs. `None` means the destination is new.
 #[cfg(unix)]
-fn base_mode_for_permissions(
+fn chmod_tweaked_dest_mode(
+    modifiers: Option<&crate::ChmodModifiers>,
     destination: &Path,
-    metadata: &fs::Metadata,
+    source_mode: u32,
+    source_is_dir: bool,
+    source_is_regular: bool,
     options: &MetadataOptions,
-    existing: Option<&fs::Metadata>,
-) -> Result<u32, MetadataError> {
+    pre_transfer: Option<&fs::Metadata>,
+) -> u32 {
     use std::os::unix::fs::PermissionsExt;
 
-    if options.permissions() {
-        return Ok(metadata.permissions().mode());
-    }
-
-    // upstream: rsync.c:455-470 - existing files keep destination's perm
-    // bits with the type bits from the source mode; new files mask the
-    // source mode by `dflt_perms = default_perms_for_dir(dn)`, which folds
-    // the parent's POSIX default ACL when one is present (acls.c:1083) and
-    // otherwise reduces to `ACCESSPERMS & ~orig_umask`. The destination
-    // tempfile mode is never the baseline.
-    let source_mode = metadata.permissions().mode();
-    let mut destination_permissions = if let Some(existing) = existing {
-        (source_mode & !0o7777) | (existing.permissions().mode() & 0o7777)
-    } else {
-        let dflt_perms = default_perms_seed(destination.parent());
-        source_mode & (!0o7777 | dflt_perms)
+    let tweaked = match modifiers {
+        Some(modifiers) => modifiers.apply(source_mode, source_is_dir),
+        None => source_mode,
     };
-
-    if options.executability() && metadata.is_file() && existing.is_some() {
-        // upstream: rsync.c:457-465 dest_mode() - for existing files only,
-        // copy source's exec presence: if source has no exec bits, clear
-        // them on dest; else if dest has no exec bits, grant exec to
-        // everyone who can already read (`new_mode & 0444 >> 2`). When dest
-        // already has some exec bits they are preserved verbatim. Upstream
-        // skips this branch for new files - the umask-masked source mode
-        // already encodes the right answer there.
-        if source_mode & 0o111 == 0 {
-            destination_permissions &= !0o111;
-        } else if destination_permissions & 0o111 == 0 {
-            destination_permissions |= (destination_permissions & 0o444) >> 2;
-        }
+    if options.permissions() {
+        // upstream: receiver.c:1181 / generator.c:1855 - `dest_mode()` only
+        // runs when `!preserve_perms`; with `--perms` the tweaked mode is
+        // applied as-is.
+        return tweaked;
     }
 
-    // `destination` is unused on the new-file path now that the base mode
-    // is derived from the source rather than from a destination stat.
-    // Keep the parameter for API parity with the fd-based sibling.
-    let _ = destination;
-    Ok(destination_permissions)
+    if let Some(existing) = pre_transfer {
+        // upstream: rsync.c:470-482 - an existing destination keeps its own
+        // permission bits with the type bits from the (tweaked) flist mode.
+        let mut new_mode = (tweaked & !0o7777) | (existing.permissions().mode() & 0o7777);
+        if options.executability() && source_is_regular {
+            // upstream: rsync.c:472-481 dest_mode() - for existing regular
+            // files only, copy the (tweaked) source's exec presence: if it
+            // has no exec bits, clear them on dest; else if dest has no exec
+            // bits, grant exec to everyone who can already read
+            // (`new_mode & 0444 >> 2`). Upstream skips this for new files -
+            // the umask-masked source mode already encodes the right answer.
+            if tweaked & 0o111 == 0 {
+                new_mode &= !0o111;
+            } else if new_mode & 0o111 == 0 {
+                new_mode |= (new_mode & 0o444) >> 2;
+            }
+        }
+        new_mode
+    } else {
+        // upstream: rsync.c:483-485 - fresh destination: mask by
+        // `dflt_perms = default_perms_for_dir(dn)`, which folds the parent's
+        // POSIX default ACL when one is present (acls.c:1083) and otherwise
+        // reduces to `ACCESSPERMS & ~orig_umask`; special bits drop out.
+        tweaked & (!0o7777 | default_perms_seed(destination.parent()))
+    }
 }
 
 /// Applies permissions without chmod modifiers (direct copy or executability only).
@@ -1161,16 +1191,15 @@ pub(super) fn apply_permissions_from_entry(
         }
 
         if let Some(chmod) = options.chmod() {
-            // upstream: rsync.c:510+518 - `new_mode = file->mode` then
-            // `new_mode = tweak_mode(new_mode, daemon_chmod_modes)`. The
-            // chmod baseline is the source file's mode (already collapsed
-            // through `dest_mode()` in the generator at generator.c:1467 +
-            // :1547 when `!preserve_perms`), NEVER the destination's
-            // tempfile mode. Reading the destination would feed back the
-            // `O_TMPFILE` 0o600 default for fresh transfers and produce
-            // 0o600 under e.g. `Fo-x` instead of the expected umask
-            // default (UTS-17.REOPEN: testsuite/chmod-option daemon
-            // upload).
+            // upstream: flist.c:996-997 - `recv_file_entry` runs
+            // `tweak_mode(mode, chmod_modes)` while the flist is built, and
+            // `dest_mode()` (rsync.c:464-486) then collapses the TWEAKED
+            // mode when `!preserve_perms`. The chmod baseline is therefore
+            // the entry's mode, NEVER the destination's tempfile mode -
+            // reading the destination would feed back the `O_TMPFILE` 0o600
+            // default for fresh transfers and produce 0o600 under e.g.
+            // `Fo-x` instead of the expected umask default (UTS-17.REOPEN:
+            // testsuite/chmod-option daemon upload).
             let fresh_meta;
             let current_meta = if options.permissions() && perms_changed {
                 fresh_meta = fs::metadata(destination)
@@ -1185,29 +1214,21 @@ pub(super) fn apply_permissions_from_entry(
             };
             let current_mode = current_meta.permissions().mode();
 
-            let base_mode = if options.permissions() {
-                // -p: the immediately preceding branch chmod'd to the
-                // source mode, so current_mode IS the source mode.
-                current_mode
-            } else {
-                // --no-perms: mirror upstream `dest_mode()`. For a fresh
-                // transfer (`cached_meta.is_none()`), use the new-file
-                // branch (`flist_mode & (~CHMOD_BITS | dflt_perms)`) where
-                // `dflt_perms` honours the parent's POSIX default ACL via
-                // `default_perms_for_dir` (acls.c:1083); for a quick-check
-                // skip on an existing dest, use the existing-file branch
-                // (keep destination's perm bits).
-                let source_mode = entry.permissions();
-                if cached_meta.is_none() {
-                    let dflt_perms = default_perms_seed(destination.parent());
-                    source_mode & (!0o7777 | dflt_perms)
-                } else {
-                    (source_mode & !0o7777) | (current_mode & 0o7777)
-                }
-            };
-
-            let new_mode = chmod.apply(base_mode, current_meta.is_dir());
-            if new_mode != current_mode {
+            // The exists split consumes the PRE-transfer destination stat
+            // (upstream receiver.c:1181-1192 judges `exists` by the basis
+            // fd). When the caller tracked none (quick-check skip, public
+            // `apply_metadata_from_file_entry` API), no rename happened and
+            // the cached current stat IS the pre-transfer stat.
+            let new_mode = chmod_tweaked_dest_mode(
+                Some(chmod),
+                destination,
+                entry.permissions(),
+                entry.file_type().is_dir(),
+                entry.file_type().is_regular(),
+                options,
+                pre_transfer_meta.or(cached_meta),
+            );
+            if (new_mode & 0o7777) != (current_mode & 0o7777) {
                 // upstream: syscall.c:do_chmod_at() symlink-race-safe variant.
                 // Helper follows symlinked parents under `--keep-dirlinks` to
                 // mirror upstream `generator.c:1356`.

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -351,6 +351,7 @@ fn directory_metadata_with_options_no_times() {
         &dest,
         &metadata,
         MetadataOptions::new().preserve_times(false),
+        None,
     )
     .expect("apply dir metadata");
 
@@ -912,6 +913,223 @@ fn no_perms_existing_file_from_entry_keeps_prior_mode() {
         current_mode(&dest) & 0o7777,
         0o755,
         "no-perms existing file must keep its prior 0o755 mode, not adopt temp 0o600 or source 0o644",
+    );
+}
+
+/// `--chmod` without `--perms` over an EXISTING destination: upstream tweaks
+/// the flist mode at build time (flist.c:996-997) and `dest_mode()`
+/// (rsync.c:470-471) then discards the tweak in favour of the destination's
+/// own permission bits. Applying the tweak to the destination is the inverted
+/// composition this pin guards against.
+// upstream: flist.c:996-997 tweak_mode + rsync.c:464-486 dest_mode().
+#[cfg(unix)]
+#[test]
+fn chmod_without_perms_existing_file_from_entry_keeps_prior_mode() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("existing.bin");
+    fs::write(&dest, b"payload").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o620)).expect("seed temp mode");
+
+    // The destination existed pre-transfer at 0o600.
+    let pre = temp.path().join("pre.bin");
+    fs::write(&pre, b"old").expect("write pre");
+    fs::set_permissions(&pre, PermissionsExt::from_mode(0o600)).expect("seed pre mode");
+    let pre_meta = fs::metadata(&pre).expect("pre metadata");
+
+    let entry = FileEntry::new_file("existing.bin".into(), 7, 0o644);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .with_chmod(Some(crate::ChmodModifiers::parse("F604").expect("parse")));
+
+    apply_metadata_with_pre_transfer_stat(&dest, &entry, &opts, None, Some(pre_meta))
+        .expect("apply from entry");
+
+    assert_eq!(
+        current_mode(&dest) & 0o7777,
+        0o600,
+        "an existing destination keeps its own bits; the F604 tweak is discarded",
+    );
+}
+
+/// `--chmod` without `--perms` on a NEW destination: the tweak lands first
+/// and `dest_mode()`'s fresh arm then masks it by `dflt_perms` (umask 022 ->
+/// 0o755), so `F666` yields 0o644 - never the unmasked 0o666 the inverted
+/// composition (tweak after collapse) produces.
+// upstream: flist.c:996-997 tweak_mode + rsync.c:483-485 dest_mode() fresh arm.
+#[cfg(unix)]
+#[test]
+fn chmod_without_perms_new_file_from_entry_masks_tweak_by_umask() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Pin the umask so the expected dest_mode is deterministic under nextest's
+    // process-per-test isolation (the crate caches the umask on first read).
+    let prev = nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o022));
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("newfile.bin");
+    fs::write(&dest, b"payload").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("seed temp mode");
+
+    let entry = FileEntry::new_file("newfile.bin".into(), 7, 0o644);
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .with_chmod(Some(crate::ChmodModifiers::parse("F666").expect("parse")));
+
+    // cached_meta = None (fresh commit), pre_transfer_meta = None (new file).
+    apply_metadata_with_cached_stat(&dest, &entry, &opts, None).expect("apply from entry");
+
+    let got = current_mode(&dest) & 0o7777;
+    nix::sys::stat::umask(prev);
+    assert_eq!(
+        got, 0o644,
+        "a new destination masks the F666 tweak by dflt_perms (0o666 & 0o755)",
+    );
+}
+
+/// Local-copy analogue of the two entry-path pins, through
+/// `apply_dest_mode_pre_transfer`: a `--chmod` without `--perms` must ride
+/// the exists split (existing keeps its bits) instead of bypassing it.
+// upstream: receiver.c:964 dest_mode() invocation + rsync.c:464-486.
+#[cfg(unix)]
+#[test]
+fn chmod_without_perms_pre_transfer_rides_the_exists_split() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let prev = nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o022));
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("source.bin");
+    fs::write(&source, b"payload").expect("write source");
+    fs::set_permissions(&source, PermissionsExt::from_mode(0o644)).expect("chmod source");
+    let source_meta = fs::metadata(&source).expect("source metadata");
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .with_chmod(Some(crate::ChmodModifiers::parse("F604").expect("parse")));
+
+    // Existing destination (pre-transfer 0o600): the tweak is discarded.
+    let dest = temp.path().join("existing.bin");
+    fs::write(&dest, b"payload").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o620)).expect("seed temp mode");
+    let pre = temp.path().join("pre.bin");
+    fs::write(&pre, b"old").expect("write pre");
+    fs::set_permissions(&pre, PermissionsExt::from_mode(0o600)).expect("seed pre mode");
+    let pre_meta = fs::metadata(&pre).expect("pre metadata");
+    apply_dest_mode_pre_transfer(&dest, &source_meta, &opts, Some(&pre_meta))
+        .expect("apply dest_mode");
+    let existing_got = current_mode(&dest) & 0o7777;
+
+    // Fresh destination: the tweak is masked by dflt_perms (0o604 & 0o755).
+    let fresh = temp.path().join("fresh.bin");
+    fs::write(&fresh, b"payload").expect("write fresh");
+    fs::set_permissions(&fresh, PermissionsExt::from_mode(0o600)).expect("seed temp mode");
+    apply_dest_mode_pre_transfer(&fresh, &source_meta, &opts, None).expect("apply dest_mode");
+    let fresh_got = current_mode(&fresh) & 0o7777;
+
+    nix::sys::stat::umask(prev);
+    assert_eq!(
+        existing_got, 0o600,
+        "existing destination keeps its pre-transfer bits under --chmod without --perms",
+    );
+    assert_eq!(
+        fresh_got, 0o604,
+        "fresh destination lands the tweaked mode masked by dflt_perms",
+    );
+}
+
+/// Directory arm of the composition: an existing directory keeps its own
+/// bits under `--chmod` without `--perms` (upstream never rewrites it),
+/// while a directory this transfer created composes tweak-then-collapse and
+/// then keeps the during-transfer owner-`rwx` grant when the owner can
+/// write (generator.c:1904-1905 fixup; touch_up_dirs only restores a mode
+/// lacking owner write).
+// upstream: generator.c:1856 dest_mode() for dirs + generator.c:1904-1920.
+#[cfg(unix)]
+#[test]
+fn chmod_without_perms_directory_rides_the_exists_split() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let prev = nix::sys::stat::umask(nix::sys::stat::Mode::from_bits_truncate(0o022));
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src_dir");
+    fs::create_dir(&src).expect("create src dir");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).expect("chmod src");
+    let src_meta = fs::symlink_metadata(&src).expect("stat src");
+
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .with_chmod(Some(crate::ChmodModifiers::parse("644").expect("parse")));
+
+    // Existing directory (pre-transfer 0o711): untouched.
+    let existing = temp.path().join("existing_dir");
+    fs::create_dir(&existing).expect("create existing dir");
+    fs::set_permissions(&existing, fs::Permissions::from_mode(0o711)).expect("chmod existing");
+    let pre_meta = fs::symlink_metadata(&existing).expect("stat existing");
+    apply_directory_metadata_with_options(&existing, &src_meta, opts.clone(), Some(&pre_meta))
+        .expect("apply dir metadata");
+    let existing_got = fs::symlink_metadata(&existing).expect("restat").mode() & 0o7777;
+
+    // Fresh directory: 0o755 tweaked to 0o644, masked by dflt (no-op), then
+    // the owner-rwx transfer grant sticks because 0o644 keeps owner write.
+    let fresh = temp.path().join("fresh_dir");
+    fs::create_dir(&fresh).expect("create fresh dir");
+    apply_directory_metadata_with_options(&fresh, &src_meta, opts, None)
+        .expect("apply dir metadata");
+    let fresh_got = fs::symlink_metadata(&fresh).expect("restat").mode() & 0o7777;
+    let fresh_want = crate::directory_transfer_mode(0o644, crate::am_root());
+
+    nix::sys::stat::umask(prev);
+    assert_eq!(
+        existing_got, 0o711,
+        "an existing directory keeps its own bits under --chmod without --perms",
+    );
+    assert_eq!(
+        fresh_got, fresh_want,
+        "a fresh directory lands the composed mode plus the owner-rwx grant",
+    );
+}
+
+/// Non-vacuity companion: with `--perms` the tweak applies to the source
+/// mode EXACTLY - `dest_mode()` never runs (receiver.c:1181) - so the
+/// exists split above cannot be satisfied by simply never chmodding.
+// upstream: flist.c:996-997 tweak_mode; preserve_perms skips dest_mode().
+#[cfg(unix)]
+#[test]
+fn chmod_with_perms_applies_tweaked_source_mode_exactly() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("existing.bin");
+    fs::write(&dest, b"payload").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("seed dest mode");
+
+    let pre = temp.path().join("pre.bin");
+    fs::write(&pre, b"old").expect("write pre");
+    fs::set_permissions(&pre, PermissionsExt::from_mode(0o600)).expect("seed pre mode");
+    let pre_meta = fs::metadata(&pre).expect("pre metadata");
+
+    let entry = FileEntry::new_file("existing.bin".into(), 7, 0o644);
+    let opts = MetadataOptions::new()
+        .preserve_times(false)
+        .with_chmod(Some(crate::ChmodModifiers::parse("F604").expect("parse")));
+
+    apply_metadata_with_pre_transfer_stat(&dest, &entry, &opts, None, Some(pre_meta))
+        .expect("apply from entry");
+
+    assert_eq!(
+        current_mode(&dest) & 0o7777,
+        0o604,
+        "--perms + --chmod applies the tweaked source mode, existing dest notwithstanding",
     );
 }
 
@@ -1542,7 +1760,7 @@ fn fake_super_chmod_deflects_directory_real_mode() {
         .preserve_permissions(true)
         .with_chmod(Some(ChmodModifiers::parse("a=").expect("parse a=")));
 
-    apply_directory_metadata_with_options(&dst, &src_meta, opts).expect("apply dir metadata");
+    apply_directory_metadata_with_options(&dst, &src_meta, opts, None).expect("apply dir metadata");
 
     // The real directory mode must stay self-accessible (0700), never 000.
     let real = fs::metadata(&dst).expect("stat dst").mode() & 0o777;
@@ -1618,7 +1836,7 @@ fn fake_super_faithful_directory_writes_no_stat_xattr() {
         .preserve_group(true)
         .preserve_permissions(true);
 
-    apply_directory_metadata_with_options(&dst, &src_meta, opts).expect("apply dir metadata");
+    apply_directory_metadata_with_options(&dst, &src_meta, opts, None).expect("apply dir metadata");
 
     // Same-owner 0755 dir: the real 0755 mode already conveys the intent, so no
     // %stat shim is written (matching upstream's write-or-remove rule).
@@ -2080,22 +2298,58 @@ fn metadata_unchanged_executability_ignores_matching_presence_and_non_files() {
 #[test]
 fn metadata_unchanged_returns_false_when_chmod_would_change_mode() {
     use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
 
     let temp = tempdir().expect("tempdir");
     let dest = temp.path().join("chmod-changes.txt");
     fs::write(&dest, b"data").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o644)).expect("set perms");
 
     let meta = fs::metadata(&dest).expect("metadata");
 
     let entry = FileEntry::new_file("chmod-changes.txt".into(), 4, 0o644);
 
-    // u+x would change 0o644 to 0o744
+    // With --perms, u+x tweaks the flist mode 0o644 to 0o744 (flist.c:1741),
+    // which differs from the destination's 0o644.
     let chmod = crate::ChmodModifiers::parse("u+x").expect("parse chmod");
-    let opts = MetadataOptions::new().with_chmod(Some(chmod));
+    let opts = MetadataOptions::new()
+        .preserve_permissions(true)
+        .with_chmod(Some(chmod));
 
     assert!(
         !metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
-        "should return false when chmod would change mode"
+        "should return false when the tweaked flist mode differs under --perms"
+    );
+}
+
+/// Without `--perms`, `dest_mode()` (rsync.c:470-471) keeps an existing
+/// destination's own permission bits - the `--chmod` tweak is discarded - so
+/// the quick-check must report the metadata unchanged even though the tweak
+/// would alter the mode.
+#[cfg(unix)]
+#[test]
+fn metadata_unchanged_ignores_chmod_without_perms_on_existing_dest() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let dest = temp.path().join("chmod-no-perms.txt");
+    fs::write(&dest, b"data").expect("write dest");
+    fs::set_permissions(&dest, PermissionsExt::from_mode(0o600)).expect("set perms");
+
+    let meta = fs::metadata(&dest).expect("metadata");
+
+    let entry = FileEntry::new_file("chmod-no-perms.txt".into(), 4, 0o644);
+
+    let chmod = crate::ChmodModifiers::parse("u+x").expect("parse chmod");
+    let opts = MetadataOptions::new()
+        .preserve_permissions(false)
+        .preserve_times(false)
+        .with_chmod(Some(chmod));
+
+    assert!(
+        metadata_unchanged(&entry, &opts, &meta, crate::ModifyWindow::ZERO),
+        "an existing destination keeps its own bits when --perms is off"
     );
 }
 

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -147,7 +147,7 @@ tracing = ["dep:tracing"]
 tempfile = { workspace = true }
 filetime = { workspace = true }
 test-support = { path = "../test-support" }
-rustix = { workspace = true, features = ["process", "stdio"] }
+rustix = { workspace = true, features = ["fs", "process", "stdio"] }
 platform = { path = "../platform" }
 criterion = { workspace = true }
 proptest = { workspace = true }

--- a/crates/transfer/src/disk_commit/process/metadata.rs
+++ b/crates/transfer/src/disk_commit/process/metadata.rs
@@ -56,11 +56,17 @@ pub(super) fn apply_file_metadata(
         //
         // upstream: rsync.c:449-472 dest_mode() is called (receiver.c:964) with
         // `statret == 0` for an inplace write, because the destination exists.
+        // upstream: receiver.c:1174-1177 - the basis fd is dropped again
+        // unless it is a regular file, so a symlink / fifo / device obstacle
+        // leaves `exists = fd1 != -1` false and dest_mode() takes the
+        // new-destination arm (its lstat mode - 0o755 for a symlink on some
+        // platforms - must never become the file's permissions).
         let pre_transfer_meta = if target_path != begin.file_path {
             std::fs::symlink_metadata(&begin.file_path).ok()
         } else {
             inplace_pre_transfer.cloned()
-        };
+        }
+        .filter(|existing| existing.file_type().is_file());
         apply_metadata_acls_and_xattrs(
             target_path,
             MetadataApplyInputs {
@@ -290,6 +296,57 @@ mod tests {
         assert_eq!(
             mtime, 1_600_000_000,
             "mtime must come from the begin-message entry"
+        );
+    }
+
+    /// A non-regular obstacle at the final destination (here a symlink) must
+    /// NOT count as an existing destination for `dest_mode()`: upstream drops
+    /// the basis fd unless it is a regular file (receiver.c:1174-1177), so
+    /// the staged file takes the new-destination arm - the entry mode masked
+    /// by the umask - never the obstacle's lstat permission bits (0o755 for a
+    /// symlink on some platforms).
+    #[cfg(unix)]
+    #[test]
+    fn non_regular_basis_takes_the_new_destination_arm() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Pin the umask; metadata caches it on first read and nextest runs
+        // each test in its own process.
+        let prev = rustix::process::umask(rustix::fs::Mode::from_bits_truncate(0o022));
+
+        let dir = test_support::create_tempdir();
+        // The final destination currently holds a symlink obstacle.
+        let final_path = dir.path().join("dest.dat");
+        let pointee = dir.path().join("pointee.dat");
+        std::fs::write(&pointee, b"pointee").unwrap();
+        std::os::unix::fs::symlink(&pointee, &final_path).unwrap();
+        // The staged temp file carries the O_TMPFILE-style creation mode.
+        let staged = dir.path().join("staged.tmp");
+        std::fs::write(&staged, b"payload").unwrap();
+        std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+        let entry =
+            protocol::flist::FileEntry::new_file(std::path::PathBuf::from("dest.dat"), 7, 0o666);
+        let config = DiskCommitConfig {
+            metadata_opts: Some(
+                metadata::MetadataOptions::new()
+                    .preserve_permissions(false)
+                    .preserve_times(false),
+            ),
+            ..DiskCommitConfig::default()
+        };
+
+        let mut begin = begin_for(&final_path, Some(entry));
+        begin.file_path = final_path.clone();
+        let err = apply_file_metadata(&staged, &begin, &config, None);
+        let got = std::fs::metadata(&staged).unwrap().permissions().mode() & 0o7777;
+        rustix::process::umask(prev);
+
+        assert!(err.is_none(), "metadata apply reported an error: {err:?}");
+        assert_eq!(
+            got, 0o644,
+            "staged file must land entry-mode & dflt_perms (0o666 & 0o755), \
+             not the symlink obstacle's lstat bits"
         );
     }
 


### PR DESCRIPTION
## What

`--chmod` without `--perms` was composed backwards: oc applied the chmod tweak ON TOP of the collapsed destination mode, where upstream tweaks the flist mode FIRST (flist.c:1741-1742 sender, :996-997 recv_file_entry) and then lets `dest_mode()` (rsync.c:464-486) collapse it — existing files keep their own permission bits (chmod'd bits discarded), fresh files are masked by `dflt_perms = ACCESSPERMS & ~umask`. Measured 72-cell matrix vs real 3.5.0: 20 of 24 no-`--perms` cells diverged; every `--perms`/`-a` cell already converged.

The worst cell is a hard failure: `--chmod=644 -r` onto an existing destination chmod'ed the destination ROOT directory to 0644, self-locked, and exited 23 with zero files copied, where upstream succeeds and leaves existing directories untouched. Existing dirs at 711 were rewritten to 755/775 in every diverging cell.

## Root cause (four sites, one inversion)

1. `apply_dest_mode_pre_transfer` early-returned whenever `options.chmod().is_some()`, bypassing the exists split entirely.
2. The engine's chmod chain received `fs::metadata` of the JUST-COPIED file, never the pre-transfer destination stat.
3. `base_mode_for_permissions` computed `tweak(dest_mode(x))` instead of `dest_mode(tweak(x))`.
4. The network receiver's `apply_permissions_from_entry` chmod branch had the same inversion (`intended_fake_super_mode` too).

## Fix — one owner

New private `chmod_tweaked_dest_mode(modifiers, dest, source_mode, is_dir, is_reg, options, pre_transfer)`: tweak first, then the `dest_mode()` collapse (including the `-E` exists-arm layer); `--perms` applies the tweaked mode as-is (receiver.c:1181 / generator.c:1855 gate `dest_mode()` on `!preserve_perms`). All chmod-branch consumers route through it. The recursive directory frame plumbs its pre-mkdir stat (`dir_pre_transfer`) into finalization and the transfer-root chmod — which preserves the fresh-root self-lock upstream also has (oracle-confirmed exit 23) while unlocking the existing-root cell. `metadata_unchanged`'s chmod leg now only compares under `--perms`.

Also included: the S_ISREG basis filter at the network receiver's `pre_transfer_meta` capture (`disk_commit/process/metadata.rs`), mirroring receiver.c:1174-1177's non-regular fd-drop — the network analogue of #7746's local fix.

## Measured (real 3.5.0 oracle, umask 022, local copy)

All 12 re-run cells byte-identical to upstream after the fix; the 5 diverging cells closed: exist600+F604`-r` (600), fresh+F666`-r` (644), fresh/exist+ug+w`-r` (644, dirs 755/711 kept), and the `--chmod=644 -r` escalation (exit 0, dirs untouched). All `--perms` and no-chmod controls unchanged.

## Tests + mutations (measured)

7 new tests (metadata composition pins + `--perms` non-vacuity companion + `metadata_unchanged` gate + transfer non-regular-basis pin + engine end-to-end octal escalation cell). Mutation A (restore the early-return): exactly 2 kills, 7738 siblings green. Mutation B (re-invert to collapse-then-tweak): exactly 5 kills, companions green. Both reverted.

## Scoped out

`apply_symlink_permissions_like` still layers chmod on symlink modes (upstream never tweaks symlinks, flist.c:1741 `!S_ISLNK`) — macOS-only surface, unmeasured, left for its own row.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p metadata -p engine -p transfer --all-targets -D warnings` clean, `nextest --lib` 7740 passed / 0 failed / 23 skipped. UTS chmod-relevant subset vs the committed macOS nonroot manifest: every row matches exactly (chmod-setid stays expected-fail); no manifest rows flip, none edited.
