### PR TITLE
fix(engine): gate the io_uring data-write mover on whole-file and report short source reads

### DIFF
--- a/crates/engine/src/local_copy/context_impl/transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/transfer.rs
@@ -649,11 +649,12 @@ impl<'a> CopyContext<'a> {
     /// from - it shrank after the file list recorded it - and lets the run
     /// continue with the remaining entries.
     ///
-    /// Every content path funnels its byte count through here so the four of
+    /// Every content path funnels its byte count through here so the five of
     /// them cannot drift: a `copy_file_range` that returns short, a dense read
-    /// loop that hits EOF early, the sparse loop, and the delta loop that runs
-    /// whenever `--no-whole-file` finds a basis to match against all describe
-    /// the same upstream condition. Upstream has one mover, `map_ptr()`, so a
+    /// loop that hits EOF early, the sparse loop, the opt-in io_uring
+    /// data-write mover whose `read_to_end` came up short, and the delta loop
+    /// that runs whenever `--no-whole-file` finds a basis to match against all
+    /// describe the same upstream condition. Upstream has one mover, `map_ptr()`, so a
     /// path that skips this call reports data loss as success on exactly the
     /// inputs that reach it - for the delta loop, a destination that already
     /// exists.

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/iouring.rs
@@ -45,16 +45,32 @@ fn start_iouring_data_write() -> Instant {
 }
 
 /// Returns whether the current transfer is eligible for the io_uring path.
+///
+/// Reads the gate flags off [`TransferFlags`] like `clonefile::eligible`,
+/// `ficlone::eligible` and `wincopy::eligible` do, so every whole-file mover
+/// consumes the one owner of `whole_file_enabled` instead of re-deriving it.
+/// Without that conjunct `--no-whole-file` was honoured by the other movers
+/// and ignored here whenever no basis existed to build a delta signature
+/// from (`delta_signature_present` only covers the existing-destination
+/// case), so the operator's request landed in this mover's unobserved
+/// whole-file path instead of the read loop.
 pub(super) fn eligible(
     context: &CopyContext,
     strategy: WriteStrategy,
     delta_signature_present: bool,
-    use_sparse_writes: bool,
-    compress_enabled: bool,
+    flags: TransferFlags,
     append_offset: u64,
     file_size: u64,
 ) -> bool {
+    let TransferFlags {
+        whole_file_enabled,
+        use_sparse_writes,
+        compress_enabled,
+        ..
+    } = flags;
+
     matches!(strategy, WriteStrategy::Direct)
+        && whole_file_enabled
         && !delta_signature_present
         && !use_sparse_writes
         && !compress_enabled
@@ -204,6 +220,12 @@ fn dispatch_iouring_data_write(
 
     match fast_io::write_file_with_io_uring(destination, &buf) {
         Ok(()) => {
+            // The `read_to_end` above is this mover's only look at the
+            // source; a byte count short of the length the transfer was
+            // sized from is the same source-shrank-mid-transfer condition
+            // the standard read loop reports, so funnel it through the one
+            // owner of that diagnostic instead of claiming the full length.
+            context.note_short_source_read(copy_source, buf.len() as u64, file_size);
             context.register_progress();
             Ok(Some(IoUringDataWriteOutcome {
                 elapsed: start.elapsed(),
@@ -211,5 +233,169 @@ fn dispatch_iouring_data_write(
         }
         Err(error) if error.kind() == std::io::ErrorKind::Unsupported => Ok(None),
         Err(error) => Err(LocalCopyError::io("copy file", destination, error)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::Path;
+
+    use tempfile::TempDir;
+
+    use super::super::super::TransferFlags;
+    use super::*;
+    use crate::local_copy::{LocalCopyExecution, LocalCopyOptions};
+
+    /// Flags that satisfy every conjunct of [`eligible`].
+    fn eligible_flags() -> TransferFlags {
+        TransferFlags {
+            append_allowed: false,
+            append_verify: false,
+            whole_file_enabled: true,
+            inplace_enabled: false,
+            partial_enabled: false,
+            use_sparse_writes: false,
+            compress_enabled: false,
+            size_only_enabled: false,
+            ignore_times_enabled: false,
+            checksum_enabled: false,
+            #[cfg(all(any(unix, windows), feature = "xattr"))]
+            preserve_xattrs: false,
+            xattrs_changed: false,
+            #[cfg(all(any(unix, windows), feature = "acl"))]
+            preserve_acls: false,
+        }
+    }
+
+    fn test_context(root: &Path) -> CopyContext<'_> {
+        CopyContext::new(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default(),
+            None,
+            root.to_path_buf(),
+        )
+    }
+
+    /// `--no-whole-file` must refuse this mover exactly like it refuses the
+    /// other whole-file movers, including when no basis exists and therefore
+    /// no delta signature was built.
+    #[test]
+    fn eligible_requires_whole_file() {
+        let temp = TempDir::new().expect("tempdir");
+        let context = test_context(temp.path());
+        let mut flags = eligible_flags();
+
+        assert!(
+            eligible(
+                &context,
+                WriteStrategy::Direct,
+                false,
+                flags,
+                0,
+                IOURING_DATA_WRITES_MIN_BYTES,
+            ),
+            "control: fully eligible flags must pass the gate",
+        );
+
+        flags.whole_file_enabled = false;
+        assert!(
+            !eligible(
+                &context,
+                WriteStrategy::Direct,
+                false,
+                flags,
+                0,
+                IOURING_DATA_WRITES_MIN_BYTES,
+            ),
+            "--no-whole-file must disqualify the io_uring data-write mover",
+        );
+    }
+
+    /// A source that ended before the length the transfer was sized from must
+    /// be reported through `note_short_source_read` (forcing exit 23), not
+    /// recorded as a full-length success.
+    #[test]
+    fn dispatch_reports_short_source_read() {
+        if !fast_io::is_io_uring_available() {
+            eprintln!("skipping: io_uring unavailable in this environment");
+            return;
+        }
+
+        let temp = TempDir::new().expect("tempdir");
+        let source = temp.path().join("src.bin");
+        let destination = temp.path().join("dst.bin");
+        const ACTUAL_LEN: usize = 1024;
+        File::create(&source)
+            .expect("create source")
+            .write_all(&[0x5a; ACTUAL_LEN])
+            .expect("write source");
+        // The file list recorded more bytes than the opened file holds.
+        let declared_len = ACTUAL_LEN as u64 + 4096;
+
+        let mut context = test_context(temp.path());
+        let mut reader = File::open(&source).expect("open source");
+        let outcome = dispatch_iouring_data_write(
+            &mut context,
+            &mut reader,
+            &source,
+            &destination,
+            declared_len,
+            start_iouring_data_write(),
+        )
+        .expect("dispatch");
+        assert!(
+            outcome.is_some(),
+            "io_uring probe passed but the dispatch fell back",
+        );
+        assert!(
+            context.source_read_error_occurred(),
+            "a short source read must be recorded for RERR_PARTIAL (23)",
+        );
+        assert_eq!(
+            fs::metadata(&destination).expect("stat destination").len(),
+            ACTUAL_LEN as u64,
+            "the destination holds exactly the bytes the source still had",
+        );
+    }
+
+    /// Control for the short-read pin: a source that still holds every
+    /// declared byte must not be flagged.
+    #[test]
+    fn dispatch_full_source_records_no_read_error() {
+        if !fast_io::is_io_uring_available() {
+            eprintln!("skipping: io_uring unavailable in this environment");
+            return;
+        }
+
+        let temp = TempDir::new().expect("tempdir");
+        let source = temp.path().join("src.bin");
+        let destination = temp.path().join("dst.bin");
+        const ACTUAL_LEN: usize = 1024;
+        File::create(&source)
+            .expect("create source")
+            .write_all(&[0x5a; ACTUAL_LEN])
+            .expect("write source");
+
+        let mut context = test_context(temp.path());
+        let mut reader = File::open(&source).expect("open source");
+        let outcome = dispatch_iouring_data_write(
+            &mut context,
+            &mut reader,
+            &source,
+            &destination,
+            ACTUAL_LEN as u64,
+            start_iouring_data_write(),
+        )
+        .expect("dispatch");
+        assert!(
+            outcome.is_some(),
+            "io_uring probe passed but the dispatch fell back",
+        );
+        assert!(
+            !context.source_read_error_occurred(),
+            "a full-length read must not be flagged as a short source read",
+        );
     }
 }

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -504,8 +504,7 @@ pub(in crate::local_copy) fn execute_transfer_once(
         context,
         strategy,
         delta_signature.is_some(),
-        use_sparse_writes,
-        compress_enabled,
+        flags,
         append_offset,
         file_size,
     ) && iouring::try_dispatch(


### PR DESCRIPTION
## What

The opt-in `iouring-data-writes` mover (Linux-only, not in default features) missed two rules the other four whole-file movers have:

1. **`eligible()` had no `whole_file_enabled` conjunct** — the gate #7537 added to the other movers for the `source-change-size-continues` cell. The existing `!delta_signature_present` term only covers `--no-whole-file` *with an existing destination* (a signature is only built then), so the live gap was `--no-whole-file` against a fresh destination: the operator's request landed in this mover's unobserved whole-file path instead of the read loop.
2. **A short source read was silently claimed as full length** — `dispatch_iouring_data_write` reads with `read_to_end` and recorded `record_file(file_size, file_size, …)` with no `note_short_source_read`, so a source that shrank mid-transfer under-copied with exit 0 where every other mover produces the `read errors mapping` diagnostic + exit 23.

## Single owner, not a copied predicate

The four movers' shared gate owner is the `TransferFlags` struct — `clonefile`, `ficlone`, and `wincopy` each destructure `whole_file_enabled` from it. `eligible()` now takes `TransferFlags` and destructures the three flags it consumes, making it the fifth consumer of the one owner instead of re-plucking individual bools through its parameter list. The short-read owner is `CopyContext::note_short_source_read`; the dispatch success branch now calls it with actual-vs-declared bytes (success branch only, so an `Unsupported` fallback does not double-report when the standard loop re-reads). The owner's "four content paths" doc inventory is updated to five.

## Verified on real io_uring

Tests live inside the mover's `linux + feature` cfg and were executed on a Linux host with io_uring genuinely running (no skip; `--nocapture` shows the real `read errors mapping … No data available (61)` line):

- `eligible_requires_whole_file` (refusal + control)
- `dispatch_reports_short_source_read` (declared > actual → `source_read_error_occurred()` and the destination holds exactly the actual bytes)
- `dispatch_full_source_records_no_read_error` (non-vacuity control)

Mutation (remove the `whole_file_enabled` conjunct): `eligible_requires_whole_file` fails at the assertion; reverted. A full `--features iouring-data-writes` engine run on that host fails an identical pre-existing set on the untouched base (environmental to that host's parallel run; 4748/4748 on macOS default features).

## CI coverage note

No feature-combinations cell builds this feature; coverage comes from the `--all-features` cells (workspace nextest on ubuntu, clippy `--all-features`, and the iouring-kernel-compat matrix), where these tests will execute.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (3426 files), `clippy -p engine --all-targets -D warnings` clean (default and `--features iouring-data-writes`), `nextest -p engine --lib` 4748 passed / 23 skipped.
