### PR TITLE
fix(daemon): refuse the malformed filter shapes upstream exits RERR_SYNTAX on

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -738,24 +738,63 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         });
     }
 
-    // upstream: exclude.c:1134-1178 - keyword-to-short-form mapping;
+    // upstream: exclude.c:1289-1327 - keyword-to-short-form mapping;
     // `hide`/`show` set FILTRULE_SENDER_SIDE (exclude.c:1345-1350),
-    // `protect`/`risk` FILTRULE_RECEIVER_SIDE (exclude.c:1351-1357).
-    // (keyword, is_include, sender_side)
-    const KEYWORDS: &[(&str, bool, bool)] = &[
-        ("exclude", false, false),
-        ("include", true, false),
-        ("hide", false, true),
-        ("show", true, true),
-        ("protect", false, false), // receiver-side upstream; see the drop below
-        ("risk", true, false),     // receiver-side upstream; see the drop below
+    // `protect`/`risk` FILTRULE_RECEIVER_SIDE (exclude.c:1351-1357). All four
+    // side keywords set `prefix_specifies_side` (exclude.c:1350, :1357), which
+    // narrows the modifier alphabet their `,` form accepts.
+    // (keyword, is_include, sender_side, specifies_side)
+    const KEYWORDS: &[(&str, bool, bool, bool)] = &[
+        ("exclude", false, false, false),
+        ("include", true, false, false),
+        ("hide", false, true, true),
+        ("show", true, true, true),
+        ("protect", false, false, true), // receiver-side upstream; see the drop below
+        ("risk", true, false, true),     // receiver-side upstream; see the drop below
     ];
 
-    for &(keyword, is_include, sender_side) in KEYWORDS {
-        if let Some(pattern) = strip_keyword_prefix(token, keyword) {
-            let pattern = pattern.trim();
+    for &(keyword, is_include, sender_side, specifies_side) in KEYWORDS {
+        if let Some(rest) = strip_matched_keyword(token, keyword) {
+            // upstream refuses a keyword that never reaches a pattern:
+            // `rule_strcmp` returns the comma's own address for a `,`
+            // terminator (exclude.c:1224-1225), so the scan loop reads every
+            // byte after it - up to the first space, `_`, or end of token
+            // (exclude.c:1364) - as a MODIFIER character, and any byte outside
+            // the alphabet exits RERR_SYNTAX (exclude.c:1369-1380).
+            //
+            // MEASURED against a real rsync 3.5.0 daemon (module holding
+            // `foo` + `keep` + `bar`, pinned 3.5.0 client, loopback TCP):
+            //   filter = - foo hide       -> rc 5 "unexpected end of filter rule: hide"
+            //   filter = - foo hide,keep  -> rc 5 "invalid modifier 'k' at position 5 in filter rule: hide,keep"
+            //   filter = protect,keep     -> rc 5 "invalid modifier 'k' at position 8 in filter rule: protect,keep"
+            //   filter = hide,r keep      -> rc 5 "invalid modifier 'r' at position 5 in filter rule: hide,r keep"
+            //   filter = hide,p keep      -> rc 0 (valid modifier; rule then dropped at add time)
+            //   filter = hide, keep       -> rc 0 (empty modifier run is valid)
+            //   filter = exclude          -> rc 5 "unexpected end of filter rule: exclude"
+            // oc served every refused config above (rc 0), handing out the
+            // very files the operator's filter names - the fail-open this arm
+            // closes. A token that PASSES the modifier scan keeps its previous
+            // handling here: the modifier semantics themselves (`p`, `x`, ...)
+            // are not implemented on this path, and growing them is a separate
+            // change from refusing what upstream refuses.
+            let pattern = if let Some(modifier_run) = rest.strip_prefix(',') {
+                validate_comma_modifiers(modifier_run, keyword.len(), specifies_side, token)?;
+                modifier_run
+            } else {
+                // Whitespace or `_` terminator: one separator consumed, the
+                // remainder is the pattern (see `strip_matched_keyword` on the
+                // run-vs-one question).
+                rest.strip_prefix('_').unwrap_or(rest)
+            }
+            .trim();
             if pattern.is_empty() {
-                return Ok(None);
+                // upstream: exclude.c:1474-1476 - `else if (!len && !CVS_IGNORE)`
+                // refuses a rule whose pattern token is empty. This covers the
+                // line-final keyword (`- foo hide`), the bare keyword
+                // (`filter = exclude`), and the patternless `,` form (`hide,`).
+                return Err(MalformedRule::UnexpectedEnd {
+                    token: token.to_owned(),
+                });
             }
             // The side test happens HERE, at add time, never at match time.
             // upstream: `add_rule` drops a rule whose side flags equal
@@ -785,15 +824,86 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         }
     }
 
-    if strip_keyword_prefix(token, "clear").is_some() {
-        return Ok(Some(clear_list_rule()));
+    if let Some(rest) = strip_matched_keyword(token, "clear") {
+        // `clear` maps to `!` (exclude.c:1290-1291), and `!` SKIPS the
+        // modifier scan (`while (ch != '!' && ...)`, exclude.c:1364). The
+        // refusal comes from the check AFTER it: with neither
+        // FILTRULE_NO_PREFIXES nor XFLG_OLD_PREFIXES in play here, any
+        // non-empty trailing text refuses (exclude.c:1467-1470).
+        //
+        // The accepted spellings are exactly `clear` and `clear,`: a `,`
+        // terminator leaves `s` on the comma and the `if (*s) s++` step
+        // (exclude.c:1444-1445) consumes it, so the token ends with `len == 0`.
+        // MEASURED against rsync 3.5.0:
+        //   filter = - foo clear,      -> rc 0, list cleared, all files served
+        //   filter = - foo clear,- keep -> rc 5 "'!' rule has trailing characters: clear,- keep"
+        //   filter = clear,x           -> rc 5 "'!' rule has trailing characters: clear,x"
+        //   filter = clear_            -> rc 5 "'!' rule has trailing characters: clear_"
+        // oc built the clear rule and IGNORED the trailer, so `- foo clear,- keep`
+        // wiped the exclude and served every file of a module upstream refuses.
+        //
+        // Only the token's FIRST whitespace-delimited word decides: upstream's
+        // word-split loop hands later words to parse_rule_tok as fresh tokens
+        // (`clear P keep` is a clear plus a valid `P keep` rule, measured
+        // rc 0), and oc's splitter glues such words onto this token - that
+        // gluing is the tracked bare-word/merge gap, not this refusal's.
+        let trailer = rest
+            .split(|c: char| c.is_ascii_whitespace())
+            .next()
+            .unwrap_or("");
+        if trailer.is_empty() || trailer == "," {
+            return Ok(Some(clear_list_rule()));
+        }
+        return Err(MalformedRule::ClearWithTrailingCharacters {
+            token: token.to_owned(),
+        });
     }
 
-    // Bare pattern defaults to exclude (upstream behaviour)
+    // A bare token falls through to a literal exclude. ⚠ NOT upstream
+    // behaviour: upstream refuses an unrecognised word ("Unknown filter rule",
+    // exclude.c:1363) and honours `merge`/`dir-merge`, both of which land here
+    // today. That gap is tracked on its own; refusing bare words before the
+    // merge keywords grow an arm would turn `filter = merge FILE` - a config
+    // upstream serves - into a refusal, which is why this arm must outlive
+    // this commit unchanged.
     if token.is_empty() {
         return Ok(None);
     }
     Ok(Some(build_pattern_rule(token, false)))
+}
+
+/// Validates the modifier run a `,`-terminated keyword carries.
+///
+/// upstream: `rule_strcmp` returns the comma's own address (exclude.c:1224-1225),
+/// so the scan loop at exclude.c:1364-1443 reads every byte after the comma -
+/// up to the first space, `_`, or end of token - as a modifier character. The
+/// daemon `filter` directive never reaches this scan with FILTRULE_MERGE_FILE,
+/// so the merge-only modifiers (`-`, `+`, `e`, `n`, `w`, exclude.c:1381-1417)
+/// refuse, `C`/`r`/`s` refuse when the keyword already names a side
+/// (`prefix_specifies_side`, exclude.c:1403-1404, :1423-1430), and any other
+/// byte hits `default: invalid` (exclude.c:1369-1380). All exits are
+/// RERR_SYNTAX with the byte and its offset from the token start named.
+fn validate_comma_modifiers(
+    modifier_run: &str,
+    keyword_len: usize,
+    specifies_side: bool,
+    token: &str,
+) -> Result<(), MalformedRule> {
+    for (offset, ch) in modifier_run.char_indices() {
+        if ch == '_' || ch.is_ascii_whitespace() {
+            break;
+        }
+        let valid = matches!(ch, '/' | '!' | 'p' | 'x')
+            || (!specifies_side && matches!(ch, 'C' | 'r' | 's'));
+        if !valid {
+            return Err(MalformedRule::InvalidModifier {
+                modifier: ch,
+                position: keyword_len + 1 + offset,
+                token: token.to_owned(),
+            });
+        }
+    }
+    Ok(())
 }
 
 /// A daemon filter token upstream's parser refuses.
@@ -881,22 +991,22 @@ fn non_empty_pattern_rule(pattern: &str, is_include: bool) -> Option<FilterRuleW
     Some(build_pattern_rule(pattern, is_include))
 }
 
-/// Strips a keyword prefix from a token, returning the remainder.
+/// Strips a keyword from a token, returning the remainder WITH its terminator.
 ///
 /// Returns `None` when the token does not start with the keyword, or starts
 /// with it but is not TERMINATED by it - `hideout` is not a `hide` rule.
+/// The terminator itself stays in the returned remainder because the callers
+/// diverge on it: a `,` opens upstream's modifier scan, while whitespace and
+/// `_` lead straight to the pattern.
 ///
 /// upstream: `exclude.c:1218-1227` `rule_strcmp`, via [`is_keyword_terminator`].
-/// The set this replaced was `' '` or `','` alone, so `_` and tab - both
-/// separators upstream accepts - made the token not-a-keyword and it fell
+/// The set an earlier version used was `' '` or `','` alone, so `_` and tab -
+/// both separators upstream accepts - made the token not-a-keyword and it fell
 /// through to the bare-pattern arm.
 ///
-/// ⚠ The trailing `trim_start` consumes a whole RUN of whitespace, where
-/// upstream consumes exactly ONE separator (`if (*s) s++`,
-/// `exclude.c:1444-1445`) and takes the remainder verbatim - a rule oc's CLI
-/// parser measured against rsync 3.5.0 for the NON-word-split `--filter`.
-///
-/// MEASURED for THIS directive against a real rsync 3.5.0 daemon, and the
+/// ⚠ The callers trim a whole RUN of separators off the pattern, where
+/// upstream consumes exactly ONE (`if (*s) s++`, `exclude.c:1444-1445`).
+/// MEASURED for this directive against a real rsync 3.5.0 daemon, and the
 /// question turns out to be UNASKABLE here rather than answered either way:
 ///
 /// - `filter = exclude bar` (ONE space) builds the pattern `bar`, NOT ` bar`.
@@ -910,17 +1020,14 @@ fn non_empty_pattern_rule(pattern: &str, is_include: bool) -> Option<FilterRuleW
 ///   pattern is ever built.
 ///
 /// So a doubled separator cannot produce a divergent PATTERN in this mode; it
-/// produces a refusal upstream and an accepted rule in oc. That gap belongs to
-/// the daemon's broader accept-where-upstream-refuses class, which is tracked
-/// separately, not to this function's run-vs-one-separator behaviour. The
-/// `trim_start` is therefore left as it is, now on measurement rather than on
-/// the absence of one.
-fn strip_keyword_prefix<'a>(token: &'a str, keyword: &str) -> Option<&'a str> {
+/// produces a refusal upstream and an accepted rule in oc. That residual gap
+/// belongs to the gluing splitter above, which is tracked with the bare-word
+/// class, not to this function's run-vs-one-separator behaviour.
+fn strip_matched_keyword<'a>(token: &'a str, keyword: &str) -> Option<&'a str> {
     let rest = token.strip_prefix(keyword)?;
-    let mut chars = rest.chars();
-    match chars.next() {
+    match rest.chars().next() {
         None => Some(rest),
-        Some(ch) if is_keyword_terminator(ch) => Some(chars.as_str().trim_start()),
+        Some(ch) if is_keyword_terminator(ch) => Some(rest),
         Some(_) => None,
     }
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2878,11 +2878,95 @@ mod module_access_tests {
     }
 
     #[test]
-    fn parse_daemon_filter_token_exclude_keyword_comma_sep() {
-        // upstream: RULE_STRCMP accepts comma as separator
-        let rule = accepted_rule("exclude,*.bak");
+    fn a_comma_joined_word_after_a_keyword_is_refused() {
+        // FLIPPED from `parse_daemon_filter_token_exclude_keyword_comma_sep`,
+        // which pinned `exclude,*.bak` as an exclude of `*.bak` on the claim
+        // "RULE_STRCMP accepts comma as separator". The premise is upstream's;
+        // the conclusion is not: `rule_strcmp` returns the COMMA's own address
+        // for that terminator (exclude.c:1224-1225), so what follows it is
+        // read as MODIFIER characters, not a pattern.
+        //
+        // MEASURED against rsync 3.5.0 (module foo+keep+bar, 3.5.0 client):
+        //   filter = exclude,*.bak     -> rc 5, serves nothing
+        //   filter = - foo hide,keep   -> rc 5, serves nothing
+        //   filter = protect,keep      -> rc 5, serves nothing
+        // oc served all three modules (rc 0) - including, for the hide cell,
+        // the file `foo` the operator's own rule names. The messages below are
+        // the daemon-log lines the real binary produced, byte for byte.
+        for (token, msg) in [
+            (
+                "exclude,*.bak",
+                "invalid modifier '*' at position 8 in filter rule: exclude,*.bak",
+            ),
+            (
+                "hide,keep",
+                "invalid modifier 'k' at position 5 in filter rule: hide,keep",
+            ),
+            (
+                "show,keep",
+                "invalid modifier 'k' at position 5 in filter rule: show,keep",
+            ),
+            (
+                "protect,keep",
+                "invalid modifier 'k' at position 8 in filter rule: protect,keep",
+            ),
+            (
+                "risk,keep",
+                "invalid modifier 'k' at position 5 in filter rule: risk,keep",
+            ),
+            (
+                "include,bar",
+                "invalid modifier 'b' at position 8 in filter rule: include,bar",
+            ),
+        ] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(err.to_string(), msg, "{token}");
+        }
+    }
+
+    #[test]
+    fn a_side_modifier_on_a_side_keyword_is_refused() {
+        // upstream: the `r`/`s` modifier arms refuse when the keyword already
+        // names a side (`prefix_specifies_side`, exclude.c:1423-1430); `C`
+        // refuses likewise (exclude.c:1403-1404). MEASURED:
+        //   filter = hide,r keep  -> rc 5 "invalid modifier 'r' at position 5..."
+        //   filter = hide,C keep  -> rc 5 "invalid modifier 'C' at position 5..."
+        let err = parse_daemon_filter_token("hide,r keep").expect_err("must refuse");
+        assert_eq!(
+            err.to_string(),
+            "invalid modifier 'r' at position 5 in filter rule: hide,r keep"
+        );
+        let err = parse_daemon_filter_token("hide,C keep").expect_err("must refuse");
+        assert_eq!(
+            err.to_string(),
+            "invalid modifier 'C' at position 5 in filter rule: hide,C keep"
+        );
+    }
+
+    #[test]
+    fn a_valid_modifier_run_after_a_comma_stays_accepted() {
+        // NON-VACUITY for the refusals above: the modifier scan must not
+        // become a blanket comma ban. MEASURED against rsync 3.5.0, all rc 0:
+        //   filter = hide, keep    (empty modifier run)
+        //   filter = hide,p keep   (perishable)
+        //   filter = hide,x keep   (xattr)
+        //   filter = hide,/ keep   (abs-path)
+        // upstream drops the hide at add time and serves everything; oc's
+        // `Ok(None)` drop is the same observable. The modifier SEMANTICS stay
+        // unimplemented on this path - these cells pin acceptance, nothing
+        // more.
+        for token in ["hide, keep", "hide,p keep", "hide,x keep", "hide,/ keep"] {
+            assert!(is_skipped(token), "{token}");
+        }
+        // `r`/`s`/`C` stay legal where no side is pre-named. MEASURED:
+        // `filter = exclude,r keep` is accepted (rc 0) and upstream keeps the
+        // rule side-blind. oc's pattern still glues the modifier run into the
+        // pattern text (`r keep` matches nothing) - a pre-existing divergence
+        // on an accepted config, pinned as-is because changing what a valid
+        // modifier MEANS is a different change from refusing invalid ones.
+        let rule = accepted_rule("exclude,r keep");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
-        assert_eq!(rule.pattern, "*.bak");
+        assert_eq!(rule.pattern, "r keep");
     }
 
     #[test]
@@ -2949,6 +3033,48 @@ mod module_access_tests {
     }
 
     #[test]
+    fn a_clear_with_a_comma_joined_trailer_is_refused() {
+        // upstream: `clear` maps to `!`, the modifier scan is SKIPPED
+        // (`while (ch != '!' && ...)`, exclude.c:1364), and the trailing-text
+        // check after it refuses any non-empty remainder (exclude.c:1467-1470).
+        //
+        // MEASURED against rsync 3.5.0 (module foo+keep+bar, 3.5.0 client):
+        //   filter = - foo clear,- keep -> rc 5 "'!' rule has trailing characters: clear,- keep"
+        //   filter = clear,x            -> rc 5 "'!' rule has trailing characters: clear,x"
+        //   filter = clear_             -> rc 5 "'!' rule has trailing characters: clear_"
+        // On the first cell oc built the clear, WIPED the operator's `- foo`
+        // exclude, and served every file of a module upstream refuses.
+        for (token, msg) in [
+            (
+                "clear,- keep",
+                "'!' rule has trailing characters: clear,- keep",
+            ),
+            ("clear,x", "'!' rule has trailing characters: clear,x"),
+            ("clear_", "'!' rule has trailing characters: clear_"),
+        ] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(err.to_string(), msg, "{token}");
+        }
+    }
+
+    #[test]
+    fn a_clear_with_a_bare_comma_stays_a_clear_rule() {
+        // NON-VACUITY for the trailer refusal: `clear,` is upstream-VALID -
+        // `rule_strcmp` leaves `s` on the comma and `if (*s) s++`
+        // (exclude.c:1444-1445) consumes it, ending the token at `len == 0`.
+        // MEASURED: `filter = - foo clear,` is rc 0 with every file served.
+        let rule = accepted_rule("clear,");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
+        // A glued FOLLOWING word is upstream's next token, not this rule's
+        // trailer - `filter = clear P keep` is accepted upstream (a clear plus
+        // a `P keep` protect). oc's splitter glues it here; only the first
+        // word may decide the refusal. The tail stays ignored - that gluing
+        // gap is tracked with the bare-word class.
+        let rule = accepted_rule("clear P keep");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
+    }
+
+    #[test]
     fn parse_daemon_filter_token_keyword_not_partial_match() {
         // "excluder" should NOT match "exclude" keyword - treated as bare pattern
         let rule = accepted_rule("excluder *.tmp");
@@ -2957,9 +3083,36 @@ mod module_access_tests {
     }
 
     #[test]
-    fn parse_daemon_filter_token_keyword_empty_pattern_returns_none() {
-        assert!(is_skipped("exclude"));
-        assert!(is_skipped("include "));
+    fn a_patternless_keyword_is_refused() {
+        // FLIPPED from `parse_daemon_filter_token_keyword_empty_pattern_returns_none`,
+        // which pinned the fail-open: a keyword that never reaches a pattern
+        // was silently skipped and the module served. upstream refuses it -
+        // `else if (!len && !CVS_IGNORE)` (exclude.c:1474-1476).
+        //
+        // MEASURED against rsync 3.5.0 (module foo+keep+bar, 3.5.0 client):
+        //   filter = - foo hide  -> rc 5 "unexpected end of filter rule: hide"
+        //   filter = exclude     -> rc 5 "unexpected end of filter rule: exclude"
+        //   filter = protect     -> rc 5 "unexpected end of filter rule: protect"
+        //   filter = hide,       -> rc 5 "unexpected end of filter rule: hide,"
+        // On the first cell oc served `keep` AND `bar` with `foo` silently
+        // hidden - a successful-looking transfer of a module upstream refuses
+        // to serve at all.
+        for token in ["hide", "exclude", "include", "protect", "hide,"] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(
+                err.to_string(),
+                format!("unexpected end of filter rule: {token}"),
+                "{token:?}"
+            );
+        }
+        // The old pin's second row, kept refusing: a keyword whose "pattern"
+        // is only whitespace. (Real tokens are trimmed by the splitter; this
+        // spelling reaches the parser only through direct calls.)
+        let err = parse_daemon_filter_token("include ").expect_err("must refuse");
+        assert!(
+            err.to_string().starts_with("unexpected end of filter rule"),
+            "{err}"
+        );
     }
 
     // ---------------------------------------------------------------------
@@ -3071,43 +3224,45 @@ mod module_access_tests {
     }
 
     #[test]
-    fn strip_keyword_prefix_space_separator() {
+    fn strip_matched_keyword_space_separator() {
+        // The terminator STAYS in the remainder: the caller's arms diverge on
+        // whether it is a `,` (modifier scan) or whitespace/`_` (pattern).
         assert_eq!(
-            strip_keyword_prefix("exclude *.tmp", "exclude"),
-            Some("*.tmp")
+            strip_matched_keyword("exclude *.tmp", "exclude"),
+            Some(" *.tmp")
         );
     }
 
     #[test]
-    fn strip_keyword_prefix_comma_separator() {
+    fn strip_matched_keyword_comma_separator() {
         assert_eq!(
-            strip_keyword_prefix("exclude,*.tmp", "exclude"),
-            Some("*.tmp")
+            strip_matched_keyword("exclude,*.tmp", "exclude"),
+            Some(",*.tmp")
         );
     }
 
     #[test]
-    fn strip_keyword_prefix_no_separator() {
+    fn strip_matched_keyword_no_separator() {
         // "excluder" should not match "exclude"
-        assert_eq!(strip_keyword_prefix("excluder *.tmp", "exclude"), None);
+        assert_eq!(strip_matched_keyword("excluder *.tmp", "exclude"), None);
     }
 
     #[test]
-    fn strip_keyword_prefix_exact_keyword_no_pattern() {
-        assert_eq!(strip_keyword_prefix("exclude", "exclude"), Some(""));
+    fn strip_matched_keyword_exact_keyword_no_pattern() {
+        assert_eq!(strip_matched_keyword("exclude", "exclude"), Some(""));
     }
 
     #[test]
-    fn strip_keyword_prefix_no_match() {
-        assert_eq!(strip_keyword_prefix("include *.tmp", "exclude"), None);
+    fn strip_matched_keyword_no_match() {
+        assert_eq!(strip_matched_keyword("include *.tmp", "exclude"), None);
     }
 
     /// upstream: `exclude.c:1222` - `rule_strcmp` accepts `_` as a keyword
     /// separator. The set this replaced was `' '` or `','` alone, so `_` made
     /// the token not-a-keyword and it fell through to the bare-pattern arm.
     #[test]
-    fn strip_keyword_prefix_underscore_separator() {
-        assert_eq!(strip_keyword_prefix("hide_bar", "hide"), Some("bar"));
+    fn strip_matched_keyword_underscore_separator() {
+        assert_eq!(strip_matched_keyword("hide_bar", "hide"), Some("_bar"));
     }
 
     /// upstream: `exclude.c:1222` - `rule_strcmp` tests `isspace`, so a TAB is
@@ -3129,8 +3284,8 @@ mod module_access_tests {
     /// into, tracked separately. Do NOT read it as "upstream parses
     /// `exclude\tbar` as an exclude of `bar`" - it does not.
     #[test]
-    fn strip_keyword_prefix_tab_separator() {
-        assert_eq!(strip_keyword_prefix("hide\tbar", "hide"), Some("bar"));
+    fn strip_matched_keyword_tab_separator() {
+        assert_eq!(strip_matched_keyword("hide\tbar", "hide"), Some("\tbar"));
     }
 
     #[test]


### PR DESCRIPTION
## What

Three arms of the daemon `filter` token parser accepted shapes upstream exits `RERR_SYNTAX` on, and **served the module anyway** — handing out the very files the operator's filter names.

Measured against a real rsync 3.5.0 daemon (module holding `foo` + `keep` + `bar`, pinned 3.5.0 client, loopback TCP), oc-base served every one of these at rc 0:

| directive | upstream | oc base | oc fix |
|---|---|---|---|
| `filter = - foo hide` | rc 5 `unexpected end of filter rule: hide` | rc 0, serves | rc 5 |
| `filter = - foo hide,keep` | rc 5 `invalid modifier 'k' at position 5 …` | rc 0, serves | rc 5 |
| `filter = protect,keep` | rc 5 `invalid modifier 'k' at position 8 …` | rc 0, serves | rc 5 |
| `filter = hide,r keep` | rc 5 `invalid modifier 'r' at position 5 …` | rc 0, serves | rc 5 |
| `filter = exclude` | rc 5 `unexpected end of filter rule: exclude` | rc 0, serves | rc 5 |
| `filter = - foo clear,- keep` | rc 5 `'!' rule has trailing characters: …` | rc 0, **clears the exclude and serves every file** | rc 5 |
| `filter = hide,p keep` / `hide, keep` / `clear,` | rc 0 | rc 0 | rc 0 (acceptance companions) |

## Upstream rule (cited at each site)

1. **Patternless keyword.** `rule_strcmp` returns the comma's own address for a `,` terminator (exclude.c:1224-1225), so the scan loop reads every byte after it — to the first space, `_`, or end of token (exclude.c:1364) — as a MODIFIER, and anything outside the alphabet exits RERR_SYNTAX (:1369-1380). An empty pattern is refused at exclude.c:1474-1476.
2. **Comma modifier alphabet.** `/`, `!`, `p`, `x` always; `C`/`r`/`s` only when the keyword does not already name a side (`prefix_specifies_side`, exclude.c:1403-1404, :1423-1430). The merge-only modifiers (`-`, `+`, `e`, `n`, `w`, exclude.c:1381-1417) refuse because the daemon `filter` directive never reaches the scan with FILTRULE_MERGE_FILE.
3. **`clear` trailers.** `clear` maps to `!` (exclude.c:1290-1291), which SKIPS the modifier scan; the refusal is the check after it (exclude.c:1467-1470). Accepted spellings are exactly `clear` and `clear,` — the `,` terminator is consumed by `if (*s) s++` (:1444-1445) leaving `len == 0`.

## Shape

`strip_matched_keyword` now keeps the terminator so the parser can tell `hide,…` from `hide …` from a line-final `hide`. A new `validate_comma_modifiers` owns the alphabet with the side-narrowing rule; refusals route through the existing `MalformedRule` → `@ERROR` path (PR #7736's shape), byte-for-byte upstream text.

## Deliberately unchanged

The bare-word fall-through to a literal exclude stays, with a comment saying why: upstream refuses an unrecognised word and honours `merge`/`dir-merge`, both of which land in that arm today. Refusing bare words before the merge keywords grow an arm would turn `filter = merge FILE` — a config upstream serves — into a refusal. That gap is tracked separately.

## Tests + mutation (measured)

4 refusal pins + 2 acceptance companions + 7 helper pins. Mutation (all three fail-open arms restored): kills exactly the 4 refusal pins, 1897 others green. Reverted.

## Gates

Pinned 1.88.0 on the rebased head: whole-tree rustfmt clean (3427 files), `clippy -p daemon --all-targets --all-features -D warnings` clean, `nextest -p daemon --lib` 1901/1901. Local UTS macOS nonroot TCP leg byte-identical to the committed manifest; no expect-manifest row edited.
