### PR TITLE
fix(engine): discard and redo a local copy whose source shrank mid-read

### DIFF
--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -198,6 +198,13 @@ pub(crate) struct CopyContext<'a> {
     // `map_ptr()` recorded, and the sender sets `io_error |= IOERR_GENERAL`
     // plus one `read errors mapping %s` line before continuing.
     source_read_error: bool,
+    /// Monotonic count of `record_source_read_error` calls. The sticky flag
+    /// above cannot tell one file's short read from an earlier file's, so the
+    /// transfer executor snapshots this counter around a copy pass to decide
+    /// whether THIS pass read a source that shrank and must be redone.
+    // upstream: the per-file equivalent is `mbuf->status` handed back by
+    // `unmap_file()` (fileio.c:385) - per-map, not global.
+    source_read_events: u64,
     /// Set when an `--iconv` filename could not be strictly transcoded to the
     /// remote charset and its entry was skipped. Drives the final
     /// `RERR_PARTIAL` (exit 23) exit code, mirroring upstream's

--- a/crates/engine/src/local_copy/context_impl/state.rs
+++ b/crates/engine/src/local_copy/context_impl/state.rs
@@ -67,6 +67,7 @@ impl<'a> CopyContext<'a> {
             io_errors_occurred: false,
             io_error_delete_warning_emitted: false,
             source_read_error: false,
+            source_read_events: 0,
             iconv_conversion_error: false,
             unsupported_operation_skipped: false,
             sender_remove_error: false,
@@ -567,6 +568,17 @@ impl<'a> CopyContext<'a> {
     pub(super) fn record_source_read_error(&mut self) {
         self.source_read_error = true;
         self.io_errors_occurred = true;
+        self.source_read_events += 1;
+    }
+
+    /// Monotonic count of short-source-read reports. A transfer pass snapshots
+    /// it before copying and compares after: a difference means THIS pass read
+    /// a source that ended early, so its staged result is inconsistent and the
+    /// pass must be discarded and redone. The sticky
+    /// [`source_read_error_occurred`](Self::source_read_error_occurred) flag
+    /// cannot carry that per-pass signal once any earlier file has set it.
+    pub(in crate::local_copy) const fn source_read_events(&self) -> u64 {
+        self.source_read_events
     }
 
     /// Reports whether a short source read must force `RERR_PARTIAL` (23).

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/execute/mod.rs
@@ -623,6 +623,9 @@ pub(in crate::local_copy) fn execute_transfer_once(
     // non-inplace here keeps matched-block bytes flowing to the writer instead of
     // being skipped against an empty file.
     let basis_separate_from_writer = delta_basis_override.is_some();
+    // Snapshot the short-read counter so the check below sees only THIS
+    // pass's report, not one an earlier file already recorded.
+    let source_read_events_before = context.source_read_events();
     let copy_result = context.copy_file_contents(
         &mut reader,
         &mut writer,
@@ -658,6 +661,34 @@ pub(in crate::local_copy) fn execute_transfer_once(
 
     let outcome = match copy_result {
         Ok(outcome) => {
+            // A short source read during this pass means the staged bytes end
+            // in a stale tail: the copy stopped at the shrunken source's new
+            // EOF but everything already written came from the longer
+            // pre-shrink content. Committing that publishes an inconsistent
+            // destination, so discard the staged result exactly like the
+            // error path below and hand the file back to `execute_transfer`
+            // for one bounded redo. The diagnostic and the exit-23 flags were
+            // already recorded by `note_short_source_read`, and they stay
+            // recorded whether or not the redo lands.
+            //
+            // upstream: the sender corrupts the whole-file checksum on a read
+            // error (match.c:454-463), so the receiver fails verification,
+            // unlinks the temp file (receiver.c:1318 `do_unlink_at(fnametmp)`)
+            // and requests the phase-2 resend (receiver.c:1355-1358).
+            if context.source_read_events() != source_read_events_before {
+                drop(writer_for_metadata.take());
+                if let Some(guard) = guard.take() {
+                    guard.discard();
+                }
+                // Mirror the error path: a partial-mode discard() finalised
+                // the temp onto its partial destination (upstream's retained
+                // partial, receiver.c:1301-1316); a plain new file is removed.
+                if existing_metadata.is_none() && !partial_enabled {
+                    remove_incomplete_destination(destination);
+                }
+                return Ok(TransferOutcome::SourceChanged);
+            }
+
             if let Err(timeout_error) = context.enforce_timeout() {
                 drop(writer_for_metadata.take());
                 if let Some(guard) = guard.take() {

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/mod.rs
@@ -42,6 +42,18 @@ pub(in crate::local_copy) enum TransferOutcome {
     /// must rerun the file as an ordinary delta transfer.
     /// upstream: receiver.c:1358 `send_msg_int(MSG_REDO, ndx)`.
     VerificationFailed,
+    /// The source ended before the length this pass was sized from - it
+    /// shrank mid-read - so the staged result carries a stale tail and was
+    /// discarded instead of committed. The caller must rerun the file once
+    /// against the source as it is now.
+    ///
+    /// upstream reaches the same redo through the checksum: a source read
+    /// error makes the sender deliberately corrupt the whole-file checksum
+    /// (match.c:454-463), the receiver fails verification, unlinks the temp
+    /// file and queues the file for the phase-2 resend
+    /// (receiver.c:1318,1325-1362 `send_msg_int(MSG_REDO, ndx)`), and the
+    /// resend re-opens and re-fstats the shrunken file (sender.c:728-760).
+    SourceChanged,
 }
 
 /// Boolean flags controlling file transfer behavior.

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/tests.rs
@@ -797,3 +797,229 @@ fn delta_copy_of_a_source_at_its_declared_length_moves_all_of_it() {
         "a delta copy of a source that matched its declared length was reported as short"
     );
 }
+
+/// Observer that rewrites the source file mid-copy, from inside the copy
+/// loop's own progress callback.
+///
+/// The loop notifies progress between chunk reads, so a rewrite fired from
+/// the callback lands exactly where a concurrent writer's truncation would:
+/// after some pre-change bytes have already been staged, before the reader
+/// reaches the (now missing) rest. This pins the shrink-mid-read race with no
+/// threads, no sleeps, and no timing window.
+///
+/// Each schedule step is `(threshold, replacement)`: when a pass's progress
+/// reaches the threshold, the source is atomically replaced (truncate +
+/// rewrite) and the schedule advances, so consecutive transfer passes can be
+/// made to shrink the source once each. The step count consumed is therefore
+/// a direct count of how many passes read far enough to trigger a shrink.
+struct ShrinkingSourceObserver {
+    source: std::path::PathBuf,
+    steps: Vec<(u64, Vec<u8>)>,
+    fired: usize,
+    records: Vec<LocalCopyRecord>,
+}
+
+impl LocalCopyRecordHandler for ShrinkingSourceObserver {
+    fn handle(&mut self, record: LocalCopyRecord) {
+        self.records.push(record);
+    }
+
+    fn handle_progress(&mut self, progress: LocalCopyProgress<'_>) {
+        if let Some((threshold, replacement)) = self.steps.get(self.fired)
+            && progress.bytes_transferred() >= *threshold
+        {
+            fs::write(&self.source, replacement).expect("shrink source mid-copy");
+            self.fired += 1;
+        }
+    }
+}
+
+/// Deterministic content for the shrink fixtures: `tag` keeps the pre- and
+/// post-shrink generations byte-distinguishable at every offset.
+fn patterned(len: usize, tag: u8) -> Vec<u8> {
+    (0..len)
+        .map(|i| (i.wrapping_mul(31) % 251) as u8 ^ tag)
+        .collect()
+}
+
+/// Drives `execute_transfer` (the redo-owning wrapper) over a fresh
+/// destination with the given shrink schedule and returns
+/// `(result, fired, records, read_error_flag)`.
+fn run_shrinking_transfer(
+    temp: &TempDir,
+    initial: &[u8],
+    steps: Vec<(u64, Vec<u8>)>,
+) -> (
+    Result<(), crate::local_copy::LocalCopyError>,
+    usize,
+    Vec<LocalCopyRecord>,
+    bool,
+) {
+    let source = temp.path().join("src.bin");
+    let destination = temp.path().join("dst.bin");
+    fs::write(&source, initial).expect("write source");
+    let recorded = fs::metadata(&source).expect("stat source");
+
+    let mut observer = ShrinkingSourceObserver {
+        source: source.clone(),
+        steps,
+        fired: 0,
+        records: Vec::new(),
+    };
+
+    let mode = LocalCopyExecution::Apply;
+    let mut context = CopyContext::new(
+        mode,
+        LocalCopyOptions::default(),
+        Some(&mut observer),
+        temp.path().to_path_buf(),
+    );
+
+    // `--no-whole-file`, the measured arm: the userspace read loop is the
+    // mover, exactly as in the live harness (the kernel `copy_file_range`
+    // tier is gated on `whole_file_enabled`).
+    let flags = TransferFlags {
+        whole_file_enabled: false,
+        ..plain_flags()
+    };
+
+    let result = super::execute_transfer(
+        &mut context,
+        &source,
+        &destination,
+        &recorded,
+        MetadataOptions::default(),
+        Path::new("src.bin"),
+        None,
+        false,
+        recorded.file_type(),
+        None,
+        flags,
+        mode,
+        None,
+        None,
+    );
+
+    let read_error = context.source_read_error_occurred();
+    drop(context);
+    (result, observer.fired, observer.records, read_error)
+}
+
+/// Sizes for the shrink-redo fixtures. The copy buffer is 128 KiB
+/// (`COPY_BUFFER_SIZE`), so a 4 MiB source crosses the 1 MiB shrink threshold
+/// mid-loop with plenty of chunks on either side.
+const SHRINK_INITIAL_LEN: usize = 4 * 1024 * 1024;
+const SHRINK_TRIGGER: u64 = 1024 * 1024;
+const SHRINK_NEW_LEN: usize = 512 * 1024;
+
+/// A source that shrinks mid-read must land a destination consistent with the
+/// post-shrink source, not the staged prefix of the pre-shrink content.
+///
+/// upstream: a source read error corrupts the whole-file checksum
+/// (match.c:454-463), the receiver discards the temp file and queues a
+/// phase-2 resend (receiver.c:1318,1355-1358 MSG_REDO), and the resend
+/// re-opens and re-fstats the shrunken file (sender.c:728-760), landing a
+/// consistent copy. Measured on rsync 3.5.0: dest == post-shrink source,
+/// exit 23, one `read errors mapping` line. Without the redo the local
+/// executor published the staged partial: a consistent prefix plus a stale
+/// tail of pre-shrink bytes past the new EOF.
+#[test]
+fn shrink_mid_read_redo_lands_a_consistent_destination() {
+    let temp = TempDir::new().expect("tempdir");
+    let initial = patterned(SHRINK_INITIAL_LEN, 0);
+    let replacement = patterned(SHRINK_NEW_LEN, 0x5a);
+
+    let (result, fired, records, read_error) =
+        run_shrinking_transfer(&temp, &initial, vec![(SHRINK_TRIGGER, replacement.clone())]);
+
+    result.expect("a shrinking source must not abort the transfer");
+    assert_eq!(fired, 1, "the shrink schedule fired more than once");
+
+    let dest_bytes = fs::read(temp.path().join("dst.bin")).expect("read destination");
+    assert_eq!(
+        dest_bytes.len(),
+        replacement.len(),
+        "destination length disagrees with the post-shrink source: a stale tail of \
+         pre-shrink bytes was published instead of being discarded and redone"
+    );
+    assert_eq!(
+        dest_bytes, replacement,
+        "destination bytes disagree with the post-shrink source"
+    );
+    assert!(
+        read_error,
+        "the short source read must still force RERR_PARTIAL (23) even though the redo landed"
+    );
+    // Only the redo pass commits, so exactly one record is emitted; the
+    // discarded pass records nothing.
+    assert_eq!(
+        records.len(),
+        1,
+        "expected exactly one committed record: {records:?}"
+    );
+}
+
+/// The redo is bounded to ONE retry, like upstream's `redoing` flag: a source
+/// that shrinks again during the retry is reported and discarded, never
+/// re-queued.
+///
+/// upstream: the resend arrives with `FLAG_FILE_SENT` set so the receiver
+/// runs it with `redoing = 1` (receiver.c:933-942); a second verification
+/// failure logs `FERROR_XFER` and the `MSG_REDO` request is guarded by
+/// `if (!redoing)` (receiver.c:1333,1355-1358), so nothing retries a third
+/// time and the unlinked temp file leaves the destination untouched.
+///
+/// The schedule holds exactly two shrink steps. A third pass would find no
+/// step, complete cleanly, and CREATE the destination - so the
+/// destination-absence assertion fails if the bound is ever removed, and the
+/// step count fails if fewer than two passes ran.
+#[test]
+fn shrink_redo_is_bounded_to_one_retry() {
+    let temp = TempDir::new().expect("tempdir");
+    let initial = patterned(SHRINK_INITIAL_LEN, 0);
+    let second = patterned(SHRINK_NEW_LEN, 0x5a);
+    let third = patterned(64 * 1024, 0xc3);
+
+    let (result, fired, records, read_error) = run_shrinking_transfer(
+        &temp,
+        &initial,
+        vec![(SHRINK_TRIGGER, second), (128 * 1024, third)],
+    );
+
+    result.expect("a doubly-shrinking source must not abort the transfer");
+    assert_eq!(fired, 2, "expected exactly two passes to read the source");
+    assert!(
+        !temp.path().join("dst.bin").exists(),
+        "the second failed pass must discard its staged result, not publish it \
+         (and a third pass must never run)"
+    );
+    assert!(read_error, "the short reads must force RERR_PARTIAL (23)");
+    assert!(
+        records.is_empty(),
+        "no pass committed, so no record may be emitted: {records:?}"
+    );
+}
+
+/// Non-vacuity companion: the identical fixture with a schedule that never
+/// fires must run a single clean pass - no redo, no read-error flag, one
+/// committed record, destination byte-identical to the source. The grow arm's
+/// companion is `copy_is_bounded_by_the_opened_file_not_the_recorded_length`
+/// above: growth never trips the short-read counter, so it never redoes.
+#[test]
+fn a_stable_source_copies_in_one_pass_with_no_redo() {
+    let temp = TempDir::new().expect("tempdir");
+    let initial = patterned(SHRINK_INITIAL_LEN, 0);
+
+    let (result, fired, records, read_error) = run_shrinking_transfer(&temp, &initial, Vec::new());
+
+    result.expect("clean transfer");
+    assert_eq!(fired, 0);
+    assert!(!read_error, "a stable source recorded a read error");
+    let dest_bytes = fs::read(temp.path().join("dst.bin")).expect("read destination");
+    assert_eq!(dest_bytes, initial, "clean copy is not byte-identical");
+    assert_eq!(
+        records.len(),
+        1,
+        "clean copy must commit exactly one record"
+    );
+}

--- a/crates/engine/src/local_copy/executor/file/copy/transfer/verify_redo.rs
+++ b/crates/engine/src/local_copy/executor/file/copy/transfer/verify_redo.rs
@@ -78,42 +78,151 @@ pub(in crate::local_copy) fn execute_transfer(
         reference_basis.clone(),
     )?;
 
-    if outcome == TransferOutcome::Complete {
-        return Ok(());
+    let redo_outcome = match outcome {
+        TransferOutcome::Complete => return Ok(()),
+        TransferOutcome::VerificationFailed => {
+            warn_verification_failed(context, record_path);
+
+            // The first pass appended in place, so the destination now holds
+            // the full source length with a wrong prefix. Re-stat it: that
+            // partial is the delta basis for the redo, exactly as upstream's
+            // `generate_and_send_sums()` reads the retained file. Losing it
+            // between the passes means there is nothing to re-delta, so a stat
+            // failure is a hard error rather than a fall-back to a whole-file
+            // copy.
+            let retained = fs::symlink_metadata(destination).map_err(|error| {
+                LocalCopyError::io("inspect retained partial", destination.to_path_buf(), error)
+            })?;
+
+            execute_transfer_once(
+                context,
+                source,
+                destination,
+                metadata,
+                metadata_options,
+                record_path,
+                Some(&retained),
+                // The destination existed before this pass: upstream counts
+                // `stats.created_files++` only on the non-redo leg
+                // (receiver.c:778).
+                true,
+                file_type,
+                relative,
+                redo_flags(flags, context.sparse_enabled()),
+                mode,
+                copy_source_override,
+                reference_basis,
+            )?
+        }
+        TransferOutcome::SourceChanged => {
+            // The source shrank while the first pass was reading it, so the
+            // staged result carried a stale tail and was discarded. Warn the
+            // way upstream's receiver does when the deliberately corrupted
+            // checksum fails verification (receiver.c:1325-1354), then rerun
+            // the file once. The retry re-opens the source and sizes itself
+            // from a fresh `fstat`, exactly as upstream's phase-2 resend does
+            // (sender.c:728-760), so it lands bytes consistent with the file
+            // as it is now. `metadata` is deliberately NOT refreshed: upstream
+            // stamps the redone destination with the attributes the file list
+            // recorded (`set_file_attrs` reads the flist entry), not with a
+            // re-stat.
+            warn_source_changed(context, record_path, &flags);
+
+            execute_transfer_once(
+                context,
+                source,
+                destination,
+                metadata,
+                metadata_options,
+                record_path,
+                existing_metadata,
+                destination_previously_existed,
+                file_type,
+                relative,
+                source_changed_redo_flags(flags),
+                mode,
+                copy_source_override,
+                reference_basis,
+            )?
+        }
+    };
+
+    // Upstream bounds the redo to ONE retry: the resend arrives with
+    // `FLAG_FILE_SENT` already set, so the receiver runs it with `redoing = 1`
+    // (receiver.c:933-942) and a second failure logs `FERROR_XFER` with no
+    // further `MSG_REDO` (receiver.c:1333,1355-1358 - the request is guarded
+    // by `if (!redoing)`). Mirror that: report the discarded update and stop.
+    // The exit-23 flags from `note_short_source_read` are already recorded.
+    if redo_outcome != TransferOutcome::Complete {
+        note_redo_discarded(context, record_path, &flags);
     }
 
-    warn_verification_failed(context, record_path);
-
-    // The first pass appended in place, so the destination now holds the full
-    // source length with a wrong prefix. Re-stat it: that partial is the delta
-    // basis for the redo, exactly as upstream's `generate_and_send_sums()` reads
-    // the retained file. Losing it between the passes means there is nothing to
-    // re-delta, so a stat failure is a hard error rather than a fall-back to a
-    // whole-file copy.
-    let retained = fs::symlink_metadata(destination).map_err(|error| {
-        LocalCopyError::io("inspect retained partial", destination.to_path_buf(), error)
-    })?;
-
-    execute_transfer_once(
-        context,
-        source,
-        destination,
-        metadata,
-        metadata_options,
-        record_path,
-        Some(&retained),
-        // The destination existed before this pass: upstream counts
-        // `stats.created_files++` only on the non-redo leg (receiver.c:778).
-        true,
-        file_type,
-        relative,
-        redo_flags(flags, context.sparse_enabled()),
-        mode,
-        copy_source_override,
-        reference_basis,
-    )?;
-
     Ok(())
+}
+
+/// The flag set for the shrink redo pass.
+///
+/// upstream: generator.c:2647-2689 - the redo dispatch in
+/// `check_for_finished_files` negates `append_mode` and bumps `ignore_times`
+/// around `recv_generator()`, so the resend can never resume-append and can
+/// never be quick-check skipped (the discarded pass may have left a
+/// destination whose size and mtime already look current). `whole_file` is NOT
+/// touched: it stays whatever the session selected.
+fn source_changed_redo_flags(flags: TransferFlags) -> TransferFlags {
+    TransferFlags {
+        append_allowed: false,
+        append_verify: false,
+        ignore_times_enabled: true,
+        ..flags
+    }
+}
+
+/// The disposition noun upstream's verification-failure lines carry.
+///
+/// upstream: receiver.c:1337-1343 - `"discarded"` unless the update was kept
+/// (`keep_partial` with a partial path, or `inplace`), in which case it is
+/// `"put into partial-dir"` under `--partial-dir` and `"retained"` otherwise.
+fn kept_description(context: &CopyContext, flags: &TransferFlags) -> &'static str {
+    if !flags.partial_enabled && !flags.inplace_enabled {
+        "discarded"
+    } else if context.options().partial_directory_path().is_some() {
+        "put into partial-dir"
+    } else {
+        "retained"
+    }
+}
+
+/// Emits upstream's first-failure warning for a source that shrank mid-read.
+///
+/// upstream: receiver.c:1333-1354 - `redoing` is still 0, so the message is
+/// `FWARNING` with `redostr = " (will try again)"`, gated behind
+/// `INFO_GTE(NAME, 1) || stdout_format_has_i` (receiver.c:1334). The wording
+/// is upstream's verbatim: on the wire this failure IS a checksum-verification
+/// failure, because the sender corrupted the whole-file checksum on the read
+/// error (match.c:454-463).
+fn warn_source_changed(context: &CopyContext, record_path: &Path, flags: &TransferFlags) {
+    if !logging::info_gte(logging::InfoFlag::Name, 1) && !context.options().is_itemize_active() {
+        return;
+    }
+    eprintln!(
+        "WARNING: {} failed verification -- update {} (will try again).",
+        record_path.display(),
+        kept_description(context, flags),
+    );
+}
+
+/// Emits upstream's second-failure error when the bounded redo also fails.
+///
+/// upstream: receiver.c:1333 - `enum logcode msgtype = redoing ? FERROR_XFER : FWARNING;`
+/// picks the error form on the second failure, and receiver.c:1344-1353 sets
+/// `errstr = "ERROR"` with an empty `redostr`. `FERROR_XFER` short-circuits the
+/// name gate at receiver.c:1334, so the line is unconditional.
+fn note_redo_discarded(context: &CopyContext, record_path: &Path, flags: &TransferFlags) {
+    eprintln!(
+        "ERROR: {} failed verification -- update {}.",
+        record_path.display(),
+        kept_description(context, flags),
+    );
 }
 
 /// The flag set upstream's generator installs around the phase-2 redo.


### PR DESCRIPTION
## What

A local copy whose source shrank mid-read published an **inconsistent destination**: the copy stopped at the shrunken source's new EOF, but every byte already written came from the longer pre-shrink content, so the dest held a correct prefix followed by a stale tail. Upstream lands a consistent post-shrink copy via its redo pass.

Measured live (32 MiB, `-a --no-whole-file --bwlimit=4096`, truncate to 4 MiB at t+2.5s, vs the real 3.5.0 binary):

| arm | exit | dest size | consistent with the post-shrink source |
|---|---|---|---|
| oc before | 23 | 4,718,592 (4 MiB prefix + 512 KiB stale tail, confirmed with `cmp -n`) | **no** |
| upstream 3.5.0 | 23 | 4,194,304 | yes |
| oc after | 23 | 4,194,304 | yes |

Diagnostics are byte-identical in all arms (`rsync: [sender] read errors mapping "…": No message available on STREAM (96)`). Under `-v` both arms now also print upstream's `WARNING: big.bin failed verification -- update discarded (will try again).`

## Upstream's redo chain (quoted)

- **match.c:454-463** — a read error makes the sender send a deliberately bad whole-file checksum: `if (buf && buf->status != 0) { … memset(sender_file_sum, 0, xfer_sum_len); }`
- **receiver.c:1318** — `do_unlink_at(fnametmp)` discards the temp; **:1333-1358** picks `FWARNING` vs `FERROR_XFER` by `redoing` and sends `MSG_REDO` only `if (!redoing)`.
- **generator.c:2647-2689** — the redo dispatch flips `csum_length = SUM_LENGTH`, negates `append_mode`, bumps `ignore_times`, and re-enters `recv_generator`.
- **sender.c:728-760** — the resend re-opens and `do_fstat`s, mapping at the *new* `st.st_size`: those are the consistent bytes.
- **Retry bound**: `redoing` (receiver.c:78, set at :941) plus the `if (!redoing)` guard on the `MSG_REDO` send give exactly ONE retry, then discard.

## Shape — reuses the existing redo host, invents no third one

The redo lands in the task-353 local `--append-verify` redo host (`verify_redo.rs::execute_transfer`), which already wraps `execute_transfer_once` and owns the second pass. The daemon-pull phase-2 redo (task 278) is wire machinery and does not reach the local executor.

Detection needed a per-pass signal: the existing `source_read_error` flag is sticky, so it cannot distinguish this file's short read from one an earlier file recorded. A monotonic `source_read_events` counter is snapshotted around the copy pass. On a difference the staged result is discarded exactly like the error path (`guard.discard()` / remove the incomplete destination) and the pass returns a new `TransferOutcome::SourceChanged`; no record is emitted for the discarded pass. Detection covers every mover that reports through `note_short_source_read` (kernel tier, dense, sparse, both delta loops).

The retry is bounded the way upstream bounds it: one redo with `append_allowed`/`append_verify` off and `ignore_times` on (generator.c:2647-2689; `whole_file` deliberately untouched), and any non-`Complete` redo outcome prints the unconditional `ERROR: … failed verification -- update discarded.` and stops. Exit-23 flags from pass one are preserved either way.

## Tests + mutation (measured)

Injection seam is the copy loop's own progress callback rewriting the source — no threads, no sleeps.

- `shrink_mid_read_redo_lands_a_consistent_destination` (the pin)
- `shrink_redo_is_bounded_to_one_retry` (two shrink steps; a third pass would create the dest and fail the assertion)
- `a_stable_source_copies_in_one_pass_with_no_redo` (non-vacuity); the grow arm stays covered by the existing `copy_is_bounded_by_the_opened_file_not_the_recorded_length`.

Mutation (detection disabled via `if false &&`): exactly the two shrink pins fail — the pin reporting "a stale tail of pre-shrink bytes was published" — with 27/29 siblings green. Reverted.

## Gates

Pinned 1.88.0 on the rebased head: whole-tree rustfmt clean (3427 files), `clippy -p engine --all-targets --all-features -D warnings` clean, `nextest -p engine --lib` 4751 passed / 23 skipped.
