### PR TITLE
fix(transfer): select the --inplace --backup pre-image copy as the delta basis

### DIFF
--- a/crates/transfer/src/disk_commit/mod.rs
+++ b/crates/transfer/src/disk_commit/mod.rs
@@ -50,3 +50,4 @@ pub(crate) use self::config::BackupEnv;
 #[cfg(test)]
 pub(crate) use self::process::ForceExdev;
 pub(crate) use self::process::make_backup;
+pub(crate) use self::process::make_backup_copy;

--- a/crates/transfer/src/disk_commit/process/commit.rs
+++ b/crates/transfer/src/disk_commit/process/commit.rs
@@ -103,8 +103,11 @@ pub(super) fn commit_file(
     // inode is rewritten in place, so a rename-to-backup here would move the very
     // file we already overwrote (its pre-transfer contents are gone by commit).
     // Upstream instead COPIES the pre-image aside BEFORE the inplace rewrite
-    // (generator.c:2281,2328); oc mirrors that in `process_file` /
-    // `process_whole_file` via `make_backup_copy` prior to the first write.
+    // (generator.c:2281 on the whole-file branch, generator.c:2328-2356 on the
+    // delta branch, which also retags the basis FNAMECMP_BACKUP); oc mirrors
+    // the delta branch in `find_basis_file_with_config` and the whole-file
+    // branch in `process_file` / `process_whole_file` via `make_backup_copy`
+    // prior to the first write.
     let backup_notice = if !config.delay_updates && !begin.is_inplace {
         if let Some(ref backup_config) = config.backup {
             // `make_backup` tags its own failures with CommitOp::Backup AND the
@@ -1050,25 +1053,33 @@ fn backup_notice(
 /// used for the `--inplace --backup` case where the destination inode is
 /// rewritten in place rather than replaced by a temp+rename.
 ///
-/// upstream: backup.c make_backup() inplace copy path - the generator makes the
-/// backup a COPY (`generator.c:2281` `copy_file(fname, backupptr, ...)`, and the
-/// delta twin at `generator.c:2328`) BEFORE the receiver rewrites the
-/// destination in place, keeping `fnamecmp_type == FNAMECMP_FNAME`. A plain
+/// upstream: the generator makes the inplace backup a COPY, on both of its
+/// branches: the whole-file/read-batch branch copies via `copy_file()` and
+/// keeps `fnamecmp_type == FNAMECMP_FNAME` (`generator.c:2280-2301`), while the
+/// delta branch opens the backup for writing, streams the pre-image into it
+/// during `generate_and_send_sums()`, and retags the basis
+/// `fnamecmp_type = FNAMECMP_BACKUP` (`generator.c:2328-2356`). Either way the
+/// copy is taken BEFORE the receiver rewrites the destination in place: a plain
 /// rename-to-backup would move the very inode we are about to update, so the
-/// pre-image must be duplicated first. Unlike the rename path this does NOT emit
-/// the `make_backup: RENAME` debug line (upstream's inplace copy bypasses
-/// `make_backup()` and so emits no `DEBUG_GTE(BACKUP, 1)` trace), but it still
-/// returns a [`BackupNotice`] so the main thread emits the same
-/// `INFO_GTE(BACKUP, 1)` "backed up X to Y" line (`generator.c:2448-2450`).
+/// pre-image must be duplicated first. oc calls this from both mirrors of those
+/// branches: `find_basis_file_with_config` for the delta path (which then
+/// selects the returned backup path as the delta basis) and
+/// `make_inplace_backup` on the disk thread for the whole-file path. Unlike the
+/// rename path this does NOT emit the `make_backup: RENAME` debug line
+/// (upstream's inplace copy bypasses `make_backup()` and so emits no
+/// `DEBUG_GTE(BACKUP, 1)` trace), but it still returns a [`BackupNotice`] so
+/// the session thread emits the same `INFO_GTE(BACKUP, 1)` "backed up X to Y"
+/// line (`generator.c:2448-2450`).
 ///
-/// Called before the first inplace write; the caller has already confirmed
-/// `begin.is_inplace`. Returns `Ok(None)` when the destination does not yet
-/// exist (nothing to back up), matching upstream's `x_lstat` guard.
-pub(super) fn make_backup_copy(
+/// Called before the first inplace write. Returns `Ok(None)` when the
+/// destination does not yet exist (nothing to back up), matching upstream's
+/// `x_lstat` guard; on success returns the absolute backup path (so the delta
+/// path can select it as the basis) alongside the notice.
+pub(crate) fn make_backup_copy(
     file_path: &Path,
     backup_config: &BackupConfig,
     env: BackupEnv<'_>,
-) -> io::Result<Option<BackupNotice>> {
+) -> io::Result<Option<(PathBuf, BackupNotice)>> {
     if !file_path.exists() {
         return Ok(None);
     }
@@ -1102,8 +1113,9 @@ pub(super) fn make_backup_copy(
 
     // upstream: generator.c:2448-2450 - INFO_GTE(BACKUP, 1) "backed up X to Y".
     // Paths are relative to the destination root to match test assertions; the
-    // `info_log!` emission happens on the main thread (see
-    // `crate::pipeline::receiver::emit_backup_notice`).
+    // `info_log!` emission happens on the session thread (see
+    // `crate::pipeline::receiver::emit_backup_notice` for the disk-thread
+    // caller and the request loop for the delta-basis caller).
     let file_rel = file_path
         .strip_prefix(&backup_config.dest_dir)
         .unwrap_or(file_path)
@@ -1112,10 +1124,11 @@ pub(super) fn make_backup_copy(
         .strip_prefix(&backup_config.dest_dir)
         .unwrap_or(&backup_path)
         .to_path_buf();
-    Ok(Some(BackupNotice {
+    let notice = BackupNotice {
         original: file_rel,
         backup: backup_rel,
-    }))
+    };
+    Ok(Some((backup_path, notice)))
 }
 
 /// The partial-basis cleanup must not delete a file outside the destination

--- a/crates/transfer/src/disk_commit/process/file_ops.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops.rs
@@ -799,11 +799,19 @@ fn discard_file_on_open_failure(
 ///
 /// Under `--inplace` the destination is rewritten in place (same inode), so the
 /// backup cannot be a rename of the destination - it must be a COPY of the
-/// pre-transfer contents taken before the first write. Upstream does this in the
-/// generator (`generator.c:1862,1898` `copy_file(fname, backupptr, ...)`) while
-/// keeping `fnamecmp_type == FNAMECMP_FNAME`. Because oc refuses
-/// `--inplace --partial-dir` (config validation), an inplace basis is always the
-/// destination itself, so `begin.is_inplace` here matches upstream's
+/// pre-transfer contents taken before the first write. Upstream does this in
+/// the generator, on its whole-file/read-batch branch
+/// (`generator.c:2280-2301` `copy_file(fname, backupptr, ...)`, keeping
+/// `fnamecmp_type == FNAMECMP_FNAME`); this function is oc's mirror of that
+/// branch. Upstream's DELTA branch (`generator.c:2328-2356`) instead makes the
+/// copy at basis-selection time and retags the basis `FNAMECMP_BACKUP`; oc
+/// mirrors that in `find_basis_file_with_config`, which selects the fresh
+/// backup as the delta basis - carried here as `begin.xattr_basis` - so this
+/// function must NOT run again for that case: re-copying would `O_TRUNC` the
+/// very file the network thread is resolving matched blocks from mid-transfer.
+/// Because oc refuses `--inplace --partial-dir` (config validation), an
+/// inplace basis is otherwise always the destination itself, so
+/// `begin.is_inplace` here matches upstream's
 /// `inplace && fnamecmp_type == FNAMECMP_FNAME` condition exactly.
 ///
 /// Returns `Ok(None)` (no backup) unless the target is inplace, backup is
@@ -819,7 +827,23 @@ fn make_inplace_backup(
     let Some(ref backup_config) = config.backup else {
         return Ok(None);
     };
+    // upstream: generator.c:2328-2356 - a delta basis that IS the backup file
+    // means the generator already wrote the pre-image copy (FNAMECMP_BACKUP)
+    // and the "backed up X to Y" notice was already emitted by the request
+    // loop. Skip so the backup the delta is being resolved against is never
+    // truncated underneath the reader.
+    let backup_path = engine::compute_backup_path(
+        &backup_config.dest_dir,
+        &begin.file_path,
+        None,
+        backup_config.backup_dir.as_deref(),
+        &backup_config.suffix,
+    );
+    if begin.xattr_basis.as_deref() == Some(backup_path.as_path()) {
+        return Ok(None);
+    }
     make_backup_copy(&begin.file_path, backup_config, config.backup_env())
+        .map(|made| made.map(|(_, notice)| notice))
 }
 
 /// Stats the destination before an inplace write so `dest_mode()` keeps its

--- a/crates/transfer/src/disk_commit/process/file_ops/tests.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops/tests.rs
@@ -86,3 +86,80 @@ fn the_prior_mode_is_restored_before_the_descriptor_is_returned() {
     assert_eq!(mode_of(&path), READ_ONLY);
     assert_eq!(fs::read(&path).unwrap(), b"old");
 }
+
+/// `--inplace --backup` delta path: when the generator already created the
+/// backup and selected it as the delta basis (`FNAMECMP_BACKUP`, upstream
+/// generator.c:2328-2356; carried here as `xattr_basis`), the disk thread must
+/// NOT copy again - re-copying would `O_TRUNC` the very file the network
+/// thread is resolving matched blocks from mid-transfer.
+#[test]
+fn make_inplace_backup_skips_when_the_delta_basis_is_the_backup() {
+    use std::ffi::OsString;
+
+    use super::super::super::config::BackupConfig;
+    use super::make_inplace_backup;
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("file.bin");
+    fs::write(&dest, b"pre-image").unwrap();
+    let backup_path = dir.path().join("file.bin~");
+
+    let config = DiskCommitConfig {
+        backup: Some(BackupConfig {
+            dest_dir: dir.path().to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        }),
+        ..DiskCommitConfig::default()
+    };
+    let mut begin = inplace_begin(&dest);
+    begin.xattr_basis = Some(backup_path.clone());
+
+    // The generator's copy, standing in for find_basis_file_with_config. The
+    // sentinel content makes a wrongful re-copy observable: it would clobber
+    // this with the destination's current bytes.
+    fs::write(&backup_path, b"sentinel: do not truncate").unwrap();
+
+    let notice = make_inplace_backup(&begin, &config).expect("gate must not fail");
+    assert!(notice.is_none(), "no second notice for the generator's backup");
+    assert_eq!(
+        fs::read(&backup_path).unwrap(),
+        b"sentinel: do not truncate",
+        "the delta basis must never be rewritten by the disk thread"
+    );
+}
+
+/// Sibling control: with no delta basis carried (whole-file transfer, or a
+/// basis that IS the destination), the disk thread still owns the pre-image
+/// copy - upstream's whole-file/read-batch branch (generator.c:2280-2301).
+#[test]
+fn make_inplace_backup_still_copies_when_no_backup_basis_is_carried() {
+    use std::ffi::OsString;
+
+    use super::super::super::config::BackupConfig;
+    use super::make_inplace_backup;
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("file.bin");
+    fs::write(&dest, b"pre-image").unwrap();
+
+    let config = DiskCommitConfig {
+        backup: Some(BackupConfig {
+            dest_dir: dir.path().to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        }),
+        ..DiskCommitConfig::default()
+    };
+    let begin = inplace_begin(&dest);
+
+    let notice = make_inplace_backup(&begin, &config)
+        .expect("copy must succeed")
+        .expect("a notice is produced");
+    assert_eq!(notice.original, PathBuf::from("file.bin"));
+    assert_eq!(
+        fs::read(dir.path().join("file.bin~")).unwrap(),
+        b"pre-image",
+        "the whole-file inplace backup still comes from the disk thread"
+    );
+}

--- a/crates/transfer/src/disk_commit/process/file_ops/tests.rs
+++ b/crates/transfer/src/disk_commit/process/file_ops/tests.rs
@@ -121,7 +121,10 @@ fn make_inplace_backup_skips_when_the_delta_basis_is_the_backup() {
     fs::write(&backup_path, b"sentinel: do not truncate").unwrap();
 
     let notice = make_inplace_backup(&begin, &config).expect("gate must not fail");
-    assert!(notice.is_none(), "no second notice for the generator's backup");
+    assert!(
+        notice.is_none(),
+        "no second notice for the generator's backup"
+    );
     assert_eq!(
         fs::read(&backup_path).unwrap(),
         b"sentinel: do not truncate",

--- a/crates/transfer/src/disk_commit/process/mod.rs
+++ b/crates/transfer/src/disk_commit/process/mod.rs
@@ -22,6 +22,7 @@ mod metadata;
 mod tests;
 
 pub(crate) use self::commit::make_backup;
+pub(crate) use self::commit::make_backup_copy;
 pub(super) use self::file_ops::{process_file, process_whole_file};
 
 /// Forces the backup ladder's link and rename tiers onto `EXDEV` for the
@@ -34,9 +35,7 @@ pub(crate) use self::commit::ForceExdev;
 #[cfg(all(test, unix))]
 use self::commit::{commit_file, rename_config_sandboxed};
 #[cfg(test)]
-use self::commit::{
-    delay_updates_staging_path, is_cross_device, make_backup_copy, rename_with_io_uring_fallback,
-};
+use self::commit::{delay_updates_staging_path, is_cross_device, rename_with_io_uring_fallback};
 #[cfg(all(test, target_os = "macos"))]
 use self::file_ops::make_writer;
 #[cfg(test)]

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -804,7 +804,7 @@ fn make_backup_copy_duplicates_and_keeps_original() {
         backup_dir: None,
         suffix: OsString::from("~"),
     };
-    let notice = make_backup_copy(
+    let (returned_backup_path, notice) = make_backup_copy(
         &file_path,
         &config,
         DiskCommitConfig::default().backup_env(),
@@ -813,6 +813,11 @@ fn make_backup_copy_duplicates_and_keeps_original() {
     .expect("notice produced when an existing file is copied");
 
     let backup_path = file_path.with_extension("bin~");
+    assert_eq!(
+        returned_backup_path, backup_path,
+        "the returned absolute backup path names the copy (the delta path \
+         selects it as the basis)"
+    );
     assert!(backup_path.exists(), "backup copy must exist");
     assert!(
         file_path.exists(),

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -579,11 +579,18 @@ fn consecutive_match_needed(config: &DeltaGeneratorConfig<'_>) -> u8 {
 ///                                            : make_backups <= 0));
 /// ```
 ///
-/// A missing basis-type byte defaults to `FNAMECMP_FNAME` (`rsync.c:326`). Note
-/// that at protocol >= 29 `--inplace --backup` still qualifies: the generator
-/// makes a side backup copy but keeps `fnamecmp_type == FNAMECMP_FNAME` and
-/// rewrites the destination in place (`generator.c:1862,1898`); the
-/// `make_backups <= 0` clause only applies to the legacy protocol < 29 path.
+/// A missing basis-type byte defaults to `FNAMECMP_FNAME` (`rsync.c:326`).
+///
+/// `--inplace --backup` splits by generator branch. On the whole-file /
+/// read-batch branch the generator backs up via `copy_file()` and keeps
+/// `fnamecmp_type == FNAMECMP_FNAME` (`generator.c:2280-2301`) - no delta, so
+/// this flag never matters there. On the DELTA branch the generator writes the
+/// backup while sending sums and retags `fnamecmp_type = FNAMECMP_BACKUP`
+/// (`generator.c:2328-2356`), so at protocol >= 29 the `FNAMECMP_FNAME` test
+/// here goes FALSE: matched blocks are read from the pristine backup copy, and
+/// the sender is free to match them in any order. The `make_backups <= 0`
+/// clause carries the same rule for the legacy protocol < 29 path, which has
+/// no basis-type byte on the wire.
 ///
 /// upstream: sender.c:337 `updating_basis_file`.
 pub(crate) fn updating_basis_file(

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -39,7 +39,10 @@ pub struct BasisFileResult {
     /// came from reference dir `j` (`--compare-dest`/`--copy-dest`/`--link-dest`)
     /// while the destination was absent (upstream: generator.c:1054),
     /// [`protocol::FnameCmpType::PartialDir`] (`0x81`) when the basis was recovered
-    /// from `--partial-dir` on a resume (upstream: generator.c:1759-1765,1853), and
+    /// from `--partial-dir` on a resume (upstream: generator.c:1759-1765,1853),
+    /// [`protocol::FnameCmpType::Backup`] (`0x82`) when `--inplace --backup`
+    /// selected the freshly written pre-image copy as the basis (upstream:
+    /// generator.c:2328-2356), and
     /// `FnameCmpType::Fuzzy(i)` (`FNAMECMP_FUZZY + i`) for a `--fuzzy` match, where
     /// `i` is 0 for the destination directory and `k + 1` for reference dir `k`
     /// (upstream: generator.c:861,903,1945).
@@ -49,6 +52,12 @@ pub struct BasisFileResult {
     /// basename, resolved by the receiver relative to the target's directory
     /// (upstream: generator.c:1948, receiver.c:838-841).
     pub xname: Option<Vec<u8>>,
+    /// The `INFO_GTE(BACKUP, 1)` "backed up X to Y" notice for the
+    /// `--inplace --backup` delta-path pre-image copy made while selecting the
+    /// basis (`fnamecmp_type == FNAMECMP_BACKUP`). The caller emits it on the
+    /// session thread, whose thread-local verbosity is actually seeded - a
+    /// rayon signature worker's is not (upstream: generator.c:2448-2450).
+    pub backup_notice: Option<crate::pipeline::messages::BackupNotice>,
 }
 
 impl BasisFileResult {
@@ -58,6 +67,7 @@ impl BasisFileResult {
         basis_path: None,
         fnamecmp_type: protocol::FnameCmpType::Fname,
         xname: None,
+        backup_notice: None,
     };
 
     /// Returns true if no basis file was found.
@@ -122,6 +132,54 @@ pub struct BasisFileConfig<'a> {
     /// the heuristic. The receiving side owns it: the generator sizes the
     /// blocks it checksums, so the sender never consults the value.
     pub block_size: Option<NonZeroU32>,
+    /// `--inplace --backup` delta-path backup inputs. `Some` exactly when
+    /// upstream's `inplace && make_backups > 0` holds (generator.c:2328) - the
+    /// caller passes `None` on the redo pass, mirroring the
+    /// `make_backups = -make_backups` negation at generator.c:2659, and on
+    /// paths upstream never takes to that branch (`--only-write-batch` has
+    /// `do_xfers == 0`, generator.c:2277).
+    ///
+    /// When set and the exact destination basis opens (`FNAMECMP_FNAME`), the
+    /// pre-image is copied to the backup path RIGHT HERE and the backup - not
+    /// the destination - is selected as the delta basis, tagged
+    /// [`protocol::FnameCmpType::Backup`] (generator.c:2328-2356). The tag
+    /// clears the sender's `updating_basis_file` (sender.c:628-629), letting
+    /// it match blocks in any order because matched data is later read from
+    /// the pristine copy while the destination is overwritten in place.
+    pub inplace_backup: Option<InplaceBackupSpec<'a>>,
+}
+
+/// Inputs for the `--inplace --backup` delta-path pre-image copy: the backup
+/// naming configuration plus the sandbox environment the copy is confined by.
+///
+/// Constructed only inside the crate (the fields feed
+/// [`crate::disk_commit::make_backup_copy`], whose environment type is
+/// crate-private); external callers of [`find_basis_file_with_config`] pass
+/// `None`.
+#[derive(Clone, Copy)]
+pub struct InplaceBackupSpec<'a> {
+    /// `--backup` / `--backup-dir` / `--suffix` naming inputs.
+    pub(crate) backup_config: &'a crate::disk_commit::BackupConfig,
+    /// Sandbox anchoring for the copy and any `--backup-dir` parents it makes.
+    pub(crate) env: crate::disk_commit::BackupEnv<'a>,
+}
+
+impl<'a> InplaceBackupSpec<'a> {
+    /// Bundles the backup naming config with its sandbox environment.
+    pub(crate) fn new(
+        backup_config: &'a crate::disk_commit::BackupConfig,
+        env: crate::disk_commit::BackupEnv<'a>,
+    ) -> Self {
+        Self { backup_config, env }
+    }
+}
+
+impl std::fmt::Debug for InplaceBackupSpec<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InplaceBackupSpec")
+            .field("backup_config", &self.backup_config)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Configuration for generating a signature from a basis file.
@@ -482,6 +540,7 @@ fn generate_basis_signature(
             basis_path: Some(basis_path),
             fnamecmp_type,
             xname,
+            backup_notice: None,
         },
         Err(_) => BasisFileResult::EMPTY,
     }
@@ -585,7 +644,11 @@ fn compute_basis_signature<R: std::io::Read>(
 /// - `generator.c:1400` - Reference directory checking
 pub fn find_basis_file_with_config(config: &BasisFileConfig<'_>) -> BasisFileResult {
     // Upstream `generator.c:1962`: when `whole_file` is set, no basis file
-    // is used - the entire file is sent as literals.
+    // is used - the entire file is sent as literals. This wins over
+    // `inplace_backup`: upstream's whole-file/read-batch branch backs up via
+    // `copy_file()` but deliberately keeps `fnamecmp_type == FNAMECMP_FNAME`
+    // (generator.c:2280-2301); oc's mirror of that copy is the disk thread's
+    // `make_inplace_backup`, not this function.
     if config.whole_file {
         return BasisFileResult::EMPTY;
     }
@@ -596,6 +659,22 @@ pub fn find_basis_file_with_config(config: &BasisFileConfig<'_>) -> BasisFileRes
     // partial-dir. The exact destination basis is reported to the sender as
     // FNAMECMP_FNAME (no basis-type byte).
     if let Some((file, size, path)) = try_open_file(config.file_path) {
+        // upstream: generator.c:2328-2356 - on the delta path, once the
+        // destination basis has opened (`inplace && make_backups > 0 &&
+        // fnamecmp_type == FNAMECMP_FNAME`), the generator creates the backup
+        // copy of the pre-image and retags `fnamecmp_type = FNAMECMP_BACKUP`.
+        // Upstream streams the copy during `generate_and_send_sums()`
+        // (generator.c:809-810); oc copies first, then signs the copy - the
+        // same bytes, taken at the same point, strictly before the receiver's
+        // first in-place write. Selecting the copy as `basis_path` is what
+        // lets matched blocks be read from the pristine pre-image while the
+        // destination is overwritten in place, in any order (the BACKUP tag
+        // clears the sender's `updating_basis_file`, sender.c:628-629).
+        if let Some(spec) = &config.inplace_backup
+            && let Some(backup_basis) = try_inplace_backup_basis(config, spec, sig_config)
+        {
+            return backup_basis;
+        }
         return generate_basis_signature(
             file,
             size,
@@ -668,6 +747,45 @@ pub fn find_basis_file_with_config(config: &BasisFileConfig<'_>) -> BasisFileRes
     }
 
     BasisFileResult::EMPTY
+}
+
+/// Creates the `--inplace --backup` pre-image copy and selects it as the delta
+/// basis, tagged `FNAMECMP_BACKUP` (upstream: generator.c:2328-2356).
+///
+/// Returns `None` - falling back to the plain `FNAMECMP_FNAME` destination
+/// basis - when the copy or its signature fails. The destination is still
+/// untouched at that point, so the disk thread's `make_inplace_backup` then
+/// retries the copy before the first in-place write and surfaces any error
+/// through its existing (fatal) path; nothing is reported from here because a
+/// rayon signature worker's thread-local verbosity is never seeded.
+fn try_inplace_backup_basis(
+    config: &BasisFileConfig<'_>,
+    spec: &InplaceBackupSpec<'_>,
+    sig_config: SignatureGenerationConfig,
+) -> Option<BasisFileResult> {
+    let (backup_path, notice) =
+        crate::disk_commit::make_backup_copy(config.file_path, spec.backup_config, spec.env)
+            .ok()
+            .flatten()?;
+    // Sign the COPY, not the destination: the receiver resolves matched blocks
+    // against `basis_path`, so the signature must describe those exact bytes
+    // even if the destination changes underneath us. Upstream reaches the same
+    // guarantee from the other side, writing the backup from the very bytes it
+    // checksums (generate_and_send_sums, generator.c:809-810).
+    let (file, size, path) = try_open_file(&backup_path)?;
+    let mut result = generate_basis_signature(
+        file,
+        size,
+        path,
+        protocol::FnameCmpType::Backup,
+        None,
+        sig_config,
+    );
+    if result.is_empty() {
+        return None;
+    }
+    result.backup_notice = Some(notice);
+    Some(result)
 }
 
 #[cfg(test)]
@@ -1105,6 +1223,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1159,6 +1278,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1202,6 +1322,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1279,6 +1400,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1351,6 +1473,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1412,6 +1535,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let result = find_basis_file_with_config(&config);
@@ -1473,6 +1597,7 @@ mod tests {
             whole_file: false,
             compat_flags: None,
             block_size: None,
+            inplace_backup: None,
         };
 
         let strong_len = |result: &BasisFileResult| -> u8 {
@@ -1747,6 +1872,193 @@ mod tests {
             requested.blocks().len(),
             2,
             "4096 bytes at 2048 is exactly two blocks",
+        );
+    }
+
+    /// Builds a `BasisFileConfig` targeting `dest_dir/file.bin` with an
+    /// optional `--inplace --backup` spec, for the delta-backup pin tests.
+    fn inplace_backup_test_config<'a>(
+        dest_file: &'a std::path::Path,
+        dest_dir: &'a std::path::Path,
+        rel: &'a std::path::Path,
+        target_size: u64,
+        whole_file: bool,
+        inplace_backup: Option<InplaceBackupSpec<'a>>,
+    ) -> BasisFileConfig<'a> {
+        BasisFileConfig {
+            file_path: dest_file,
+            dest_dir,
+            relative_path: rel,
+            target_size,
+            target_mtime: 0,
+            fuzzy_level: 0,
+            reference_directories: &[],
+            partial_dir: None,
+            protocol: ProtocolVersion::NEWEST,
+            checksum_length: NonZeroU8::new(16).unwrap(),
+            checksum_algorithm: SignatureAlgorithm::Md4,
+            whole_file,
+            compat_flags: None,
+            block_size: None,
+            inplace_backup,
+        }
+    }
+
+    /// `--inplace --backup` delta path (upstream: generator.c:2328-2356): with
+    /// the spec set and the destination present, the basis selection must
+    /// create the pre-image copy, select IT as the basis, and tag the result
+    /// `FNAMECMP_BACKUP` (0x82) so the sender clears `updating_basis_file`
+    /// (sender.c:628-629) and may match blocks in any order.
+    #[test]
+    fn inplace_backup_spec_retags_fname_basis_as_backup_and_creates_the_copy() {
+        use std::ffi::OsString;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tmp.path();
+        let dest_file = dest_dir.join("file.bin");
+        let data: Vec<u8> = (0..8192u32).map(|i| (i % 251) as u8).collect();
+        fs::write(&dest_file, &data).expect("write dest");
+
+        let backup_config = crate::disk_commit::BackupConfig {
+            dest_dir: dest_dir.to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        };
+        let spec =
+            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let rel = std::path::Path::new("file.bin");
+        let config = inplace_backup_test_config(
+            &dest_file,
+            dest_dir,
+            rel,
+            data.len() as u64,
+            false,
+            Some(spec),
+        );
+
+        let result = find_basis_file_with_config(&config);
+
+        let backup_path = dest_dir.join("file.bin~");
+        assert_eq!(
+            result.fnamecmp_type,
+            protocol::FnameCmpType::Backup,
+            "the delta basis must be tagged FNAMECMP_BACKUP (0x82 on the wire)"
+        );
+        assert_eq!(
+            result.basis_path.as_deref(),
+            Some(backup_path.as_path()),
+            "the basis must be the backup copy, not the destination being rewritten"
+        );
+        assert!(result.signature.is_some(), "a real signature must be sent");
+        assert!(result.xname.is_none(), "FNAMECMP_BACKUP carries no xname");
+        assert_eq!(
+            fs::read(&backup_path).expect("backup exists"),
+            data,
+            "the backup must hold the pristine pre-image"
+        );
+        let notice = result.backup_notice.expect("notice for the INFO line");
+        assert_eq!(notice.original, PathBuf::from("file.bin"));
+        assert_eq!(notice.backup, PathBuf::from("file.bin~"));
+
+        // The basis stays pristine even after the destination is rewritten -
+        // exactly why matched blocks may be read in any order mid-overwrite.
+        fs::write(&dest_file, b"overwritten in place").expect("rewrite dest");
+        assert_eq!(
+            fs::read(&backup_path).expect("backup still readable"),
+            data,
+            "rewriting the destination must not disturb the selected basis"
+        );
+    }
+
+    /// Negative control: without the spec (plain `--inplace`, or `--backup`
+    /// without `--inplace`, or the redo pass), the destination basis keeps
+    /// `FNAMECMP_FNAME` and no backup file appears - matching upstream, where
+    /// the branch is gated on `inplace && make_backups > 0` (generator.c:2328).
+    #[test]
+    fn without_the_spec_the_dest_basis_stays_fname_and_no_backup_is_made() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tmp.path();
+        let dest_file = dest_dir.join("file.bin");
+        let data: Vec<u8> = (0..8192u32).map(|i| (i % 251) as u8).collect();
+        fs::write(&dest_file, &data).expect("write dest");
+
+        let rel = std::path::Path::new("file.bin");
+        let config =
+            inplace_backup_test_config(&dest_file, dest_dir, rel, data.len() as u64, false, None);
+
+        let result = find_basis_file_with_config(&config);
+
+        assert_eq!(result.fnamecmp_type, protocol::FnameCmpType::Fname);
+        assert_eq!(result.basis_path.as_deref(), Some(dest_file.as_path()));
+        assert!(result.backup_notice.is_none());
+        assert!(
+            !dest_dir.join("file.bin~").exists(),
+            "no backup may be created without the inplace-backup spec"
+        );
+    }
+
+    /// `--whole-file` wins over the spec: upstream's whole-file/read-batch
+    /// branch backs up via `copy_file()` on the RECEIVE side of oc's split
+    /// (the disk thread's `make_inplace_backup`) and keeps `FNAMECMP_FNAME`
+    /// (generator.c:2280-2301), so basis selection must return EMPTY and must
+    /// not create the copy here.
+    #[test]
+    fn whole_file_short_circuit_wins_over_inplace_backup_spec() {
+        use std::ffi::OsString;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tmp.path();
+        let dest_file = dest_dir.join("file.bin");
+        fs::write(&dest_file, b"whole-file pre-image").expect("write dest");
+
+        let backup_config = crate::disk_commit::BackupConfig {
+            dest_dir: dest_dir.to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        };
+        let spec =
+            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let rel = std::path::Path::new("file.bin");
+        let config = inplace_backup_test_config(&dest_file, dest_dir, rel, 20, true, Some(spec));
+
+        let result = find_basis_file_with_config(&config);
+
+        assert!(result.is_empty(), "whole_file must yield no basis at all");
+        assert_eq!(result.fnamecmp_type, protocol::FnameCmpType::Fname);
+        assert!(
+            !dest_dir.join("file.bin~").exists(),
+            "the whole-file backup belongs to the disk thread, not basis selection"
+        );
+    }
+
+    /// A missing destination never reaches the delta-backup branch: upstream's
+    /// condition sits after `do_open_checklinks(fnamecmp)` succeeded, and a
+    /// missing dest takes `pretend_missing` (generator.c:2313-2326). No backup
+    /// file may appear.
+    #[test]
+    fn missing_dest_with_spec_yields_empty_and_no_backup() {
+        use std::ffi::OsString;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest_dir = tmp.path();
+        let dest_file = dest_dir.join("absent.bin");
+
+        let backup_config = crate::disk_commit::BackupConfig {
+            dest_dir: dest_dir.to_path_buf(),
+            backup_dir: None,
+            suffix: OsString::from("~"),
+        };
+        let spec =
+            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let rel = std::path::Path::new("absent.bin");
+        let config = inplace_backup_test_config(&dest_file, dest_dir, rel, 16, false, Some(spec));
+
+        let result = find_basis_file_with_config(&config);
+
+        assert!(result.is_empty());
+        assert!(
+            !dest_dir.join("absent.bin~").exists(),
+            "nothing to back up when the destination does not exist"
         );
     }
 }

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -1924,8 +1924,7 @@ mod tests {
             backup_dir: None,
             suffix: OsString::from("~"),
         };
-        let spec =
-            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let spec = InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
         let rel = std::path::Path::new("file.bin");
         let config = inplace_backup_test_config(
             &dest_file,
@@ -2016,8 +2015,7 @@ mod tests {
             backup_dir: None,
             suffix: OsString::from("~"),
         };
-        let spec =
-            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let spec = InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
         let rel = std::path::Path::new("file.bin");
         let config = inplace_backup_test_config(&dest_file, dest_dir, rel, 20, true, Some(spec));
 
@@ -2048,8 +2046,7 @@ mod tests {
             backup_dir: None,
             suffix: OsString::from("~"),
         };
-        let spec =
-            InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
+        let spec = InplaceBackupSpec::new(&backup_config, crate::disk_commit::BackupEnv::default());
         let rel = std::path::Path::new("absent.bin");
         let config = inplace_backup_test_config(&dest_file, dest_dir, rel, 16, false, Some(spec));
 

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -859,6 +859,10 @@ impl ReceiverContext {
             whole_file: self.config.flags.whole_file,
             compat_flags: self.compat_flags,
             block_size: self.config.block_size,
+            // Only the decoupled pipeline loop threads the `--inplace --backup`
+            // delta-basis backup (generator.c:2328-2356); this builder serves
+            // `run_sync`, which writes via temp+rename and never in place.
+            inplace_backup: None,
         }
     }
 

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -52,8 +52,8 @@ pub(crate) use crate::parallel_io::ParallelThresholds;
 use signature;
 
 pub use self::basis::{
-    BasisFileConfig, BasisFileResult, ChecksumThreadsPolicy, find_basis_file_with_config,
-    set_checksum_threads_policy,
+    BasisFileConfig, BasisFileResult, ChecksumThreadsPolicy, InplaceBackupSpec,
+    find_basis_file_with_config, set_checksum_threads_policy,
 };
 pub use self::context::ReceiverContext;
 pub(in crate::receiver) use self::dest_root::dest_arg_has_trailing_slash;

--- a/crates/transfer/src/receiver/tests/partial_resume.rs
+++ b/crates/transfer/src/receiver/tests/partial_resume.rs
@@ -60,6 +60,7 @@ fn basis_file_result_is_empty_when_no_signature() {
         basis_path: None,
         fnamecmp_type: protocol::FnameCmpType::Fname,
         xname: None,
+        backup_notice: None,
     };
     assert!(result.is_empty());
 }
@@ -81,6 +82,7 @@ fn basis_file_result_is_not_empty_when_has_signature() {
         basis_path: Some(PathBuf::from("/tmp/basis")),
         fnamecmp_type: protocol::FnameCmpType::Fname,
         xname: None,
+        backup_notice: None,
     };
     assert!(!result.is_empty());
 }

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -495,6 +495,18 @@ impl ReceiverContext {
         } else {
             None
         };
+        // upstream: generator.c:2328-2356 - with `--inplace --backup` the DELTA
+        // path's pre-image backup is made by the generator at basis-selection
+        // time and selected as the basis (FNAMECMP_BACKUP), so thread the same
+        // backup config into the basis search. The redo pass is excluded,
+        // mirroring generator.c:2659 `make_backups = -make_backups` ("avoid
+        // dup backup w/inplace") - the phase-1 backup must not be overwritten
+        // with the now-partial destination.
+        let inplace_backup_config = if self.config.write.inplace && !is_redo_pass {
+            backup.clone()
+        } else {
+            None
+        };
         // upstream: cleanup.c - compute partial mode from --partial / --partial-dir flags.
         //
         // `--delay-updates` with no explicit `--partial-dir` stages through the
@@ -567,6 +579,21 @@ impl ReceiverContext {
             // `self` mutably, so the borrow cannot be held across it.
             let wire_basis_dirs = self.config.reference_directories.clone();
             let wire_basis_fuzzy_level = self.config.flags.fuzzy_level;
+            // The `--inplace --backup` delta-basis backup spec borrows `setup`
+            // (not `self`), so it can live across the response half of the
+            // loop. `Copy`, so the rayon signature closure captures it whole.
+            let inplace_backup = inplace_backup_config.as_ref().map(|backup_config| {
+                crate::receiver::InplaceBackupSpec::new(
+                    backup_config,
+                    crate::disk_commit::BackupEnv {
+                        #[cfg(unix)]
+                        sandbox: setup.sandbox.as_deref(),
+                        #[cfg(unix)]
+                        dest_dir: Some(setup.dest_dir.as_path()),
+                        metadata_opts: Some(&setup.metadata_opts),
+                    },
+                )
+            });
             let mut flushed_pending: usize = 0;
 
             loop {
@@ -652,6 +679,7 @@ impl ReceiverContext {
                                         whole_file,
                                         compat_flags,
                                         block_size,
+                                        inplace_backup,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -679,6 +707,7 @@ impl ReceiverContext {
                                         whole_file,
                                         compat_flags,
                                         block_size,
+                                        inplace_backup,
                                     };
                                     find_basis_file_with_config(&basis_config)
                                 })
@@ -686,7 +715,7 @@ impl ReceiverContext {
                         };
 
                         // Send requests sequentially (wire order matters).
-                        for ((file_idx, file_entry, file_path, base_iflags), basis_result) in
+                        for ((file_idx, file_entry, file_path, base_iflags), mut basis_result) in
                             batch.into_iter().zip(sig_results)
                         {
                             if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0 {
@@ -708,6 +737,22 @@ impl ReceiverContext {
                             // the same basis the delta selected so --fuzzy /
                             // --link-dest / --compare-dest / --partial-dir bases
                             // drive the resolution in upstream's priority order.
+                            // upstream: generator.c:2448-2450 - INFO_GTE(BACKUP, 1)
+                            // "backed up X to Y" for the `--inplace --backup`
+                            // delta-path pre-image copy made during basis
+                            // selection. Emitted here, on the session thread,
+                            // because a rayon signature worker's thread-local
+                            // verbosity is never seeded (same reason as
+                            // `emit_backup_notice` for the disk thread).
+                            if let Some(notice) = basis_result.backup_notice.take() {
+                                info_log!(
+                                    Backup,
+                                    1,
+                                    "backed up {} to {}",
+                                    notice.original.display(),
+                                    notice.backup.display()
+                                );
+                            }
                             let xattr_request = self.build_xattr_request(
                                 &file_entry,
                                 basis_result.basis_path.as_deref(),
@@ -1255,6 +1300,11 @@ impl ReceiverContext {
                 whole_file: self.config.flags.whole_file,
                 compat_flags: self.compat_flags,
                 block_size: self.config.block_size,
+                // upstream: `--only-write-batch` clears do_xfers, so the
+                // generator bails to notify_others before the delta-path
+                // backup branch (generator.c:2277 vs :2328) - no pre-image
+                // copy is made and the basis stays FNAMECMP_FNAME.
+                inplace_backup: None,
             };
             let basis = find_basis_file_with_config(&basis_config);
 

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -149,8 +149,10 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         }
         // upstream: generator.c:1942-1943 - a non-FNAME basis sets
         // ITEM_BASIS_TYPE_FOLLOWS so the sender reads the trailing fnamecmp_type
-        // byte and echoes it back to the receiver (rsync.c:403-405). Only the
-        // --partial-dir resume basis is emitted here (FNAMECMP_PARTIAL_DIR);
+        // byte and echoes it back to the receiver (rsync.c:403-405). The
+        // --partial-dir resume basis (FNAMECMP_PARTIAL_DIR) and the
+        // `--inplace --backup` delta basis (FNAMECMP_BACKUP, which clears the
+        // sender's `updating_basis_file`, sender.c:628-629) are emitted here;
         // FNAME carries no byte, matching the ordinary request encoding.
         let emit_basis_type = fnamecmp_type != protocol::FnameCmpType::Fname;
         if emit_basis_type {

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -77,6 +77,7 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -138,6 +139,7 @@ fn fuzzy_level1_does_not_search_reference_directories() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -196,6 +198,7 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -253,6 +256,7 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -313,6 +317,7 @@ fn fuzzy_level0_skips_search() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -363,6 +368,7 @@ fn whole_file_bypasses_fuzzy_search() {
         whole_file: true,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);
@@ -415,6 +421,7 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
         whole_file: false,
         compat_flags: None,
         block_size: None,
+        inplace_backup: None,
     };
 
     let result = find_basis_file_with_config(&config);


### PR DESCRIPTION
## What

Under `--inplace --backup` on the **delta** path, oc's generator never produced the `FNAMECMP_BACKUP` basis tag, so the sender's `updating_basis_file` stayed on and the whole file was re-sent as literal.

Measured against a block-swapped 1,310,720-byte fixture (identical content, blocks permuted, so a correct delta matches everything):

| arm | literal bytes sent |
|---|---|
| oc before | 656,352 |
| upstream 3.5.0 | 1,984 |
| oc after | 1,984 |

The three control cells (no flags, `--inplace` alone, `--backup` alone) are byte-identical across all arms, and the local-copy path is unchanged.

## Upstream rule — the generator has TWO branches, and only one keeps `FNAMECMP_FNAME`

- **whole-file / read-batch branch** (`generator.c:2280-2301`): backs the pre-image up with `copy_file()` and leaves `fnamecmp_type == FNAMECMP_FNAME`. No delta is generated, so the basis tag never matters.
- **delta branch** (`generator.c:2328-2356`): opens the backup for writing, streams the pre-image into it *during* `generate_and_send_sums()`, and retags `fnamecmp_type = FNAMECMP_BACKUP`.

The `0x82` wire byte clears the sender's `updating_basis_file` (`sender.c:628-629`), which is what lets blocks be matched in **any order** against the pristine copy while the destination is rewritten in place.

oc could not express this: `FnameCmpType::Backup` had zero producers and `BasisFileConfig` carried no field for the condition. A doc comment on `updating_basis_file()` stated the rule **backwards** — claiming upstream keeps `FNAMECMP_FNAME` under `--inplace --backup` at proto >= 29 — which is true only of the whole-file branch. Corrected in the same commit.

## Shape — one owner for the copy, no second implementation

`make_backup_copy` stays the single owner of the pre-image copy; it now also returns the absolute backup path so the delta path can select it as the basis. An `InplaceBackupSpec` (backup config + sandbox env) is threaded into `BasisFileConfig`; in the `FNAMECMP_FNAME` branch the basis search creates the copy, **signs the copy rather than the destination** (the receiver resolves matched blocks against `basis_path`, and upstream reaches the same guarantee from the other side by checksumming the very bytes it writes, `generator.c:809-810`), and tags `FnameCmpType::Backup`.

**Correctness hazard closed, not just dedup:** the disk thread's `make_inplace_backup` now skips when the delta basis *is* the backup. Without the skip it would re-copy — `O_TRUNC`-ing the very file the network thread is resolving matched blocks against.

Two exclusions mirror upstream exactly:
- the **redo pass** passes no spec (`generator.c:2659` `make_backups = -make_backups`, "avoid dup backup w/inplace") — the phase-1 backup must not be overwritten with the now-partial destination;
- `--only-write-batch` passes none either (`do_xfers == 0` bails to `notify_others` before the branch, `generator.c:2277`).

The `INFO_GTE(BACKUP, 1)` "backed up X to Y" notice (`generator.c:2448-2450`) is emitted from the request loop, whose thread-local verbosity is seeded — a rayon signature worker's is not.

## Tests + mutation (measured)

Mutations M1 (drop the basis retag) and M2 (remove the disk-thread skip) each kill exactly one pin — 12 run / 11 passed / 1 failed in both sweeps — and were reverted.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean, `clippy -p transfer --all-targets --all-features -D warnings` clean, `nextest -p transfer` green. No expect-manifest row edited.
