### PR TITLE
test(cli): pin the --debug table as upstream's 24 words plus four named extensions

### DIFF
--- a/crates/cli/src/frontend/execution/flags/tests.rs
+++ b/crates/cli/src/frontend/execution/flags/tests.rs
@@ -537,6 +537,70 @@ fn info_flag_all_keywords_accepted() {
     }
 }
 
+/// The `--debug` table is upstream's 24 words plus exactly four oc-only
+/// extensions, and that over-accept is a DELIBERATE, recorded decision.
+///
+/// upstream: `debug_words[]` (options.c:305-331) holds exactly 24 entries,
+/// `ACL` through `TIME`, terminated by the NULL sentinel at options.c:331.
+/// Anything the table does not name exits `RERR_SYNTAX` at options.c:483-487,
+/// and oc mirrors that refusal exactly (`debug_flag_apply_invalid`). So every
+/// word oc accepts that upstream does not is a measured divergence:
+/// `--debug=IOURING` is rc 0 here and rc 1 `Unknown --debug item: "IOURING"`
+/// on the real 3.5.0 binary.
+///
+/// The four extras are accepted on purpose. They name accelerated-I/O
+/// dispatch-vs-fallback categories upstream has no equivalent of, each has a
+/// wired consumer, and `DEBUG_HELP_TEXT` advertises them under their own
+/// `oc-rsync extensions` heading. This test exists so the divergence stays a
+/// decision rather than reading as drift: a 25th upstream word, a dropped
+/// upstream word, or a fifth oc extension each fail here and force the
+/// question to be answered again rather than absorbed silently.
+///
+/// `--info` deliberately has no counterpart to this: its table matches
+/// upstream's `info_words[]` exactly.
+#[test]
+fn the_debug_table_is_upstream_plus_exactly_four_named_oc_extensions() {
+    // Upstream's debug_words[] in table order (options.c:306-330).
+    const UPSTREAM: [&str; 24] = [
+        "acl", "backup", "bind", "chdir", "connect", "cmd", "del", "deltasum", "dup", "exit",
+        "filter", "flist", "fuzzy", "genr", "hash", "hlink", "iconv", "io", "nstr", "own", "proto",
+        "recv", "send", "time",
+    ];
+    // Accepted by oc, refused by upstream. See DEBUG_HELP_TEXT's extensions block.
+    const OC_EXTENSIONS: [&str; 4] = ["iouring", "clone", "sockopt", "iocp"];
+
+    // `all1` routes through the live parse path to set every word the applying
+    // table knows, so this enumerates the real accepted set rather than a copy.
+    let mut settings = DebugFlagSettings::default();
+    settings.apply("all1").unwrap();
+    let accepted: Vec<&str> = settings
+        .iter_enabled_flags()
+        .map(|(name, _)| name)
+        .collect();
+
+    let expected: Vec<&str> = UPSTREAM
+        .iter()
+        .chain(OC_EXTENSIONS.iter())
+        .copied()
+        .collect();
+    assert_eq!(
+        accepted, expected,
+        "the --debug word set changed; if a word was added, decide whether it is an \
+         upstream word (mirror options.c:306-330) or a fifth oc extension (document it \
+         in DEBUG_HELP_TEXT's extensions block) before updating this test"
+    );
+
+    // Non-vacuity: the four really are accepted, so this pins the over-accept
+    // itself and not merely the table's contents.
+    for extension in &OC_EXTENSIONS {
+        let mut settings = DebugFlagSettings::default();
+        assert!(
+            settings.apply(extension).is_ok(),
+            "oc extension '{extension}' must stay accepted"
+        );
+    }
+}
+
 #[test]
 fn debug_flag_all_keywords_accepted() {
     let keywords = [


### PR DESCRIPTION
## What

oc's `--debug` word table accepts **four words upstream refuses**. That is deliberate, but nothing recorded the decision, so it read as drift on a surface where every other cell is now byte-identical to upstream.

Measured against the real 3.5.0 binary:

| cell | upstream 3.5.0 | oc |
|---|---|---|
| `--debug=IOURING` | rc 1, `Unknown --debug item: "IOURING"` | rc 0, accepted |
| `--debug=CLONE` / `SOCKOPT` / `IOCP` | rc 1, same form | rc 0, accepted |
| every other word, valid or unknown | — | matches on exit code **and** message text |

## Why the four stay

They name accelerated-I/O dispatch-vs-fallback categories upstream has no equivalent of (`DebugFlag::Iouring` and siblings, each with a wired consumer), and `DEBUG_HELP_TEXT` already advertises them under its own `oc-rsync extensions` heading — the same convention EXT-2 established for oc-only CLI flags. Removing them would break accelerated-I/O fallback diagnostics for a purely nominal compat gain: the over-accept has no wire effect and changes nothing for any input upstream accepts.

So this PR records the decision rather than reversing it.

## Upstream anchors

- `options.c:305-331` — `debug_words[]`, exactly 24 entries (`ACL` … `TIME`) plus the NULL sentinel at :331.
- `options.c:483-487` — the sole refusal site inside `parse_output_words()`: `if (len && !words[j].name && !am_server) { rprintf(FERROR, "Unknown %s item: \"%.*s\"\n", …); exit_cleanup(RERR_SYNTAX); }`. `RERR_SYNTAX` is 1 (`errcode.h:25`).

## Shape

One test enumerates the accepted set **through the live parse path** (`apply("all1")` → `iter_enabled_flags`) rather than reading a copy of the list, and asserts it equals upstream's 24 followed by exactly those four. A 25th upstream word, a dropped upstream word, or a fifth oc extension each fail here and force the question to be answered again instead of being absorbed silently.

A companion loop asserts the four really are accepted, so the pin covers the **over-accept itself**, not merely the table's contents.

`--info` needs no counterpart — its table matches upstream's `info_words[]` exactly.

## Mutation (measured)

Two mutations, each killing a **different** assertion, so both halves are load-bearing:

- drop an upstream word from the enumeration → the table assertion fails, diffing the 24-word list.
- make `--debug=iocp` unknown → the non-vacuity loop fails with `oc extension 'iocp' must stay accepted`.

Both reverted.

## Gates

Pinned 1.88.0: whole-tree rustfmt clean (`tools/ci/check_rustfmt_all.py`), `clippy -p cli --all-targets --all-features -D warnings` clean, `nextest -p cli --lib --no-fail-fast` 3405 run / 3404 passed.

The one failure is `transfer_request_with_sparse_preserves_holes`, a pre-existing APFS sparse-block-count flake. Attributed by running the full parallel suite on the **pristine base**, where it fails identically (3404 run / 3403 passed) while passing in isolation on both arms — this change adds exactly one test and leaves the failure set unchanged.
