### PR TITLE
fix(metadata): give a symlink upstream's dest_mode() and never tweak it with --chmod

### DIFF
--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -742,6 +742,15 @@ pub(crate) fn copy_symlink(
     } else {
         metadata_options.clone()
     };
+    // upstream: generator.c:1937-1940 - with `-p` off the generator rewrites
+    // `file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, exists)`
+    // for every type, symlinks included (the rewrite sits above the
+    // `preserve_links && ftype == FT_SYMLINK` branch at generator.c:1948).
+    // `exists` is `statret == 0 && stype != FT_DIR`, i.e. whether the
+    // destination was there BEFORE this transfer - so the freshly created link
+    // must take the new-file arm and be chmod'd to `source & dflt_perms`
+    // instead of keeping the umask default `symlink(2)` gave it.
+    let symlink_options = symlink_options.with_destination_is_new(!destination_previously_existed);
     apply_symlink_metadata_with_options(destination, metadata, &symlink_options)
         .map_err(map_metadata_error)?;
 

--- a/crates/engine/src/local_copy/plan/change_set/detection.rs
+++ b/crates/engine/src/local_copy/plan/change_set/detection.rs
@@ -94,9 +94,9 @@ impl LocalCopyChangeSet {
         // link (`metadata::CAN_CHMOD_SYMLINK` = macOS/BSD), so report and
         // action never drift: a reported `p` is always backed by the matching
         // apply in metadata::apply_symlink_permissions_like. Upstream skips the
-        // compare only where `CAN_CHMOD_SYMLINK` is undefined (rsync.h:438-440,
-        // HAVE_LCHMOD or HAVE_SETATTRLIST, probed at configure.ac:911,918); the
-        // `#ifndef` block at generator.c:542-544 then compiles out. On Linux
+        // compare only where `CAN_CHMOD_SYMLINK` is undefined (rsync.h:455-456,
+        // HAVE_LCHMOD or HAVE_SETATTRLIST, probed at configure.ac:942,950); the
+        // `#ifndef` block at generator.c:548-552 then compiles out. On Linux
         // the const is false and a link's `st_mode` is a fixed 0777, so nothing
         // is reported or applied. Mirrors the receiver itemize guard.
         let is_symlink = metadata.file_type().is_symlink();
@@ -132,7 +132,16 @@ impl LocalCopyChangeSet {
             change_set = change_set.with_permissions_changed(true);
         }
 
-        if symlink_perms_ok && metadata_options.chmod().is_some() {
+        // A `--chmod` spec never reaches a symlink's mode: upstream gates every
+        // `tweak_mode()` call on `!S_ISLNK` (flist.c:1741-1742 send_file_name,
+        // flist.c:996-997 recv_file_entry, rsync.c:647-648 the daemon
+        // `outgoing chmod`), so a link's mode arrives at itemize() untweaked and
+        // the `p` column stays driven by the plain `-p` / `-E` compare
+        // (generator.c:424-433 `perms_differ`). Reporting `p` here would be a
+        // report with no apply behind it, since
+        // metadata::apply_symlink_permissions_like ignores `--chmod` for the
+        // same reason.
+        if !is_symlink && metadata_options.chmod().is_some() {
             change_set = change_set.with_permissions_changed(true);
         }
 

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -1112,3 +1112,71 @@ fn for_file_atimes_differing_access_time_sets_u_glyph() {
     assert!(!change_set.access_time_changed());
     assert!(!change_set.has_any_change());
 }
+
+/// A `--chmod` spec must not raise the `p` column for a SYMLINK.
+///
+/// Upstream gates every `tweak_mode()` call on `!S_ISLNK`
+/// (flist.c:1741-1742 `send_file_name`, flist.c:996-997 `recv_file_entry`,
+/// rsync.c:647-648 the daemon `outgoing chmod`), so a link's mode reaches
+/// `itemize()` untweaked and the `p` decision there is the plain `-p` / `-E`
+/// compare (generator.c:424-433 `perms_differ`, inlined at
+/// generator.c:548-558). Reporting `p` here would be a report with no apply
+/// behind it, because `metadata::apply_symlink_permissions_like` ignores
+/// `--chmod` for exactly the same reason.
+///
+/// The regular-file arm is the non-vacuity control: the SAME options object
+/// must still raise `p` there, or this test would pass on a dead `--chmod`.
+#[test]
+fn for_file_chmod_does_not_report_perms_for_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let temp = tempfile::tempdir().expect("tempdir");
+    let target = temp.path().join("target.txt");
+    fs::write(&target, b"content").expect("write target");
+
+    let src_link = temp.path().join("src-link");
+    let dst_link = temp.path().join("dst-link");
+    symlink("target.txt", &src_link).expect("create src link");
+    symlink("target.txt", &dst_link).expect("create dst link");
+    let src_link_meta = fs::symlink_metadata(&src_link).expect("src link meta");
+    let dst_link_meta = fs::symlink_metadata(&dst_link).expect("dst link meta");
+
+    let file_meta = fs::metadata(&target).expect("file meta");
+
+    let chmod = ::metadata::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+    let options = MetadataOptions::new()
+        .preserve_permissions(false)
+        .with_chmod(Some(chmod));
+
+    let link_change_set = LocalCopyChangeSet::for_file(
+        &src_link_meta,
+        Some(&dst_link_meta),
+        &options,
+        true,
+        false,
+        false,
+        false,
+        ModifyWindow::ZERO,
+    );
+    assert!(
+        !link_change_set.permissions_changed(),
+        "--chmod must not raise `p` for a symlink: upstream never tweaks a \
+         link's mode, so nothing would be applied"
+    );
+
+    let file_change_set = LocalCopyChangeSet::for_file(
+        &file_meta,
+        Some(&file_meta),
+        &options,
+        true,
+        false,
+        false,
+        false,
+        ModifyWindow::ZERO,
+    );
+    assert!(
+        file_change_set.permissions_changed(),
+        "non-vacuity control: the same --chmod spec DOES raise `p` for a \
+         regular file"
+    );
+}

--- a/crates/engine/src/local_copy/plan/change_set/tests.rs
+++ b/crates/engine/src/local_copy/plan/change_set/tests.rs
@@ -1126,6 +1126,11 @@ fn for_file_atimes_differing_access_time_sets_u_glyph() {
 ///
 /// The regular-file arm is the non-vacuity control: the SAME options object
 /// must still raise `p` there, or this test would pass on a dead `--chmod`.
+///
+/// Unix-only: the fixture creates real symlinks via `std::os::unix`, and the
+/// `p` decision it pins reads a link's lstat permission bits, which only the
+/// unix `MetadataExt` surface exposes.
+#[cfg(unix)]
 #[test]
 fn for_file_chmod_does_not_report_perms_for_a_symlink() {
     use std::os::unix::fs::symlink;

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -1533,3 +1533,119 @@ fn execute_symlink_tree_stats_match_upstream() {
         "an unchanged symlink must not be counted as created (upstream reports 0)"
     );
 }
+
+/// A NEW symlink copied WITHOUT `-p` must land on upstream's `dest_mode()`
+/// result, not on the umask default that `symlink(2)` leaves behind.
+///
+/// upstream: generator.c:1937-1940 rewrites `file->mode = dest_mode(file->mode,
+/// sx.st.st_mode, dflt_perms, exists)` for EVERY type - the rewrite sits above
+/// the `preserve_links && ftype == FT_SYMLINK` branch at generator.c:1948 - and
+/// `set_file_attrs()` then chmods the link to it (rsync.c:510 + 806-822). This
+/// covers the `with_destination_is_new` plumbing at the local-copy symlink
+/// create site, which the `symlink_target_mode()` unit pins cannot reach.
+///
+/// Only meaningful where the OS can chmod a link at all; on Linux
+/// `CAN_CHMOD_SYMLINK` is false, `st_mode` is a fixed 0o777, and there is
+/// nothing to assert.
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_new_symlink_without_perms_takes_the_dest_mode_reduction() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    let dst_dir = temp.path().join("dst");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::write(src_dir.join("target.txt"), b"data").expect("write target");
+    let src_link = src_dir.join("link");
+    symlink("target.txt", &src_link).expect("create src link");
+    // A source link mode that no umask can produce by accident.
+    fast_io::secure_chmod_at(&src_link, 0o711, false).expect("seed src link mode");
+
+    let operands = vec![
+        src_dir.join("").into_os_string(),
+        dst_dir.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .permissions(false);
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_link = dst_dir.join("link");
+    let got = fs::symlink_metadata(&dest_link)
+        .expect("dest link metadata")
+        .permissions()
+        .mode()
+        & 0o7777;
+
+    // Derive `dflt_perms` from the OS rather than from the implementation:
+    // mkdir(2) applies exactly `0o777 & ~umask`, which is upstream's
+    // `ACCESSPERMS & ~orig_umask` (generator.c:2770). A fresh symlink gets the
+    // same bits, so this doubles as the mode the link would have kept had the
+    // dest_mode() chmod never run.
+    let probe = temp.path().join("umask-probe");
+    fs::create_dir(&probe).expect("mkdir probe");
+    let dflt = fs::metadata(&probe)
+        .expect("probe metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        got,
+        0o711 & dflt,
+        "a new link must be chmod'd to `source & dflt_perms`, not left at the \
+         {dflt:o} that symlink(2) produced"
+    );
+}
+
+/// An EXISTING symlink re-synced WITHOUT `-p` must keep its own bits:
+/// `dest_mode()`'s `exists` arm returns `(flist_mode & ~CHMOD_BITS) |
+/// (stat_mode & CHMOD_BITS)` (rsync.c:470-480), so `BITS_EQUAL` at rsync.c:807
+/// holds and upstream issues no chmod at all. This is the control for the test
+/// above: the same source link, the same flags, opposite arm.
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_existing_symlink_without_perms_keeps_its_own_mode() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    let dst_dir = temp.path().join("dst");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::create_dir_all(&dst_dir).expect("mkdir dst");
+    fs::write(src_dir.join("target.txt"), b"data").expect("write src target");
+    fs::write(dst_dir.join("target.txt"), b"data").expect("write dst target");
+    let src_link = src_dir.join("link");
+    symlink("target.txt", &src_link).expect("create src link");
+    fast_io::secure_chmod_at(&src_link, 0o711, false).expect("seed src link mode");
+
+    let dest_link = dst_dir.join("link");
+    symlink("target.txt", &dest_link).expect("create dst link");
+    fast_io::secure_chmod_at(&dest_link, 0o700, false).expect("seed dst link mode");
+
+    let operands = vec![
+        src_dir.join("").into_os_string(),
+        dst_dir.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .permissions(false);
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let got = fs::symlink_metadata(&dest_link)
+        .expect("dest link metadata")
+        .permissions()
+        .mode()
+        & 0o7777;
+    assert_eq!(
+        got, 0o700,
+        "an existing link keeps its own 0o700 without -p; the source's 0o711 \
+         must not reach it"
+    );
+}

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -531,12 +531,16 @@ pub fn apply_symlink_metadata(
 /// elsewhere the chmod is a no-op, matching upstream where `CAN_CHMOD_SYMLINK`
 /// is undefined and a symlink's `st_mode` is a fixed `0o777`.
 ///
-/// `rsync.c:658-668` calls `do_chmod_at()` for every file type with no
-/// `S_ISLNK` gate (the comment at `rsync.c:667`, "ret == 1 if symlink could
+/// `rsync.c:806-822` calls `do_chmod_at()` for every file type with no
+/// `S_ISLNK` gate (the comment at `rsync.c:819`, "ret == 1 if symlink could
 /// not be set", shows a failed symlink chmod is a soft outcome). All the
-/// portability lives in `syscall.c:761 do_chmod()`, which tries `lchmod()`,
-/// falls through to `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`, and only then
-/// gives up.
+/// portability lives in `syscall.c:1566-1604 do_chmod()`, which tries
+/// `lchmod()`, falls through to `setattrlist(FSOPT_NOFOLLOW)` for `S_ISLNK`,
+/// and only then gives up.
+///
+/// The mode itself never carries a `--chmod` tweak for a link: upstream gates
+/// all three `tweak_mode()` sites on `!S_ISLNK` (flist.c:1741-1742,
+/// flist.c:996-997, rsync.c:647-648).
 pub fn apply_symlink_metadata_with_options(
     destination: &Path,
     metadata: &fs::Metadata,
@@ -566,10 +570,12 @@ pub fn apply_symlink_metadata_with_options(
 ///
 /// # Upstream Reference
 ///
-/// - `rsync.c:658-668` - upstream chmods every file type with no `S_ISLNK`
+/// - `rsync.c:806-822` - upstream chmods every file type with no `S_ISLNK`
 ///   gate; oc mirrors this on platforms where [`crate::CAN_CHMOD_SYMLINK`]
-///   holds. Symlink portability lives in `syscall.c:761 do_chmod()`
-///   (`lchmod()`, then `setattrlist(FSOPT_NOFOLLOW)`).
+///   holds. Symlink portability lives in `syscall.c:1566-1604 do_chmod()`
+///   (`lchmod()`, then `setattrlist(FSOPT_NOFOLLOW)`). The mode reaching that
+///   chmod is never `--chmod`-tweaked for a link (flist.c:1741-1742,
+///   flist.c:996-997 and rsync.c:647-648 all gate on `!S_ISLNK`).
 /// - `rsync.c:set_times()` - uses `lutimes` when the target is a symlink
 /// - `generator.c:1604` - `set_file_attrs(fname, file, NULL, NULL, 0)` runs
 ///   after `atomic_create` -> `do_symlink` so the new symlink's mtime matches

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -720,22 +720,103 @@ fn chmod_path_honoring_keep_dirlinks(
     Ok(())
 }
 
+/// Maps a symlink apply into [`chmod_tweaked_dest_mode`]'s `pre_transfer`
+/// argument, i.e. `dest_mode()`'s `exists` input.
+///
+/// Both symlink apply paths run AFTER the link is on disk, so their own lstat
+/// cannot tell "was here before" from "we just made it". `destination_is_new`
+/// carries that answer down from the executor, which knows it: upstream's
+/// `exists` is `statret == 0 && stype != FT_DIR` (generator.c:1938), the
+/// generator's lstat from BEFORE `do_symlink` ran.
+///
+/// When the link is not new, its current stat IS the pre-transfer stat - except
+/// for a destination that existed as a NON-symlink and was replaced, where
+/// upstream still holds the obstacle's old `st_mode` and this hands back the
+/// fresh link's instead. That single cell is a known gap, tracked with the rest
+/// of the symlink-obstacle mode work rather than papered over here.
+#[cfg(unix)]
+fn symlink_pre_transfer_stat<'a>(
+    options: &MetadataOptions,
+    current: &'a fs::Metadata,
+) -> Option<&'a fs::Metadata> {
+    if options.destination_is_new() {
+        None
+    } else {
+        Some(current)
+    }
+}
+
+/// The single owner of "which permission bits does a symlink end up with".
+///
+/// A link is not a special case in upstream: it walks the SAME
+/// `tweak_mode()`-then-`dest_mode()` pipeline every other type walks, and the
+/// only two symlink-specific facts are which gates it fails. So this is a thin
+/// adapter over [`chmod_tweaked_dest_mode`] that supplies those two facts as
+/// arguments rather than restating the pipeline:
+///
+/// * **`modifiers = None` - the `!S_ISLNK` gate.** `--chmod` reaches
+///   `tweak_mode()` at exactly three places and every one of them excludes a
+///   link, so a link's mode is never tweaked:
+///   - `flist.c:1741-1742` `send_file_name()` -
+///     `if (chmod_modes && !S_ISLNK(file->mode) && file->mode)`
+///   - `flist.c:996-997` `recv_file_entry()` -
+///     `if (chmod_modes && !S_ISLNK(mode) && mode)`
+///   - `rsync.c:647-648` `set_file_attrs()` (daemon `outgoing chmod`) -
+///     `if (daemon_chmod_modes && !S_ISLNK(new_mode))`
+/// * **`source_is_regular = false` - the `S_ISREG` gate.** `dest_mode()`'s
+///   `-E` tweak is `if (preserve_executability && S_ISREG(flist_mode))`
+///   (rsync.c:472), so `-E` contributes NOTHING to a link's mode. (`-E` still
+///   drives the `p` COLUMN through `perms_differ()`; that is the caller's
+///   business, not this one's.)
+///
+/// The `dest_mode()` collapse itself is not symlink-specific either:
+/// `generator.c:1937-1940` runs
+/// `file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, exists)` for
+/// every type, sitting ABOVE the `preserve_links && ftype == FT_SYMLINK` branch
+/// at generator.c:1948, so a link takes the same two arms as a file - keep the
+/// destination's own bits when it already existed (rsync.c:470-480), else mask
+/// the sender's bits with `dflt_perms` and drop the special bits
+/// (rsync.c:481-485).
+///
+/// `pre_transfer` is the destination's PRE-transfer stat, exactly as
+/// [`chmod_tweaked_dest_mode`] means it: `None` says the link is new.
+///
+/// The result is the full `CHMOD_BITS` the link should end up with; when it
+/// already matches, the caller's `current != target` test turns the whole thing
+/// into the no-op `BITS_EQUAL(sxp->st.st_mode, new_mode, CHMOD_BITS)` produces
+/// upstream (rsync.c:807).
+#[cfg(unix)]
+fn symlink_target_mode(
+    destination: &Path,
+    source_mode: u32,
+    options: &MetadataOptions,
+    pre_transfer: Option<&fs::Metadata>,
+) -> u32 {
+    chmod_tweaked_dest_mode(
+        None, // !S_ISLNK: --chmod never reaches a link
+        destination,
+        source_mode,
+        false, // a link is never S_ISDIR
+        false, // !S_ISREG: dest_mode()'s -E tweak never fires for a link
+        options,
+        pre_transfer,
+    ) & 0o7777
+}
+
 /// Chmods a symbolic link's own permission bits, matching the itemize `p`
 /// decision the receiver reports from a `FileEntry`.
 ///
-/// Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds (macOS/BSD). Reproduces
-/// upstream `generator.c:546-552`: under `-p` the link is chmod'd to the
-/// sender's mode bits; under `-E` (without `-p`) only the execute bits track
-/// the source. The chmod uses `fchmodat(AT_SYMLINK_NOFOLLOW)` via
-/// [`fast_io::secure_chmod_at`] (`follow_symlinks = false`) so the link
-/// itself, not its target, is modified.
+/// Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds (macOS/BSD). The mode is
+/// decided by [`symlink_target_mode`]. The chmod uses
+/// `fchmodat(AT_SYMLINK_NOFOLLOW)` via [`fast_io::secure_chmod_at`]
+/// (`follow_symlinks = false`) so the link itself, not its target, is modified.
 ///
-/// upstream: rsync.c:658-668 (`set_file_attrs()` chmods every file type with
-/// no `S_ISLNK` gate) + syscall.c:761 `do_chmod()`. The symlink chmod is a
-/// SOFT outcome (`rsync.c:667`, `ret == 1`), so any failure is swallowed and
-/// never propagated - exactly as an unsupported symlink chmod is on any
-/// platform that compiled the const to `true` but hit a filesystem that
-/// refuses it at runtime.
+/// upstream: rsync.c:806-822 (`set_file_attrs()` chmods every file type with
+/// no `S_ISLNK` gate) + syscall.c `do_chmod_at()`. The symlink chmod is a SOFT
+/// outcome (`rsync.c:819`, `ret == 1`), so any failure is swallowed and never
+/// propagated - exactly as an unsupported symlink chmod is on any platform
+/// that compiled the const to `true` but hit a filesystem that refuses it at
+/// runtime.
 pub(super) fn apply_symlink_permissions_from_entry(
     destination: &Path,
     entry: &protocol::flist::FileEntry,
@@ -746,24 +827,25 @@ pub(super) fn apply_symlink_permissions_from_entry(
     if crate::CAN_CHMOD_SYMLINK {
         use std::os::unix::fs::PermissionsExt;
 
-        let current_mode = match cached_meta {
-            Some(meta) => meta.permissions().mode(),
+        let owned_meta;
+        let meta = match cached_meta {
+            Some(meta) => meta,
             None => match fs::symlink_metadata(destination) {
-                Ok(meta) => meta.permissions().mode(),
+                Ok(meta) => {
+                    owned_meta = meta;
+                    &owned_meta
+                }
                 Err(_) => return Ok(()),
             },
         };
-        let current = current_mode & 0o7777;
-        let target = if options.permissions() {
-            Some(entry.mode() & 0o7777)
-        } else if options.executability() {
-            Some((current & !0o111) | (entry.mode() & 0o111))
-        } else {
-            None
-        };
-        if let Some(target) = target
-            && current != target
-        {
+        let current = meta.permissions().mode() & 0o7777;
+        let target = symlink_target_mode(
+            destination,
+            entry.mode(),
+            options,
+            symlink_pre_transfer_stat(options, meta),
+        );
+        if current != target {
             let _ = fast_io::secure_chmod_at(destination, target, false);
         }
     }
@@ -775,13 +857,15 @@ pub(super) fn apply_symlink_permissions_from_entry(
 /// Chmods a symbolic link's own permission bits from a source [`fs::Metadata`],
 /// matching the local-copy change-set `p` decision.
 ///
-/// The local-copy counterpart to [`apply_symlink_permissions_from_entry`].
-/// Reproduces the change-set detection compare (`-p` full-bits, `-E`
-/// exec-bits) plus the `--chmod` tweak that upstream `tweak_mode()` layers on
-/// every file type. Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds; the
-/// chmod is a SOFT outcome and any error is swallowed.
+/// The local-copy counterpart to [`apply_symlink_permissions_from_entry`];
+/// both defer to [`symlink_target_mode`], so the local and receiver paths can
+/// never drift. In particular `--chmod` is NOT layered on here, and without
+/// `-p` the mode is upstream's `dest_mode()` result rather than the umask
+/// default the `symlink(2)` call left behind - see [`symlink_target_mode`] for
+/// both halves. Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds; the chmod
+/// is a SOFT outcome and any error is swallowed.
 ///
-/// upstream: rsync.c:658-668 + syscall.c:761 `do_chmod()`.
+/// upstream: rsync.c:806-822 + syscall.c `do_chmod_at()`.
 pub(super) fn apply_symlink_permissions_like(
     destination: &Path,
     source_metadata: &fs::Metadata,
@@ -791,28 +875,19 @@ pub(super) fn apply_symlink_permissions_like(
     if crate::CAN_CHMOD_SYMLINK {
         use std::os::unix::fs::PermissionsExt;
 
-        let current = match fs::symlink_metadata(destination) {
-            Ok(meta) => meta.permissions().mode() & 0o7777,
+        let meta = match fs::symlink_metadata(destination) {
+            Ok(meta) => meta,
             Err(_) => return Ok(()),
         };
+        let current = meta.permissions().mode() & 0o7777;
         let source = source_metadata.permissions().mode();
-        let base = if options.permissions() {
-            Some(source & 0o7777)
-        } else if options.executability() {
-            Some((current & !0o111) | (source & 0o111))
-        } else {
-            None
-        };
-        let target = match options.chmod() {
-            Some(modifiers) => {
-                let start = base.unwrap_or(current);
-                Some(modifiers.apply(start, source_metadata.is_dir()) & 0o7777)
-            }
-            None => base,
-        };
-        if let Some(target) = target
-            && current != target
-        {
+        let target = symlink_target_mode(
+            destination,
+            source,
+            options,
+            symlink_pre_transfer_stat(options, &meta),
+        );
+        if current != target {
             let _ = fast_io::secure_chmod_at(destination, target, false);
         }
     }
@@ -1396,5 +1471,139 @@ mod tests {
         );
         // Any value with bits above the 9 umask bits is equally impossible.
         assert_eq!(super::sanitize_umask(0o1000), super::FALLBACK_UMASK);
+    }
+
+    /// `symlink_target_mode()` table pins.
+    ///
+    /// The absolute mode a NEW link ends up with depends on the process umask,
+    /// and that dependence is proven against the real 3.5.0 binary at the CLI
+    /// level (source 0o777 under umask 022 / 077 / 000 gives 755 / 700 / 777 in
+    /// both). What is pinned here is the structure upstream fixes regardless of
+    /// umask: which `dest_mode()` arm a link takes, that `--chmod` never
+    /// reaches it, and that `-E` never reaches it.
+    fn symlink_opts(perms: bool, exec: bool, is_new: bool) -> MetadataOptions {
+        MetadataOptions::new()
+            .preserve_permissions(perms)
+            .preserve_executability(exec)
+            .preserve_times(false)
+            .with_destination_is_new(is_new)
+    }
+
+    /// upstream: `dest_mode()` only runs under `!preserve_perms`
+    /// (generator.c:1937), so with `-p` the link takes the sender's bits
+    /// verbatim - no umask reduction, and no `--chmod`.
+    #[test]
+    fn symlink_target_mode_under_preserve_perms_is_the_source_bits_verbatim() {
+        let dir = tempdir().expect("tempdir");
+        let link = dir.path().join("l");
+        let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+
+        for source in [0o777u32, 0o700, 0o644, 0o711] {
+            let plain = symlink_opts(true, false, true);
+            assert_eq!(
+                symlink_target_mode(&link, 0o120000 | source, &plain, None),
+                source,
+                "-p must hand back the source bits {source:o} untouched"
+            );
+            let with_chmod = symlink_opts(true, false, true).with_chmod(Some(chmod.clone()));
+            assert_eq!(
+                symlink_target_mode(&link, 0o120000 | source, &with_chmod, None),
+                source,
+                "--chmod must not reach a link (upstream gates tweak_mode on \
+                 !S_ISLNK at flist.c:1741-1742); go-rwx would have given {:o}",
+                source & 0o700
+            );
+        }
+    }
+
+    /// upstream: rsync.c:470-480 - `dest_mode()`'s `exists` arm returns
+    /// `(flist_mode & ~CHMOD_BITS) | (stat_mode & CHMOD_BITS)`, so a link that
+    /// was already there keeps its own bits and `BITS_EQUAL` at rsync.c:807
+    /// makes the chmod a no-op. `-E` cannot change that: its tweak is nested
+    /// under `S_ISREG(flist_mode)` (rsync.c:472).
+    ///
+    /// Both `-E` directions are exercised, because each fires only one of
+    /// upstream's two branches and a fixture that trips neither would pass
+    /// with the `S_ISREG` gate removed:
+    ///   * dest has NO exec, source HAS exec -> `new_mode |= (new_mode & 0444) >> 2`
+    ///     would grant 0o644 -> 0o755;
+    ///   * dest HAS exec, source has NO exec -> `new_mode &= ~0111` would strip
+    ///     0o755 -> 0o644.
+    ///
+    /// A link must show neither.
+    #[test]
+    fn symlink_target_mode_existing_link_keeps_its_own_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let chmod = crate::ChmodModifiers::parse("a=rw").expect("parse chmod");
+
+        // (dest bits, source mode, what the S_ISREG-gated -E tweak would do)
+        let cases = [(0o644u32, 0o120777u32, 0o755u32), (0o755, 0o120600, 0o644)];
+
+        for (dest_bits, source_mode, would_be) in cases {
+            let link = dir.path().join(format!("l{dest_bits:o}"));
+            std::fs::write(&link, b"x").expect("write");
+            std::fs::set_permissions(&link, std::fs::Permissions::from_mode(dest_bits))
+                .expect("seed dest bits");
+            let on_disk = std::fs::metadata(&link).expect("meta");
+
+            for (exec, label) in [(false, "no -p, no -E"), (true, "-E, no -p")] {
+                let opts = symlink_opts(false, exec, false);
+                assert_eq!(
+                    symlink_target_mode(&link, source_mode, &opts, Some(&on_disk)),
+                    dest_bits,
+                    "{label}: an existing link keeps its own {dest_bits:o}; the \
+                     S_ISREG-gated -E tweak would have made it {would_be:o}"
+                );
+                let opts = opts.with_chmod(Some(chmod.clone()));
+                assert_eq!(
+                    symlink_target_mode(&link, source_mode, &opts, Some(&on_disk)),
+                    dest_bits,
+                    "{label} + --chmod=a=rw: still {dest_bits:o}, never 0o666"
+                );
+            }
+        }
+    }
+
+    /// upstream: rsync.c:481-485 - the new arm is
+    /// `flist_mode & (~CHMOD_BITS | dflt_perms)`. Two umask-independent
+    /// consequences are pinned here: the mask can only remove bits the source
+    /// had, and the special bits always drop out ("turn off special
+    /// permissions", rsync.c:482-483).
+    #[test]
+    fn symlink_target_mode_new_link_masks_the_source_and_drops_special_bits() {
+        let dir = tempdir().expect("tempdir");
+        let link = dir.path().join("l");
+        let dflt = default_perms_seed(link.parent());
+        let opts = symlink_opts(false, false, true);
+
+        for source in [0o777u32, 0o700, 0o644, 0o711, 0o755] {
+            let got = symlink_target_mode(&link, 0o120000 | source, &opts, None);
+            assert_eq!(got, source & dflt, "new link takes source & dflt_perms");
+            assert_eq!(got & !source, 0, "the mask can only remove bits");
+        }
+
+        let got = symlink_target_mode(&link, 0o120000 | 0o4755, &opts, None);
+        assert_eq!(got & 0o7000, 0, "suid/sgid/sticky must not survive");
+    }
+
+    /// `-E` alone must not synthesise a mode for a link: upstream's `-E` tweak
+    /// lives inside `dest_mode()` under `S_ISREG(flist_mode)` (rsync.c:472), so
+    /// a link under `-E` takes the plain arm, never an exec blend of the
+    /// destination's bits with the source's.
+    #[test]
+    fn symlink_target_mode_executability_never_blends_a_link() {
+        let dir = tempdir().expect("tempdir");
+        let link = dir.path().join("l");
+        let dflt = default_perms_seed(link.parent());
+
+        let opts = symlink_opts(false, true, true);
+        assert_eq!(
+            symlink_target_mode(&link, 0o120700, &opts, None),
+            0o700 & dflt,
+            "-E on a new link is the plain dest_mode() arm; an exec blend from \
+             a 0o755 link would have produced 0o744"
+        );
     }
 }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -3015,6 +3015,163 @@ fn symlink_own_mode_applied_from_source_metadata_local_copy() {
     );
 }
 
+// A `--chmod` spec must never reach a symlink's own mode. Upstream tweaks a
+// mode with `tweak_mode()` at exactly three sites and every one is gated on
+// `!S_ISLNK`:
+//
+//   flist.c:1741-1742  send_file_name()   - the sender's flist rewrite
+//   flist.c:996-997    recv_file_entry()  - the receiver's flist read
+//   rsync.c:647-648    set_file_attrs()   - the daemon `outgoing chmod`
+//
+// so `set_file_attrs()` (rsync.c:510 `mode_t new_mode = file->mode;`) chmods a
+// link to the mode the `-p` / `-E` compare produced and nothing else. Measured
+// against the pinned 3.5.0 binary on macOS: `-a --chmod=go-rwx` over a
+// `link -> file.txt` seeded at 0755 leaves the destination link at 0755, while
+// the same run drops the regular file to 0600 and the directory to 0700.
+//
+// These tests only have a subject where the OS can chmod a link at all
+// (`CAN_CHMOD_SYMLINK` = macOS/BSD); on Linux the whole arm is compiled out and
+// this surface does not exist.
+#[cfg(target_os = "macos")]
+#[test]
+fn symlink_chmod_spec_is_ignored_without_preserve_perms_local_copy() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("t.txt");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &src).expect("create src link");
+    symlink(&target, &dst).expect("create dst link");
+
+    fast_io::secure_chmod_at(&src, 0o714, false).expect("seed src mode");
+    fast_io::secure_chmod_at(&dst, 0o777, false).expect("seed dst mode");
+
+    let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+    let src_meta = fs::symlink_metadata(&src).expect("src link metadata");
+    super::apply_symlink_metadata_with_options(
+        &dst,
+        &src_meta,
+        &MetadataOptions::new()
+            .preserve_permissions(false)
+            .with_chmod(Some(chmod)),
+    )
+    .expect("apply symlink metadata");
+
+    assert_eq!(
+        fs::symlink_metadata(&dst).unwrap().permissions().mode() & 0o7777,
+        0o777,
+        "--chmod alone must not touch a link's mode (upstream flist.c:1741-1742 \
+         gates the tweak on !S_ISLNK); the link must keep its own 0o777"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn symlink_chmod_spec_does_not_compose_with_preserve_perms_local_copy() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("t.txt");
+    let src = temp.path().join("src");
+    let dst = temp.path().join("dst");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &src).expect("create src link");
+    symlink(&target, &dst).expect("create dst link");
+
+    fast_io::secure_chmod_at(&src, 0o714, false).expect("seed src mode");
+    fast_io::secure_chmod_at(&dst, 0o777, false).expect("seed dst mode");
+
+    let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+    let src_meta = fs::symlink_metadata(&src).expect("src link metadata");
+    super::apply_symlink_metadata_with_options(
+        &dst,
+        &src_meta,
+        &MetadataOptions::new()
+            .preserve_permissions(true)
+            .with_chmod(Some(chmod)),
+    )
+    .expect("apply symlink metadata");
+
+    assert_eq!(
+        fs::symlink_metadata(&dst).unwrap().permissions().mode() & 0o7777,
+        0o714,
+        "under -p the link takes the SOURCE link's bits verbatim; layering \
+         go-rwx on top would have produced 0o700"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn symlink_chmod_spec_does_not_compose_with_preserve_perms_from_entry() {
+    use protocol::flist::FileEntry;
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    // The receiver path already ignores `--chmod` for a link; pin it so the two
+    // paths keep sharing the one rule in `permissions::symlink_target_mode`.
+    let temp = tempdir().expect("tempdir");
+    let target = temp.path().join("target.txt");
+    let link = temp.path().join("link");
+    fs::write(&target, b"data").expect("write target");
+    symlink(&target, &link).expect("create link");
+    fast_io::secure_chmod_at(&link, 0o777, false).expect("seed link mode");
+
+    let mut entry = FileEntry::new_symlink("link".into(), "target.txt".into());
+    entry.set_mode(0o120741);
+
+    let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+    super::apply_symlink_metadata_from_entry(
+        &link,
+        &entry,
+        &MetadataOptions::new()
+            .preserve_permissions(true)
+            .with_chmod(Some(chmod)),
+    )
+    .expect("apply symlink metadata");
+
+    assert_eq!(
+        fs::symlink_metadata(&link).unwrap().permissions().mode() & 0o7777,
+        0o741,
+        "the receiver path must chmod the link to the sender's bits, untweaked"
+    );
+}
+
+/// Non-vacuity control for the two `--chmod`-on-a-link tests above: the very
+/// same `go-rwx` spec, on a REGULAR file, MUST still strip the group/other
+/// bits. Without this a broken `ChmodModifiers::parse` would make the symlink
+/// pins pass for the wrong reason.
+#[cfg(unix)]
+#[test]
+fn chmod_spec_used_by_the_symlink_pins_still_tweaks_a_regular_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = tempdir().expect("tempdir");
+    let src = temp.path().join("src.txt");
+    let dst = temp.path().join("dst.txt");
+    fs::write(&src, b"data").expect("write src");
+    fs::write(&dst, b"data").expect("write dst");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o714)).expect("chmod src");
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o777)).expect("chmod dst");
+
+    let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+    let src_meta = fs::metadata(&src).expect("src metadata");
+    super::apply_file_metadata_with_options(
+        &dst,
+        &src_meta,
+        &MetadataOptions::new()
+            .preserve_permissions(true)
+            .with_chmod(Some(chmod)),
+    )
+    .expect("apply file metadata");
+
+    assert_eq!(
+        fs::metadata(&dst).unwrap().permissions().mode() & 0o7777,
+        0o700,
+        "the go-rwx spec must be live: a regular file DOES get tweaked"
+    );
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn symlink_own_mode_is_noop_on_linux() {


### PR DESCRIPTION
## What

oc had **both halves of upstream's symlink-mode rule inverted**:

| | upstream | oc before |
|---|---|---|
| `dest_mode()` | applied to **every** type, symlinks included (`generator.c:1937-1940`, above the symlink branch at `:1948`) | never applied to a symlink |
| `tweak_mode()` (`--chmod`) | **never** reaches a symlink (`flist.c:1741-1742`, `:996-997`, `rsync.c:647-648` — all three gated `!S_ISLNK`) | layered onto the link's mode |

Fixing only the `--chmod` half traded 8 divergences for a new one, because removing the tweak with no `dest_mode()` underneath lands on the umask default. Both halves land here.

Measured against the real 3.5.0 binary, **all 19 main cells × 3 columns are now table-identical**, and the `dest_mode()` reduction is 21/21:

| src | `-rl` up/before/after | `-rlE` up/before/after |
|---|---|---|
| 0700 | 700 / 755 / **700** | 700 / 744 / **700** |
| 0750 | 750 / 755 / **750** | 750 / 754 / **750** |
| 0600 | 600 / 755 / **600** | 600 / 644 / **600** |
| 0711 | 711 / 755 / **711** | 711 / 755 / **711** |
| 0777 | 755 / 755 / 755 | 755 / 755 / 755 |

New umask cells prove the `dflt_perms` mask is load-bearing rather than incidental: `-rl` on src 0777 gives 755 / 700 / 777 at umask 022 / 077 / 000, matching upstream at each.

## Shape — an adapter, not a second implementation

`symlink_target_mode()` is a thin adapter over the `chmod_tweaked_dest_mode()` owner that #7748 landed. The two symlink facts become arguments:

```rust
chmod_tweaked_dest_mode(
    None,  // !S_ISLNK: --chmod never reaches a link
    destination, source_mode,
    false, // a link is never S_ISDIR
    false, // !S_ISREG: dest_mode()'s -E tweak never fires for a link
    options, pre_transfer,
) & 0o7777
```

One `dest_mode()` implementation now serves files, dirs and links. `symlink_pre_transfer_stat()` maps `destination_is_new` onto `dest_mode()`'s `exists` input. Four stale citations in the touched file are corrected (`rsync.c:658-668`→`806-822`, `syscall.c:761`→`1566-1604`, `rsync.h:438-440`→`455-456`, `generator.c:542-544`→`548-552`).

## Mutations — 5, perfectly additive

| | intended red | total |
|---|---|---|
| M1 `--chmod` layered on a link again | 3 | 3 |
| M2 `p` column raised for a link under `--chmod` | 1 | 1 |
| M3a `dest_mode()` `exists` plumbing dropped | 1 | 1 |
| M3b `S_ISREG` gate removed so `-E` blends a link | 1 | 1 |
| M4 all four at once | union | **6 = 3+1+1+1**, no overlap, no over-kill |
| M5 every link treated as new (inverse of M3a) | 2 | 2 |

**M3b initially killed nothing** — a real coverage hole, fixed rather than hidden. The fixture used dest `0o751`, which already has an exec bit, so neither of upstream's two `-E` branches could fire. Restated to exercise both directions (`dest 0o644 + src exec`; `dest 0o755 + src no-exec`); only then does the `S_ISREG` gate have a pin. The mutation itself was left alone.

## Platform scope, stated plainly

This entire surface is `CAN_CHMOD_SYMLINK`-only (`rsync.h:455-456`, `HAVE_LCHMOD || HAVE_SETATTRLIST`, probed `configure.ac:942,950`) — macOS/BSD. **Every measurement is macOS; there is no Linux coverage and none is claimed.** On Linux the const is false, a link's `st_mode` is a fixed 0777, and the arm compiles out. The macOS-only tests are `#[cfg(target_os = "macos")]`; the pure `symlink_target_mode()` table pins are `#[cfg(unix)]` and do run on Linux.

## Gates

Re-run on the rebased head at pinned 1.88.0: whole-tree rustfmt clean, `clippy -p metadata -p engine --all-targets --all-features -D warnings` clean, `nextest -p metadata -p engine --lib --no-fail-fast` 5265 run / 5264 passed.

The one failure, `execute_with_sparse_enabled_creates_holes`, is a pre-existing APFS sparse-block-count flake: it fails identically **in isolation on pristine current master** (`731e87e4e`) and passes under full-suite load on both arms. No expect-manifest touched.

## Residuals, reported not fixed

- **New, found while extending**: dest exists as a regular file at 0600, source is a symlink at 0700, `-rl` → upstream **600**, oc **755**. Upstream's `exists` arm still holds the *obstacle's* old `st_mode` while oc's post-create lstat only sees the fresh link. Base behaves identically, so this is untouched by the change; documented on `symlink_pre_transfer_stat()`.
- **The receiver's 4 symlink call sites never set `preserve_permissions`/`preserve_executability`** (`receiver/directory/links.rs:169,312,446,539`); `MetadataOptions::new()` defaults it true, so a link always takes `-p` semantics there regardless of the actual flags. That is why this change is confined to the local-copy path and carries zero receiver risk — but it is a real divergence in `crates/transfer` deserving its own row.
- `--chmod=a=rw` destination-root failure (rc 23 vs upstream 0) deliberately untouched — its own task.
