### PR TITLE
perf(flist): share one dirname allocation per directory on the sender

### DIFF
--- a/crates/transfer/src/generator/context.rs
+++ b/crates/transfer/src/generator/context.rs
@@ -79,6 +79,26 @@ pub struct GeneratorContext {
     /// base, so caching the last `Arc<Path>` collapses them onto a single shared
     /// allocation without the overhead of a full interning map.
     last_source_base: Option<Arc<Path>>,
+    /// One-entry interning cache for the entry dirname, used by
+    /// [`Self::push_file_item`].
+    ///
+    /// `FileEntry::new_*` derives the dirname from the entry name and gives
+    /// every entry its own `Arc<Path>`, so a sender walking a directory of N
+    /// files allocates the same directory string N times. A recursive walk
+    /// visits a directory's children consecutively, so a single-slot cache
+    /// collapses them onto one allocation - the same reason upstream can get
+    /// away with one cached string rather than a map.
+    ///
+    /// This shares the allocation only; the dirname value is unchanged, and
+    /// the receiver already does the equivalent through its `PathInterner`.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `flist.c:1547-1557` - `make_file()` reallocates `lastdir` only when
+    ///   the directory prefix differs from the previous entry's.
+    /// - `flist.c:1683-1684` - `file->dirname = lastdir` aliases that one
+    ///   string from every entry in the directory.
+    last_dirname: Option<Arc<Path>>,
     /// Per-directory scoped filter chain for file list building and deletion.
     ///
     /// Combines global filter rules (from command-line or wire) with per-directory
@@ -312,6 +332,7 @@ impl GeneratorContext {
             file_list: DualFileList::new(),
             source_bases: Vec::new(),
             last_source_base: None,
+            last_dirname: None,
             filter_chain: FilterChain::empty(),
             negotiated_algorithms: handshake.negotiated_algorithms,
             compat_flags: handshake.compat_flags,
@@ -589,13 +610,14 @@ impl GeneratorContext {
     ///
     /// This method maintains the invariant that `file_list` and `source_bases`
     /// have the same length and corresponding entries at each index.
-    pub(crate) fn push_file_item(&mut self, entry: FileEntry, full_path: PathBuf) {
+    pub(crate) fn push_file_item(&mut self, mut entry: FileEntry, full_path: PathBuf) {
         debug_assert_eq!(
             self.file_list.len(),
             self.source_bases.len(),
             "file_list and source_bases must be kept in sync before push"
         );
         let base = self.intern_source_base(&full_path, entry.path());
+        self.intern_dirname(&mut entry);
         self.file_list.push(entry);
         self.source_bases.push(base);
     }
@@ -610,6 +632,25 @@ impl GeneratorContext {
                 let arc: Arc<Path> = Arc::from(base.as_path());
                 self.last_source_base = Some(Arc::clone(&arc));
                 arc
+            }
+        }
+    }
+
+    /// Points `entry` at the shared `Arc<Path>` for its dirname when that
+    /// dirname equals the previously pushed entry's.
+    ///
+    /// Replaces the pointer only. The dirname bytes are identical either way,
+    /// so no comparison, encoding, or output can observe the difference; the
+    /// per-entry allocation the constructor made is simply dropped.
+    ///
+    /// upstream: flist.c:1547-1557, flist.c:1683-1684 (`lastdir`).
+    fn intern_dirname(&mut self, entry: &mut FileEntry) {
+        match &self.last_dirname {
+            Some(cached) if cached == entry.dirname() => {
+                entry.set_dirname(Arc::clone(cached));
+            }
+            _ => {
+                self.last_dirname = Some(Arc::clone(entry.dirname()));
             }
         }
     }
@@ -781,6 +822,7 @@ impl GeneratorContext {
         self.file_list = DualFileList::new();
         self.source_bases.clear();
         self.last_source_base = None;
+        self.last_dirname = None;
     }
 
     /// Determines if input multiplex should be activated based on mode and protocol.

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6955,3 +6955,71 @@ fn the_recursive_walk_still_expands_the_same_fixture() {
         ]
     );
 }
+
+#[test]
+fn consecutive_entries_in_one_directory_share_a_dirname_allocation() {
+    // Non-vacuity guard for the sender-side `lastdir` cache
+    // (upstream: flist.c:1547-1557, flist.c:1683-1684). `FileEntry::new_file`
+    // derives a FRESH `Arc<Path>` per entry, so without the cache in
+    // `push_file_item` each of these three entries would own a separate copy
+    // of "a/b" and the pointer-equality assertions below would fail.
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    for name in ["a/b/one", "a/b/two", "a/b/three"] {
+        ctx.push_file_item(
+            protocol::flist::FileEntry::new_file(name.into(), 1, 0o644),
+            PathBuf::from(name),
+        );
+    }
+
+    let first = ctx.file_list[0].dirname();
+    for i in 1..3 {
+        assert!(
+            std::sync::Arc::ptr_eq(first, ctx.file_list[i].dirname()),
+            "entry {i} must alias the cached dirname allocation, not its own"
+        );
+    }
+    // The shared value must still be the correct dirname, not merely shared.
+    assert_eq!(first.as_ref(), std::path::Path::new("a/b"));
+}
+
+#[test]
+fn a_new_directory_replaces_the_cached_dirname_rather_than_aliasing_it() {
+    // The complement of the guard above: the cache must MISS on a directory
+    // change, or entries would inherit the previous directory's name. This is
+    // what makes the sharing safe rather than merely cheap.
+    let handshake = test_handshake();
+    let mut ctx = GeneratorContext::new_for_test(&handshake, test_config());
+
+    for name in ["a/one", "a/two", "b/three", "b/four", "a/five"] {
+        ctx.push_file_item(
+            protocol::flist::FileEntry::new_file(name.into(), 1, 0o644),
+            PathBuf::from(name),
+        );
+    }
+
+    let dirs: Vec<&std::path::Path> = (0..5)
+        .map(|i| ctx.file_list[i].dirname().as_ref())
+        .collect();
+    assert_eq!(
+        dirs,
+        vec![
+            std::path::Path::new("a"),
+            std::path::Path::new("a"),
+            std::path::Path::new("b"),
+            std::path::Path::new("b"),
+            std::path::Path::new("a"),
+        ]
+    );
+    // Same directory, non-adjacent: a one-slot cache correctly does NOT share
+    // these, which is why the value check above is the load-bearing assertion.
+    assert!(std::sync::Arc::ptr_eq(
+        ctx.file_list[0].dirname(),
+        ctx.file_list[1].dirname()
+    ));
+    assert!(!std::sync::Arc::ptr_eq(
+        ctx.file_list[0].dirname(),
+        ctx.file_list[4].dirname()
+    ));
+}


### PR DESCRIPTION
## What

`FileEntry::new_*` derives each entry's dirname from its name and hands every entry its **own** `Arc<Path>`. A sender walking a directory of N files therefore allocates the same directory string N times. Upstream does not: `make_file()` reallocates `lastdir` only when the directory prefix differs from the previous entry's (`flist.c:1547-1557`), and `file->dirname = lastdir` (`flist.c:1683-1684`) aliases that single string from every entry in the directory.

This ports the `lastdir` cache to `push_file_item`, the sender's one push point.

A recursive walk visits a directory's children consecutively, which is exactly why upstream gets away with **one cached string rather than a map** — and why a single-slot cache is the right shape here too, not an under-engineered version of an interner.

## What this does not change

Pointer only. The dirname *value* is identical either way, so no comparison, encoding, wire byte, or output can observe the difference; the per-entry allocation the constructor made is simply dropped. The receiver already does the equivalent through its `PathInterner` — this brings the sender to parity with it.

## Measurement, stated precisely

This is **one allocation per entry**, not the whole flist gap. I have not run a before/after RSS A/B for this change in isolation, and I am not claiming one.

What is measured is the surrounding campaign (loopback client/server pair, per-process peak RSS, macOS release arm64):

| n | upstream default | upstream `--no-inc-recursive` | oc |
|---|---|---|---|
| 100 000 | 5.57 MB | 10.10 | 65.02 |
| 200 000 | 5.74 | 17.70 | 107.67 |

Fitted: upstream default ~1.7 B/entry (flat); oc **422 B/entry** on the client, 416 on the sender. oc gets no relief from incremental recursion. Two separate causes sit behind that number — per-entry density and segment retention — and this change addresses one contributor to the first. The remaining density work and the retention half are their own tasks.

⚠ Correction carried from that measurement, since it invalidates an earlier instrument: `--list-only` on a **local** path never builds an flist in oc (`crates/core/src/client/run/mod.rs:443` → `LocalCopyPlan` → `Vec<LocalCopyRecord>`, no `FileEntry` constructed). Any earlier per-entry figure derived from a local `--list-only` run was comparing oc's *listing-record* allocator against upstream's *flist* allocator, and does not describe this code path.

## Tests — two, and the second is the one that makes sharing safe

`consecutive_entries_in_one_directory_share_a_dirname_allocation` asserts `Arc::ptr_eq` across three entries in `a/b`, **and** that the shared value is still `a/b` — shared-but-wrong would otherwise pass. Non-vacuous by construction: `FileEntry::new_file` allocates fresh, so without the cache the pointer assertions fail.

`a_new_directory_replaces_the_cached_dirname_rather_than_aliasing_it` is the complement: interleaving `a/`, `b/`, `a/` pins that the cache **misses** on a directory change. Without that, entries would silently inherit the previous directory's name. It also pins the non-adjacent `a/` case as deliberately *not* shared — a one-slot cache is expected to miss there, and the value assertion is what stays load-bearing.

## Gates

Pinned 1.88.0, on the rebased head: whole-tree rustfmt clean, `clippy -p transfer --all-targets --all-features -D warnings` clean, `nextest -p transfer --no-fail-fast` **2886 run / 2886 passed / 3 skipped**.

⚠ Method note: the first run of that suite reported 74 failures. Every one was the #7385 binary-freshness guard (`oc-rsync … is older than Cargo.toml`), all at 0.014–0.024s — the vacuity tell. `cargo build --bin oc-rsync` first, then green. Worth stating rather than quietly re-running, because a truncated fail-fast run had shown only 5 of those 74 and would have read as a small real regression.

No expect-manifest touched.
