### PR TITLE
fix(daemon): read the short-form filter prefixes and split the modifier run off the pattern

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -607,9 +607,6 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
         return Vec::new();
     }
 
-    // Prefixes that start a new rule token when found after whitespace.
-    const SHORT_PREFIXES: &[&str] = &["+ ", "- ", "+/", "-/"];
-
     /// Returns true if `s` starts with a filter rule prefix.
     ///
     /// The keyword arm asks `is_rule_keyword`, so a keyword terminated by any
@@ -618,9 +615,17 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
     /// line-final `clear` matched nothing, no token boundary opened, and the
     /// whole remainder collapsed into one rule whose pattern was the literal
     /// compound string.
+    ///
+    /// The short arm asks the SAME question [`parse_daemon_filter_token`]
+    /// asks - does a one-character rule prefix carry a valid modifier run? -
+    /// so the splitter and the parser cannot disagree about what a token is.
+    /// The hardcoded `["+ ", "- ", "+/", "-/"]` table it replaced recognised
+    /// no `P`/`R`/`H`/`S` prefix at all, so `filter = - foo P bar` collapsed
+    /// into ONE rule whose pattern was the literal `foo P bar` and the module
+    /// served both `foo` and `bar`; upstream hides both (MEASURED, rc 0 with
+    /// only `keep` and `ctl` listed).
     fn starts_with_rule_prefix(s: &str) -> bool {
-        SHORT_PREFIXES.iter().any(|p| s.starts_with(p))
-            || RULE_KEYWORDS.iter().any(|kw| is_rule_keyword(s, kw))
+        opens_short_rule(s) || RULE_KEYWORDS.iter().any(|kw| is_rule_keyword(s, kw))
     }
 
     let mut tokens = Vec::new();
@@ -677,46 +682,62 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
 /// - `exclude.c:1096-1131` - the modifier scan that rejects `-foo` on `f`
 /// - `exclude.c:1134-1178` - long-form keyword to short-form char mapping
 fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
-    // Short-form prefixes: `+` and `-` are RULE CHARACTERS, and upstream's
-    // parser requires a separator after them. `parse_rule_tok` reads the
-    // prefix, then `while (*s && *s != ' ')` scans modifier characters and
-    // rejects any byte that is not a known modifier (exclude.c:1096-1131) -
-    // so `-foo` refuses on `f`, it does not silently become an exclude of
-    // `foo`.
+    // Short-form prefixes. upstream's `default:` arm makes ANY single
+    // `+ - P R S H . : !` character a rule character (exclude.c:1325-1329):
     //
-    // ⚠ The `.or_else(|| strip_prefix('+'))` fallback this replaces accepted
-    // the separator-less spelling and, for `-foo`, SILENTLY EXCLUDED `foo`
-    // from a module whose config upstream refuses to serve at all.
-    if let Some(pattern) = token.strip_prefix("+ ") {
-        return Ok(non_empty_pattern_rule(pattern, true));
-    }
-    if let Some(pattern) = token.strip_prefix("- ") {
-        return Ok(non_empty_pattern_rule(pattern, false));
-    }
-    // The `+ `/`- ` arms above consumed the separator spelling, so a `+`/`-`
-    // reaching here is one upstream does NOT read as a bare include/exclude.
-    // Two upstream arms split on what follows it.
-    if let Some(rest) = token.strip_prefix(['+', '-']) {
-        return Err(match rest.chars().next() {
-            // `-foo`: upstream reads the rule character, then scans MODIFIER
-            // characters up to the first space and rejects any byte that is
-            // not a known modifier (exclude.c:1364-1379). `f` is not one, so
-            // it refuses at position 1.
+    //     default:
+    //             ch = *s;
+    //             if (s[1] == ',')
+    //                     s++;
+    //             break;
+    //
+    // `s` is left ON the rule character (or on the `,` that follows it), so
+    // the modifier scan's `*++s` starts at the very next byte - a short prefix
+    // takes a modifier run with NO comma (`-p foo`), where a multi-char
+    // keyword can only reach the scan through one (see `strip_matched_keyword`).
+    if let Some((prefix, ch)) = short_rule_prefix(token) {
+        let rest = &token[ch.len_utf8()..];
+        // `if (s[1] == ',') s++` - the comma is consumed as part of the
+        // prefix, so the scan begins one byte later and upstream's reported
+        // modifier POSITION shifts with it.
+        let (run, base) = match rest.strip_prefix(',') {
+            Some(after_comma) => (after_comma, 2),
+            None => (rest, 1),
+        };
+        match scan_modifiers(run, prefix.specifies_side, base, token) {
+            Ok((modifiers, used)) => {
+                return build_prefixed_rule(prefix, modifiers, run, used, token);
+            }
+            // ⚠ THE TWO CHAR CLASSES PART COMPANY HERE, and only here.
             //
-            // ⚠ oc accepted this spelling and SILENTLY EXCLUDED `foo` from a
-            // module upstream refuses to serve at all.
-            Some(c) => MalformedRule::InvalidModifier {
-                modifier: c,
-                position: 1,
-                token: token.to_owned(),
-            },
-            // A BARE `-` or `+`: the modifier scan ends immediately, leaving
-            // an empty pattern, and upstream's `else if (!len ...)` arm
-            // refuses (exclude.c:1474-1476).
-            None => MalformedRule::UnexpectedEnd {
-                token: token.to_owned(),
-            },
-        });
+            // `+`/`-` cannot open a bare pattern - upstream reads them as rule
+            // characters unconditionally and oc has refused `-foo` since the
+            // modifier scan landed - so an invalid modifier is the refusal
+            // upstream reports.
+            //
+            // `P R S H` DO compete with the bare-word fall-through at the
+            // bottom of this function: `Pictures` is a rule character followed
+            // by the invalid modifier `i` upstream (rc 5, MEASURED), but oc
+            // still serves that module with `Pictures` excluded literally.
+            // Refusing it here would be a second, unrelated behaviour change
+            // riding on this one, so a failed scan hands such a token back to
+            // the fall-through unchanged; that residual belongs to the
+            // bare-word class.
+            //
+            // ⚠ NOT when a `,` follows the character. `,` is a keyword
+            // TERMINATOR (`rule_strcmp`, exclude.c:1224-1225), so `P,` is a rule
+            // prefix under exactly the test `strip_matched_keyword` applies to
+            // the long keywords - there is no bare word to compete with, and
+            // the fall-through would serve a module upstream refuses. MEASURED:
+            // `filter = P,r bar` is rc 5 upstream (`r` after a side-naming
+            // prefix, exclude.c:1424-1425) and, with the fall-through taken
+            // unconditionally, was rc 0 in oc with every file served.
+            Err(err) => {
+                if !prefix.competes_with_bare_words || rest.starts_with(',') {
+                    return Err(err);
+                }
+            }
+        }
     }
 
     // `!` is upstream's clear rule. It takes no pattern, and because a daemon
@@ -738,29 +759,21 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         });
     }
 
-    // upstream: exclude.c:1289-1327 - keyword-to-short-form mapping;
-    // `hide`/`show` set FILTRULE_SENDER_SIDE (exclude.c:1345-1350),
-    // `protect`/`risk` FILTRULE_RECEIVER_SIDE (exclude.c:1351-1357). All four
+    // upstream: exclude.c:1288-1330 - keyword-to-short-form mapping;
+    // `hide`/`show` set FILTRULE_SENDER_SIDE (exclude.c:1345-1351),
+    // `protect`/`risk` FILTRULE_RECEIVER_SIDE (exclude.c:1352-1358). All four
     // side keywords set `prefix_specifies_side` (exclude.c:1350, :1357), which
     // narrows the modifier alphabet their `,` form accepts.
-    // (keyword, is_include, sender_side, specifies_side)
-    const KEYWORDS: &[(&str, bool, bool, bool)] = &[
-        ("exclude", false, false, false),
-        ("include", true, false, false),
-        ("hide", false, true, true),
-        ("show", true, true, true),
-        ("protect", false, false, true), // receiver-side upstream; see the drop below
-        ("risk", true, false, true),     // receiver-side upstream; see the drop below
-    ];
-
-    for &(keyword, is_include, sender_side, specifies_side) in KEYWORDS {
+    for &(keyword, prefix) in KEYWORD_PREFIXES {
         if let Some(rest) = strip_matched_keyword(token, keyword) {
-            // upstream refuses a keyword that never reaches a pattern:
-            // `rule_strcmp` returns the comma's own address for a `,`
-            // terminator (exclude.c:1224-1225), so the scan loop reads every
-            // byte after it - up to the first space, `_`, or end of token
-            // (exclude.c:1364) - as a MODIFIER character, and any byte outside
-            // the alphabet exits RERR_SYNTAX (exclude.c:1369-1380).
+            // ⚠ A multi-char keyword can only reach the modifier scan through
+            // a `,`. `rule_strcmp` returns `str + rule_len - 1` for a space,
+            // `_` or end-of-string terminator (exclude.c:1222-1223) - one byte
+            // BEFORE the terminator - so the scan's first `*++s` lands ON the
+            // terminator and stops at once. Only the `,` terminator returns
+            // `str + rule_len` (exclude.c:1224-1225), putting the scan inside
+            // the modifier run, and any byte outside the alphabet then exits
+            // RERR_SYNTAX (exclude.c:1371-1380).
             //
             // MEASURED against a real rsync 3.5.0 daemon (module holding
             // `foo` + `keep` + `bar`, pinned 3.5.0 client, loopback TCP):
@@ -771,65 +784,25 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
             //   filter = hide,p keep      -> rc 0 (valid modifier; rule then dropped at add time)
             //   filter = hide, keep       -> rc 0 (empty modifier run is valid)
             //   filter = exclude          -> rc 5 "unexpected end of filter rule: exclude"
+            //   filter = exclude,r keep   -> rc 0, excludes `keep` - the run is
+            //                                NOT part of the pattern
             // oc served every refused config above (rc 0), handing out the
-            // very files the operator's filter names - the fail-open this arm
-            // closes. A token that PASSES the modifier scan keeps its previous
-            // handling here: the modifier semantics themselves (`p`, `x`, ...)
-            // are not implemented on this path, and growing them is a separate
-            // change from refusing what upstream refuses.
-            let pattern = if let Some(modifier_run) = rest.strip_prefix(',') {
-                validate_comma_modifiers(modifier_run, keyword.len(), specifies_side, token)?;
-                modifier_run
-            } else {
-                // Whitespace or `_` terminator: one separator consumed, the
-                // remainder is the pattern (see `strip_matched_keyword` on the
-                // run-vs-one question).
-                rest.strip_prefix('_').unwrap_or(rest)
-            }
-            .trim();
-            if pattern.is_empty() {
-                // upstream: exclude.c:1474-1476 - `else if (!len && !CVS_IGNORE)`
-                // refuses a rule whose pattern token is empty. This covers the
-                // line-final keyword (`- foo hide`), the bare keyword
-                // (`filter = exclude`), and the patternless `,` form (`hide,`).
-                return Err(MalformedRule::UnexpectedEnd {
-                    token: token.to_owned(),
-                });
-            }
-            // The side test happens HERE, at add time, never at match time.
-            // upstream: `add_rule` drops a rule whose side flags equal
-            // `am_sender ? FILTRULE_RECEIVER_SIDE : FILTRULE_SENDER_SIDE` when
-            // the parse passes XFLG_ANCHORED2ABS/XFLG_ABS_IF_SLASH
-            // (exclude.c:279-285), and every daemon module directive passes
-            // XFLG_ABS_IF_SLASH (clientserver.c:933-952). Those directives
-            // parse before `parse_arguments` runs (clientserver.c:933 vs
-            // :1160), so `am_sender` is still its static 0 (options.c:97)
-            // WHATEVER role the transfer later takes: `hide`/`show` are
-            // dropped, `protect`/`risk` are kept.
-            //
-            // The kept rules then match SIDE-BLIND. The only match-time side
-            // mechanism upstream has is `elide` (exclude.c:1010), and it is
-            // armed exclusively by `send_rules` (exclude.c:1912) - the daemon
-            // list is never transmitted, so its rules keep `elide = 0`
-            // (exclude.c:324) forever. A kept `protect` therefore hides files
-            // from a pulling client and refuses incoming writes alike, which
-            // is why no side flag goes on the wire rule here: copying the
-            // receiver-side bit made the match-time DecisionContext test skip
-            // the rule wherever the role disagreed, serving what upstream
-            // hides.
-            if sender_side {
-                return Ok(None);
-            }
-            return Ok(Some(build_pattern_rule(pattern, is_include)));
+            // very files the operator's filter names.
+            let (run, base) = match rest.strip_prefix(',') {
+                Some(after_comma) => (after_comma, keyword.len() + 1),
+                None => (rest, keyword.len()),
+            };
+            let (modifiers, used) = scan_modifiers(run, prefix.specifies_side, base, token)?;
+            return build_prefixed_rule(prefix, modifiers, run, used, token);
         }
     }
 
     if let Some(rest) = strip_matched_keyword(token, "clear") {
         // `clear` maps to `!` (exclude.c:1290-1291), and `!` SKIPS the
-        // modifier scan (`while (ch != '!' && ...)`, exclude.c:1364). The
+        // modifier scan (`while (ch != '!' && ...)`, exclude.c:1365). The
         // refusal comes from the check AFTER it: with neither
         // FILTRULE_NO_PREFIXES nor XFLG_OLD_PREFIXES in play here, any
-        // non-empty trailing text refuses (exclude.c:1467-1470).
+        // non-empty trailing text refuses (exclude.c:1467-1471).
         //
         // The accepted spellings are exactly `clear` and `clear,`: a `,`
         // terminator leaves `s` on the comma and the `if (*s) s++` step
@@ -870,40 +843,6 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         return Ok(None);
     }
     Ok(Some(build_pattern_rule(token, false)))
-}
-
-/// Validates the modifier run a `,`-terminated keyword carries.
-///
-/// upstream: `rule_strcmp` returns the comma's own address (exclude.c:1224-1225),
-/// so the scan loop at exclude.c:1364-1443 reads every byte after the comma -
-/// up to the first space, `_`, or end of token - as a modifier character. The
-/// daemon `filter` directive never reaches this scan with FILTRULE_MERGE_FILE,
-/// so the merge-only modifiers (`-`, `+`, `e`, `n`, `w`, exclude.c:1381-1417)
-/// refuse, `C`/`r`/`s` refuse when the keyword already names a side
-/// (`prefix_specifies_side`, exclude.c:1403-1404, :1423-1430), and any other
-/// byte hits `default: invalid` (exclude.c:1369-1380). All exits are
-/// RERR_SYNTAX with the byte and its offset from the token start named.
-fn validate_comma_modifiers(
-    modifier_run: &str,
-    keyword_len: usize,
-    specifies_side: bool,
-    token: &str,
-) -> Result<(), MalformedRule> {
-    for (offset, ch) in modifier_run.char_indices() {
-        if ch == '_' || ch.is_ascii_whitespace() {
-            break;
-        }
-        let valid = matches!(ch, '/' | '!' | 'p' | 'x')
-            || (!specifies_side && matches!(ch, 'C' | 'r' | 's'));
-        if !valid {
-            return Err(MalformedRule::InvalidModifier {
-                modifier: ch,
-                position: keyword_len + 1 + offset,
-                token: token.to_owned(),
-            });
-        }
-    }
-    Ok(())
 }
 
 /// A daemon filter token upstream's parser refuses.
@@ -982,32 +921,35 @@ impl std::fmt::Display for MalformedRule {
     }
 }
 
-/// Returns a rule if the trimmed pattern is non-empty, `None` otherwise.
-fn non_empty_pattern_rule(pattern: &str, is_include: bool) -> Option<FilterRuleWireFormat> {
-    let pattern = pattern.trim();
-    if pattern.is_empty() {
-        return None;
-    }
-    Some(build_pattern_rule(pattern, is_include))
-}
-
 /// Strips a keyword from a token, returning the remainder WITH its terminator.
 ///
 /// Returns `None` when the token does not start with the keyword, or starts
 /// with it but is not TERMINATED by it - `hideout` is not a `hide` rule.
-/// The terminator itself stays in the returned remainder because the callers
-/// diverge on it: a `,` opens upstream's modifier scan, while whitespace and
-/// `_` lead straight to the pattern.
 ///
 /// upstream: `exclude.c:1218-1227` `rule_strcmp`, via [`is_keyword_terminator`].
 /// The set an earlier version used was `' '` or `','` alone, so `_` and tab -
 /// both separators upstream accepts - made the token not-a-keyword and it fell
 /// through to the bare-pattern arm.
 ///
-/// ⚠ The callers trim a whole RUN of separators off the pattern, where
-/// upstream consumes exactly ONE (`if (*s) s++`, `exclude.c:1444-1445`).
-/// MEASURED for this directive against a real rsync 3.5.0 daemon, and the
-/// question turns out to be UNASKABLE here rather than answered either way:
+/// The terminator itself STAYS in the returned remainder because the two
+/// terminator classes lead to different places, and `rule_strcmp` says so with
+/// the address it returns:
+///
+/// ```c
+/// if (isspace(str[rule_len]) || str[rule_len] == '_' || !str[rule_len])
+///         return str + rule_len - 1;
+/// if (str[rule_len] == ',')
+///         return str + rule_len;
+/// ```
+///
+/// The `- 1` for a space/`_`/end terminator puts `s` one byte BEFORE it, so the
+/// modifier scan's first `*++s` lands on the terminator and stops immediately:
+/// a multi-char keyword can carry modifiers ONLY through the `,` form.
+///
+/// ⚠ The callers trim a whole RUN of separators off the pattern, where upstream
+/// consumes exactly ONE (`if (*s) s++`, `exclude.c:1444-1445`). MEASURED for
+/// this directive against a real rsync 3.5.0 daemon, and the question turns out
+/// to be UNASKABLE here rather than answered either way:
 ///
 /// - `filter = exclude bar` (ONE space) builds the pattern `bar`, NOT ` bar`.
 ///   Discriminated with a module holding both `bar` and ` bar`: upstream hides
@@ -1030,6 +972,255 @@ fn strip_matched_keyword<'a>(token: &'a str, keyword: &str) -> Option<&'a str> {
         Some(ch) if is_keyword_terminator(ch) => Some(rest),
         Some(_) => None,
     }
+}
+
+/// What a filter-rule prefix - long keyword or short character - decides.
+///
+/// upstream: the second `switch (ch)` of `parse_rule_tok`
+/// (`exclude.c:1331-1364`). The long keywords are pure aliases for the short
+/// characters (`exclude.c:1288-1330`), so ONE table describes both.
+#[derive(Clone, Copy)]
+struct RulePrefix {
+    /// `FILTRULE_INCLUDE` (`+`, `S`, `R`).
+    is_include: bool,
+    /// `FILTRULE_SENDER_SIDE` (`H`, `S`).
+    sender_side: bool,
+    /// `prefix_specifies_side` (`H`, `S`, `P`, `R`), which makes `C`, `r` and
+    /// `s` invalid modifiers (`exclude.c:1403-1404`, `:1424-1425`, `:1429-1430`).
+    specifies_side: bool,
+    /// True for the SHORT characters that a bare pattern could also start
+    /// with. See the failed-scan arm in [`parse_daemon_filter_token`].
+    competes_with_bare_words: bool,
+}
+
+/// The long-form keywords, in upstream's own mapping order.
+const KEYWORD_PREFIXES: &[(&str, RulePrefix)] = &[
+    ("exclude", SHORT_EXCLUDE),
+    ("include", SHORT_INCLUDE),
+    ("hide", SHORT_HIDE),
+    ("show", SHORT_SHOW),
+    ("protect", SHORT_PROTECT),
+    ("risk", SHORT_RISK),
+];
+
+const SHORT_EXCLUDE: RulePrefix = RulePrefix {
+    is_include: false,
+    sender_side: false,
+    specifies_side: false,
+    competes_with_bare_words: false,
+};
+const SHORT_INCLUDE: RulePrefix = RulePrefix {
+    is_include: true,
+    ..SHORT_EXCLUDE
+};
+const SHORT_HIDE: RulePrefix = RulePrefix {
+    sender_side: true,
+    specifies_side: true,
+    competes_with_bare_words: true,
+    ..SHORT_EXCLUDE
+};
+const SHORT_SHOW: RulePrefix = RulePrefix {
+    is_include: true,
+    ..SHORT_HIDE
+};
+const SHORT_PROTECT: RulePrefix = RulePrefix {
+    sender_side: false,
+    ..SHORT_HIDE
+};
+const SHORT_RISK: RulePrefix = RulePrefix {
+    is_include: true,
+    ..SHORT_PROTECT
+};
+
+/// Matches the one-character rule prefixes upstream's `default:` arm accepts.
+///
+/// upstream: `exclude.c:1325-1329` makes any single character a rule
+/// character, and the second switch (`exclude.c:1331-1364`) gives
+/// `+ - S H R P` their meanings. `.`, `:` and `!` are the merge and clear
+/// characters; oc handles `!` on its own arm and does not implement the merge
+/// characters at all, so they are deliberately absent here - adding them would
+/// be the merge change, not this one.
+///
+/// ⚠ `competes_with_bare_words` is what keeps the four UPPERCASE characters
+/// from swallowing the bare-word fall-through; only a token whose modifier run
+/// VALIDATES is taken as a rule.
+fn short_rule_prefix(token: &str) -> Option<(RulePrefix, char)> {
+    let ch = token.chars().next()?;
+    let prefix = match ch {
+        '+' => SHORT_INCLUDE,
+        '-' => SHORT_EXCLUDE,
+        'S' => SHORT_SHOW,
+        'H' => SHORT_HIDE,
+        'R' => SHORT_RISK,
+        'P' => SHORT_PROTECT,
+        _ => return None,
+    };
+    Some((prefix, ch))
+}
+
+/// Returns true when `s` opens with a one-character rule prefix whose modifier
+/// run is valid - the token-boundary question, asked through the same two
+/// helpers the parser uses so the two cannot drift apart.
+fn opens_short_rule(s: &str) -> bool {
+    let Some((prefix, ch)) = short_rule_prefix(s) else {
+        return false;
+    };
+    let rest = &s[ch.len_utf8()..];
+    // A `,` terminates the prefix outright (`rule_strcmp`, exclude.c:1224-1225), so
+    // the token IS a rule token even when its modifier run is one upstream
+    // refuses - the same split the parser's failed-scan arm makes.
+    rest.starts_with(',') || scan_modifiers(rest, prefix.specifies_side, 1, s).is_ok()
+}
+
+/// The flags upstream's modifier scan can raise on a daemon `filter` rule.
+#[derive(Clone, Copy, Default)]
+struct RuleModifiers {
+    /// `/` - `FILTRULE_ABS_PATH` (`exclude.c:1392-1394`).
+    abs_path: bool,
+    /// `s` - `FILTRULE_SENDER_SIDE` (`exclude.c:1428-1432`).
+    sender_side: bool,
+    /// `!`, `x` or `C`: upstream ACCEPTS these and gives them meanings this
+    /// daemon path cannot express. See [`scan_modifiers`].
+    inexpressible: bool,
+}
+
+/// Runs upstream's modifier scan over `run` and reports what it raised.
+///
+/// upstream: `exclude.c:1365-1443`
+///
+/// ```c
+/// while (ch != '!' && *++s && *s != ' ' && *s != '_') {
+/// ```
+///
+/// The scan reads every byte up to the first space, `_` or end of token as a
+/// MODIFIER character; `base` is the offset of `run[0]` within `token`, which
+/// is what upstream's `(int)(s - (const uchar *)*rulestr_ptr)` reports.
+/// Returns the flags and the byte length of the run consumed, so the caller can
+/// step over the one separator `if (*s) s++` (`exclude.c:1444-1445`) eats and
+/// take the PATTERN from what is left - the split oc previously did not make,
+/// gluing `r keep` into the pattern of `filter = exclude,r keep` where upstream
+/// builds an exclude of `keep`.
+///
+/// Modifiers this daemon path cannot express are flagged rather than refused,
+/// because upstream ACCEPTS all three and refusing them would break configs it
+/// serves. MEASURED against rsync 3.5.0 (module `foo`+`bar`+`keep`+`ctl`,
+/// 3.5.0 client, loopback TCP, both directions):
+///
+/// - `filter = exclude,x keep` - rc 0, `keep` SERVED. `x` makes the rule match
+///   xattr names only (`FILTRULE_XATTR`), so it never matches the file. The
+///   daemon's own `xattr_only` bit is read on the sender path only
+///   (`generator/filters.rs`) and dropped on the receiver path
+///   (`receiver/pipeline_setup.rs`), so setting it would hide `keep` on a push.
+/// - `filter = exclude,C keep` - rc 0, `keep` SERVED. `C` turns the rule into a
+///   CVS-ignore rule whose OWN pattern is never matched (`check_filter`
+///   short-circuits on `FILTRULE_CVS_IGNORE`, `exclude.c:1201-1206`).
+/// - `filter = exclude,! keep` - rc 0, ONLY `keep` served. `!` negates, and the
+///   `negate` bit has the same sender-only plumbing as `xattr_only`.
+///
+/// Dropping the rule reproduces upstream EXACTLY for `x` and `C`. For `!` it
+/// does not: upstream serves only `keep` where oc then serves everything. That
+/// residual is left open rather than half-closed, because expressing `!` needs
+/// the receiver-side plumbing this change does not touch, and a half-expressed
+/// `!` would INVERT the served set on a push.
+fn scan_modifiers(
+    run: &str,
+    specifies_side: bool,
+    base: usize,
+    token: &str,
+) -> Result<(RuleModifiers, usize), MalformedRule> {
+    let mut modifiers = RuleModifiers::default();
+    for (offset, ch) in run.char_indices() {
+        // upstream stops at `' '` or `'_'`, and `FILTRULE_WORD_SPLIT` - which
+        // every daemon module directive sets (clientserver.c:934) - stops at
+        // any `isspace` byte too (exclude.c:1366-1368).
+        if ch == '_' || ch.is_ascii_whitespace() {
+            return Ok((modifiers, offset));
+        }
+        match ch {
+            '/' => modifiers.abs_path = true,
+            // `p` is FILTRULE_PERISHABLE, which steers --delete only and never
+            // the name match this list performs.
+            'p' => {}
+            '!' | 'x' => modifiers.inexpressible = true,
+            'C' if !specifies_side => modifiers.inexpressible = true,
+            // `r`/`s` are the SIDE modifiers. `r` (receiver) is kept, matching
+            // side-blind like `protect`; `s` (sender) is dropped at add time.
+            // Both are invalid once the prefix already named a side.
+            'r' if !specifies_side => {}
+            's' if !specifies_side => modifiers.sender_side = true,
+            _ => {
+                return Err(MalformedRule::InvalidModifier {
+                    modifier: ch,
+                    position: base + offset,
+                    token: token.to_owned(),
+                });
+            }
+        }
+    }
+    Ok((modifiers, run.len()))
+}
+
+/// Turns a matched prefix plus its modifier run into a wire rule.
+///
+/// `run` is the text the modifier scan read, `used` how much of it the scan
+/// consumed; the pattern is what follows the ONE separator upstream then eats
+/// (`if (*s) s++`, `exclude.c:1444-1445`).
+///
+/// A rule that never reaches a pattern is REFUSED, on both the short-character
+/// and the long-keyword path: upstream's `else if (!len && !CVS_IGNORE)`
+/// (`exclude.c:1474-1476`) exits RERR_SYNTAX for `filter = -`, `filter = P`,
+/// `filter = exclude` and `filter = hide,` alike. There is one answer here, not
+/// one per path.
+fn build_prefixed_rule(
+    prefix: RulePrefix,
+    modifiers: RuleModifiers,
+    run: &str,
+    used: usize,
+    token: &str,
+) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
+    let pattern = run.get(used + 1..).unwrap_or("").trim();
+    if pattern.is_empty() {
+        return Err(MalformedRule::UnexpectedEnd {
+            token: token.to_owned(),
+        });
+    }
+
+    // The side test happens HERE, at add time, never at match time.
+    // upstream: `add_rule` drops a rule whose side flags equal
+    // `am_sender ? FILTRULE_RECEIVER_SIDE : FILTRULE_SENDER_SIDE` when the
+    // parse passes XFLG_ANCHORED2ABS/XFLG_ABS_IF_SLASH (exclude.c:279-285),
+    // and every daemon module directive passes XFLG_ABS_IF_SLASH
+    // (clientserver.c:933-952). Those directives parse before
+    // `parse_arguments` runs, so `am_sender` is still its static 0
+    // WHATEVER role the transfer later takes: `hide`/`show`/`H`/`S` and the
+    // `s` MODIFIER are dropped, `protect`/`risk`/`P`/`R` and the `r` modifier
+    // are kept.
+    //
+    // The kept rules then match SIDE-BLIND. The only match-time side mechanism
+    // upstream has is `elide` (exclude.c:1010), armed exclusively by
+    // `send_rules` (exclude.c:1912) - the daemon list is never transmitted, so
+    // its rules keep `elide = 0` forever. A kept `protect` therefore hides
+    // files from a pulling client and refuses incoming writes alike, which is
+    // why no side flag goes on the wire rule here.
+    //
+    // MEASURED against rsync 3.5.0, module `foo`+`bar`+`keep`+`ctl`:
+    //   filter = P bar          -> list serves foo,keep,ctl; push refuses bar
+    //   filter = H bar          -> both directions serve everything
+    //   filter = exclude,r keep -> list serves foo,bar,ctl; push refuses keep
+    //   filter = exclude,s keep -> both directions serve everything
+    if prefix.sender_side || modifiers.sender_side || modifiers.inexpressible {
+        return Ok(None);
+    }
+
+    let mut rule = build_pattern_rule(pattern, prefix.is_include);
+    if modifiers.abs_path {
+        // upstream: `/` presets FILTRULE_ABS_PATH, which makes add_rule's
+        // XFLG_ABS_IF_SLASH branch a no-op and leaves the pattern anchored at
+        // the module root (exclude.c:296-306). MEASURED: `filter = -/ keep`
+        // hides the module-root `keep`.
+        rule.anchored = true;
+    }
+    Ok(Some(rule))
 }
 
 /// Constructs a `FilterRuleWireFormat` from a pattern string.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2877,26 +2877,37 @@ mod module_access_tests {
         assert_eq!(rule.pattern, "*.bak");
     }
 
+    /// FLIPPED from `parse_daemon_filter_token_exclude_keyword_comma_sep`,
+    /// which pinned `exclude,*.bak` as an exclude of `*.bak` on the claim
+    /// "RULE_STRCMP accepts comma as separator". The premise is upstream's;
+    /// the conclusion is not. `rule_strcmp` returns the COMMA's OWN address
+    /// for that terminator (`exclude.c:1224-1225`), one byte further along
+    /// than the `- 1` it returns for a space, so the scan at
+    /// `exclude.c:1365-1443` reads what follows as MODIFIER characters.
+    ///
+    /// MEASURED against a real rsync 3.5.0 daemon (module `foo`+`bar`+`keep`
+    /// +`ctl`, 3.5.0 client, loopback TCP, list and push): `filter =
+    /// exclude,*.bak` and `filter = exclude,foo` are BOTH rc 5, serving
+    /// nothing, in both directions.
+    ///
+    /// ⚠ This refusal is a by-product: separating the modifier run from the
+    /// pattern is what task 1178 needed, and an invalid modifier character
+    /// cannot then be anything but a refusal. The same cell is the subject of
+    /// PR #7750, which reaches it deliberately.
     #[test]
     fn a_comma_joined_word_after_a_keyword_is_refused() {
-        // FLIPPED from `parse_daemon_filter_token_exclude_keyword_comma_sep`,
-        // which pinned `exclude,*.bak` as an exclude of `*.bak` on the claim
-        // "RULE_STRCMP accepts comma as separator". The premise is upstream's;
-        // the conclusion is not: `rule_strcmp` returns the COMMA's own address
-        // for that terminator (exclude.c:1224-1225), so what follows it is
-        // read as MODIFIER characters, not a pattern.
-        //
-        // MEASURED against rsync 3.5.0 (module foo+keep+bar, 3.5.0 client):
-        //   filter = exclude,*.bak     -> rc 5, serves nothing
-        //   filter = - foo hide,keep   -> rc 5, serves nothing
-        //   filter = protect,keep      -> rc 5, serves nothing
-        // oc served all three modules (rc 0) - including, for the hide cell,
-        // the file `foo` the operator's own rule names. The messages below are
-        // the daemon-log lines the real binary produced, byte for byte.
+        // The messages below are the daemon-log lines the real 3.5.0 binary
+        // produced, byte for byte. oc served every one of these modules (rc 0)
+        // - including, for the `hide` cell, the file the operator's own rule
+        // names.
         for (token, msg) in [
             (
                 "exclude,*.bak",
                 "invalid modifier '*' at position 8 in filter rule: exclude,*.bak",
+            ),
+            (
+                "exclude,foo",
+                "invalid modifier 'f' at position 8 in filter rule: exclude,foo",
             ),
             (
                 "hide,keep",
@@ -2927,8 +2938,8 @@ mod module_access_tests {
     #[test]
     fn a_side_modifier_on_a_side_keyword_is_refused() {
         // upstream: the `r`/`s` modifier arms refuse when the keyword already
-        // names a side (`prefix_specifies_side`, exclude.c:1423-1430); `C`
-        // refuses likewise (exclude.c:1403-1404). MEASURED:
+        // names a side (`prefix_specifies_side`, exclude.c:1424-1425,
+        // :1429-1430); `C` refuses likewise (exclude.c:1403-1404). MEASURED:
         //   filter = hide,r keep  -> rc 5 "invalid modifier 'r' at position 5..."
         //   filter = hide,C keep  -> rc 5 "invalid modifier 'C' at position 5..."
         let err = parse_daemon_filter_token("hide,r keep").expect_err("must refuse");
@@ -2952,21 +2963,273 @@ mod module_access_tests {
         //   filter = hide,x keep   (xattr)
         //   filter = hide,/ keep   (abs-path)
         // upstream drops the hide at add time and serves everything; oc's
-        // `Ok(None)` drop is the same observable. The modifier SEMANTICS stay
-        // unimplemented on this path - these cells pin acceptance, nothing
-        // more.
+        // `Ok(None)` drop is the same observable.
         for token in ["hide, keep", "hide,p keep", "hide,x keep", "hide,/ keep"] {
             assert!(is_skipped(token), "{token}");
         }
         // `r`/`s`/`C` stay legal where no side is pre-named. MEASURED:
         // `filter = exclude,r keep` is accepted (rc 0) and upstream keeps the
-        // rule side-blind. oc's pattern still glues the modifier run into the
-        // pattern text (`r keep` matches nothing) - a pre-existing divergence
-        // on an accepted config, pinned as-is because changing what a valid
-        // modifier MEANS is a different change from refusing invalid ones.
+        // rule side-blind, excluding `keep`.
+        //
+        // ⚠ This assertion previously read `"r keep"` - the modifier run glued
+        // into the pattern text, which matches no file at all - and was pinned
+        // as a known divergence pending the run/pattern split. That split is
+        // this change; the pattern is now what follows the ONE separator
+        // upstream consumes (`if (*s) s++`, exclude.c:1444-1445).
         let rule = accepted_rule("exclude,r keep");
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
-        assert_eq!(rule.pattern, "r keep");
+        assert_eq!(rule.pattern, "keep");
+    }
+
+    /// ARM 1: a one-character side prefix is the keyword it abbreviates.
+    ///
+    /// upstream: `parse_rule_tok`'s `default:` arm (`exclude.c:1325-1329`)
+    /// takes ANY single character as `ch`, and the second switch
+    /// (`exclude.c:1345-1358`) gives `H`/`S` FILTRULE_SENDER_SIDE and
+    /// `P`/`R` FILTRULE_RECEIVER_SIDE - exactly what `hide`/`show` and
+    /// `protect`/`risk` set. oc recognised NEITHER character, so all four fell
+    /// through to the bare-pattern arm and became a literal exclude of e.g.
+    /// `P bar`, a pattern no file can match.
+    ///
+    /// ⚠ NON-VACUITY: `P` is the discriminating one, because the daemon list
+    /// keeps receiver-side rules and matches them SIDE-BLIND (see
+    /// `build_prefixed_rule`). MEASURED against rsync 3.5.0, module holding
+    /// BAIT `bar` and CONTROL `ctl`:
+    ///   filter = P bar  -> list rc 0 serving foo,keep,ctl (bar HIDDEN);
+    ///                      push rc 23, `bar` refused, ctl written
+    /// oc served `bar` in both directions. `H`/`S` are the opposite arm - they
+    /// are DROPPED at add time - so their own served set cannot discriminate;
+    /// the `R bar - b*` and `S bar - b*` cells below do it instead.
+    #[test]
+    fn a_short_side_prefix_is_the_keyword_it_abbreviates() {
+        let rule = accepted_rule("P bar");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "bar");
+        assert_eq!(accepted_rule("protect bar").pattern, rule.pattern);
+
+        let rule = accepted_rule("R keep");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rule.pattern, "keep");
+
+        // `H`/`S` name the SENDER side, which the daemon parse drops at add
+        // time because `am_sender` is still 0 (exclude.c:279-285). MEASURED:
+        // `filter = H bar` and `filter = S bar` serve every file, and
+        // `filter = H bar - b*` hides `bar` through the `- b*` rule alone.
+        assert!(is_skipped("H bar"), "H");
+        assert!(is_skipped("S bar"), "S");
+        assert!(is_skipped("hide bar"), "hide control");
+
+        // The `_` terminator reaches the same arm.
+        assert_eq!(accepted_rule("P_bar").pattern, "bar");
+    }
+
+    /// The bare-word fall-through survives arm 1.
+    ///
+    /// Refusing an uppercase-initial bare word would be upstream-correct
+    /// (`filter = Pictures` is rc 5 upstream, MEASURED) but it is the
+    /// bare-word change, not this one, and the same arm carries `merge FILE`,
+    /// a config upstream SERVES. A one-character prefix is therefore only
+    /// taken when its modifier run validates.
+    #[test]
+    fn an_uppercase_bare_word_is_still_a_literal_pattern() {
+        for token in ["Pictures", "README", "Series7", "Home"] {
+            let rule = accepted_rule(token);
+            assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+            assert_eq!(rule.pattern, token, "{token}");
+        }
+    }
+
+    /// ARM 2: a modifier run after a SHORT prefix is accepted, with or
+    /// without the comma.
+    ///
+    /// upstream: `default:` leaves `s` ON the rule character (or on the `,`
+    /// after it), so the scan's first `*++s` (`exclude.c:1365`) reads the very
+    /// next byte as a modifier. oc refused every such spelling.
+    ///
+    /// ⚠ NON-VACUITY: these are cells upstream ACCEPTS, so the pin is that the
+    /// BAIT is hidden and the CONTROL is served - not merely that nothing
+    /// errors. MEASURED against rsync 3.5.0:
+    ///   filter = -p foo   -> list rc 0 serving bar,keep,ctl (BAIT `foo` hidden)
+    ///   filter = -,p foo  -> identical
+    ///   filter = +p foo   -> list rc 0 serving all four (an include alone
+    ///                        hides nothing; the pin here is rc 0, not a set)
+    ///   filter = -/ keep  -> list rc 0 serving foo,bar,ctl (BAIT `keep` hidden)
+    /// oc answered rc 5 - a module REFUSAL - on all four.
+    #[test]
+    fn a_modifier_run_after_a_short_prefix_is_accepted() {
+        let rule = accepted_rule("-p foo");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "foo");
+
+        let rule = accepted_rule("-,p foo");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, "foo");
+
+        let rule = accepted_rule("+p foo");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rule.pattern, "foo");
+
+        // `/` presets FILTRULE_ABS_PATH (exclude.c:1392-1394), anchoring the
+        // pattern at the module root.
+        let rule = accepted_rule("-/ keep");
+        assert_eq!(rule.pattern, "keep");
+        assert!(rule.anchored, "-/ keep must anchor");
+
+        // A side-naming short prefix takes a modifier run too.
+        assert_eq!(accepted_rule("P,p bar").pattern, "bar");
+        assert_eq!(accepted_rule("P/ bar").pattern, "bar");
+    }
+
+    /// The refusals arm 2 must NOT swallow.
+    ///
+    /// `-foo` and `-,foo` stay refusals, at upstream's own byte offsets:
+    /// `s - *rulestr_ptr` is 1 without the comma and 2 with it, because
+    /// `if (s[1] == ',') s++` consumed the comma as part of the prefix.
+    /// MEASURED: both are rc 5 upstream. A bare `-`/`+`/`P` and a modifier run
+    /// that never reaches a pattern (`-p`, `P,`) are the empty-pattern refusal
+    /// instead (`exclude.c:1474-1476`), also rc 5 upstream.
+    #[test]
+    fn a_short_prefix_with_an_invalid_modifier_is_still_refused() {
+        for (token, msg) in [
+            (
+                "-foo",
+                "invalid modifier 'f' at position 1 in filter rule: -foo",
+            ),
+            (
+                "-,foo",
+                "invalid modifier 'f' at position 2 in filter rule: -,foo",
+            ),
+            (
+                "-p!e foo",
+                "invalid modifier 'e' at position 3 in filter rule: -p!e foo",
+            ),
+        ] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(err.to_string(), msg, "{token}");
+        }
+        for token in ["-", "+", "P", "-p", "P,"] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(
+                err.to_string(),
+                format!("unexpected end of filter rule: {token}"),
+                "{token}"
+            );
+        }
+    }
+
+    /// A side modifier on a prefix that ALREADY names a side is refused.
+    ///
+    /// upstream: `prefix_specifies_side` gates `r`, `s` (`exclude.c:1424-1425`, `:1429-1430`)
+    /// and `C` (`exclude.c:1403-1404`). MEASURED: `filter = P,r bar` and
+    /// `filter = hide,r keep` are both rc 5 upstream.
+    ///
+    /// ⚠ The `P,r bar` cell is why the failed-scan fall-through checks for a
+    /// leading `,`: a comma TERMINATES the prefix, so there is no bare word to
+    /// fall back to, and taking the fall-through served a module upstream
+    /// refuses.
+    #[test]
+    fn a_side_modifier_on_a_side_naming_prefix_is_refused() {
+        for (token, msg) in [
+            (
+                "P,r bar",
+                "invalid modifier 'r' at position 2 in filter rule: P,r bar",
+            ),
+            (
+                "hide,r keep",
+                "invalid modifier 'r' at position 5 in filter rule: hide,r keep",
+            ),
+            (
+                "S,s bar",
+                "invalid modifier 's' at position 2 in filter rule: S,s bar",
+            ),
+        ] {
+            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            assert_eq!(err.to_string(), msg, "{token}");
+        }
+    }
+
+    /// ARM 3: the modifier run is not part of the pattern.
+    ///
+    /// upstream consumes the run, then ONE separator (`if (*s) s++`,
+    /// `exclude.c:1444-1445`), and the PATTERN is what is left. oc glued the
+    /// whole remainder in, so `exclude,r keep` became an exclude of the literal
+    /// text `r keep` - a pattern no file matches.
+    ///
+    /// ⚠ NON-VACUITY: `keep` is the BAIT and `foo`/`bar`/`ctl` the controls.
+    /// MEASURED against rsync 3.5.0:
+    ///   filter = exclude,r keep  -> list rc 0 serving foo,bar,ctl; push rc 23
+    ///                               with `keep` refused    (BAIT hidden)
+    ///   filter = exclude,p keep  -> same
+    ///   filter = exclude,/ keep  -> same
+    ///   filter = exclude,rp keep -> same
+    /// oc served `keep` on every one of them.
+    #[test]
+    fn a_comma_modifier_run_is_not_part_of_the_pattern() {
+        for token in [
+            "exclude,r keep",
+            "exclude,p keep",
+            "exclude,rp keep",
+            "exclude, keep",
+        ] {
+            let rule = accepted_rule(token);
+            assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+            assert_eq!(rule.pattern, "keep", "{token}");
+        }
+        let rule = accepted_rule("exclude,/ keep");
+        assert_eq!(rule.pattern, "keep");
+        assert!(rule.anchored, "exclude,/ keep must anchor");
+    }
+
+    /// The `s` modifier is the add-time DROP, and `r` is not.
+    ///
+    /// upstream: `add_rule` drops a rule whose sides equal
+    /// `am_sender ? RECEIVER : SENDER` (`exclude.c:279-285`), and the daemon
+    /// parse runs with `am_sender == 0` whatever the transfer later does.
+    ///
+    /// ⚠ This is the CONTROL for the row above, and it is the pair that makes
+    /// the split observable rather than cosmetic: with the modifier glued into
+    /// the pattern BOTH tokens served `keep`. MEASURED:
+    ///   filter = exclude,s keep -> serves all four, BOTH directions
+    ///   filter = exclude,r keep -> hides `keep`, BOTH directions
+    #[test]
+    fn the_sender_side_modifier_drops_the_rule_and_the_receiver_one_keeps_it() {
+        assert!(is_skipped("exclude,s keep"), "s drops");
+        assert!(is_skipped("-,s keep"), "s drops on a short prefix too");
+        assert_eq!(accepted_rule("exclude,r keep").pattern, "keep");
+    }
+
+    /// `!`, `x` and `C` are ACCEPTED by upstream and dropped here.
+    ///
+    /// Splitting the run off the pattern makes each modifier's meaning
+    /// observable for the first time, and these three have meanings the daemon
+    /// rule cannot carry: `xattr_only` and `negate` are read on oc's SENDER
+    /// path and dropped on its RECEIVER path, so setting either would give the
+    /// two directions different answers.
+    ///
+    /// MEASURED against rsync 3.5.0, both directions:
+    ///   filter = exclude,x keep -> rc 0, ALL FOUR served (an xattr rule never
+    ///                              matches the file name)
+    ///   filter = exclude,C keep -> rc 0, ALL FOUR served (`check_filter`
+    ///                              short-circuits FILTRULE_CVS_IGNORE and
+    ///                              never matches the rule's own pattern)
+    ///   filter = -x keep        -> rc 0, ALL FOUR served
+    /// Dropping the rule reproduces all three EXACTLY.
+    ///
+    /// ⚠ `!` is the one it does NOT reproduce: `filter = exclude,! keep` serves
+    /// ONLY `keep` upstream, where dropping serves everything. Left open rather
+    /// than half-closed - a `negate` bit honoured on the sender path alone
+    /// would INVERT the served set on a push. RESIDUAL.
+    #[test]
+    fn an_inexpressible_modifier_drops_the_rule_rather_than_refusing_it() {
+        for token in [
+            "exclude,x keep",
+            "exclude,C keep",
+            "-x keep",
+            "exclude,! keep",
+            "-,! keep",
+        ] {
+            assert!(is_skipped(token), "{token}");
+        }
     }
 
     #[test]
@@ -3223,10 +3486,13 @@ mod module_access_tests {
         assert_eq!(rules[0].pattern, "*.tmp");
     }
 
+    /// The remainder now keeps its TERMINATOR, because `rule_strcmp` returns
+    /// two different addresses for the two terminator classes
+    /// (`exclude.c:1222-1226`) and the callers act on the difference: a `,`
+    /// opens upstream's modifier scan, a space or `_` leads straight to the
+    /// pattern.
     #[test]
     fn strip_matched_keyword_space_separator() {
-        // The terminator STAYS in the remainder: the caller's arms diverge on
-        // whether it is a `,` (modifier scan) or whitespace/`_` (pattern).
         assert_eq!(
             strip_matched_keyword("exclude *.tmp", "exclude"),
             Some(" *.tmp")
@@ -3672,6 +3938,63 @@ mod module_access_tests {
     fn split_filter_tokens_bare_pattern() {
         let tokens = split_filter_tokens("*.bak");
         assert_eq!(tokens, vec!["*.bak"]);
+    }
+
+    /// A one-character side prefix opens its own token.
+    ///
+    /// upstream: the `default:` arm of `parse_rule_tok` (`exclude.c:1325-1329`)
+    /// makes `P` a rule character, and `parse_filter_str`'s word-split loop
+    /// hands it to that arm as its own token.
+    ///
+    /// ⚠ NON-VACUITY: `- foo P bar` is the shape where the boundary is
+    /// OBSERVABLE. MEASURED against rsync 3.5.0 (module `foo`+`bar`+`keep`
+    /// +`ctl`): upstream serves `keep` and `ctl` only, hiding BOTH named files.
+    /// With the old `["+ ", "- ", "+/", "-/"]` table this line collapsed into
+    /// one rule whose pattern was the literal `foo P bar`, and oc served all
+    /// four - including `foo`, which even the `- foo` half names.
+    #[test]
+    fn split_filter_tokens_short_side_prefix_opens_its_own_token() {
+        assert_eq!(
+            split_filter_tokens("- foo P bar"),
+            vec!["- foo", "P bar"],
+            "P"
+        );
+        assert_eq!(
+            split_filter_tokens("P bar H foo"),
+            vec!["P bar", "H foo"],
+            "H"
+        );
+        assert_eq!(
+            split_filter_tokens("- foo R keep - k*"),
+            vec!["- foo", "R keep", "- k*"],
+            "R"
+        );
+        assert_eq!(
+            split_filter_tokens("S bar - b*"),
+            vec!["S bar", "- b*"],
+            "S"
+        );
+    }
+
+    /// The splitter must NOT take an uppercase-initial bare word for a rule.
+    ///
+    /// This is the control for the cell above: the same character opens a rule
+    /// token only when what follows it is a valid modifier run. `Pictures` is
+    /// `P` plus the invalid modifier `i`, which upstream refuses outright
+    /// (rc 5, MEASURED) and oc still serves as a literal bare pattern - the
+    /// deliberately preserved fall-through.
+    #[test]
+    fn split_filter_tokens_bare_word_after_a_rule_is_not_a_short_prefix() {
+        assert_eq!(
+            split_filter_tokens("- foo Pictures"),
+            vec!["- foo Pictures"],
+            "Pictures"
+        );
+        assert_eq!(
+            split_filter_tokens("- foo README"),
+            vec!["- foo README"],
+            "README"
+        );
     }
 
     /// A keyword at END OF STRING terminates and opens its own token.


### PR DESCRIPTION
## What

oc's daemon filter parser refused the **short-form rule prefixes** upstream accepts, and glued the comma modifier run onto the pattern. Both are fixed here, and the parser is restructured so one scanner owns the modifier alphabet.

Upstream's `parse_rule_tok` default arm makes any single `P R S H . : ! + -` a valid prefix (`exclude.c:1325-1329`): `default: ch = *s; if (s[1] == ',') s++; break;` leaves `s` **on** the rule character, so the scan's first `*++s` (`:1365`) reads the next byte as a *modifier*. That one line is the whole short-form arm.

The `,` asymmetry is why a multi-char keyword behaves differently: `rule_strcmp` returns `str + rule_len - 1` for a space/`_`/end terminator (`exclude.c:1222-1223`) but `str + rule_len` for `,` (`:1224-1225`). One byte, and it decides whether the scan lands inside the modifier run.

## Oracle — 42 configs × 2 directions against real 3.5.0

List-only pull *and* push (daemon as receiver), module holding `foo`/`bar`/`keep` plus `ctl`, named by no rule, as the always-served control. After the fix every cell matches upstream except the `!` and bare-word rows, both deliberately out of scope.

| config | oc before | after |
|---|---|---|
| `P bar` (list) | serves all four | `ctl,foo,keep` |
| `P bar` (push) | rc 0 | rc 23 |
| `-p foo` / `-,p foo` | **rc 5 (over-refusal)** | rc 0, matching upstream |
| `exclude,r keep` | serves all four | `bar,ctl,foo` |
| `R bar - b*` | wrongly hid `b*` | serves all four |

Non-vacuity controls that must keep serving — `exclude,s`, `exclude,x`, `exclude,C`, `H bar` — all stay green. A naive pattern-split would have started hiding them.

Diagnostics were checked byte-for-byte against the real daemon's log lines including offsets: `invalid modifier 'r' at position 2 in filter rule: P,r bar`; `'f' at position 1` for `-foo` versus `position 2` for `-,foo`.

## Reconciliation with master — both halves kept

This branch was cut before #7747/#7750 landed on the same function. Master's contributions all survive:

- **`UnexpectedEnd` on a patternless keyword** — the branch had staged this as `EmptyPattern::{Refuse, Skip}` with `Skip` passed and a note that closing it was a separate change. Master closed it, so `Refuse` wins and the enum is deleted (it was single-variant once `Skip` went).
- **`ClearWithTrailingCharacters`** — master's `clear` arm verbatim, including the first-whitespace-word-only rule.
- **The add-time side drop** is not only preserved but **widened**: `prefix.sender_side || modifiers.sender_side || modifiers.inexpressible`.

`validate_comma_modifiers` (master) is deleted rather than kept alongside `scan_modifiers`, because it is exactly subsumed: same alphabet (`/ ! p x`, plus `C r s` when `!specifies_side`), same reported offset (`keyword_len + 1 + offset` ≡ `base + offset`). The replacement additionally *acts* on the modifiers instead of discarding them. All four `,`-keyword refusal messages master added are pinned and pass.

**Upstream line ranges were re-derived, not copied forward.** Several had drifted: the `default:` arm is `1325-1329` (not `1322-1326`), the second `switch (ch)` is `1331-1364`, the modifier scan `1365-1443`, `/` is `1392-1394`, `s` is `1428-1432`. One citation pointed at `parse_rule_tok`'s template inheritance rather than `check_filter`'s CVS-ignore short-circuit (`1201-1206`) — a different function entirely.

## One test expectation changed

`a_valid_modifier_run_after_a_comma_stays_accepted`: `accepted_rule("exclude,r keep").pattern` re-pinned `"r keep"` → `"keep"`. The branch's behaviour wins over master's here **deliberately** — master's own comment marked the glued pattern as "a pre-existing divergence… pinned as-is because changing what a valid modifier MEANS is a different change", which is precisely the change this PR makes. Upstream builds an exclude of `keep`; the old string matched no file at all.

No branch test needed updating: it had already pre-shaped both flashpoints.

## Mutations — measured, 325 tests (baseline 325/0)

| | mutation | predicted | measured |
|---|---|---|---|
| A | drop `S H R P` from the prefix set | 5 | **5** ✓ |
| B | restore master's blanket position-1 refusal | 7 | **7** (full) / **4** (narrow) |
| C | restore the pattern/modifier gluing | 5 | **6** (+1) |
| D | `Refuse` → skip on an empty pattern | — | **4** |
| E | remove the add-time `sender_side` drop | — | **6** |

**B is the interesting one, and it was localised rather than adjusted.** The first B — inserting master's position-1 refusal *ahead of* the surviving short-form arm — killed only 4, an under-kill against the branch's registered 7. Rather than reshape the mutation to hit its number, the same narrow mutation was run **on the branch's own pre-rebase files**, where it also killed exactly 4 — the same four tests. That proves the reconciliation lost no coverage; the narrow form simply was not the branch author's B. Restoring master's short-form handling *in full* (deleting the `P R S H` arm **and** reverting the splitter table) gives 7. Both numbers are reported because the pair localises the coverage: 3 of the 7 belong to A's scope, 1 to the splitter, leaving 4 for the position-1 refusal itself.

**C over-kills by exactly 1**, and the extra kill is the one test whose expectation changed — direct confirmation that the re-pin is load-bearing rather than cosmetic.

**D and E both bite**, so master's patternless-refusal and side-drop pins survive the restructure as live assertions, not decoration.

## Gates

Pinned 1.88.0: whole-tree rustfmt `$? = 0` (3426 files), `clippy -p daemon --all-targets --all-features -D warnings` clean, `nextest -p daemon --no-fail-fast` **1924 run / 1924 passed / 6 skipped**. `passed + failed == run`, so that is the failure set and not a fail-fast lower bound. No expect-manifest touched.

Not run: workspace-wide nextest, the upstream testsuite legs, interop — none reachable in-turn on this host. Nothing outside these two files changed, and no crate other than `daemon` references the three deleted private items.

## Residuals, reported not fixed

- `!` negate (`exclude,! keep`): upstream serves only the negated file, oc drops the rule. `negate` is read on oc's sender path but dropped on the receiver path, so setting it would **invert** the served set on a push — needs `crates/transfer` plumbing. Documented in-code.
- Bare-word class (`Pictures`, `Pfoo`) deliberately preserved — its own task, and refusing bare words before the `merge` keywords grow an arm would turn a config upstream serves into a refusal.
- A refused module leaks the operator's filter text to the client via `@ERROR: failed to load module filter rules: <text>`, where upstream's child dies before the startup line. Pre-existing, present on base.
- Tab-vs-space after a modifier run: upstream's `WORD_SPLIT` makes `exclude,p\tfoo` a refusal; oc treats both as separators.
