### PR TITLE
fix(ci): make the legacy-oracle slot prove which release filled it

### DIFF
--- a/tools/ci/run_upstream_testsuite.sh
+++ b/tools/ci/run_upstream_testsuite.sh
@@ -24,6 +24,9 @@
 #                             # remote-shell --rsync-path. Pointing it at a real
 #                             # upstream build is what makes the run a VERSION-
 #                             # MIXING run; without it the suite is oc vs oc.
+#                             # Refused on a leg where a test would adopt it as
+#                             # a legacy-version ORACLE it does not match - see
+#                             # ensure_legacy_oracles().
 #   EXPECT_RESULT=<file>      # --expect-result: expected-outcome manifest.
 #   EMIT_EXPECT_RESULT=<file> # write an EXPECT_RESULT manifest from this run,
 #                             # so the ledger is generated, never hand-typed.
@@ -818,6 +821,35 @@ python_suite_available() {
 # daemon-max-alloc-zero, i.e. it MOVES expect-manifest rows. Those rows may
 # only be re-baselined from a measured run (EMIT_EXPECT_RESULT), so a leg opts
 # in when someone is ready to measure the move - never as a side effect.
+#
+# THE ORACLE SLOT IS HIJACKABLE, AND THE LABEL DOES NOT FOLLOW THE BINARY.
+#
+# daemon-symlink-escape-matrix does not only read old_versions/. It prefers the
+# --rsync-bin2 peer whenever one differs from the binary under test
+# (3.5.0 testsuite/daemon-symlink-escape-matrix_test.py:75-79):
+#
+#     ORACLE_BIN = None
+#     if RSYNC_PEER != RSYNC:
+#         ORACLE_BIN = RSYNC_PEER
+#     elif (_repo / 'old_versions' / 'rsync_3.2.7').is_file():
+#         ORACLE_BIN = str(_repo / 'old_versions' / 'rsync_3.2.7')
+#
+# and its only acceptance test is that `--version` EXITS ZERO (:87-94) - the
+# banner it prints is read by nobody. The grid then labels the column with a
+# hardcoded '327' (:256-257) whatever answered. Note the `elif`: a peer WINS
+# over a real rsync_3.2.7 this script just built, so building the right oracle
+# does not rescue a hijacked slot.
+#
+# MEASURED by executing that file's own oracle-selection block with
+# RSYNC_PEER=<a 3.5.0 build>: the oracle daemon starts from the 3.5.0 binary
+# and all 100 `insecure links = yes` cells print `want=N(327)`. So the grid can
+# say "3.2.7 says X" over a release that is not 3.2.7 and never says otherwise.
+#
+# That code is upstream's, inside a tarball this script re-extracts, so it
+# cannot be fixed here. What CAN be fixed is the hand-off: this script is what
+# puts UPSTREAM_PEER_BIN into --rsync-bin2, and it now refuses to do so when a
+# consumer that would take that binary as its version-N oracle is reachable on
+# this leg and the binary does not report version N. See ensure_legacy_oracles.
 # --------------------------------------------------------------------------
 
 # on: build every oracle a consumer on this leg can reach. off: build none and
@@ -844,8 +876,38 @@ gha_annotate_warn() {
         "$title" "$sanitized"
 }
 
+# The version an rsync binary reports for ITSELF, or non-zero if it will not
+# say. The binary is the only authority on which release it is: a path, a flag
+# name and a CI variable are all just labels somebody typed.
+#
+# One command substitution, never `--version | head -1`. rsync does not buffer
+# its banner - MEASURED on 3.2.7, 20 separate write(2) calls - so under
+# `set -o pipefail` head can close the pipe first and the pipeline reports 141
+# for a binary that answered perfectly. build_old_rsync_oracle.sh carries the
+# same shape and the same note at oracle_version_line().
+#
+# The match is leftmost, which is what makes it right on rsync's own banner:
+# "rsync  version 3.5.0  protocol version 32" contains the word twice and the
+# first one carries the release.
+rsync_reported_version() {
+    local banner first
+    banner=$("$1" --version 2>/dev/null) || return 1
+    first=${banner%%$'\n'*}
+    [[ $first =~ version[[:space:]]+([0-9]+(\.[0-9]+)*) ]] || return 1
+    printf '%s' "${BASH_REMATCH[1]}"
+}
+
+# The binary's first banner line verbatim, stderr folded in so a binary that
+# fails to run (wrong arch, missing library) names its own reason.
+rsync_version_banner() {
+    local banner
+    banner=$("$1" --version 2>&1) || true
+    printf '%s' "${banner%%$'\n'*}"
+}
+
 # One TSV row per (oracle version, consuming test): version, test base name,
-# whether that test needs the TCP transport, whether it needs root.
+# whether that test needs the TCP transport, whether it needs root, and whether
+# the test will take the --rsync-bin2 peer as its oracle.
 #
 # DISCOVERED from the tests, never listed here. A second copy of "3.2.7" in
 # this file would drift the moment upstream retargets the oracle, and the drift
@@ -913,9 +975,17 @@ for path in sorted(glob.glob(os.path.join('testsuite', '*_test.py'))):
                  'the oracle it wants cannot be derived from its source' % path)
     needs_tcp = 'yes' if 'require_tcp(' in text else 'no'
     needs_root = 'yes' if 'geteuid()' in text else 'no'
+    # Whether the --rsync-bin2 peer can OCCUPY this test's oracle slot. Read
+    # from the test for the same reason the version is: a test that reads
+    # RSYNC_PEER in CODE can substitute it for the archive binary, and no
+    # amount of building the right oracle changes that. An `ast.Name` node,
+    # so the `from rsyncfns import (..., RSYNC_PEER, ...)` alias every test in
+    # the suite carries does not count as use - only evaluating it does.
+    peer_slot = 'yes' if any(isinstance(n, ast.Name) and n.id == 'RSYNC_PEER'
+                             for n in ast.walk(tree)) else 'no'
     base = os.path.basename(path)[:-len('_test.py')]
     for version in versions:
-        rows.append('\t'.join((version, base, needs_tcp, needs_root)))
+        rows.append('\t'.join((version, base, needs_tcp, needs_root, peer_slot)))
 print('\n'.join(rows))
 PY
     )
@@ -945,10 +1015,11 @@ ensure_legacy_oracles() {
     local old_versions_dir="${upstream_src_dir}/old_versions"
     local oracle_workdir="${workspace_root}/target/interop/old-versions-build"
     local euid=${EUID:-$(id -u)}
-    local built=0 unreachable=0 degraded=0
+    local built=0 unreachable=0 degraded=0 from_peer=0
     local degraded_names=""
-    local version test_name needs_tcp needs_root reason
-    while IFS=$'\t' read -r version test_name needs_tcp needs_root; do
+    local version test_name needs_tcp needs_root peer_slot reason
+    local peer_version peer_banner
+    while IFS=$'\t' read -r version test_name needs_tcp needs_root peer_slot; do
         [[ -n "$version" ]] || continue
         reason=""
         if [[ "$needs_tcp" == "yes" && "${USE_TCP:-no}" != "yes" ]]; then
@@ -962,6 +1033,33 @@ ensure_legacy_oracles() {
         if [[ -n "$reason" ]]; then
             echo "==> Legacy oracle rsync ${version}: not needed - ${test_name} cannot run on this leg (${reason})." >&2
             unreachable=$((unreachable + 1))
+            continue
+        fi
+        # PROVENANCE. This consumer reads RSYNC_PEER, so a --rsync-bin2 binary
+        # takes the oracle slot ahead of anything in old_versions/ - and the
+        # grid still labels the column with the version it ASKED for. Make the
+        # binary prove it is that version before we hand it over.
+        if [[ "$peer_slot" == "yes" && -n "$upstream_peer_bin" ]]; then
+            peer_version=$(rsync_reported_version "$upstream_peer_bin") \
+                || peer_version=""
+            if [[ "$peer_version" != "$version" ]]; then
+                peer_banner=$(rsync_version_banner "$upstream_peer_bin")
+                echo "ERROR: UPSTREAM_PEER_BIN would become ${test_name}'s rsync ${version} oracle, and it is not rsync ${version}." >&2
+                echo "       peer: ${upstream_peer_bin}" >&2
+                echo "       says: ${peer_banner:-<no --version output>}" >&2
+                echo "       ${test_name} prefers the --rsync-bin2 peer over old_versions/rsync_${version}" >&2
+                echo "       and labels the resulting column with a hardcoded '${version//./}'. Run this" >&2
+                echo "       way and the grid reports what rsync ${version} says about cells rsync" >&2
+                echo "       ${peer_version:-?} answered - a confident, wrong differential result, and" >&2
+                echo "       building the real oracle does not help because the peer wins the tie." >&2
+                echo "       Either unset UPSTREAM_PEER_BIN on this leg (LEGACY_ORACLES=on then" >&2
+                echo "       supplies a real rsync ${version}), or point it at an actual rsync ${version}." >&2
+                gha_annotate_fail "legacy rsync oracle slot hijacked" \
+                    "UPSTREAM_PEER_BIN (${upstream_peer_bin}, ${peer_banner:-unknown version}) would fill ${test_name}'s rsync ${version} oracle slot, which the test labels '${version//./}' whatever answers it."
+                exit 1
+            fi
+            echo "==> Legacy oracle rsync ${version}: supplied by the --rsync-bin2 peer ${upstream_peer_bin}, which reports ${peer_version}." >&2
+            from_peer=$((from_peer + 1))
             continue
         fi
         if [[ "$legacy_oracles_mode" == "off" ]]; then
@@ -988,7 +1086,7 @@ ensure_legacy_oracles() {
         gha_annotate_warn "legacy rsync oracles not built" \
             "LEGACY_ORACLES=off on this leg, so ${degraded} test(s) assert against a static fallback rather than the release they name: ${degraded_names}. Set legacy_oracles: 'on' for this leg once its expect manifest can be re-measured."
     fi
-    echo "==> Legacy oracles: ${built} on disk, ${degraded} consumer(s) running degraded, ${unreachable} not needed on this leg." >&2
+    echo "==> Legacy oracles: ${built} on disk, ${from_peer} from the --rsync-bin2 peer, ${degraded} consumer(s) running degraded, ${unreachable} not needed on this leg." >&2
 }
 
 # Drive upstream's own runtests.py against oc-rsync.
@@ -1094,6 +1192,10 @@ run_python_suite_mode() {
     # the wire and upstream on the other: this, not the wire-format interop
     # cells, is what actually tests compatibility with a given release. Absent,
     # the suite runs oc against oc and proves only self-consistency.
+    #
+    # ensure_legacy_oracles() has already refused this binary if a test on this
+    # leg would take it as an oracle for a version it does not report; see the
+    # provenance block there.
     if [[ -n "$upstream_peer_bin" ]]; then
         if [[ ! -x "$upstream_peer_bin" ]]; then
             echo "ERROR: UPSTREAM_PEER_BIN is set but not executable: ${upstream_peer_bin}" >&2
@@ -1102,7 +1204,10 @@ run_python_suite_mode() {
             exit 1
         fi
         echo "==> Peer (--rsync-bin2): ${upstream_peer_bin}" >&2
-        "$upstream_peer_bin" --version 2>&1 | head -n1 | sed 's/^/    /' >&2
+        # Not `--version | head -1`: rsync writes the banner unbuffered, so
+        # under `set -o pipefail` an early close reports 141 and `set -e` kills
+        # the run. rsync_version_banner() reads to EOF instead.
+        echo "    $(rsync_version_banner "$upstream_peer_bin")" >&2
         runtests_argv+=(--rsync-bin2="$upstream_peer_bin")
     fi
     # An expected-outcome manifest runs ONLY the tests it lists, so a truncated

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -490,13 +490,21 @@ class RsyncReportedVersionTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "3.5.0")
 
-    def test_an_unbuffered_banner_is_read_whole(self) -> None:
-        # rsync writes its banner in ~20 unbuffered write(2)s. A `| head -1`
-        # reading would SIGPIPE it and, under pipefail, report 141.
+    def test_a_banner_still_being_written_is_read_whole(self) -> None:
+        # rsync writes its banner in ~20 unbuffered write(2)s - MEASURED, 793
+        # bytes on 3.2.7 - so a reader that closes the pipe after line 1 kills
+        # the producer with SIGPIPE and, under `set -o pipefail`, the whole
+        # pipeline reports 141 for a binary that answered perfectly.
+        #
+        # The sleep is what makes that DETERMINISTIC. Without it the outcome is
+        # a race the producer usually wins: 20 small writes fit in the pipe
+        # buffer and complete before the reader exits, so a `| head -1` spelling
+        # passes this cell most of the time. MEASURED: mutating
+        # rsync_reported_version() to pipe through `head -n1` killed nothing
+        # until the producer was made to still be writing when the reader left.
         script = 'printf "%s\\n" "rsync  version 3.2.7  protocol version 31"\n'
-        script += "".join(
-            f'printf "line {i}\\n"\n' for i in range(40)
-        )
+        script += "sleep 0.5\n"
+        script += 'printf "%s\\n" "Copyright (C) 1996-2024 by Andrew Tridgell"\n'
         result = self._probe(script)
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout, "3.2.7")

--- a/tools/tests/test_upstream_testsuite_oracle.py
+++ b/tools/tests/test_upstream_testsuite_oracle.py
@@ -78,14 +78,29 @@ print(ORACLE)
 '''
 
 
-def consumer_needing(tcp: bool, root: bool) -> str:
+def consumer_needing(tcp: bool, root: bool, peer_slot: bool = False) -> str:
     """A consuming test carrying the preconditions the harness reads."""
     body = CONSUMER
     if tcp:
         body += "require_tcp('needs a real TCP peer')\n"
     if root:
         body += "import os\nif os.geteuid() != 0:\n    raise SystemExit(0)\n"
+    if peer_slot:
+        # daemon-symlink-escape-matrix_test.py:75-79 verbatim in shape: the
+        # peer WINS over the archive binary, so a wrong peer is not merely an
+        # extra oracle, it is a substitute one.
+        body += (
+            "from rsyncfns import RSYNC, RSYNC_PEER\n"
+            "if RSYNC_PEER != RSYNC:\n"
+            "    ORACLE = RSYNC_PEER\n"
+        )
     return body
+
+
+# A consumer that only IMPORTS RSYNC_PEER without evaluating it. The import
+# alias is not an ast.Name, so the scan must not read this as a hijackable
+# slot - every test in the 3.5.0 suite imports from rsyncfns.
+PEER_IMPORTED_UNUSED = CONSUMER + "from rsyncfns import RSYNC, RSYNC_PEER\n"
 
 
 class LegacyOracleDiscoveryTests(unittest.TestCase):
@@ -119,13 +134,48 @@ class LegacyOracleDiscoveryTests(unittest.TestCase):
         self._test("matrix", consumer_needing(tcp=True, root=True))
         result = self._run()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "3.2.7\tmatrix\tyes\tyes")
+        self.assertEqual(result.stdout.strip(), "3.2.7\tmatrix\tyes\tyes\tno")
 
     def test_preconditions_are_read_from_the_test_not_assumed(self) -> None:
         self._test("plain", consumer_needing(tcp=False, root=False))
         result = self._run()
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "3.2.7\tplain\tno\tno")
+        self.assertEqual(result.stdout.strip(), "3.2.7\tplain\tno\tno\tno")
+
+    def test_a_peer_readable_oracle_slot_is_discovered(self) -> None:
+        # The hijackable slot. A test that evaluates RSYNC_PEER takes the
+        # --rsync-bin2 binary as its oracle IN PREFERENCE to old_versions/,
+        # and labels the column with the version it asked for either way.
+        self._test("matrix", consumer_needing(tcp=False, root=False, peer_slot=True))
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "3.2.7\tmatrix\tno\tno\tyes")
+
+    def test_importing_the_peer_name_is_not_using_it(self) -> None:
+        # Every test in the suite imports from rsyncfns. Counting the import
+        # would mark all 345 as hijackable and make the gate below fire on
+        # legs where no oracle slot exists at all.
+        self._test("plain", PEER_IMPORTED_UNUSED)
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "3.2.7\tplain\tno\tno\tno")
+
+    def test_the_real_matrix_test_is_classified_as_peer_readable(self) -> None:
+        # The population this gate exists for, read from the real tree rather
+        # than from a fixture shaped like it. Skipped, never faked, when the
+        # tarball is not extracted here.
+        tree = REPO / "target" / "interop" / "upstream-src" / "rsync-3.5.0"
+        consumer = tree / "testsuite" / "daemon-symlink-escape-matrix_test.py"
+        if not consumer.is_file():
+            self.skipTest(f"{consumer} is not extracted here")
+        self.tree = tree
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rows = [line.split("\t") for line in result.stdout.splitlines()]
+        matrix = [r for r in rows if r[1] == "daemon-symlink-escape-matrix"]
+        self.assertEqual(len(matrix), 1, result.stdout)
+        self.assertEqual(matrix[0][0], "3.2.7")
+        self.assertEqual(matrix[0][4], "yes", result.stdout)
 
     def test_docstring_mention_is_not_a_consumer(self) -> None:
         # The whole reason the scan is over the AST. A text scan reports this
@@ -156,15 +206,20 @@ class LegacyOracleDiscoveryTests(unittest.TestCase):
         result = self._run()
         self.assertEqual(result.returncode, 0, result.stderr)
         for line in result.stdout.splitlines():
-            version, name, needs_tcp, needs_root = line.split("\t")
+            version, name, needs_tcp, needs_root, peer_slot = line.split("\t")
             self.assertRegex(version, r"^\d+\.\d+(\.\d+)?$")
             self.assertTrue(name)
             self.assertIn(needs_tcp, ("yes", "no"))
             self.assertIn(needs_root, ("yes", "no"))
+            self.assertIn(peer_slot, ("yes", "no"))
 
 
-class EnsureLegacyOraclesTests(unittest.TestCase):
-    """ensure_legacy_oracles(): builds, refuses, or names the degradation."""
+class LegacyOracleHarnessFixture:
+    """A synthetic upstream tree, a stub builder, and a sourced-harness runner.
+
+    A mixin rather than a TestCase base so the classes below do not inherit one
+    another's cases: shared fixture, disjoint populations.
+    """
 
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -191,11 +246,27 @@ class EnsureLegacyOraclesTests(unittest.TestCase):
         )
         stub.chmod(0o755)
 
+    def _peer(self, banner: str | None) -> str:
+        """A stand-in --rsync-bin2 binary. `banner` None => --version fails."""
+        peer = self.tmp / "peer-rsync"
+        if banner is None:
+            peer.write_text("#!/usr/bin/env bash\nexit 1\n")
+        else:
+            # Upstream's banner shape, "version" twice, release token first.
+            peer.write_text(
+                "#!/usr/bin/env bash\n"
+                f'printf "%s\\n" {shlex.quote(banner)}\n'
+                'printf "%s\\n" "Copyright (C) 1996-2024 by Andrew Tridgell"\n'
+            )
+        peer.chmod(0o755)
+        return str(peer)
+
     def _run(self, env_overrides: dict, extra: str = "") -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env.pop("LEGACY_ORACLES", None)
         env.pop("USE_TCP", None)
         env.pop("EXPECT_RESULT", None)
+        env.pop("UPSTREAM_PEER_BIN", None)
         env.update(env_overrides)
         program = textwrap.dedent(
             f"""
@@ -210,6 +281,10 @@ class EnsureLegacyOraclesTests(unittest.TestCase):
             ["bash", "-c", program], capture_output=True, text=True,
             check=False, env=env,
         )
+
+
+class EnsureLegacyOraclesTests(LegacyOracleHarnessFixture, unittest.TestCase):
+    """ensure_legacy_oracles(): builds, refuses, or names the degradation."""
 
     def test_on_builds_the_oracle_the_consumer_names(self) -> None:
         self._builder(0)
@@ -275,6 +350,166 @@ class EnsureLegacyOraclesTests(unittest.TestCase):
         result = self._run({"LEGACY_ORACLES": "yes"})
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must be 'on' or 'off'", result.stderr)
+
+
+class OracleSlotProvenanceTests(LegacyOracleHarnessFixture, unittest.TestCase):
+    """The --rsync-bin2 peer may only fill an oracle slot it matches.
+
+    MEASURED on the real 3.5.0 tree before this gate existed: running
+    daemon-symlink-escape-matrix_test.py with RSYNC_PEER pointed at the 3.5.0
+    build started the oracle daemon FROM 3.5.0 and printed all 100
+    `insecure links = yes` cells as `want=N(327)`. The label is a hardcoded
+    string in upstream's test (:256-257) and the slot's only acceptance test
+    is that `--version` exits zero (:87-94), so nothing downstream can tell a
+    3.2.7 answer from any other binary's.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        (self.tree / "testsuite" / "matrix_test.py").write_text(
+            consumer_needing(tcp=False, root=False, peer_slot=True)
+        )
+
+    def test_a_peer_that_is_not_the_named_version_is_refused(self) -> None:
+        self._builder(0)
+        peer = self._peer("rsync  version 3.5.0  protocol version 32")
+        result = self._run({"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer})
+        self.assertNotEqual(result.returncode, 0, result.stderr)
+        self.assertIn("is not rsync 3.2.7", result.stderr)
+        self.assertIn("3.5.0", result.stderr)
+        self.assertIn("matrix", result.stderr)
+
+    def test_the_refusal_survives_a_built_oracle(self) -> None:
+        # The peer wins the `elif`, so building the real 3.2.7 does not rescue
+        # the slot - refusing is the only truthful outcome, and it must not be
+        # softened into "we built one too".
+        self._builder(0)
+        peer = self._peer("rsync  version 3.4.1  protocol version 32")
+        result = self._run({"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer})
+        self.assertNotEqual(result.returncode, 0, result.stderr)
+        self.assertIn("the peer wins the tie", result.stderr)
+
+    def test_the_refusal_is_annotated_on_github(self) -> None:
+        self._builder(0)
+        peer = self._peer("rsync  version 3.5.0  protocol version 32")
+        result = self._run(
+            {"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer,
+             "GITHUB_ACTIONS": "true"}
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("::error ", result.stdout + result.stderr)
+
+    def test_a_peer_that_will_not_say_its_version_is_refused(self) -> None:
+        # Unreadable provenance is not "probably fine". The pre-existing probe
+        # in the test only checks the exit status, so a binary that answers
+        # nothing intelligible still fills the slot.
+        self._builder(0)
+        peer = self._peer(None)
+        result = self._run({"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer})
+        self.assertNotEqual(result.returncode, 0, result.stderr)
+        self.assertIn("is not rsync 3.2.7", result.stderr)
+
+    def test_a_matching_peer_supplies_the_oracle(self) -> None:
+        self._builder(0)
+        peer = self._peer("rsync  version 3.2.7  protocol version 31")
+        result = self._run({"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("supplied by the --rsync-bin2 peer", result.stderr)
+        self.assertIn("1 from the --rsync-bin2 peer", result.stderr)
+        # It is the oracle, so it is neither built nor degraded - reporting it
+        # as degraded would be the same lie pointed the other way.
+        self.assertFalse(self.calls.exists())
+        self.assertIn("0 consumer(s) running degraded", result.stderr)
+
+    def test_a_matching_peer_is_the_oracle_even_with_oracles_off(self) -> None:
+        self._builder(0)
+        peer = self._peer("rsync  version 3.2.7  protocol version 31")
+        result = self._run({"LEGACY_ORACLES": "off", "UPSTREAM_PEER_BIN": peer})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("supplied by the --rsync-bin2 peer", result.stderr)
+        self.assertIn("0 consumer(s) running degraded", result.stderr)
+
+    def test_a_consumer_that_cannot_run_here_does_not_gate_the_peer(self) -> None:
+        # The narrow scope is the whole point: UPSTREAM_PEER_BIN's job is
+        # version MIXING, and on a leg where no test can adopt it as an oracle
+        # a 3.5.0 peer is exactly what it should be. Refusing there would break
+        # the knob's documented purpose to fix a problem that is not present.
+        (self.tree / "testsuite" / "matrix_test.py").write_text(
+            consumer_needing(tcp=True, root=False, peer_slot=True)
+        )
+        self._builder(0)
+        peer = self._peer("rsync  version 3.5.0  protocol version 32")
+        result = self._run(
+            {"LEGACY_ORACLES": "on", "USE_TCP": "no", "UPSTREAM_PEER_BIN": peer}
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("not needed", result.stderr)
+
+    def test_a_consumer_that_ignores_the_peer_does_not_gate_it(self) -> None:
+        (self.tree / "testsuite" / "matrix_test.py").write_text(
+            consumer_needing(tcp=False, root=False, peer_slot=False)
+        )
+        self._builder(0)
+        peer = self._peer("rsync  version 3.5.0  protocol version 32")
+        result = self._run({"LEGACY_ORACLES": "on", "UPSTREAM_PEER_BIN": peer})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("1 on disk", result.stderr)
+
+
+class RsyncReportedVersionTests(unittest.TestCase):
+    """rsync_reported_version(): the binary is the authority, not the path."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _probe(self, script: str) -> subprocess.CompletedProcess[str]:
+        # Named for a version it is NOT, so a reading that trusts the filename
+        # rather than the banner cannot pass.
+        binary = self.tmp / "rsync_3.2.7"
+        binary.write_text("#!/usr/bin/env bash\n" + script)
+        binary.chmod(0o755)
+        program = textwrap.dedent(
+            f"""
+            source {shlex.quote(str(HARNESS))}
+            rsync_reported_version {shlex.quote(str(binary))}
+            """
+        )
+        return subprocess.run(
+            ["bash", "-c", program], capture_output=True, text=True, check=False
+        )
+
+    def test_the_release_token_wins_over_the_protocol_one(self) -> None:
+        # "rsync  version 3.5.0  protocol version 32" says "version" twice.
+        result = self._probe(
+            'printf "%s\\n" "rsync  version 3.5.0  protocol version 32"\n'
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "3.5.0")
+
+    def test_an_unbuffered_banner_is_read_whole(self) -> None:
+        # rsync writes its banner in ~20 unbuffered write(2)s. A `| head -1`
+        # reading would SIGPIPE it and, under pipefail, report 141.
+        script = 'printf "%s\\n" "rsync  version 3.2.7  protocol version 31"\n'
+        script += "".join(
+            f'printf "line {i}\\n"\n' for i in range(40)
+        )
+        result = self._probe(script)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "3.2.7")
+
+    def test_a_binary_that_fails_reports_failure(self) -> None:
+        result = self._probe("exit 1\n")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    def test_an_unparseable_banner_reports_failure(self) -> None:
+        result = self._probe('printf "%s\\n" "some other program"\n')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
 
 
 class BuildOldRsyncOracleTests(unittest.TestCase):


### PR DESCRIPTION
## What

`daemon-symlink-escape-matrix` labels its oracle column `(327)` — a hardcoded string — whatever binary actually answered. And it prefers the `--rsync-bin2` peer over `old_versions/rsync_3.2.7`:

```python
ORACLE_BIN = None
if RSYNC_PEER != RSYNC:
    ORACLE_BIN = RSYNC_PEER
elif (_repo/'old_versions'/'rsync_3.2.7').is_file():
    ...
```

Note the `elif`. **Building the real oracle does not rescue a hijacked slot — the peer wins the tie.** The only acceptance test is that `--version` exits zero; the banner it prints is read by nobody.

So `UPSTREAM_PEER_BIN=<any rsync>` on the root/tcp leg produces a grid that says "this is what rsync 3.2.7 does" about cells a completely different release answered. A confident, wrong differential result.

## Where the defect lives — and why the fix is a refusal

**The mislabelling code is upstream's, not ours.** It is inside the 3.5.0 tarball that `run_upstream_testsuite.sh:229` downloads from download.samba.org and re-extracts. Any edit there is wiped by the next extraction. There is nothing downstream of the hand-off to relabel, so the only truthful repo-side outcome is to refuse the hand-off.

## The refusal is narrow, and that is the substance

`UPSTREAM_PEER_BIN`'s documented job is version *mixing* — pointing it at a real 3.5.0 build is the intended use, and a blanket refusal would break it. The gate fires only when a consumer that actually **evaluates** `RSYNC_PEER` is reachable on this leg. Measured on the real tree, that is exactly one of the three:

```
3.1.3  daemon-auth-digest-floor       no  no  no
3.2.7  daemon-max-alloc-zero          no  no  no
3.2.7  daemon-symlink-escape-matrix   yes yes yes
```

That column is AST-discovered (an `ast.Name` load, so the `from rsyncfns import (…)` alias every test carries does not count as use), never listed in the shell — a second copy of "3.2.7" here would drift the moment upstream retargets, and the drift is the invisible kind.

A peer that **does** report the named version is accepted and reported as the oracle. Calling a real 3.2.7 peer "degraded" would be the same lie pointed the other way.

## RED / POST-FIX

Executed the real upstream test file unmodified, environment stubbed (uid gate stood down — the consumer needs root, this host is uid 501):

```
ARM A: no peer          rows labelled (327): 0     rows labelled (contract): 100
ARM B: peer = 3.5.0     rows labelled (327): 100   rows labelled (contract): 0
       ("rsync  version 3.5.0  protocol version 32")
```

The oracle daemon starts from the **3.5.0** binary and all 100 cells are labelled `(327)`.

Harness level, RED on master: announces "asserts against rsync 3.2.7", builds the 3.2.7 oracle, exits 0 — and hands 3.5.0 into the slot that wins the `elif`. Post-fix it refuses with the peer's own banner, names why building the oracle does not help, and gives both exits (unset the var, or point it at a real 3.2.7).

## Absent binary: deliberately unchanged

`daemon-max-alloc-zero` already calls `test_skipped(f"{OLD_CLIENT} not present")` and the manifest carries `daemon-max-alloc-zero skip`. Counted, reason-carrying, and it never reads `RSYNC_PEER`. Untouched.

## Mutations — 7, measured

| # | Mutation | Kills |
|---|---|---|
| M1 | drop the refusal | 4 |
| M2 | label from the flag, not the binary | 4 |
| M3 | count the import as use | 1 |
| M4 | drop the peer-slot column | 8 |
| M5 | greedy version regex (yields `32`) | 4 |
| M6 | pipe the banner through `head -n1` | 1 |
| M7 | a mute peer defaults to matching | 1 |

**M6 initially killed nothing, and that is reported rather than hidden.** The cell was reading a race: 20 small writes fit in the pipe buffer and usually finish before the reader exits. The second commit holds the producer open across the reader's exit; M6 now kills. One coverage hole found, closed.

M5 is why the version match is leftmost: `rsync  version 3.5.0  protocol version 32` contains the word twice and only the first carries the release. M6 also removes a latent `pipefail` kill at the `--rsync-bin2` hand-off (`--version | head -1`), the same trap `build_old_rsync_oracle.sh:53-70` already documents.

## Gates

| Gate | Result |
|---|---|
| `tools/ci/run_tools_tests.sh` (rides CI) | rc=0, 104 tests, OK |
| `tools/tests/test_upstream_testsuite_oracle.py` | 34 passed / 0 failed / 0 skipped |
| `shellcheck -s bash` | rc=0 |
| `bash -n` / `py_compile` | rc=0 / rc=0 |
| `check_rustfmt_all.py` @1.88.0 | rc=0, 3426 files |

Not run, with reason: clippy and nextest — shell + Python only, zero `.rs` files touched. No expect-manifest touched, and the gate only refuses; it never un-skips a test, so no manifest row can move.

## One correction to the record

`tools/ci/build_old_rsync_oracle.sh` already exists, is called by `ensure_legacy_oracles()`, is gated by `LEGACY_ORACLES`, and `upstream-testsuite-root-tcp.yml:66` already sets `legacy_oracles: 'on'`. Earlier notes said the 3.2.7 build was wired into nothing — that was true of *upstream's* `build_static.sh`, not of the repo's replacement. The finding that survives is the interaction: on that same leg, a set `UPSTREAM_PEER_BIN` silently shadowed the oracle that build was producing. That is what this refuses.

⚠ Full-grid RED end-to-end was not reproducible on this host — the consumer needs root and a foreign-owned symlink plant. Stated plainly rather than worked around: the grid capture came from executing upstream's real file with the uid gate stood down, and the harness capture from the real tree with the measured requirement row.
