### PR TITLE
fix(flist): send a symlink's real mode instead of a hardcoded 0o777

### DIFF
--- a/crates/batch/src/tests.rs
+++ b/crates/batch/src/tests.rs
@@ -1981,11 +1981,15 @@ mod integration {
             e.set_mtime(1_700_000_000, 0);
             e
         };
-        // Symlink "nolf-symlink -> nolf". new_symlink() sets mode to 0o777
-        // unconditionally, matching the kernel default that `ln -s` produces.
+        // Symlink "nolf-symlink -> nolf". The fixture pins mode 0o777, the
+        // value Linux's kernel gives every link; the wire encoding under test
+        // is indifferent to which permission bits the entry carries.
         let link_entry = {
-            let mut e =
-                FileEntry::new_symlink("nolf-symlink".into(), std::path::PathBuf::from("nolf"));
+            let mut e = FileEntry::new_symlink(
+                "nolf-symlink".into(),
+                0o777,
+                std::path::PathBuf::from("nolf"),
+            );
             e.set_mtime(1_700_000_000, 0);
             e
         };

--- a/crates/engine/src/delete/plan.rs
+++ b/crates/engine/src/delete/plan.rs
@@ -252,7 +252,9 @@ fn entry_as_file_entry(dir: &std::path::Path, e: &DeleteEntry) -> FileEntry {
     let full = dir.join(&e.name);
     match e.kind {
         DeleteEntryKind::Dir => FileEntry::new_directory(full, 0o755),
-        DeleteEntryKind::Symlink => FileEntry::new_symlink(full, std::path::PathBuf::from("")),
+        DeleteEntryKind::Symlink => {
+            FileEntry::new_symlink(full, 0o777, std::path::PathBuf::from(""))
+        }
         DeleteEntryKind::File | DeleteEntryKind::Device | DeleteEntryKind::Special => {
             FileEntry::new_file(full, 0, 0o644)
         }

--- a/crates/engine/src/delete/traversal.rs
+++ b/crates/engine/src/delete/traversal.rs
@@ -270,7 +270,7 @@ mod tests {
             &[
                 dir_entry("root/sub"),
                 file_entry("root/file.txt"),
-                FileEntry::new_symlink(PathBuf::from("root/link"), PathBuf::from("target")),
+                FileEntry::new_symlink(PathBuf::from("root/link"), 0o777, PathBuf::from("target")),
             ],
         );
         let seq: Vec<PathBuf> = std::iter::from_fn(|| cursor.next_ready()).collect();

--- a/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/batch.rs
@@ -62,7 +62,8 @@ fn build_protocol_file_entry(
         // upstream: flist.c:1465 - symlinks carry stat.st_size (the target byte
         // length), matching the directory case above; only devices/specials are
         // zeroed.
-        let mut symlink_entry = protocol::flist::FileEntry::new_symlink(name, link_target);
+        let mut symlink_entry =
+            protocol::flist::FileEntry::new_symlink(name, permissions, link_target);
         symlink_entry.set_size(metadata.len());
         symlink_entry
     } else {
@@ -288,6 +289,31 @@ mod tests {
             entry.size(),
             meta.len(),
             "F_LENGTH must mirror lstat st_size"
+        );
+    }
+
+    /// upstream: flist.c:1669 - `file->mode = st.st_mode` is one assignment for
+    /// every type. A batch capture is the same flist the network path would
+    /// send, so a symlink's recorded mode must be its lstat mode. On Linux that
+    /// is 0o777 by kernel fiat; on the `CAN_CHMOD_SYMLINK` platforms
+    /// (rsync.h:455-456) it is whatever `lchmod` set, and a hardcoded constant
+    /// would lose it. Asserting equality with lstat covers both.
+    #[test]
+    fn symlink_batch_entry_carries_the_lstat_mode() {
+        use std::os::unix::fs::MetadataExt;
+
+        let tmp = TempDir::new().expect("tempdir");
+        let link = tmp.path().join("link");
+        symlink("target", &link).expect("create symlink");
+        let meta = std::fs::symlink_metadata(&link).expect("metadata");
+
+        let entry = build_protocol_file_entry(&link, &PathBuf::from("link"), &meta, false, true);
+
+        assert!(entry.is_symlink());
+        assert_eq!(
+            entry.permissions() & 0o7777,
+            meta.mode() & 0o7777,
+            "batch symlink mode must mirror lstat st_mode, not a constant",
         );
     }
 }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -623,7 +623,7 @@ fn symlink_owner_override_non_root_chown_is_skipped_not_fatal() {
     let cached_meta = fs::symlink_metadata(&dest_link).ok();
 
     // owner_override bypasses the entry's own uid, so the entry is a placeholder.
-    let entry = FileEntry::new_symlink("dest-link".into(), "target.txt".into());
+    let entry = FileEntry::new_symlink("dest-link".into(), 0o777, "target.txt".into());
 
     // Explicit `--chown=root:...` (uid 0) as non-root: upstream never attempts
     // the do_lchown (change_uid requires am_root), so oc-rsync must complete
@@ -675,7 +675,7 @@ fn symlink_group_override_non_root_chown_to_foreign_group_is_skipped_not_fatal()
         .gid();
     let cached_meta = fs::symlink_metadata(&dest_link).ok();
 
-    let entry = FileEntry::new_symlink("dest-link-grp".into(), "target-grp.txt".into());
+    let entry = FileEntry::new_symlink("dest-link-grp".into(), 0o777, "target-grp.txt".into());
 
     // Explicit `--chown=:<foreign-group>` as non-root: FLAG_SKIP_GROUP drops the
     // do_lchown before it runs, so the link's group must be left untouched.
@@ -2961,7 +2961,7 @@ fn symlink_own_mode_applied_from_entry_under_preserve_perms() {
         0o777
     );
 
-    let mut entry = FileEntry::new_symlink("link".into(), "target.txt".into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target.txt".into());
     entry.set_mode(0o120741);
 
     super::apply_symlink_metadata_from_entry(

--- a/crates/protocol/benches/flist_benchmark.rs
+++ b/crates/protocol/benches/flist_benchmark.rs
@@ -105,6 +105,7 @@ fn bench_file_entry_creation(c: &mut Criterion) {
                 .map(|i| {
                     FileEntry::new_symlink(
                         black_box(format!("link_{i}").into()),
+                        0o777,
                         black_box(format!("../target_{i}").into()),
                     )
                 })

--- a/crates/protocol/src/flist/accessor.rs
+++ b/crates/protocol/src/flist/accessor.rs
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn file_entry_accessor_symlink() {
         use std::path::PathBuf;
-        let entry = FileEntry::new_symlink("link".into(), PathBuf::from("../target"));
+        let entry = FileEntry::new_symlink("link".into(), 0o777, PathBuf::from("../target"));
         let acc: &dyn FileEntryAccessor = &entry;
         assert!(acc.is_symlink());
         assert_eq!(acc.link_target_bytes(), Some(b"../target" as &[u8]));

--- a/crates/protocol/src/flist/entry/constructors.rs
+++ b/crates/protocol/src/flist/entry/constructors.rs
@@ -57,12 +57,22 @@ impl FileEntry {
         Self::new_with_type(name, 0, FileType::Directory, permissions, None)
     }
 
-    /// Creates a new symlink entry with `S_IFLNK` mode and 0o777 permissions.
+    /// Creates a new symlink entry with `S_IFLNK` mode and the given permissions.
     ///
-    /// Symlinks always have 0o777 permissions per POSIX convention.
+    /// A symlink's permission bits are *not* universally 0o777. Upstream
+    /// `flist.c:1669` stores `file->mode = st.st_mode` verbatim for every file
+    /// type, symlinks included, and whether that carries a meaningful value is
+    /// a platform property: `rsync.h:455-456` defines `CAN_CHMOD_SYMLINK` when
+    /// `HAVE_LCHMOD || HAVE_SETATTRLIST`, which holds on macOS and the BSDs,
+    /// where `lchmod`/`setattrlist` give a link a real, settable mode. On Linux
+    /// the kernel pins a link's `st_mode` permission bits to 0o777 and nothing
+    /// can change them, so a Linux caller passing the stat mode through yields
+    /// 0o777 anyway. Callers must therefore forward the stat mode rather than
+    /// substitute a constant; only a synthesized entry with no underlying stat
+    /// (a deletion sentinel, a decode fixture) should pass 0o777 literally.
     #[must_use]
-    pub fn new_symlink(name: PathBuf, target: PathBuf) -> Self {
-        Self::new_with_type(name, 0, FileType::Symlink, 0o777, Some(target))
+    pub fn new_symlink(name: PathBuf, permissions: u32, target: PathBuf) -> Self {
+        Self::new_with_type(name, 0, FileType::Symlink, permissions, Some(target))
     }
 
     /// Creates a new block device entry.

--- a/crates/protocol/src/flist/entry/tests.rs
+++ b/crates/protocol/src/flist/entry/tests.rs
@@ -110,12 +110,32 @@ fn new_directory_entry() {
 
 #[test]
 fn new_symlink_entry() {
-    let entry = FileEntry::new_symlink("link".into(), "target".into());
+    let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
     assert_eq!(entry.name(), "link");
     assert!(entry.is_symlink());
     assert_eq!(
         entry.link_target().map(|p| p.as_path()),
         Some("target".as_ref())
+    );
+    // Non-vacuity control for `new_symlink_keeps_non_0777_permissions`: 0o777
+    // in must still be 0o777 out.
+    assert_eq!(entry.permissions(), 0o777);
+}
+
+#[test]
+fn new_symlink_keeps_non_0777_permissions() {
+    // upstream: flist.c:1669 - `file->mode = st.st_mode` for every type. A
+    // symlink's permission bits are not universally 0o777: rsync.h:455-456
+    // defines `CAN_CHMOD_SYMLINK` on the platforms with `lchmod`/`setattrlist`
+    // (macOS, the BSDs), where a link carries a real, settable mode. The
+    // constructor must therefore store what it is handed, like every sibling.
+    let entry = FileEntry::new_symlink("link".into(), 0o700, "target".into());
+    assert!(entry.is_symlink());
+    assert_eq!(entry.file_type(), FileType::Symlink);
+    assert_eq!(
+        entry.permissions(),
+        0o700,
+        "new_symlink must not flatten its permissions argument to 0o777",
     );
 }
 
@@ -231,7 +251,7 @@ fn entry_file_type_fallback() {
 
 #[test]
 fn symlink_not_file() {
-    let entry = FileEntry::new_symlink("link".into(), "target".into());
+    let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
     assert!(!entry.is_file());
     assert!(!entry.is_dir());
     assert!(entry.is_symlink());
@@ -371,7 +391,7 @@ fn regular_file_no_extras() {
 /// Symlink entries should allocate extras for the link target.
 #[test]
 fn symlink_has_extras() {
-    let entry = FileEntry::new_symlink("link".into(), "target".into());
+    let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
     assert!(entry.extras.is_some());
     assert_eq!(
         entry.link_target().map(|p| p.as_path()),
@@ -850,7 +870,7 @@ fn socket_no_extras() {
 /// Symlink constructor allocates extras; other extras fields default.
 #[test]
 fn symlink_extras_other_fields_default() {
-    let entry = FileEntry::new_symlink("lnk".into(), "/dest".into());
+    let entry = FileEntry::new_symlink("lnk".into(), 0o777, "/dest".into());
     assert!(entry.extras.is_some());
     assert_eq!(
         entry.link_target().map(|p| p.as_path()),
@@ -1170,7 +1190,7 @@ fn extras_on_directory_entry() {
 
 #[test]
 fn extras_on_symlink_entry() {
-    let mut entry = FileEntry::new_symlink("lnk".into(), "/target".into());
+    let mut entry = FileEntry::new_symlink("lnk".into(), 0o777, "/target".into());
     assert!(entry.extras.is_some());
     entry.set_user_name("owner".to_string());
     assert_eq!(entry.user_name(), Some("owner"));
@@ -1495,7 +1515,7 @@ fn reclaim_heap_data_clears_name_and_extras() {
 
 #[test]
 fn reclaim_heap_data_on_symlink_drops_target() {
-    let mut entry = FileEntry::new_symlink("link".into(), "/usr/lib/target".into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, "/usr/lib/target".into());
     assert!(entry.link_target().is_some());
 
     entry.reclaim_heap_data();

--- a/crates/protocol/src/flist/incremental/tests.rs
+++ b/crates/protocol/src/flist/incremental/tests.rs
@@ -501,7 +501,7 @@ fn test_finalization_stats_predicates() {
 #[test]
 fn test_finalize_symlink_orphan() {
     let mut incremental = IncrementalFileList::new();
-    let symlink = FileEntry::new_symlink("missing_dir/link".into(), "target".into());
+    let symlink = FileEntry::new_symlink("missing_dir/link".into(), 0o777, "target".into());
     incremental.push(symlink);
 
     let result = incremental.finalize();
@@ -546,7 +546,7 @@ fn test_finalize_with_builder_pre_created_dirs() {
 }
 
 fn make_symlink(name: &str, target: &str) -> FileEntry {
-    FileEntry::new_symlink(name.into(), target.into())
+    FileEntry::new_symlink(name.into(), 0o777, target.into())
 }
 
 fn make_block_device(name: &str) -> FileEntry {

--- a/crates/protocol/src/flist/read/tests.rs
+++ b/crates/protocol/src/flist/read/tests.rs
@@ -1929,7 +1929,7 @@ mod acl_integration {
         let mut data = Vec::new();
 
         let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
-        let mut entry = FileEntry::new_symlink("link".into(), "target".into());
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
@@ -2292,7 +2292,7 @@ mod acl_integration {
         let mut data = Vec::new();
 
         let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
-        let mut entry = FileEntry::new_symlink("link".into(), "target".into());
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
@@ -2508,7 +2508,7 @@ mod xattr_integration {
         let mut data = Vec::new();
 
         let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
-        let mut entry = FileEntry::new_symlink("link".into(), "target".into());
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
         entry.set_mtime(1700000000, 0);
         writer.write_entry(&mut data, &entry).unwrap();
 
@@ -2746,7 +2746,7 @@ mod iconv_integration {
         use std::path::PathBuf;
 
         let target = PathBuf::from(std::ffi::OsStr::from_bytes(target_wire));
-        let mut entry = FileEntry::new_symlink("link".into(), target);
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, target);
         entry.set_mtime(1_700_000_000, 0);
 
         let protocol = test_protocol();
@@ -2950,7 +2950,7 @@ fn update_stats_saturates_on_symlink_target_overflow() {
     let primer = FileEntry::new_file(PathBuf::from("primer"), u64::MAX, 0o100644);
     reader.update_stats(&primer);
 
-    let link = FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("target"));
+    let link = FileEntry::new_symlink(PathBuf::from("link"), 0o777, PathBuf::from("target"));
     reader.update_stats(&link);
 
     assert_eq!(reader.stats().num_symlinks, 1);

--- a/crates/protocol/src/flist/write/tests/basic.rs
+++ b/crates/protocol/src/flist/write/tests/basic.rs
@@ -275,7 +275,7 @@ fn stats_tracking() {
     let file1 = FileEntry::new_file("file1.txt".into(), 100, 0o644);
     let file2 = FileEntry::new_file("file2.txt".into(), 200, 0o644);
     let dir = FileEntry::new_directory("mydir".into(), 0o755);
-    let link = FileEntry::new_symlink("mylink".into(), "/target".into());
+    let link = FileEntry::new_symlink("mylink".into(), 0o777, "/target".into());
     let dev = FileEntry::new_block_device("sda".into(), 0o660, 8, 0);
 
     writer.write_entry(&mut buf, &file1).unwrap();

--- a/crates/protocol/src/flist/write/tests/symlink.rs
+++ b/crates/protocol/src/flist/write/tests/symlink.rs
@@ -9,7 +9,7 @@ fn write_symlink_entry_with_preserve_links() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
 
-    let entry = FileEntry::new_symlink("link".into(), "/target/path".into());
+    let entry = FileEntry::new_symlink("link".into(), 0o777, "/target/path".into());
 
     writer.write_entry(&mut buf, &entry).unwrap();
     writer.write_end(&mut buf, None).unwrap();
@@ -37,7 +37,7 @@ fn write_symlink_entry_without_preserve_links_omits_target() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol);
 
-    let entry = FileEntry::new_symlink("link".into(), "/target/path".into());
+    let entry = FileEntry::new_symlink("link".into(), 0o777, "/target/path".into());
 
     writer.write_entry(&mut buf, &entry).unwrap();
     writer.write_end(&mut buf, None).unwrap();
@@ -61,7 +61,7 @@ fn write_symlink_round_trip_protocol_30_varint() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
 
-    let entry = FileEntry::new_symlink("mylink".into(), "../relative/path".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "../relative/path".into());
 
     writer.write_entry(&mut buf, &entry).unwrap();
     writer.write_end(&mut buf, None).unwrap();
@@ -90,7 +90,7 @@ fn write_symlink_round_trip_protocol_29_fixed_int() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
 
-    let entry = FileEntry::new_symlink("oldlink".into(), "/old/target".into());
+    let entry = FileEntry::new_symlink("oldlink".into(), 0o777, "/old/target".into());
 
     writer.write_entry(&mut buf, &entry).unwrap();
     writer.write_end(&mut buf, None).unwrap();
@@ -120,7 +120,7 @@ fn wire_encoded_symlink_target_never_contains_backslash_byte() {
     let mut target = PathBuf::from("sub");
     target.push("target.txt");
 
-    let mut entry = FileEntry::new_symlink("link".into(), target);
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, target);
     entry.set_mtime(0, 0);
 
     let mut buf = Vec::new();
@@ -159,7 +159,7 @@ fn write_symlink_target_transcodes_with_iconv_to_remote_charset() {
         .with_iconv(converter)
         .with_symlink_iconv(true);
 
-    let mut entry = FileEntry::new_symlink("link".into(), utf8_target.into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, utf8_target.into());
     entry.set_mtime(1_700_000_000, 0);
     let mut buf = Vec::new();
     writer.write_entry(&mut buf, &entry).unwrap();
@@ -199,7 +199,7 @@ fn write_symlink_target_without_negotiated_flag_passes_raw_local_bytes() {
         .with_preserve_links(true)
         .with_iconv(converter);
 
-    let mut entry = FileEntry::new_symlink("link".into(), utf8_target.into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, utf8_target.into());
     entry.set_mtime(1_700_000_000, 0);
     let mut buf = Vec::new();
     writer.write_entry(&mut buf, &entry).unwrap();
@@ -223,7 +223,7 @@ fn write_symlink_target_without_iconv_emits_raw_bytes() {
     let utf8_bytes = utf8_target.as_bytes();
 
     let mut writer = FileListWriter::new(test_protocol()).with_preserve_links(true);
-    let mut entry = FileEntry::new_symlink("link".into(), utf8_target.into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, utf8_target.into());
     entry.set_mtime(1_700_000_000, 0);
     let mut buf = Vec::new();
     writer.write_entry(&mut buf, &entry).unwrap();

--- a/crates/protocol/tests/acl_compat_309.rs
+++ b/crates/protocol/tests/acl_compat_309.rs
@@ -177,7 +177,8 @@ fn reader_with_acls_fails_on_stream_without_acl_data() {
 fn symlink_entries_skip_acl_data() {
     let (protocol, compat) = proto30_setup();
 
-    let mut symlink = FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("/target"));
+    let mut symlink =
+        FileEntry::new_symlink(PathBuf::from("link"), 0o777, PathBuf::from("/target"));
     symlink.set_mtime(1_700_000_000, 0);
 
     // Write with ACLs enabled.
@@ -210,7 +211,8 @@ fn symlink_entries_skip_acl_data() {
 fn symlink_roundtrip_no_acl_indices() {
     let (protocol, compat) = proto30_setup();
 
-    let mut symlink = FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("/target"));
+    let mut symlink =
+        FileEntry::new_symlink(PathBuf::from("link"), 0o777, PathBuf::from("/target"));
     symlink.set_mtime(1_700_000_000, 0);
 
     let mut buf = Vec::new();

--- a/crates/protocol/tests/async_flist_parity.rs
+++ b/crates/protocol/tests/async_flist_parity.rs
@@ -96,8 +96,11 @@ fn build_corpus() -> Vec<FileEntry> {
     entries.push(d1);
 
     // Symlink with a target (exercises the symlink-target read leaf).
-    let mut s1 =
-        FileEntry::new_symlink(PathBuf::from("dir/sub/link"), PathBuf::from("../alpha.txt"));
+    let mut s1 = FileEntry::new_symlink(
+        PathBuf::from("dir/sub/link"),
+        0o777,
+        PathBuf::from("../alpha.txt"),
+    );
     s1.set_mtime(1_700_000_200, 0);
     entries.push(s1);
 

--- a/crates/protocol/tests/flist_stress_tests.rs
+++ b/crates/protocol/tests/flist_stress_tests.rs
@@ -79,6 +79,7 @@ fn generate_mixed_tree(num_dirs: usize, files_per_dir: usize) -> Vec<FileEntry> 
         let link_path = PathBuf::from(format!("{dir_str}/latest"));
         entries.push(FileEntry::new_symlink(
             link_path,
+            0o777,
             PathBuf::from(format!("impl_{:04}.rs", files_per_dir.saturating_sub(1))),
         ));
     }
@@ -94,6 +95,7 @@ fn generate_varied_types(count: usize) -> Vec<FileEntry> {
             1 => FileEntry::new_directory(format!("dir_{i:06}").into(), 0o755),
             2 => FileEntry::new_symlink(
                 format!("link_{i:06}").into(),
+                0o777,
                 format!("../target_{i:06}").into(),
             ),
             3 => FileEntry::new_fifo(format!("fifo_{i:06}").into(), 0o644),

--- a/crates/protocol/tests/flist_wire_flags_rp28g.rs
+++ b/crates/protocol/tests/flist_wire_flags_rp28g.rs
@@ -125,7 +125,7 @@ fn encode_fixture(protocol: ProtocolVersion) -> (Vec<u8>, [usize; 3]) {
     writer.write_entry(&mut buf, &dir).unwrap();
 
     offsets[2] = buf.len();
-    let link = FileEntry::new_symlink("link".into(), "/target/path".into());
+    let link = FileEntry::new_symlink("link".into(), 0o777, "/target/path".into());
     writer.write_entry(&mut buf, &link).unwrap();
 
     (buf, offsets)

--- a/crates/protocol/tests/golden_protocol_v28_flist.rs
+++ b/crates/protocol/tests/golden_protocol_v28_flist.rs
@@ -618,7 +618,7 @@ fn golden_v28_symlink_target_length_fixed_int() {
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
 
     let target = "/very/long/symlink/target/path";
-    let mut entry = FileEntry::new_symlink("link".into(), target.into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, target.into());
     entry.set_mtime(1_700_000_000, 0);
 
     writer.write_entry(&mut buf, &entry).unwrap();

--- a/crates/protocol/tests/golden_protocol_v28_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v28_wire.rs
@@ -235,7 +235,7 @@ fn golden_v28_symlink_entry() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(proto28()).with_preserve_links(true);
 
-    let mut entry = FileEntry::new_symlink("link".into(), "target".into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
     entry.set_mtime(1_700_000_000, 0);
 
     writer.write_entry(&mut buf, &entry).unwrap();
@@ -269,7 +269,7 @@ fn golden_v28_symlink_roundtrip() {
     let mut buf = Vec::new();
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
 
-    let entry = FileEntry::new_symlink("mylink".into(), "/usr/bin/foo".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "/usr/bin/foo".into());
 
     writer.write_entry(&mut buf, &entry).unwrap();
     writer.write_end(&mut buf, None).unwrap();
@@ -647,7 +647,7 @@ fn golden_v28_multi_entry_roundtrip() {
     let mut f2 = FileEntry::new_file("src/main.rs".into(), 2000, 0o644);
     f2.set_mtime(1_700_000_100, 0);
 
-    let s1 = FileEntry::new_symlink("latest".into(), "src/main.rs".into());
+    let s1 = FileEntry::new_symlink("latest".into(), 0o777, "src/main.rs".into());
 
     writer.write_entry(&mut buf, &f1).unwrap();
     writer.write_entry(&mut buf, &d1).unwrap();
@@ -1301,7 +1301,7 @@ fn golden_v28_mixed_all_preserves_roundtrip() {
     fifo.set_uid(1000);
     fifo.set_gid(1000);
 
-    let s1 = FileEntry::new_symlink("link".into(), "config.yml".into());
+    let s1 = FileEntry::new_symlink("link".into(), 0o777, "config.yml".into());
 
     writer.write_entry(&mut buf, &f1).unwrap();
     writer.write_entry(&mut buf, &d1).unwrap();

--- a/crates/protocol/tests/golden_protocol_v29_flist.rs
+++ b/crates/protocol/tests/golden_protocol_v29_flist.rs
@@ -155,7 +155,7 @@ fn golden_v29_symlink_entry() {
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
     let mut buf = Vec::new();
 
-    let mut entry = FileEntry::new_symlink("link".into(), "/target/path".into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, "/target/path".into());
     entry.set_mtime(1_700_000_000, 0);
 
     writer.write_entry(&mut buf, &entry).unwrap();
@@ -546,7 +546,7 @@ fn golden_v29_symlink_round_trip() {
     let mut writer = FileListWriter::new(protocol).with_preserve_links(true);
     let mut buf = Vec::new();
 
-    let mut entry = FileEntry::new_symlink("mylink".into(), "/usr/bin/target".into());
+    let mut entry = FileEntry::new_symlink("mylink".into(), 0o777, "/usr/bin/target".into());
     entry.set_mtime(1_700_000_000, 0);
 
     writer.write_entry(&mut buf, &entry).unwrap();
@@ -716,7 +716,7 @@ fn golden_v29_mixed_file_list_round_trip() {
     let mut file = FileEntry::new_file("project/main.rs".into(), 2048, 0o644);
     file.set_mtime(1_700_000_001, 0);
 
-    let mut link = FileEntry::new_symlink("project/latest".into(), "main.rs".into());
+    let mut link = FileEntry::new_symlink("project/latest".into(), 0o777, "main.rs".into());
     link.set_mtime(1_700_000_002, 0);
 
     writer.write_entry(&mut buf, &dir).unwrap();

--- a/crates/protocol/tests/golden_protocol_v29_wire.rs
+++ b/crates/protocol/tests/golden_protocol_v29_wire.rs
@@ -609,7 +609,7 @@ fn golden_v29_flist_wire_identical_to_v28() {
         let mut buf_28 = Vec::new();
         let mut buf_29 = Vec::new();
 
-        let mut entry = FileEntry::new_symlink("link".into(), "/target".into());
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, "/target".into());
         entry.set_mtime(1_700_000_000, 0);
 
         writer_28.write_entry(&mut buf_28, &entry).unwrap();
@@ -702,7 +702,7 @@ fn golden_v29_full_session_flist_and_stats() {
     file.set_uid(1000);
     file.set_gid(1000);
 
-    let mut link = FileEntry::new_symlink("src/latest".into(), "lib.rs".into());
+    let mut link = FileEntry::new_symlink("src/latest".into(), 0o777, "lib.rs".into());
     link.set_mtime(1_700_000_200, 0);
 
     writer.write_entry(&mut flist_buf, &dir).unwrap();

--- a/crates/protocol/tests/proptest_file_entry_roundtrip.rs
+++ b/crates/protocol/tests/proptest_file_entry_roundtrip.rs
@@ -287,7 +287,7 @@ proptest! {
         target in symlink_target_strategy(),
     ) {
         let protocol = ProtocolVersion::try_from(proto).unwrap();
-        let entry = FileEntry::new_symlink(name, target.clone());
+        let entry = FileEntry::new_symlink(name, 0o777, target.clone());
 
         let mut writer = FileListWriter::new(protocol)
             .with_preserve_links(true);
@@ -471,7 +471,7 @@ proptest! {
         file_entry.set_mtime(mtime, 0);
         let mut dir_entry = FileEntry::new_directory("beta".into(), perms);
         dir_entry.set_mtime(mtime, 0);
-        let symlink_entry = FileEntry::new_symlink("gamma".into(), "alpha.txt".into());
+        let symlink_entry = FileEntry::new_symlink("gamma".into(), 0o777, "alpha.txt".into());
         let mut file2_entry = FileEntry::new_file("delta.bin".into(), 1000, perms);
         file2_entry.set_mtime(mtime, 0);
 

--- a/crates/protocol/tests/symlink_target_encoding.rs
+++ b/crates/protocol/tests/symlink_target_encoding.rs
@@ -26,7 +26,7 @@ use protocol::wire::file_entry_decode::decode_symlink_target;
 
 /// Roundtrip a single symlink entry through FileListWriter/FileListReader.
 fn roundtrip_symlink(name: &str, target: PathBuf, protocol: ProtocolVersion) -> FileEntry {
-    let mut entry = FileEntry::new_symlink(PathBuf::from(name), target);
+    let mut entry = FileEntry::new_symlink(PathBuf::from(name), 0o777, target);
     entry.set_mtime(1700000000, 0);
 
     let mut buf = Vec::new();
@@ -62,7 +62,7 @@ fn roundtrip_entries(entries: &[FileEntry], protocol: ProtocolVersion) -> Vec<Fi
 
 /// Creates a symlink FileEntry with the given name and target path.
 fn make_symlink(name: &str, target: &str) -> FileEntry {
-    let mut entry = FileEntry::new_symlink(PathBuf::from(name), PathBuf::from(target));
+    let mut entry = FileEntry::new_symlink(PathBuf::from(name), 0o777, PathBuf::from(target));
     entry.set_mtime(1700000000, 0);
     entry
 }
@@ -73,7 +73,7 @@ fn make_symlink_from_bytes(name: &str, target_bytes: &[u8]) -> FileEntry {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;
     let target = PathBuf::from(OsStr::from_bytes(target_bytes));
-    let mut entry = FileEntry::new_symlink(PathBuf::from(name), target);
+    let mut entry = FileEntry::new_symlink(PathBuf::from(name), 0o777, target);
     entry.set_mtime(1700000000, 0);
     entry
 }
@@ -866,9 +866,39 @@ fn wire_format_encode_decode_consistency() {
 fn flist_symlink_mode_preserved() {
     let decoded = roundtrip_symlink("link", PathBuf::from("/target"), ProtocolVersion::NEWEST);
 
-    // Symlinks always have mode 0o120777 (S_IFLNK | 0o777)
+    // The fixture pins 0o777, the mode Linux gives every link.
     assert_eq!(decoded.mode() & 0o170000, 0o120000, "S_IFLNK must be set");
     assert_eq!(decoded.mode() & 0o7777, 0o777, "permissions must be 0o777");
+}
+
+/// A symlink's permission bits are not universally 0o777: on the platforms
+/// where `CAN_CHMOD_SYMLINK` holds (rsync.h:455-456 - `HAVE_LCHMOD ||
+/// HAVE_SETATTRLIST`, i.e. macOS and the BSDs) `lchmod` gives a link a real
+/// mode, which upstream sends verbatim (flist.c:1669). Pin that the wire
+/// encoding carries such a mode instead of flattening it.
+#[test]
+fn flist_symlink_non_0777_mode_preserved() {
+    let mut entry = FileEntry::new_symlink(PathBuf::from("link"), 0o700, PathBuf::from("/target"));
+    entry.set_mtime(1700000000, 0);
+
+    let mut buf = Vec::new();
+    let mut writer = FileListWriter::new(ProtocolVersion::NEWEST).with_preserve_links(true);
+    writer.write_entry(&mut buf, &entry).expect("write failed");
+    writer.write_end(&mut buf, None).expect("write end failed");
+
+    let mut cursor = Cursor::new(&buf);
+    let mut reader = FileListReader::new(ProtocolVersion::NEWEST).with_preserve_links(true);
+    let decoded = reader
+        .read_entry(&mut cursor)
+        .expect("read failed")
+        .expect("entry expected");
+
+    assert_eq!(decoded.mode() & 0o170000, 0o120000, "S_IFLNK must be set");
+    assert_eq!(
+        decoded.mode() & 0o7777,
+        0o700,
+        "a 0o700 symlink mode must survive the wire round-trip",
+    );
 }
 
 /// Tests that symlink entries have zero file size.

--- a/crates/protocol/tests/unicode_wire_format.rs
+++ b/crates/protocol/tests/unicode_wire_format.rs
@@ -74,7 +74,7 @@ fn test_dir(name: &str) -> FileEntry {
 
 /// Creates a test symlink entry with the given name and target.
 fn test_symlink(name: &str, target: &str) -> FileEntry {
-    let mut entry = FileEntry::new_symlink(PathBuf::from(name), PathBuf::from(target));
+    let mut entry = FileEntry::new_symlink(PathBuf::from(name), 0o777, PathBuf::from(target));
     entry.set_mtime(1700000000, 0);
     entry
 }

--- a/crates/transfer/src/generator/file_list/entry/create.rs
+++ b/crates/transfer/src/generator/file_list/entry/create.rs
@@ -208,11 +208,26 @@ impl GeneratorContext {
             // re-applies the prefix when the link is materialized on disk.
             let target = strip_symlink_munge_prefix(self.config.munge_symlinks, raw_target);
 
+            // upstream: flist.c:1669 - `file->mode = st.st_mode` runs verbatim
+            // for every type, symlinks included; there is no symlink special
+            // case at the flist layer. On Linux a link's permission bits are
+            // pinned to 0o777 by the kernel so this reads back as 0o777 anyway,
+            // but on the platforms where `CAN_CHMOD_SYMLINK` holds
+            // (rsync.h:455-456: `HAVE_LCHMOD || HAVE_SETATTRLIST`, i.e. macOS
+            // and the BSDs) a link carries a real, settable mode that the
+            // receiver's `-p` apply must be able to reproduce.
+            #[cfg(unix)]
+            let link_mode = metadata.mode() & 0o7777;
+            // No settable symlink mode exists on Windows; keep the historical
+            // 0o777 so the wire value stays stable there.
+            #[cfg(not(unix))]
+            let link_mode = 0o777;
+
             // upstream: flist.c:1501 - symlinks carry `st_size`, which lstat
             // reports as the byte length of the link target. The receiver gets
             // the target separately, so this length is purely the size shown by
             // `--list-only`/`%l` and summed into the `--stats` total.
-            let mut entry = FileEntry::new_symlink(relative_path, target);
+            let mut entry = FileEntry::new_symlink(relative_path, link_mode, target);
             entry.set_size(metadata.len());
             entry
         } else {
@@ -1175,6 +1190,153 @@ mod munge_symlinks_tests {
             "without `munge symlinks`, the prefix is part of the target and \
              must round-trip verbatim",
         );
+    }
+}
+
+#[cfg(all(test, unix))]
+mod symlink_mode_tests {
+    //! Sender-side symlink mode fidelity.
+    //!
+    //! upstream: flist.c:1669 - `file->mode = st.st_mode` is one assignment
+    //! covering every file type; there is no symlink special case at the flist
+    //! layer. Whether that mode carries information is a platform property:
+    //! rsync.h:455-456 defines `CAN_CHMOD_SYMLINK` when
+    //! `HAVE_LCHMOD || HAVE_SETATTRLIST` (configure.ac:942,950), which holds on
+    //! macOS and the BSDs. On Linux the kernel pins a link's permission bits to
+    //! 0o777, so forwarding the stat mode is value-identical there; the
+    //! invariant "the entry's mode is the lstat mode" is what both platforms
+    //! share, and it is what these tests assert.
+
+    use crate::config::ServerConfig;
+    use crate::generator::GeneratorContext;
+    use crate::handshake::HandshakeResult;
+    use crate::role::ServerRole;
+    use protocol::ProtocolVersion;
+    use std::ffi::OsString;
+    use std::os::unix::fs::{MetadataExt, symlink};
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn generator() -> GeneratorContext {
+        let handshake = HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        };
+        let config = ServerConfig {
+            role: ServerRole::Generator,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            flag_string: "-logDtpre.".to_owned(),
+            args: vec![OsString::from(".")],
+            ..Default::default()
+        };
+        GeneratorContext::new_for_test(&handshake, config)
+    }
+
+    /// Builds the flist entry for `link` and returns
+    /// `(entry permission bits, on-disk lstat permission bits)`.
+    fn entry_and_disk_perms(link: &std::path::Path) -> (u32, u32) {
+        let meta = std::fs::symlink_metadata(link).expect("lstat");
+        let disk = meta.mode() & 0o7777;
+        let entry = generator()
+            .create_entry(
+                link,
+                PathBuf::from("link"),
+                &fast_io::pinned_root::SourceMetadata::from(meta),
+            )
+            .expect("create_entry");
+        assert!(entry.is_symlink(), "the fixture must route through S_IFLNK");
+        (entry.permissions() & 0o7777, disk)
+    }
+
+    #[test]
+    fn symlink_entry_mode_is_the_lstat_mode() {
+        // The platform-neutral half: whatever lstat reports for the link is
+        // what the flist entry must carry. On Linux both sides are 0o777; on
+        // macOS/BSD `chmod_symlink` below moves them together off 0o777.
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("link");
+        symlink("target", &link).expect("symlink");
+
+        let (entry_perms, disk_perms) = entry_and_disk_perms(&link);
+        assert_eq!(
+            entry_perms, disk_perms,
+            "upstream flist.c:1669 assigns st_mode verbatim for symlinks too",
+        );
+    }
+
+    /// Sets a symlink's own mode, returning false when the platform has no
+    /// settable symlink mode (`CAN_CHMOD_SYMLINK` unset, e.g. Linux).
+    ///
+    /// `chmod -h` is the shell spelling of `lchmod`; going through the tool
+    /// keeps this crate free of `unsafe` (`generator/mod.rs` is
+    /// `#![deny(unsafe_code)]`).
+    fn chmod_symlink(link: &std::path::Path, mode: u32) -> bool {
+        if !cfg!(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "netbsd",
+        )) {
+            return false;
+        }
+        let status = std::process::Command::new("/bin/chmod")
+            .arg("-h")
+            .arg(format!("{mode:o}"))
+            .arg(link)
+            .status()
+            .expect("spawn chmod");
+        assert!(
+            status.success(),
+            "chmod -h must succeed where CAN_CHMOD_SYMLINK holds: {status}",
+        );
+        true
+    }
+
+    #[test]
+    fn a_non_0777_symlink_mode_reaches_the_flist_entry() {
+        // The behaviour-moving half. On a CAN_CHMOD_SYMLINK platform a link
+        // carries a real mode; hardcoding 0o777 in the constructor loses it.
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("link");
+        symlink("target", &link).expect("symlink");
+        if !chmod_symlink(&link, 0o700) {
+            // Linux: no settable symlink mode exists, so there is no non-0o777
+            // input to lose. The lstat-equality test above still covers it.
+            return;
+        }
+
+        let (entry_perms, disk_perms) = entry_and_disk_perms(&link);
+        // Non-vacuity: the fixture only discriminates if lchmod actually moved
+        // the on-disk mode off 0o777.
+        assert_eq!(
+            disk_perms, 0o700,
+            "the fixture link must really be 0o700 on disk",
+        );
+        assert_eq!(
+            entry_perms, 0o700,
+            "a 0o700 symlink must not be flattened to 0o777 on the wire",
+        );
+    }
+
+    #[test]
+    fn a_genuinely_0777_symlink_stays_0777() {
+        // Non-vacuity control for the pair above: forwarding the stat mode must
+        // not perturb the case the old hardcoded constant happened to get
+        // right, on either platform.
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("link");
+        symlink("target", &link).expect("symlink");
+        chmod_symlink(&link, 0o777);
+
+        let (entry_perms, disk_perms) = entry_and_disk_perms(&link);
+        assert_eq!(disk_perms, 0o777, "the control fixture must be 0o777");
+        assert_eq!(entry_perms, 0o777, "a 0o777 symlink must stay 0o777");
     }
 }
 

--- a/crates/transfer/src/generator/file_list/entry/fake_super.rs
+++ b/crates/transfer/src/generator/file_list/entry/fake_super.rs
@@ -42,7 +42,7 @@ pub(super) fn build_entry_from_fake_super(
             // upstream: fake-super symlinks stash the target separately;
             // when the xattr alone is the source of truth, we emit an empty
             // target to match the placeholder content.
-            FileEntry::new_symlink(relative_path, PathBuf::new())
+            FileEntry::new_symlink(relative_path, perm_bits, PathBuf::new())
         }
         Some(FileType::BlockDevice) => {
             FileEntry::new_block_device(relative_path, perm_bits, rdev_major, rdev_minor)
@@ -158,6 +158,31 @@ mod fake_super_tests {
         };
         let entry = build_entry_from_fake_super(PathBuf::from("link"), 0, &stat);
         assert_eq!(entry.file_type(), FileType::Symlink);
+        // Non-vacuity control for the test below: a genuinely 0o777 xattr mode
+        // must still read back as 0o777.
+        assert_eq!(entry.permissions() & 0o7777, 0o777);
+    }
+
+    #[test]
+    fn build_from_fake_super_symlink_keeps_the_xattr_permission_bits() {
+        // upstream: xattrs.c:1172 `from_wire_mode()` - the stashed mode
+        // replaces st_mode wholesale, permission bits included. The symlink arm
+        // has the same `perm_bits` in hand as every sibling arm and must not
+        // substitute a constant for it.
+        let stat = FakeSuperStat {
+            mode: 0o120700,
+            uid: 1000,
+            gid: 1000,
+            rdev: None,
+        };
+        let entry = build_entry_from_fake_super(PathBuf::from("link"), 0, &stat);
+        assert_eq!(entry.file_type(), FileType::Symlink);
+        assert_eq!(
+            entry.permissions() & 0o7777,
+            0o700,
+            "the fake-super symlink arm must forward the xattr's permission \
+             bits, not a hardcoded 0o777",
+        );
     }
 
     #[test]

--- a/crates/transfer/src/generator/file_list/iconv.rs
+++ b/crates/transfer/src/generator/file_list/iconv.rs
@@ -161,7 +161,7 @@ mod drop_decision_tests {
     #[test]
     fn symlink_with_unconvertible_target_dropped_when_negotiated() {
         let conv = latin1_converter();
-        let entry = FileEntry::new_symlink("link".into(), "あ".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "あ".into());
         assert!(!GeneratorContext::entry_is_convertible(&conv, true, &entry));
     }
 
@@ -172,7 +172,7 @@ mod drop_decision_tests {
     #[test]
     fn symlink_with_unconvertible_target_kept_when_not_negotiated() {
         let conv = latin1_converter();
-        let entry = FileEntry::new_symlink("link".into(), "あ".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "あ".into());
         assert!(GeneratorContext::entry_is_convertible(&conv, false, &entry));
     }
 
@@ -191,7 +191,7 @@ mod drop_decision_tests {
     #[test]
     fn convertible_symlink_survives_with_gate_on() {
         let conv = latin1_converter();
-        let entry = FileEntry::new_symlink("link".into(), "sub/target".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "sub/target".into());
         assert!(GeneratorContext::entry_is_convertible(&conv, true, &entry));
     }
 }

--- a/crates/transfer/src/generator/itemize.rs
+++ b/crates/transfer/src/generator/itemize.rs
@@ -352,7 +352,7 @@ mod tests {
     }
 
     fn make_symlink_entry(name: &str) -> FileEntry {
-        FileEntry::new_symlink(PathBuf::from(name), PathBuf::from("target"))
+        FileEntry::new_symlink(PathBuf::from(name), 0o777, PathBuf::from("target"))
     }
 
     /// Default context: preserve_mtimes=true, receiver_symlink_times=true.

--- a/crates/transfer/src/generator/stats.rs
+++ b/crates/transfer/src/generator/stats.rs
@@ -247,7 +247,7 @@ mod tests {
         s.record(&FileEntry::new_directory(PathBuf::from("d"), 0o755));
         // The wire flist stores a symlink's size as its target string length;
         // set it explicitly so the test reflects the on-wire entry.
-        let mut link = FileEntry::new_symlink(PathBuf::from("l"), PathBuf::from("abc"));
+        let mut link = FileEntry::new_symlink(PathBuf::from("l"), 0o777, PathBuf::from("abc"));
         link.set_size(3);
         s.record(&link);
         s.record(&FileEntry::new_fifo(PathBuf::from("f"), 0o644));

--- a/crates/transfer/src/generator/tests.rs
+++ b/crates/transfer/src/generator/tests.rs
@@ -6672,7 +6672,7 @@ fn server_sender_symlink_time_glyph(
             | super::item_flags::ItemFlags::ITEM_REPORT_TIME,
     );
     let entry =
-        protocol::flist::FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("dst"));
+        protocol::flist::FileEntry::new_symlink(PathBuf::from("link"), 0o777, PathBuf::from("dst"));
     let row = super::itemize::format_iflags(&iflags, &entry, true, &ctx.itemize_context());
     // "<L..t......" - position 4 is the time glyph.
     row.chars().nth(4).unwrap()

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -1209,7 +1209,8 @@ mod tests {
         // Sender's view: same target, but an mtime far from the freshly created
         // on-disk link (which carries ~now). Same target routes through the
         // up-to-date branch; the differing mtime is the only change.
-        let mut entry = FileEntry::new_symlink(PathBuf::from("link"), PathBuf::from("target"));
+        let mut entry =
+            FileEntry::new_symlink(PathBuf::from("link"), 0o777, PathBuf::from("target"));
         entry.set_mtime(1_000_000_000, 0);
 
         // -t without -J: keep_time is true, so the mtime difference lights `t`.

--- a/crates/transfer/src/receiver/ndx_stream/tests.rs
+++ b/crates/transfer/src/receiver/ndx_stream/tests.rs
@@ -530,6 +530,7 @@ fn receiver_with_symlink_then_file() -> ReceiverContext {
     let mut ctx = inc_recurse_receiver(&["d0"]);
     ctx.file_list.push(FileEntry::new_symlink(
         PathBuf::from("link"),
+        0o777,
         PathBuf::from("target"),
     ));
     ctx.file_list

--- a/crates/transfer/src/receiver/quick_check.rs
+++ b/crates/transfer/src/receiver/quick_check.rs
@@ -1850,7 +1850,7 @@ mod update_type_guard_tests {
         symlink(&target, &dest).expect("create dest symlink");
 
         // Source is also a symlink -> same type, guard matches.
-        let sym_entry = FileEntry::new_symlink("item".into(), target.clone());
+        let sym_entry = FileEntry::new_symlink("item".into(), 0o777, target.clone());
         assert!(
             dest_type_matches_source(&dest, &sym_entry),
             "symlink dest vs symlink source must match (lstat, not followed)"
@@ -2453,7 +2453,7 @@ mod non_regular_alt_dest_tests {
     fn compare_dest_identical_symlink_skips_creation() {
         let (_tmp, basis, dest) = dirs();
         symlink("target", basis.join("link")).expect("basis symlink");
-        let entry = FileEntry::new_symlink("link".into(), "target".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
 
         let handled = try_reference_dest_non(
             &entry,
@@ -2481,7 +2481,7 @@ mod non_regular_alt_dest_tests {
     fn copy_dest_identical_symlink_is_not_handled() {
         let (_tmp, basis, dest) = dirs();
         symlink("target", basis.join("link")).expect("basis symlink");
-        let entry = FileEntry::new_symlink("link".into(), "target".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
 
         let handled = try_reference_dest_non(
             &entry,
@@ -2509,7 +2509,7 @@ mod non_regular_alt_dest_tests {
         let (_tmp, basis, dest) = dirs();
         let basis_link = basis.join("link");
         symlink("target", &basis_link).expect("basis symlink");
-        let entry = FileEntry::new_symlink("link".into(), "target".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
 
         let handled = try_reference_dest_non(
             &entry,
@@ -2575,7 +2575,7 @@ mod non_regular_alt_dest_tests {
         let (_tmp, basis, dest) = dirs();
         symlink("OTHER", basis.join("link")).expect("basis symlink");
         // The source link points elsewhere than the basis link.
-        let entry = FileEntry::new_symlink("link".into(), "target".into());
+        let entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
 
         let handled = try_reference_dest_non(
             &entry,
@@ -2638,7 +2638,7 @@ mod non_regular_alt_dest_tests {
         )
         .expect("set basis symlink times");
 
-        let mut entry = FileEntry::new_symlink("link".into(), "target".into());
+        let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target".into());
         entry.set_mtime(1_700_000_000, 0);
 
         let opts = MetadataOptions::new().preserve_times(true);

--- a/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
+++ b/crates/transfer/src/receiver/tests/file_list/incremental_receiver.rs
@@ -325,7 +325,7 @@ fn try_read_one_reads_symlink_entry() {
     let mut writer = protocol::flist::FileListWriter::new(protocol);
     writer = writer.with_preserve_links(true);
 
-    let symlink = FileEntry::new_symlink("link.txt".into(), "/target".into());
+    let symlink = FileEntry::new_symlink("link.txt".into(), 0o777, "/target".into());
     writer.write_entry(&mut data, &symlink).unwrap();
     writer.write_end(&mut data, None).unwrap();
 

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -88,6 +88,7 @@ fn receiver_prepends_munge_prefix_to_on_disk_symlink() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, munge_receiver_config());
     ctx.file_list = vec![FileEntry::new_symlink(
         "escape".into(),
+        0o777,
         "/etc/passwd".into(),
     )];
 
@@ -154,6 +155,7 @@ fn create_symlinks_surfaces_non_eacces_error() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
     ctx.file_list = vec![FileEntry::new_symlink(
         "blocked/link".into(),
+        0o777,
         "/etc/passwd".into(),
     )];
 
@@ -225,7 +227,7 @@ fn receiver_preserves_symlink_mtime_on_creation() {
     // exact and the test never races against the wall clock the way the
     // pre-fix receiver did.
     const SOURCE_MTIME_SECS: i64 = 7_200;
-    let mut entry = FileEntry::new_symlink("nolf-symlink".into(), "nolf".into());
+    let mut entry = FileEntry::new_symlink("nolf-symlink".into(), 0o777, "nolf".into());
     entry.set_mtime(SOURCE_MTIME_SECS, 0);
     ctx.file_list = vec![entry];
 
@@ -256,6 +258,7 @@ fn receiver_writes_unmunged_target_when_disabled() {
     let mut ctx = ReceiverContext::new_for_test(&handshake, plain_receiver_config());
     ctx.file_list = vec![FileEntry::new_symlink(
         "escape".into(),
+        0o777,
         "/etc/passwd".into(),
     )];
 

--- a/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
+++ b/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
@@ -118,7 +118,11 @@ fn create_one_symlink_at(
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_symlink(entry_path.into(), target.into())];
+    ctx.file_list = vec![FileEntry::new_symlink(
+        entry_path.into(),
+        0o777,
+        target.into(),
+    )];
 
     let mut writer = NullMsgInfoWriter;
     ctx.create_symlinks(&dest, None, &mut writer)
@@ -203,7 +207,7 @@ fn a_non_utf8_target_is_sanitized_byte_exactly() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, daemon_receiver_without_munging());
-    ctx.file_list = vec![FileEntry::new_symlink("escape".into(), target)];
+    ctx.file_list = vec![FileEntry::new_symlink("escape".into(), 0o777, target)];
 
     let mut writer = NullMsgInfoWriter;
     ctx.create_symlinks(&dest, None, &mut writer)

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -272,7 +272,7 @@ fn out_format_collects_symlink() {
     let ctx = ReceiverContext::new_for_test(&handshake, config);
     let mut writer = MockMsgInfoWriter::new();
 
-    let entry = FileEntry::new_symlink("mylink".into(), "target".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "target".into());
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     ctx.emit_or_record_itemize(&mut writer, 5, &iflags, &entry)
@@ -429,7 +429,7 @@ fn default_i_symlink_defers_into_flist_order_on_pull() {
     ctx.defer_itemize = true;
     let mut writer = MockMsgInfoWriter::new();
 
-    let entry = FileEntry::new_symlink("blink".into(), "afile.txt".into());
+    let entry = FileEntry::new_symlink("blink".into(), 0o777, "afile.txt".into());
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     ctx.emit_or_record_itemize(&mut writer, 7, &iflags, &entry)
@@ -473,7 +473,7 @@ fn render_itemize_symlink_with_target() {
     let config = receiver_config_with_itemize();
     let ctx = ReceiverContext::new_for_test(&handshake, config);
 
-    let entry = FileEntry::new_symlink("mylink".into(), "target".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "target".into());
     let iflags = ItemFlags::from_raw(ItemFlags::ITEM_LOCAL_CHANGE | ItemFlags::ITEM_IS_NEW);
 
     assert_eq!(
@@ -552,7 +552,11 @@ fn receiver_backs_up_existing_symlink_before_replacing() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, config);
-    ctx.file_list = vec![FileEntry::new_symlink("mylink".into(), "new-target".into())];
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "mylink".into(),
+        0o777,
+        "new-target".into(),
+    )];
 
     let mut writer = MockMsgInfoWriter::new();
     ctx.create_symlinks(dest, None, &mut writer)
@@ -607,7 +611,7 @@ fn replaced_symlink_itemizes_as_change_not_create() {
     std::os::unix::fs::symlink("old-target", dest.join("mylink")).expect("seed old symlink");
     let old_meta = std::fs::symlink_metadata(dest.join("mylink")).expect("lstat old symlink");
 
-    let mut entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    let mut entry = FileEntry::new_symlink("mylink".into(), 0o777, "new-target".into());
     // Same whole second as the on-disk link: `t` must stay dark (same_time()
     // compares whole seconds at modify_window 0, util1.c:1478).
     entry.set_mtime(old_meta.mtime(), 0);
@@ -648,7 +652,7 @@ fn absent_symlink_still_itemizes_as_all_new() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let dest = tmp.path();
 
-    let entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "new-target".into());
     let ctx = repointed_symlink_ctx(vec![entry]);
 
     let mut writer = MockMsgInfoWriter::new();
@@ -676,7 +680,7 @@ fn non_symlink_obstacle_replacement_itemizes_as_all_new() {
     let dest = tmp.path();
     std::fs::write(dest.join("mylink"), b"obstacle").expect("seed obstacle file");
 
-    let entry = FileEntry::new_symlink("mylink".into(), "new-target".into());
+    let entry = FileEntry::new_symlink("mylink".into(), 0o777, "new-target".into());
     let ctx = repointed_symlink_ctx(vec![entry]);
 
     let mut writer = MockMsgInfoWriter::new();

--- a/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/windows_receiver_symlinks.rs
@@ -82,7 +82,11 @@ fn windows_receiver_symlink_materializes_directory() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, links_receiver_config());
-    ctx.file_list = vec![FileEntry::new_symlink("link".into(), target_dir.clone())];
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "link".into(),
+        0o777,
+        target_dir.clone(),
+    )];
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_symlinks(dest, &mut writer)
@@ -120,7 +124,11 @@ fn windows_receiver_symlink_skips_file_on_privilege_refusal() {
 
     let handshake = test_handshake();
     let mut ctx = ReceiverContext::new_for_test(&handshake, links_receiver_config());
-    ctx.file_list = vec![FileEntry::new_symlink("flink".into(), target_file.clone())];
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "flink".into(),
+        0o777,
+        target_file.clone(),
+    )];
 
     let mut writer = CapturingMsgInfoWriter;
     ctx.create_symlinks(dest, &mut writer)

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -2354,7 +2354,7 @@ mod itemize_order_tests {
         ctx.file_list = vec![
             FileEntry::new_directory("d".into(), 0o755),  // idx 0
             FileEntry::new_file("d/f1".into(), 5, 0o644), // idx 1
-            FileEntry::new_symlink("d/lnk".into(), "target".into()), // idx 2
+            FileEntry::new_symlink("d/lnk".into(), 0o777, "target".into()), // idx 2
         ];
 
         // Read-only pass against an empty destination: every entry is new.
@@ -2512,7 +2512,7 @@ mod itemize_order_tests {
         config.flags.times = true;
         let mut ctx = ReceiverContext::new_for_test(&hs, config);
         ctx.defer_itemize = true;
-        let mut entry = FileEntry::new_symlink("lnk".into(), "newtgt".into());
+        let mut entry = FileEntry::new_symlink("lnk".into(), 0o777, "newtgt".into());
         {
             use std::os::unix::fs::MetadataExt;
             let old_meta = std::fs::symlink_metadata(dest.join("lnk")).expect("lstat");

--- a/crates/transfer/src/transfer_ops/mod.rs
+++ b/crates/transfer/src/transfer_ops/mod.rs
@@ -968,6 +968,7 @@ mod tests {
             FileEntry::new_file(std::path::PathBuf::from("a.txt"), 0, 0o100644),
             FileEntry::new_symlink(
                 std::path::PathBuf::from("link"),
+                0o777,
                 std::path::PathBuf::from("a.txt"),
             ),
         ]);

--- a/fuzz/fuzz_targets/differential_flist.rs
+++ b/fuzz/fuzz_targets/differential_flist.rs
@@ -159,7 +159,7 @@ fn build_entry(fields: &EntryFields) -> Option<FileEntry> {
         FileTypeSelector::Directory => FileEntry::new_directory(path, permissions),
         FileTypeSelector::Symlink => {
             let target = sanitise_target(&fields.symlink_target_bytes)?;
-            FileEntry::new_symlink(path, PathBuf::from(target))
+            FileEntry::new_symlink(path, 0o777, PathBuf::from(target))
         }
     };
 


### PR DESCRIPTION
## What

`FileEntry::new_symlink` hardcoded `0o777` and took **no** permissions parameter, so the source link's real mode could not reach the wire even in principle — the constructor's signature made it unrepresentable.

Upstream stores the stat mode verbatim for *every* file type, symlinks included (`flist.c:1669`, `file->mode = st.st_mode`). There is no symlink special case there.

## Why the constant was wrong rather than merely redundant

A symlink's permission bits are **not** universally `0o777`. Whether they carry a meaningful value is a platform property, and upstream names it: `CAN_CHMOD_SYMLINK` is defined when `HAVE_LCHMOD || HAVE_SETATTRLIST` (`rsync.h:455-456`, `configure.ac:942,950`) — macOS and the BSDs. On Linux the kernel pins a link's `st_mode` to `0o777`, so forwarding the stat mode is **value-identical** there and the change is observable only on the platforms that can express it.

That asymmetry is why the old comment ("Symlinks always have 0o777 permissions per POSIX convention") was a plausible-sounding statement that happens to be false on half the supported platforms. It is replaced with the platform rule and its citations.

## Shape

`new_symlink(name, permissions, target)` — the mode becomes a parameter, so each caller has to answer where its mode comes from:

- **Three real call sites forward the stat mode.** The primary one is `crates/transfer/src/generator/file_list/entry/create.rs`, which now takes `metadata.mode() & 0o7777` on unix. Windows keeps the historical `0o777` behind `#[cfg(not(unix))]` with a comment saying why — there is no settable symlink mode there, so the wire value stays stable.
- **One deliberate literal is kept**: the `delete/plan.rs` sort-key entry is synthesized with no underlying stat, so it has no real mode to forward. That is the one case the new doc comment explicitly sanctions.
- **89 test fixtures keep their literals** — they construct entries without a filesystem behind them.

## Gates (pinned toolchain 1.88.0)

| Gate | Result |
|---|---|
| `tools/ci/check_rustfmt_all.py` | exit 0, 3427 files |
| `clippy -p protocol -p transfer -p engine -p metadata -p batch --all-targets --all-features` | clean |
| `nextest` (same five crates, `--no-fail-fast`) | 14742 run / 14740 passed / 2 failed |

**The 2 failures are inherited, and that is measured rather than asserted.** `execute_with_sparse_enabled_creates_holes` and `execute_sparse_with_multiple_hole_patterns` fail identically on **pristine current master** in isolation:

```
master 9abc1c133:  sparse: 8192, dense: 5912   (2 run, 0 passed, 2 failed)
this branch:       sparse: 8192, dense: 5616   (same two tests, same assertion)
```

Both assert that a sparse copy allocates *fewer* blocks than a dense one; on this APFS volume it allocates more. The small dense delta is filesystem variance between runs, not a behaviour difference. This diff touches symlink permissions and cannot reach sparse block accounting.

⚠ Note these fail **in isolation too**, so they are not the "passes alone, fails under parallelism" APFS flake class — worth a separate row rather than filing under the existing one.

## Base

Rebased onto current master (`9abc1c133`). The commit's own diff is 41 files +399/-90 and the three-dot diff against master is **the same 41 files +399/-90**, so the rebase reverts nothing that landed in between.

Touches no expect-manifest, so no derived-tally skew is armed.
