### PR TITLE
fix(engine): feed a replaced obstacle's lstat to the local symlink dest_mode()

### DIFF
--- a/crates/engine/src/local_copy/executor/special/symlink.rs
+++ b/crates/engine/src/local_copy/executor/special/symlink.rs
@@ -24,7 +24,10 @@ use crate::local_copy::{
     follow_symlink_metadata, map_metadata_error, overrides::create_hard_link,
     remove_source_entry_if_requested,
 };
-use ::metadata::{MetadataOptions, apply_symlink_metadata_with_options};
+use ::metadata::{
+    MetadataOptions, apply_symlink_metadata_with_options,
+    apply_symlink_metadata_with_options_and_pre_transfer,
+};
 
 use super::super::{is_device, is_fifo};
 use super::{device::copy_device, fifo::copy_fifo, try_hard_link_basis};
@@ -469,6 +472,18 @@ pub(crate) fn copy_symlink(
         .filter(|existing| existing.file_type().is_symlink())
         .cloned();
 
+    // upstream: generator.c:1938 - `exists = statret == 0 && stype != FT_DIR`,
+    // measured on the `sx.st` lstat taken BEFORE atomic_create()
+    // (generator.c:2002) removes the obstacle. dest_mode()'s `exists` arm
+    // (rsync.c:470-471) keeps that OLD stat's permission bits, so the obstacle
+    // lstat must be captured here, ahead of the backup/removal below - the
+    // fresh link's own stat only carries the umask default `symlink(2)` left.
+    // Unlike `pre_replace_symlink_metadata` above (kept symlink-only so the
+    // itemize renders a non-symlink replacement as ITEM_IS_NEW), this keeps
+    // ANY remaining obstacle: a directory obstacle was already collapsed to
+    // `None` when it was cleared, exactly the `stype != FT_DIR` exclusion.
+    let pre_transfer_metadata = destination_metadata.clone();
+
     if !mode.is_dry_run()
         && let Some(existing) = destination_metadata.take()
     {
@@ -746,13 +761,20 @@ pub(crate) fn copy_symlink(
     // `file->mode = dest_mode(file->mode, sx.st.st_mode, dflt_perms, exists)`
     // for every type, symlinks included (the rewrite sits above the
     // `preserve_links && ftype == FT_SYMLINK` branch at generator.c:1948).
-    // `exists` is `statret == 0 && stype != FT_DIR`, i.e. whether the
-    // destination was there BEFORE this transfer - so the freshly created link
-    // must take the new-file arm and be chmod'd to `source & dflt_perms`
-    // instead of keeping the umask default `symlink(2)` gave it.
-    let symlink_options = symlink_options.with_destination_is_new(!destination_previously_existed);
-    apply_symlink_metadata_with_options(destination, metadata, &symlink_options)
-        .map_err(map_metadata_error)?;
+    // `exists` is `statret == 0 && stype != FT_DIR`, i.e. whether a
+    // NON-DIRECTORY destination was there BEFORE this transfer - a fresh link
+    // and one that replaced a directory obstacle both take the new-file arm
+    // and are chmod'd to `source & dflt_perms` instead of keeping the umask
+    // default `symlink(2)` gave it, while one that replaced any other obstacle
+    // keeps the OBSTACLE's old bits via `pre_transfer_metadata`.
+    let symlink_options = symlink_options.with_destination_is_new(pre_transfer_metadata.is_none());
+    apply_symlink_metadata_with_options_and_pre_transfer(
+        destination,
+        metadata,
+        &symlink_options,
+        pre_transfer_metadata.as_ref(),
+    )
+    .map_err(map_metadata_error)?;
 
     #[cfg(all(unix, feature = "xattr"))]
     sync_xattrs_if_requested(

--- a/crates/engine/src/local_copy/tests/execute_symlinks.rs
+++ b/crates/engine/src/local_copy/tests/execute_symlinks.rs
@@ -1649,3 +1649,151 @@ fn execute_existing_symlink_without_perms_keeps_its_own_mode() {
          must not reach it"
     );
 }
+
+/// Shared driver for the obstacle-replacement pins below: sync a source link
+/// (mode `src_mode`) over whatever `seed_obstacle` planted at `dst/link`, with
+/// or without `-p`, and return the landed link's permission bits.
+#[cfg(target_os = "macos")]
+fn landed_symlink_mode_over_obstacle(
+    src_mode: u32,
+    perms: bool,
+    seed_obstacle: impl FnOnce(&std::path::Path),
+) -> (u32, u32) {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let temp = tempdir().expect("tempdir");
+    let src_dir = temp.path().join("src");
+    let dst_dir = temp.path().join("dst");
+    fs::create_dir_all(&src_dir).expect("mkdir src");
+    fs::create_dir_all(&dst_dir).expect("mkdir dst");
+    fs::write(src_dir.join("target.txt"), b"data").expect("write target");
+    let src_link = src_dir.join("link");
+    symlink("target.txt", &src_link).expect("create src link");
+    fast_io::secure_chmod_at(&src_link, src_mode, false).expect("seed src link mode");
+
+    seed_obstacle(&dst_dir.join("link"));
+
+    let operands = vec![
+        src_dir.join("").into_os_string(),
+        dst_dir.clone().into_os_string(),
+    ];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+    let options = LocalCopyOptions::default()
+        .recursive(true)
+        .links(true)
+        .permissions(perms);
+    plan.execute_with_options(LocalCopyExecution::Apply, options)
+        .expect("copy succeeds");
+
+    let dest_link = dst_dir.join("link");
+    assert!(
+        fs::symlink_metadata(&dest_link)
+            .expect("dest link metadata")
+            .file_type()
+            .is_symlink(),
+        "the obstacle must have been replaced by the link"
+    );
+    let got = fs::symlink_metadata(&dest_link)
+        .expect("dest link metadata")
+        .permissions()
+        .mode()
+        & 0o7777;
+
+    // upstream's `dflt_perms` = `ACCESSPERMS & ~orig_umask` (generator.c:2770),
+    // recovered from the OS via mkdir(2) exactly as the fresh-dest test above.
+    let probe = temp.path().join("umask-probe");
+    fs::create_dir(&probe).expect("mkdir probe");
+    let dflt = fs::metadata(&probe)
+        .expect("probe metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    (got, dflt)
+}
+
+/// The formerly-diverging cell of the obstacle matrix: dest holds a REGULAR
+/// FILE (0o600), source is a symlink (0o711), `-rl` and no `-p`.
+///
+/// upstream: generator.c:1938 - `exists = statret == 0 && stype != FT_DIR` on
+/// the lstat taken BEFORE `atomic_create` (generator.c:2002) removes the
+/// obstacle, so `dest_mode()`'s exists arm (rsync.c:470-471) keeps the
+/// OBSTACLE's 0o600. Reading the fresh link's own stat instead lands the
+/// umask default `symlink(2)` produced (0o755 under 022) - the divergence this
+/// pins shut. Only meaningful where `CAN_CHMOD_SYMLINK` holds; on Linux a
+/// link's mode is a fixed 0o777 and the arm is inert.
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_symlink_over_regular_file_obstacle_without_perms_keeps_the_obstacles_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (got, _dflt) = landed_symlink_mode_over_obstacle(0o711, false, |obstacle| {
+        fs::write(obstacle, b"old").expect("write obstacle");
+        fs::set_permissions(obstacle, fs::Permissions::from_mode(0o600)).expect("seed obstacle");
+    });
+    assert_eq!(
+        got, 0o600,
+        "without -p the link that replaced a 0o600 file must keep the \
+         obstacle's bits, not the fresh symlink(2) default"
+    );
+}
+
+/// Same replacement, dest was a SYMLINK to a different target (0o600): still
+/// `stype != FT_DIR`, so the exists arm keeps the OLD link's bits.
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_symlink_over_different_target_link_obstacle_without_perms_keeps_the_old_mode() {
+    use std::os::unix::fs::symlink;
+
+    let (got, _dflt) = landed_symlink_mode_over_obstacle(0o711, false, |obstacle| {
+        symlink("elsewhere.txt", obstacle).expect("create obstacle link");
+        fast_io::secure_chmod_at(obstacle, 0o600, false).expect("seed obstacle mode");
+    });
+    assert_eq!(
+        got, 0o600,
+        "a replaced different-target link still feeds dest_mode() its OLD \
+         0o600, exactly like any other non-directory obstacle"
+    );
+}
+
+/// A DIRECTORY obstacle is the one replacement upstream excludes from the
+/// exists arm: `exists = statret == 0 && stype != FT_DIR` (generator.c:1938)
+/// is false, so the link takes the new-destination reduction
+/// `source & dflt_perms` (rsync.c:481-485) even though something WAS there.
+/// This pins the `destination_is_new` decision to "was a non-directory there",
+/// not "was anything there".
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_symlink_over_directory_obstacle_without_perms_takes_the_dest_mode_reduction() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (got, dflt) = landed_symlink_mode_over_obstacle(0o711, false, |obstacle| {
+        fs::create_dir(obstacle).expect("mkdir obstacle");
+        fs::set_permissions(obstacle, fs::Permissions::from_mode(0o710)).expect("seed obstacle");
+    });
+    assert_eq!(
+        got,
+        0o711 & dflt,
+        "a rmdir'd directory obstacle takes dest_mode()'s NEW arm; neither its \
+         0o710 nor the bare symlink(2) default may survive"
+    );
+}
+
+/// Non-vacuity companion: the SAME regular-file obstacle under `-rlp` was
+/// correct before the pre-transfer plumbing and must stay so - with `-p`,
+/// `dest_mode()` never runs (generator.c:1936 gates on `!preserve_perms`), so
+/// the obstacle's stat must not leak into the landed mode.
+#[cfg(target_os = "macos")]
+#[test]
+fn execute_symlink_over_regular_file_obstacle_with_perms_takes_the_source_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let (got, _dflt) = landed_symlink_mode_over_obstacle(0o711, true, |obstacle| {
+        fs::write(obstacle, b"old").expect("write obstacle");
+        fs::set_permissions(obstacle, fs::Permissions::from_mode(0o600)).expect("seed obstacle");
+    });
+    assert_eq!(
+        got, 0o711,
+        "-p hands the link the source's bits verbatim; the obstacle's 0o600 \
+         must not reach it"
+    );
+}

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -546,8 +546,33 @@ pub fn apply_symlink_metadata_with_options(
     metadata: &fs::Metadata,
     options: &MetadataOptions,
 ) -> Result<(), MetadataError> {
+    apply_symlink_metadata_with_options_and_pre_transfer(destination, metadata, options, None)
+}
+
+/// Applies symlink metadata using the destination's PRE-transfer `lstat`.
+///
+/// Identical to [`apply_symlink_metadata_with_options`] except that the caller
+/// supplies the `lstat` the destination had before the link was written. Every
+/// symlink apply runs after `symlink(2)`, so the link's own stat cannot
+/// distinguish "was already here" from "we just made it, and destroyed what
+/// was"; upstream reads `sx.st` at generator.c:1937-1940, BEFORE
+/// `atomic_create` (generator.c:2002) deletes the obstacle, and feeds that to
+/// `dest_mode()`. A destination that was replaced - a symlink to a different
+/// target, or a non-symlink obstacle - therefore keeps contributing its OLD
+/// permission bits to the `exists` arm (rsync.c:470-471).
+///
+/// `pre_transfer_meta` is `None` when the caller did not replace anything, in
+/// which case the link's current stat is its own pre-transfer stat. It is
+/// ignored entirely when `options.destination_is_new()` says the destination
+/// was absent.
+pub fn apply_symlink_metadata_with_options_and_pre_transfer(
+    destination: &Path,
+    metadata: &fs::Metadata,
+    options: &MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
     ownership::set_owner_like(metadata, destination, false, options, None)?;
-    permissions::apply_symlink_permissions_like(destination, metadata, options)?;
+    permissions::apply_symlink_permissions_like(destination, metadata, options, pre_transfer_meta)?;
     if options.times() {
         timestamps::set_timestamp_like(metadata, destination, false, None, Some(options))?;
     }

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -730,19 +730,23 @@ fn chmod_path_honoring_keep_dirlinks(
 /// generator's lstat from BEFORE `do_symlink` ran.
 ///
 /// When the link is not new, its current stat IS the pre-transfer stat - except
-/// for a destination that existed as a NON-symlink and was replaced, where
-/// upstream still holds the obstacle's old `st_mode` and this hands back the
-/// fresh link's instead. That single cell is a known gap, tracked with the rest
-/// of the symlink-obstacle mode work rather than papered over here.
+/// for a destination that was REPLACED, where the fresh link's stat says
+/// nothing about what upstream measured. `explicit` carries the caller's
+/// pre-replace lstat for that case; upstream's `statret`/`sx.st` pair at
+/// generator.c:1937-1940 is taken before `atomic_create` deletes the obstacle,
+/// so a replaced destination - symlink or not - still feeds `dest_mode()` the
+/// OLD mode. Callers that never replace anything pass `None` and get the
+/// current stat.
 #[cfg(unix)]
 fn symlink_pre_transfer_stat<'a>(
     options: &MetadataOptions,
     current: &'a fs::Metadata,
+    explicit: Option<&'a fs::Metadata>,
 ) -> Option<&'a fs::Metadata> {
     if options.destination_is_new() {
         None
     } else {
-        Some(current)
+        explicit.or(Some(current))
     }
 }
 
@@ -843,7 +847,9 @@ pub(super) fn apply_symlink_permissions_from_entry(
             destination,
             entry.mode(),
             options,
-            symlink_pre_transfer_stat(options, meta),
+            // The receiver path has no replace-an-obstacle caller yet; when it
+            // grows one it must pass the obstacle's pre-replace lstat here.
+            symlink_pre_transfer_stat(options, meta, None),
         );
         if current != target {
             let _ = fast_io::secure_chmod_at(destination, target, false);
@@ -865,11 +871,17 @@ pub(super) fn apply_symlink_permissions_from_entry(
 /// both halves. Only runs where [`crate::CAN_CHMOD_SYMLINK`] holds; the chmod
 /// is a SOFT outcome and any error is swallowed.
 ///
+/// `pre_transfer_meta` is the destination's lstat from BEFORE the executor
+/// replaced an obstacle with the link, or `None` when nothing was replaced -
+/// see [`symlink_pre_transfer_stat`] for why the fresh link's own stat cannot
+/// stand in for it.
+///
 /// upstream: rsync.c:806-822 + syscall.c `do_chmod_at()`.
 pub(super) fn apply_symlink_permissions_like(
     destination: &Path,
     source_metadata: &fs::Metadata,
     options: &MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     #[cfg(unix)]
     if crate::CAN_CHMOD_SYMLINK {
@@ -885,14 +897,14 @@ pub(super) fn apply_symlink_permissions_like(
             destination,
             source,
             options,
-            symlink_pre_transfer_stat(options, &meta),
+            symlink_pre_transfer_stat(options, &meta, pre_transfer_meta),
         );
         if current != target {
             let _ = fast_io::secure_chmod_at(destination, target, false);
         }
     }
     #[cfg(not(unix))]
-    let _ = (destination, source_metadata, options);
+    let _ = (destination, source_metadata, options, pre_transfer_meta);
     Ok(())
 }
 
@@ -1604,6 +1616,51 @@ mod tests {
             0o700 & dflt,
             "-E on a new link is the plain dest_mode() arm; an exec blend from \
              a 0o755 link would have produced 0o744"
+        );
+    }
+
+    /// upstream: generator.c:1937-1940 reads `sx.st.st_mode` BEFORE
+    /// `atomic_create` (generator.c:2002) deletes an obstacle, so a link that
+    /// replaced one must feed `dest_mode()` the OBSTACLE's old bits, not the
+    /// umask default the fresh `symlink(2)` left behind. `explicit` carries
+    /// that pre-replace lstat; absent it, the current stat stands in; and a
+    /// NEW destination takes no pre-transfer stat at all.
+    #[test]
+    fn symlink_pre_transfer_stat_prefers_the_explicit_obstacle_stat() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let current_path = dir.path().join("current");
+        let obstacle_path = dir.path().join("obstacle");
+        std::fs::write(&current_path, b"x").expect("write current");
+        std::fs::write(&obstacle_path, b"x").expect("write obstacle");
+        std::fs::set_permissions(&current_path, std::fs::Permissions::from_mode(0o755))
+            .expect("seed current");
+        std::fs::set_permissions(&obstacle_path, std::fs::Permissions::from_mode(0o600))
+            .expect("seed obstacle");
+        let current = std::fs::metadata(&current_path).expect("current meta");
+        let obstacle = std::fs::metadata(&obstacle_path).expect("obstacle meta");
+
+        let existing = symlink_opts(false, false, false);
+        let got = symlink_pre_transfer_stat(&existing, &current, Some(&obstacle))
+            .expect("existing destination has a pre-transfer stat");
+        assert_eq!(
+            got.permissions().mode() & 0o7777,
+            0o600,
+            "a replaced destination must hand dest_mode() the obstacle's bits"
+        );
+        let got = symlink_pre_transfer_stat(&existing, &current, None)
+            .expect("existing destination has a pre-transfer stat");
+        assert_eq!(
+            got.permissions().mode() & 0o7777,
+            0o755,
+            "with nothing replaced, the current stat is its own pre-transfer stat"
+        );
+        let new = symlink_opts(false, false, true);
+        assert!(
+            symlink_pre_transfer_stat(&new, &current, Some(&obstacle)).is_none(),
+            "destination_is_new wins: a brand-new destination has no \
+             pre-transfer stat, whatever the caller passes"
         );
     }
 }

--- a/crates/metadata/src/apply/tests.rs
+++ b/crates/metadata/src/apply/tests.rs
@@ -3117,7 +3117,7 @@ fn symlink_chmod_spec_does_not_compose_with_preserve_perms_from_entry() {
     symlink(&target, &link).expect("create link");
     fast_io::secure_chmod_at(&link, 0o777, false).expect("seed link mode");
 
-    let mut entry = FileEntry::new_symlink("link".into(), "target.txt".into());
+    let mut entry = FileEntry::new_symlink("link".into(), 0o777, "target.txt".into());
     entry.set_mode(0o120741);
 
     let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -302,7 +302,8 @@ pub use apply::{
     apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
     apply_metadata_with_attrs_flags_and_pre_transfer, apply_metadata_with_cached_stat,
     apply_metadata_with_pre_transfer_stat, apply_symlink_metadata,
-    apply_symlink_metadata_from_entry, apply_symlink_metadata_with_options, metadata_unchanged,
+    apply_symlink_metadata_from_entry, apply_symlink_metadata_with_options,
+    apply_symlink_metadata_with_options_and_pre_transfer, metadata_unchanged,
 };
 
 pub use chmod::{ChmodError, ChmodModifiers, directory_transfer_mode, transfer_root_self_locks};


### PR DESCRIPTION
## What

When the destination is an existing non-directory (regular file, or a symlink) and the source is a symlink, oc decided the new link's mode from the *options default* instead of the obstacle's own mode. Upstream reads `sx.st` for the destination **before** `atomic_create()` removes the obstacle (generator.c:1936-1940) and feeds it to `dest_mode()`, whose exists-arm keeps `stat_mode & CHMOD_BITS` (rsync.c:464-487). So replacing a 0600 regular file with a symlink keeps 600 upstream; oc produced 755.

The `exists` decision is `statret == 0 && stype != FT_DIR`: a directory obstacle is *cleared first* and then takes the fresh-destination arm — that boundary is part of the fix and pinned.

## Fix

`symlink_pre_transfer_stat()` gains an `explicit` pre-replace-lstat argument (`explicit.or(Some(current))`), and `copy_symlink()` clones the obstacle's lstat **before** backup/removal, passing it through the new `apply_symlink_metadata_with_options_and_pre_transfer()` wrapper. `destination_is_new = pre_transfer_metadata.is_none()`, so a cleared directory obstacle correctly lands on the new-destination arm.

## Measured A/B (real 3.5.0 oracle)

Matrix: obstacle ∈ {regular 600, regular 640, symlink, directory, none} × {-r, -rp}. Before: both regular-obstacle `-r` cells diverged (oc 755 vs upstream keeping the obstacle mode). After: all cells match upstream.

## Verification

- Mutations M1 (drop the pre-replace clone), M2 (invert `destination_is_new`), M3 (drop the `explicit.or` fold), and M1+M2 combined — each kills its exact predicted test set; all reverted.
- Gates at pinned 1.88.0: whole-tree rustfmt clean; clippy engine+metadata `--all-targets --all-features` clean; nextest engine+metadata green (the 2 `execute_sparse*` failures are the documented pre-existing APFS flakes, reproduced on pristine master).

## Included master repair (macOS gates)

`crates/metadata/src/apply/tests.rs:3120` still calls the 2-arg `FileEntry::new_symlink` after #7760 made it 3-arg — a macOS-only test, invisible to Linux CI, and it blocks the macOS clippy/nextest cells on master today. This PR adds the missing mode argument (0o777, inert for that test's assertion) so the macOS gates compile again.

## Overlap note

Branch `fix/receiver-symlink-dest-mode` (task on receiver `-p` semantics, not yet PR'd) touches the same adapter; its hunk was made textually identical here so the two merge cleanly. Its call-site comment claiming the local-copy executor never replaces through that path is falsified by this change and must be updated when it lands.

Touches no expect-manifests.
