### PR TITLE
docs(contributing): explain absent dependent cells when fmt + clippy fails

### DIFF
--- a/docs/contributing/ONBOARDING.md
+++ b/docs/contributing/ONBOARDING.md
@@ -182,6 +182,12 @@ All of these must pass before a PR can merge:
 | upstream-testsuite-tcp / upstream testsuite | Upstream's own testsuite over a TCP daemon, unprivileged |
 | upstream-testsuite-tcp / upstream testsuite (root) | Upstream's own testsuite over a TCP daemon, privileged |
 
+Note on a failing `fmt + clippy`: the seven test-suite cells above depend on it,
+so when it fails they are reported as **absent** on the PR - not "skipped", they
+simply never appear. An absent required context blocks the merge exactly like a
+failure, so this fail-fast shape is safe; it just looks confusing when a PR
+shows only one red check. Fix the lint failure and the dependent cells run.
+
 Master is protected, so every change lands through a pull request. No approving
 review is required - the checks above are the gate. The branch ruleset is the
 authority for this list; [TESTING.md](TESTING.md) carries the command to


### PR DESCRIPTION
When the fmt + clippy job fails, the seven dependent required test-suite cells never start, so the PR shows them as absent rather than skipped or failed. That absence blocks the merge exactly like a failure - the fail-fast shape is safe, just visually confusing. This adds a short note at the required-checks table in ONBOARDING.md saying so, so nobody reads a one-red-check PR as "almost green" or tries to restructure CI into always-run cells (which would burn the full matrix on every lint failure).