### PR TITLE
fix(receiver): apply symlink modes from the transfer flags, not the options default

### DIFF
--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -610,6 +610,31 @@ pub fn apply_symlink_metadata_from_entry(
     entry: &protocol::flist::FileEntry,
     options: &MetadataOptions,
 ) -> Result<(), MetadataError> {
+    apply_symlink_metadata_from_entry_with_pre_transfer(destination, entry, options, None)
+}
+
+/// Applies symlink metadata using the destination's PRE-transfer `lstat`.
+///
+/// Identical to [`apply_symlink_metadata_from_entry`] except that the caller
+/// supplies the `lstat` the destination had before the link was written. Every
+/// symlink apply runs after `symlinkat(2)`, so the link's own stat cannot
+/// distinguish "was already here" from "we just made it, and destroyed what
+/// was"; upstream reads `sx.st` at generator.c:1937-1940, BEFORE
+/// `atomic_create` deletes the obstacle, and feeds that to `dest_mode()`. A
+/// destination that was replaced - a symlink to a different target, or a
+/// non-symlink obstacle - therefore keeps contributing its OLD permission bits
+/// to the `exists` arm.
+///
+/// `pre_transfer_meta` is `None` when the caller did not replace anything, in
+/// which case the link's current stat is its own pre-transfer stat. It is
+/// ignored entirely when `options.destination_is_new()` says the destination
+/// was absent.
+pub fn apply_symlink_metadata_from_entry_with_pre_transfer(
+    destination: &Path,
+    entry: &protocol::flist::FileEntry,
+    options: &MetadataOptions,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) -> Result<(), MetadataError> {
     let cached_meta = fs::symlink_metadata(destination).ok();
 
     #[cfg(unix)]
@@ -631,6 +656,7 @@ pub fn apply_symlink_metadata_from_entry(
         entry,
         options,
         cached_meta.as_ref(),
+        pre_transfer_meta,
     )?;
 
     if options.times() {

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -826,6 +826,7 @@ pub(super) fn apply_symlink_permissions_from_entry(
     entry: &protocol::flist::FileEntry,
     options: &MetadataOptions,
     cached_meta: Option<&fs::Metadata>,
+    pre_transfer_meta: Option<&fs::Metadata>,
 ) -> Result<(), MetadataError> {
     #[cfg(unix)]
     if crate::CAN_CHMOD_SYMLINK {
@@ -847,16 +848,14 @@ pub(super) fn apply_symlink_permissions_from_entry(
             destination,
             entry.mode(),
             options,
-            // The receiver path has no replace-an-obstacle caller yet; when it
-            // grows one it must pass the obstacle's pre-replace lstat here.
-            symlink_pre_transfer_stat(options, meta, None),
+            symlink_pre_transfer_stat(options, meta, pre_transfer_meta),
         );
         if current != target {
             let _ = fast_io::secure_chmod_at(destination, target, false);
         }
     }
     #[cfg(not(unix))]
-    let _ = (destination, entry, options, cached_meta);
+    let _ = (destination, entry, options, cached_meta, pre_transfer_meta);
     Ok(())
 }
 

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -302,8 +302,9 @@ pub use apply::{
     apply_metadata_from_file_entry, apply_metadata_with_attrs_flags,
     apply_metadata_with_attrs_flags_and_pre_transfer, apply_metadata_with_cached_stat,
     apply_metadata_with_pre_transfer_stat, apply_symlink_metadata,
-    apply_symlink_metadata_from_entry, apply_symlink_metadata_with_options,
-    apply_symlink_metadata_with_options_and_pre_transfer, metadata_unchanged,
+    apply_symlink_metadata_from_entry, apply_symlink_metadata_from_entry_with_pre_transfer,
+    apply_symlink_metadata_with_options, apply_symlink_metadata_with_options_and_pre_transfer,
+    metadata_unchanged,
 };
 
 pub use chmod::{ChmodError, ChmodModifiers, directory_transfer_mode, transfer_root_self_locks};

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -10,7 +10,10 @@ use std::path::{Path, PathBuf};
 
 use logging::{debug_log, info_log};
 #[cfg(any(unix, windows))]
-use metadata::{MetadataOptions, apply_symlink_metadata_from_entry};
+use metadata::{
+    MetadataOptions, apply_symlink_metadata_from_entry,
+    apply_symlink_metadata_from_entry_with_pre_transfer,
+};
 use protocol::flist::{trace_leader_is, trace_looking_for_leader, trace_virtual_first};
 
 use crate::generator::ItemFlags;
@@ -178,6 +181,12 @@ impl ReceiverContext {
             // destination arrives with it, so both render ITEM_IS_NEW.
             // Capture the old lstat before the obstacle is backed up/unlinked.
             let mut pre_replace_symlink_meta: Option<fs::Metadata> = None;
+            // Distinct from `pre_replace_symlink_meta` above, which stays
+            // symlink-only because the post-create itemize must render a
+            // non-symlink obstacle as ITEM_IS_NEW. `dest_mode()` makes no such
+            // distinction: its `exists` is `statret == 0 && stype != FT_DIR`
+            // (generator.c:1938), true for ANY non-directory that was here.
+            let mut pre_replace_meta: Option<fs::Metadata> = None;
 
             // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
@@ -193,7 +202,15 @@ impl ReceiverContext {
                     // upstream: generator.c:1575 - even on the up-to-date branch
                     // `set_file_attrs(fname, file, &sx, NULL, maybe_ATTRS_REPORT)`
                     // still runs so a stale on-disk mtime is corrected.
+                    // `MetadataOptions::new()` defaults `preserve_permissions`
+                    // to true, so these two must be set from the real flags or
+                    // every link silently takes `-p` semantics: upstream
+                    // collapses the mode through `dest_mode()` at
+                    // generator.c:1937-1940 whenever `-p` is off, and that runs
+                    // for a link exactly as for any other type.
                     let symlink_options = MetadataOptions::new()
+                        .preserve_permissions(self.config.flags.perms)
+                        .preserve_executability(self.config.flags.preserve_executability)
                         .preserve_owner(self.config.flags.owner)
                         .preserve_group(self.config.flags.group)
                         .preserve_times(self.preserve_symlink_times())
@@ -219,6 +236,7 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
+                pre_replace_meta = pre_replace_symlink_meta.clone();
                 // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
                 // - one decision for the obstacle: rmdir a directory, back up
                 // or unlink anything else. The refusal is reported inside.
@@ -235,18 +253,21 @@ impl ReceiverContext {
                 {
                     continue;
                 }
-            } else if fast_io::lstat_via_sandbox_or_fallback(
-                sandbox,
-                dest_dir,
-                relative_path,
-                &link_path,
-            )
-            .is_ok()
+            } else if let Ok(obstacle) =
+                fast_io::lstat_via_sandbox_or_fallback(sandbox, dest_dir, relative_path, &link_path)
             {
                 // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
                 // for a non-symlink obstacle. The stat above only selects this
                 // arm; `make_way_for_replacement` re-reads the type through the
                 // same sandbox dirfd to decide between rmdir and backup/unlink.
+                //
+                // `dest_mode()`'s `exists` is `statret == 0 && stype != FT_DIR`
+                // (generator.c:1938), so an obstacle of any non-directory type
+                // still hands its own permission bits to the link that replaces
+                // it; a directory obstacle takes the absent arm instead.
+                if !obstacle.is_dir() {
+                    pre_replace_meta = fs::symlink_metadata(&link_path).ok();
+                }
                 if self
                     .make_way_for_replacement(
                         writer,
@@ -336,16 +357,29 @@ impl ReceiverContext {
             // step the receiver-created symlink wears the wall-clock time from
             // `symlinkat(2)`, breaking the `--copy-dest` parity that
             // `testsuite/alt-dest.test` enforces over SSH.
+            // `preserve_permissions` defaults to true, so it must be set from
+            // the real flags: without `-p` upstream feeds the link through
+            // `dest_mode()` (generator.c:1937-1940) like every other type.
+            // `pre_replace_meta` is that call's `sx.st` - read BEFORE
+            // `atomic_create` unlinked whatever was here - so a replaced
+            // destination still contributes its old bits to the `exists` arm,
+            // and `None` marks the absent destination as new.
             let symlink_options = MetadataOptions::new()
+                .preserve_permissions(self.config.flags.perms)
+                .preserve_executability(self.config.flags.preserve_executability)
                 .preserve_owner(self.config.flags.owner)
                 .preserve_group(self.config.flags.group)
                 .preserve_times(self.preserve_symlink_times())
                 .preserve_atimes(self.config.flags.atimes)
                 .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
-                .fake_super(self.config.fake_super);
-            if let Err(error) =
-                apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
-            {
+                .fake_super(self.config.fake_super)
+                .with_destination_is_new(pre_replace_meta.is_none());
+            if let Err(error) = apply_symlink_metadata_from_entry_with_pre_transfer(
+                &link_path,
+                entry,
+                &symlink_options,
+                pre_replace_meta.as_ref(),
+            ) {
                 debug_log!(
                     Recv,
                     1,
@@ -449,6 +483,12 @@ impl ReceiverContext {
             // non-symlink obstacle has `statret` forced to -1 and an absent
             // destination arrives with it, so both render ITEM_IS_NEW.
             let mut pre_replace_symlink_meta: Option<fs::Metadata> = None;
+            // Distinct from `pre_replace_symlink_meta` above, which stays
+            // symlink-only because the post-create itemize must render a
+            // non-symlink obstacle as ITEM_IS_NEW. `dest_mode()` makes no such
+            // distinction: its `exists` is `statret == 0 && stype != FT_DIR`
+            // (generator.c:1938), true for ANY non-directory that was here.
+            let mut pre_replace_meta: Option<fs::Metadata> = None;
 
             // upstream: generator.c:1573 - quick_check_ok(FT_SYMLINK, ...)
             if let Ok(existing_target) = std::fs::read_link(&link_path) {
@@ -463,7 +503,15 @@ impl ReceiverContext {
                         ItemFlags::from_raw(self.existing_symlink_iflags(entry, &link_path));
                     // upstream: generator.c:1563 - refresh metadata even when the
                     // link is already up-to-date so a stale mtime is corrected.
+                    // `MetadataOptions::new()` defaults `preserve_permissions`
+                    // to true, so these two must be set from the real flags or
+                    // every link silently takes `-p` semantics: upstream
+                    // collapses the mode through `dest_mode()` at
+                    // generator.c:1937-1940 whenever `-p` is off, and that runs
+                    // for a link exactly as for any other type.
                     let symlink_options = MetadataOptions::new()
+                        .preserve_permissions(self.config.flags.perms)
+                        .preserve_executability(self.config.flags.preserve_executability)
                         .preserve_owner(self.config.flags.owner)
                         .preserve_group(self.config.flags.group)
                         .preserve_times(self.preserve_symlink_times())
@@ -488,6 +536,7 @@ impl ReceiverContext {
                     continue;
                 }
                 pre_replace_symlink_meta = fs::symlink_metadata(&link_path).ok();
+                pre_replace_meta = pre_replace_symlink_meta.clone();
                 // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK).
                 if self
                     .make_way_for_replacement(
@@ -501,9 +550,15 @@ impl ReceiverContext {
                 {
                     continue;
                 }
-            } else if fs::symlink_metadata(&link_path).is_ok() {
+            } else if let Ok(obstacle) = fs::symlink_metadata(&link_path) {
                 // upstream: generator.c:2002 atomic_create(..., DEL_FOR_SYMLINK)
-                // for a non-symlink obstacle.
+                // for a non-symlink obstacle. `dest_mode()`'s `exists` is
+                // `statret == 0 && stype != FT_DIR` (generator.c:1938), so a
+                // non-directory obstacle still supplies the replacement link's
+                // permission bits.
+                if !obstacle.is_dir() {
+                    pre_replace_meta = Some(obstacle);
+                }
                 if self
                     .make_way_for_replacement(
                         writer,
@@ -556,16 +611,29 @@ impl ReceiverContext {
             // upstream: generator.c:1604 - set_file_attrs() runs immediately
             // after atomic_create -> do_symlink so the new link's mtime matches
             // the sender-supplied value.
+            // `preserve_permissions` defaults to true, so it must be set from
+            // the real flags: without `-p` upstream feeds the link through
+            // `dest_mode()` (generator.c:1937-1940) like every other type.
+            // `pre_replace_meta` is that call's `sx.st` - read BEFORE
+            // `atomic_create` unlinked whatever was here - so a replaced
+            // destination still contributes its old bits to the `exists` arm,
+            // and `None` marks the absent destination as new.
             let symlink_options = MetadataOptions::new()
+                .preserve_permissions(self.config.flags.perms)
+                .preserve_executability(self.config.flags.preserve_executability)
                 .preserve_owner(self.config.flags.owner)
                 .preserve_group(self.config.flags.group)
                 .preserve_times(self.preserve_symlink_times())
                 .preserve_atimes(self.config.flags.atimes)
                 .numeric_ids(self.config.flags.numeric_ids.maps_numeric())
-                .fake_super(self.config.fake_super);
-            if let Err(error) =
-                apply_symlink_metadata_from_entry(&link_path, entry, &symlink_options)
-            {
+                .fake_super(self.config.fake_super)
+                .with_destination_is_new(pre_replace_meta.is_none());
+            if let Err(error) = apply_symlink_metadata_from_entry_with_pre_transfer(
+                &link_path,
+                entry,
+                &symlink_options,
+                pre_replace_meta.as_ref(),
+            ) {
                 debug_log!(
                     Recv,
                     1,

--- a/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
+++ b/crates/transfer/src/receiver/tests/symlinks_and_devices.rs
@@ -704,3 +704,164 @@ fn non_symlink_obstacle_replacement_itemizes_as_all_new() {
         "an obstacle replacement is ITEM_IS_NEW and counts as created"
     );
 }
+
+/// The receiver must decide a symlink's mode from the REAL `-p` flag.
+///
+/// `MetadataOptions::new()` defaults `preserve_permissions` to true, so a call
+/// site that omits it gives every link `-p` semantics no matter what the
+/// operator asked for. Upstream has no such default: when `-p` is off it
+/// rewrites `file->mode` through `dest_mode()` at generator.c:1937-1940, and
+/// that line sits ABOVE the `preserve_links && ftype == FT_SYMLINK` branch at
+/// generator.c:1948, so a link takes the collapse exactly like every other
+/// type. `dest_mode()` (rsync.c:464-486) then has two arms, and this pins both:
+///
+/// * destination ABSENT -> `flist_mode & (~CHMOD_BITS | dflt_perms)`, i.e. the
+///   sender's bits masked by `0777 & ~umask`.
+/// * destination EXISTED -> `(flist_mode & ~CHMOD_BITS) | (stat_mode &
+///   CHMOD_BITS)`, i.e. keep whatever was already on the destination. Upstream
+///   reads that `sx.st` BEFORE `atomic_create` removes the obstacle, so a
+///   REPLACED destination still contributes its old bits - and `exists` is
+///   `statret == 0 && stype != FT_DIR`, which a non-symlink obstacle satisfies.
+///
+/// Measured against the real 3.5.0 binary over an rsh pair: source link 0700
+/// onto a 0644 destination link gives 644 without `-p` and 700 with it; onto a
+/// 0600 regular-file obstacle, 600 without `-p` and 700 with it.
+///
+/// Gated on `metadata::CAN_CHMOD_SYMLINK` because a link's mode is not writable
+/// on Linux (`fchmodat` rejects `AT_SYMLINK_NOFOLLOW`) and every link there
+/// reads back a fixed 0777; the assertions below would be vacuous.
+#[test]
+#[cfg(unix)]
+fn symlink_mode_follows_the_perms_flag_not_the_options_default() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if !metadata::CAN_CHMOD_SYMLINK {
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Upstream's `dflt_perms` is `ACCESSPERMS & ~orig_umask` (main.c), which is
+    // exactly the mode `mkdir(2)` leaves on a fresh directory. Probing for it
+    // beats hardcoding a umask the test process does not control.
+    let probe = tmp.path().join("dflt-perms-probe");
+    std::fs::create_dir(&probe).expect("probe dir");
+    let dflt_perms = std::fs::metadata(&probe)
+        .expect("probe stat")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_ne!(
+        dflt_perms, 0o777,
+        "a zero umask would make the absent-destination cell non-discriminating"
+    );
+
+    let run = |perms: bool, src_mode: u32, seed: Option<&dyn Fn(&std::path::Path)>| -> u32 {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dest = tmp.path();
+        if let Some(seed) = seed {
+            seed(&dest.join("mylink"));
+        }
+
+        let mut config = test_config();
+        config.flags.links = true;
+        config.flags.perms = perms;
+        // Only the directory-obstacle cell needs it, and upstream's rmdir of a
+        // directory obstacle is likewise gated on it.
+        config.flags.force = true;
+        config.connection.client_mode = false;
+
+        let handshake = test_handshake();
+        let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+        // The sender's real lstat bits are what upstream puts on the wire.
+        let entry = FileEntry::new_symlink("mylink".into(), src_mode, "new-target".into());
+        ctx.file_list = vec![entry];
+
+        let mut writer = MockMsgInfoWriter::new();
+        ctx.create_symlinks(dest, None, &mut writer)
+            .expect("create_symlinks must succeed");
+
+        let meta = std::fs::symlink_metadata(dest.join("mylink")).expect("link must exist");
+        assert!(meta.file_type().is_symlink(), "destination must be a link");
+        meta.permissions().mode() & 0o7777
+    };
+
+    // Chmod the LINK itself, not its (absent) target - the same helper the
+    // receiver uses, so the seed cannot drift from the code under test.
+    let seed_link = |p: &std::path::Path| {
+        std::os::unix::fs::symlink("old-target", p).expect("seed old symlink");
+        fast_io::secure_chmod_at(p, 0o644, false).expect("seed the link's own mode");
+    };
+    let seed_file = |p: &std::path::Path| {
+        std::fs::write(p, b"obstacle").expect("seed obstacle");
+        std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+    };
+    let seed_dir = |p: &std::path::Path| {
+        std::fs::create_dir(p).expect("seed dir obstacle");
+        std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o700)).expect("chmod");
+    };
+
+    // NON-VACUITY: with `-p` every cell must land on the sender's own bits.
+    // This is the companion that proves the fixture actually reaches the chmod
+    // - a receiver that never chmodded a link would leave the `symlink(2)`
+    // umask default (`dflt_perms`) behind, which the probe above pins != 0777.
+    assert_eq!(run(true, 0o777, None), 0o777, "-p, absent destination");
+    assert_eq!(
+        run(true, 0o700, None),
+        0o700,
+        "-p, absent destination, non-default source bits"
+    );
+    assert_eq!(
+        run(true, 0o777, Some(&seed_link)),
+        0o777,
+        "-p, replaced destination link"
+    );
+    assert_eq!(
+        run(true, 0o777, Some(&seed_file)),
+        0o777,
+        "-p, replaced file obstacle"
+    );
+
+    // Without `-p` each cell must take its `dest_mode()` arm instead. Before
+    // the call sites passed `config.flags.perms` all of these read the source
+    // bits, because `MetadataOptions::new()` had already answered "preserve
+    // permissions" on the operator's behalf.
+    assert_eq!(
+        run(false, 0o777, None),
+        dflt_perms,
+        "no -p, absent destination: the sender's bits masked by 0777 & ~umask"
+    );
+    // A 0700 source separates dest_mode()'s two ARMS, which a 0777 source
+    // cannot: `0777 & dflt_perms` and "keep the fresh link's own bits" both
+    // equal `dflt_perms`, so only a source whose bits are not a superset of
+    // `dflt_perms` can tell "destination was absent" from "destination
+    // existed". Without this cell, hardcoding `destination_is_new` to false
+    // changes no observable output.
+    assert_eq!(
+        run(false, 0o700, None),
+        0o700 & dflt_perms,
+        "no -p, absent destination takes dest_mode()'s absent arm, not the \
+         fresh link's own umask-default bits"
+    );
+    assert_eq!(
+        run(false, 0o777, Some(&seed_link)),
+        0o644,
+        "no -p, replaced destination link: upstream keeps the OLD link's bits"
+    );
+    assert_eq!(
+        run(false, 0o777, Some(&seed_file)),
+        0o600,
+        "no -p, replaced file obstacle: dest_mode()'s `exists` is true for any \
+         non-directory, so the obstacle's bits carry over"
+    );
+    // ...and a DIRECTORY obstacle is the one that does not: `exists` is
+    // `statret == 0 && stype != FT_DIR`, so the rmdir'd directory's 0700
+    // contributes nothing and the absent arm applies. Measured the same way
+    // against 3.5.0 (`-rl --force`, source 0777 over a 0700 directory -> 755).
+    assert_eq!(
+        run(false, 0o777, Some(&seed_dir)),
+        dflt_perms,
+        "no -p, replaced DIRECTORY obstacle takes the absent arm, not the \
+         directory's own bits"
+    );
+}


### PR DESCRIPTION
## What

On the network receiver, every symlink apply ran with `-p` semantics regardless of the client's flags: `MetadataOptions::new()` defaults `preserve_permissions = true`, and all four receiver symlink apply sites built options from that default instead of the negotiated flags. On platforms where symlink modes are appliable (macOS/BSD via `CAN_CHMOD_SYMLINK`; inert on Linux), a plain `-a`-without-`-p` pull still stamped the sender's link mode onto the destination link, where upstream derives it through `dest_mode()`.

## Fix

- All 4 receiver symlink apply sites set `preserve_permissions`/`preserve_executability` from the real transfer flags.
- The pre-replace lstat is plumbed via `apply_symlink_metadata_from_entry_with_pre_transfer` + `with_destination_is_new(pre_replace_meta.is_none())`, so a replaced obstacle takes upstream's exists-arm (`generator.c:1936-1940`: `exists = statret == 0 && stype != FT_DIR` — a directory obstacle is excluded) and `rsync.c:464-487` keeps `stat_mode & CHMOD_BITS`.
- `apply_symlink_permissions_from_entry` grows the `pre_transfer_meta` parameter; the sibling `_like` path (which #7766 plumbed for the local-copy executor) and this network path now both pass their real values through the one `symlink_pre_transfer_stat` owner — the stale "the receiver path has no replace-an-obstacle caller yet" comment is discharged by this change, and #7766 discharged its mirror-image comment on the other site.

## Measured

60 + 16 + 8 cells against real rsync 3.5.0 over rsh with oc-receiver/upstream-sender isolation (only the receiver varies); regular-file control rows flat across arms. Linux is inert by `CAN_CHMOD_SYMLINK` and the test self-gates.

## Verification

- Rebased onto master past the #7755 squash (`--onto` from the pre-squash base); seam vs #7766 resolved as the plumbing union above; one mechanical test adaptation to the post-#7760 3-arg `FileEntry::new_symlink` (semantically identical — the constructor composes `S_IFLNK | (permissions & 0o7777)`).
- Gates at pinned 1.88.0: whole-tree rustfmt clean (3425 files); clippy metadata+transfer+engine `--all-targets --all-features` clean; nextest metadata+transfer --lib 3058/3058.
- New table-driven test `symlink_mode_follows_the_perms_flag_not_the_options_default` covers the seed/perms cells.
