### PR TITLE
fix(engine): route directory modes through dest_mode() and raise unwritable dirs first

### DIFF
--- a/crates/core/src/client/run/mod.rs
+++ b/crates/core/src/client/run/mod.rs
@@ -446,9 +446,15 @@ fn run_client_internal(
             Err(error) => return Err(map_local_copy_error(error)),
         };
 
-    // upstream: main.c:760 validates destination directory access early,
-    // returning FILE_SELECTION (3) for PermissionDenied instead of
-    // PARTIAL_TRANSFER (23). Other errors (e.g. NotFound) proceed normally.
+    // upstream: main.c:763-768 - `get_local_name()` chdirs the receiver into
+    // an existing destination directory before any transfer runs
+    // (`change_dir(dest_path, CD_NORMAL)`), and a failure reports
+    // `change_dir#1 %s failed` and exits with RERR_FILESELECT (3). `chdir`
+    // needs search (`x`) permission, not read: a 0644 destination fails it
+    // (before any mode preservation could repair it) while an unreadable but
+    // searchable one passes, so probe traversability by stat'ing `<dest>/.`
+    // rather than reading the directory. Other errors (e.g. NotFound for a
+    // destination this run will create) proceed normally.
     use std::fs;
     let dest_to_check = if plan.destination().is_dir() {
         plan.destination()
@@ -458,7 +464,7 @@ fn run_client_internal(
         plan.destination()
     };
 
-    if let Err(error) = fs::read_dir(dest_to_check) {
+    if let Err(error) = fs::metadata(dest_to_check.join(".")) {
         if error.kind() == std::io::ErrorKind::PermissionDenied {
             return Err(super::error::destination_access_error(dest_to_check, error));
         }

--- a/crates/core/tests/error_recovery.rs
+++ b/crates/core/tests/error_recovery.rs
@@ -163,10 +163,13 @@ mod error_recovery {
         });
     }
 
-    /// When the destination directory is read-only, writing files should fail
-    /// with an appropriate error.
+    /// When the destination directory is read-only, the transfer recovers by
+    /// temporarily raising the directory to mode|S_IRWXU before writing its
+    /// contents, then restoring the original mode afterwards.
     ///
-    /// upstream: rsync reports a write error and exits with code 23.
+    /// upstream: generator.c:1904-1912 chmods a pre-existing unwritable
+    /// directory writable before its contents and restores the final mode
+    /// once the directory is done; the transfer exits 0.
     #[test]
     fn error_recovery_readonly_destination() {
         run_with_timeout(LOCAL_TIMEOUT, || {
@@ -192,22 +195,23 @@ mod error_recovery {
 
             let result = run_client(config);
 
-            // Restore permissions before assertions so tempdir cleanup succeeds.
+            // Capture the directory mode before restoring it for cleanup.
+            let dest_mode = fs::metadata(&dest).expect("stat dest").permissions().mode() & 0o7777;
             let _ = fs::set_permissions(&dest, fs::Permissions::from_mode(0o755));
 
-            // The transfer must fail - either FileSelect (3) or PartialTransfer (23).
-            let error = result.expect_err("write to read-only dest should fail");
-            let code = error.exit_code();
-            assert!(
-                code == PARTIAL_TRANSFER_EXIT_CODE
-                    || code == core::client::FILE_SELECTION_EXIT_CODE,
-                "expected exit code 23 or 3, got {code}"
+            result.expect("transfer into a read-only destination should recover");
+
+            // The file was written through the temporary raise.
+            assert_eq!(
+                fs::read(dest.join("file.txt")).expect("read transferred file"),
+                b"content to write",
+                "file should be written into the raised destination"
             );
 
-            // The file should not have been written.
-            assert!(
-                !dest.join("file.txt").exists(),
-                "file should not be created in read-only destination"
+            // The original read-only mode was restored after the contents.
+            assert_eq!(
+                dest_mode, 0o555,
+                "destination directory mode should be restored to read-only"
             );
         });
     }

--- a/crates/core/tests/error_recovery_permission_denied.rs
+++ b/crates/core/tests/error_recovery_permission_denied.rs
@@ -237,4 +237,115 @@ mod permission_denied {
             );
         });
     }
+
+    /// A pre-existing destination directory the user cannot traverse (owner-x
+    /// absent, e.g. 0o644) fails upstream's receiver chdir BEFORE any transfer
+    /// runs: `change_dir#1 %s failed` and RERR_FILESELECT (3), with the
+    /// destination left untouched - even under `-p`, since nothing gets far
+    /// enough to repair the mode.
+    ///
+    /// Measured against rsync 3.5.0: dest root 0o644, `-r` and `-rp` both give
+    /// rc 3, zero files, root still 0o644. A read-based probe cannot pin this:
+    /// 0o644 IS readable, so the pre-fix probe passed and the run limped to a
+    /// divergent exit 23.
+    ///
+    /// upstream: main.c:763-768 get_local_name() ->
+    /// `change_dir(dest_path, CD_NORMAL)` -> exit_cleanup(RERR_FILESELECT).
+    #[test]
+    fn untraversable_destination_root_fails_file_selection() {
+        run_with_timeout(LOCAL_TIMEOUT, || {
+            if nix_is_root() {
+                return; // root traverses any directory; the fixture cannot fire.
+            }
+
+            let temp = tempdir().expect("tempdir");
+            let source_root = temp.path().join("source");
+            let dest_root = temp.path().join("dest");
+            fs::create_dir_all(&source_root).expect("create source root");
+            fs::create_dir_all(&dest_root).expect("create dest root");
+            touch(&source_root.join("f1.txt"), b"one");
+            touch(&source_root.join("f2.txt"), b"two");
+
+            // Readable but not searchable: r would satisfy a read_dir probe,
+            // the missing x fails chdir.
+            fs::set_permissions(&dest_root, fs::Permissions::from_mode(0o644))
+                .expect("chmod dest root");
+
+            let mut source_arg = source_root.into_os_string();
+            source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+            let config = ClientConfig::builder()
+                .transfer_args([source_arg, dest_root.clone().into_os_string()])
+                .build();
+
+            let result = run_client(config);
+
+            let mode = fs::metadata(&dest_root)
+                .expect("dest meta")
+                .permissions()
+                .mode()
+                & 0o777;
+            let _ = fs::set_permissions(&dest_root, fs::Permissions::from_mode(0o755));
+
+            let error = result.expect_err("an untraversable destination must fail");
+            assert_eq!(
+                error.exit_code(),
+                3,
+                "exit code should be 3 (RERR_FILESELECT), got {}",
+                error.exit_code()
+            );
+            assert_eq!(mode, 0o644, "the destination root must be left untouched");
+            assert!(
+                !dest_root.join("f1.txt").exists() && !dest_root.join("f2.txt").exists(),
+                "nothing may transfer into an untraversable destination"
+            );
+        });
+    }
+
+    /// Non-vacuity companion: an unreadable-but-searchable destination root
+    /// (0o333) passes upstream's chdir - search permission is what `chdir`
+    /// checks, not read - so the transfer must proceed and land the files.
+    /// A probe that read the directory instead of traversing it would fail
+    /// this cell with a spurious exit 3.
+    #[test]
+    fn unreadable_but_searchable_destination_root_still_transfers() {
+        run_with_timeout(LOCAL_TIMEOUT, || {
+            if nix_is_root() {
+                return;
+            }
+
+            let temp = tempdir().expect("tempdir");
+            let source_root = temp.path().join("source");
+            let dest_root = temp.path().join("dest");
+            fs::create_dir_all(&source_root).expect("create source root");
+            fs::create_dir_all(&dest_root).expect("create dest root");
+            touch(&source_root.join("f1.txt"), b"one");
+
+            // wx but no r: chdir succeeds, read_dir would EACCES.
+            fs::set_permissions(&dest_root, fs::Permissions::from_mode(0o333))
+                .expect("chmod dest root");
+
+            let mut source_arg = source_root.into_os_string();
+            source_arg.push(std::path::MAIN_SEPARATOR.to_string());
+
+            let config = ClientConfig::builder()
+                .transfer_args([source_arg, dest_root.clone().into_os_string()])
+                .build();
+
+            let result = run_client(config);
+            let _ = fs::set_permissions(&dest_root, fs::Permissions::from_mode(0o755));
+
+            result.expect("a searchable destination must not fail file selection");
+            assert_eq!(
+                fs::read(dest_root.join("f1.txt")).expect("f1 landed"),
+                b"one"
+            );
+        });
+    }
+
+    /// `geteuid() == 0` probe for the fixtures above, without adding a nix
+    /// dependency to the test crate.
+    fn nix_is_root() -> bool {
+        rustix::process::geteuid().is_root()
+    }
 }

--- a/crates/engine/src/local_copy/context.rs
+++ b/crates/engine/src/local_copy/context.rs
@@ -551,14 +551,14 @@ pub(crate) struct DeferredOperationQueue {
     /// directory is kept temporarily writable during the transfer so the
     /// deferred deletions/updates can still write into it.
     ///
-    /// upstream: generator.c:2093 `touch_up_dirs()`; generator.c:2271
-    /// `need_retouch_dir_times`; generator.c:2122-2127 `fix_dir_perms`.
+    /// upstream: generator.c:2565 `touch_up_dirs()`; generator.c:2744
+    /// `need_retouch_dir_times`; generator.c:2594 `fix_dir_perms`.
     pub(crate) finalized_dirs: Vec<FinalizedDir>,
 }
 
 /// A directory recorded during traversal for the final `touch_up_dirs` pass.
 ///
-/// upstream: generator.c:2089-2136 `touch_up_dirs()` restores the real mode
+/// upstream: generator.c:2565-2611 `touch_up_dirs()` restores the real mode
 /// (`fix_dir_perms`) and re-sets tweaked mtimes after the delayed-update and
 /// deletion phases complete.
 pub(crate) struct FinalizedDir {

--- a/crates/engine/src/local_copy/context_impl/reporting.rs
+++ b/crates/engine/src/local_copy/context_impl/reporting.rs
@@ -313,10 +313,10 @@ impl<'a> CopyContext<'a> {
     /// destination directory mtimes. The perm repair is independent of that
     /// gating and always runs for the directories that were kept writable.
     ///
-    /// upstream: generator.c:2449-2451 - touch_up_dirs(dir_flist, -1) runs
-    /// after handle_delayed_updates() and the delete phase; generator.c:2089
-    /// touch_up_dirs(); generator.c:2122-2127 fix_dir_perms restores the real
-    /// mode; generator.c:2271 need_retouch_dir_times = preserve_mtimes &&
+    /// upstream: generator.c:2923-2925 - touch_up_dirs(dir_flist, -1) runs
+    /// after handle_delayed_updates() and the delete phase; generator.c:2565
+    /// touch_up_dirs(); generator.c:2594 fix_dir_perms restores the real
+    /// mode; generator.c:2744 need_retouch_dir_times = preserve_mtimes &&
     /// !omit_dir_times.
     pub(super) fn touch_up_dirs(&mut self) {
         let mut dirs = std::mem::take(&mut self.deferred_ops.finalized_dirs);
@@ -330,7 +330,7 @@ impl<'a> CopyContext<'a> {
 
         // Deepest-first, mirroring upstream's reverse flist walk, so a child's
         // perm/mtime change cannot re-clobber a parent handled earlier.
-        // upstream: generator.c:2083 for (i = dir_flist->used - 1; i >= 0; i--).
+        // upstream: generator.c:2581 for (i = dir_flist->used - 1; i >= 0; i--).
         dirs.sort_by(|a, b| {
             b.path
                 .components()
@@ -341,7 +341,7 @@ impl<'a> CopyContext<'a> {
             // Reinstate the real (restricted) directory mode last, after every
             // deferred deletion/update ran while the directory was kept
             // writable. This runs regardless of the mtime gating above.
-            // upstream: generator.c:2124-2126 - fix_dir_perms does
+            // upstream: generator.c:2598-2599 - fix_dir_perms does
             // do_chmod_at(fname, file->mode) before the mtime repair.
             #[cfg(unix)]
             if let Some(mode) = dir.restore_mode {
@@ -355,7 +355,7 @@ impl<'a> CopyContext<'a> {
             let Some(mtime) = dir.mtime else {
                 continue;
             };
-            // upstream: generator.c:2130 - only re-set when mtime_differs(), so
+            // upstream: generator.c:2602 - only re-set when mtime_differs(), so
             // directories untouched by a late mutation are left alone.
             let needs_update = match fs::metadata(&dir.path) {
                 Ok(meta) => filetime::FileTime::from_last_modification_time(&meta) != mtime,

--- a/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/dir_metadata.rs
@@ -76,11 +76,11 @@ pub(super) fn apply_final_directory_metadata(
     )
     .map_err(map_metadata_error)?;
 
-    // upstream: generator.c:1508-1521 - a directory whose real mode lacks owner
+    // upstream: generator.c:1904-1912 - a directory whose real mode lacks owner
     // rwx is kept writable during the transfer so its contents, and the deferred
     // deletions/updates that run in the final flush, can still write into it;
     // the real (restricted) mode is reinstated LAST in touch_up_dirs
-    // (generator.c:2122-2127 fix_dir_perms). Applying the restricted mode (e.g.
+    // (generator.c:2594 fix_dir_perms). Applying the restricted mode (e.g.
     // 0555) now, before the deferred flush, makes a local --delete-after /
     // --delay-updates / in-place --backup copy fail EACCES when the deferred
     // rename/unlink tries to write into the now read-only directory.
@@ -94,8 +94,8 @@ pub(super) fn apply_final_directory_metadata(
     // directory's mtime after we set it here, so a single final pass re-applies
     // the recorded source mtime and reinstates the restricted mode once
     // everything else is done.
-    // upstream: generator.c:2089 touch_up_dirs() re-touches directory perms and
-    // mtimes after the delayed-update and deletion phases complete.
+    // upstream: generator.c:2565-2611 touch_up_dirs() re-touches directory perms
+    // and mtimes after the delayed-update and deletion phases complete.
     let mtime = metadata_options
         .times()
         .then(|| filetime::FileTime::from_last_modification_time(metadata));
@@ -142,15 +142,24 @@ pub(super) fn apply_final_directory_metadata(
 /// Keeps a directory whose applied mode lacks full owner `rwx` temporarily
 /// writable so the deferred deletions/updates in the final flush can still
 /// write into it, returning the restricted mode for `touch_up_dirs` to
-/// reinstate last (or `None` when no tweak is needed).
+/// reinstate last (or `None` when no restore is due).
 ///
-/// Mirrors upstream `generator.c:1508-1521`: when not root, not `--fake-super`,
-/// preserving perms, and the applied mode lacks full owner `rwx`
-/// (`(file->mode & S_IRWXU) != S_IRWXU`), the generator chmods the directory to
-/// `mode | S_IRWXU` and sets `need_retouch_dir_perms` so the real mode is
-/// restored (`generator.c:2122-2127` `fix_dir_perms`) after the delayed-update
-/// and deletion phases. The applied mode is read back from the destination so a
-/// `--chmod` tweak is reflected exactly.
+/// Mirrors upstream `generator.c:1904-1912`: when not root, not `--fake-super`
+/// (upstream's `am_root = -1` makes `!am_root` false), and the applied mode
+/// lacks full owner `rwx` (`(file->mode & S_IRWXU) != S_IRWXU`), the generator
+/// chmods the directory to `mode | S_IRWXU` and sets `need_retouch_dir_perms`.
+/// The gate carries NO `--perms` condition - it is `!am_root && (file->mode &
+/// S_IRWXU) != S_IRWXU && dir_tweaking`, and `dir_tweaking = !(list_only ||
+/// solo_file || dry_run)` (generator.c:2743), all of which hold on this apply
+/// path. The applied mode is read back from the destination so a `--chmod`
+/// tweak and the `!preserve_perms` `dest_mode()` collapse are both reflected
+/// exactly.
+///
+/// The restore is narrower than the raise: `touch_up_dirs` reinstates the
+/// strict mode only when `fix_dir_perms = !am_root && !(file->mode & S_IWUSR)`
+/// (generator.c:2594). An owner-writable-but-not-executable mode therefore
+/// keeps the transient owner-`rwx` bits on disk (e.g. source 0644 lands 0744),
+/// which is upstream's observed residue.
 #[cfg(unix)]
 fn keep_directory_writable(
     destination: &Path,
@@ -158,38 +167,110 @@ fn keep_directory_writable(
 ) -> Result<Option<u32>, LocalCopyError> {
     use std::os::unix::fs::PermissionsExt;
 
-    // upstream: generator.c:1512 gate - !am_root && ... && dir_tweaking, plus we
-    // only manage the mode when preserving perms and not under --fake-super
-    // (which stashes the intended mode in an xattr instead of the inode).
-    if !metadata_options.permissions()
-        || metadata_options.fake_super_enabled()
-        || ::metadata::am_root()
-    {
+    // upstream: generator.c:1904 gate - !am_root (false under --fake-super,
+    // which stashes the intended mode in an xattr instead of the inode).
+    if metadata_options.fake_super_enabled() || ::metadata::am_root() {
         return Ok(None);
     }
 
     let applied = fs::symlink_metadata(destination)
         .map_err(|error| LocalCopyError::io("stat", destination, error))?;
     let mode = applied.permissions().mode() & 0o7777;
-    // upstream: generator.c:1512 - (file->mode & S_IRWXU) != S_IRWXU.
+    // upstream: generator.c:1904 - (file->mode & S_IRWXU) != S_IRWXU.
     if mode & 0o700 == 0o700 {
         return Ok(None);
     }
 
-    // upstream: generator.c:1513-1514 - do_chmod_at(fname, mode | S_IRWXU).
+    // upstream: generator.c:1905-1906 - gen_entry_chmod(fname, file, mode | S_IRWXU).
     fs::set_permissions(destination, fs::Permissions::from_mode(mode | 0o700))
         .map_err(|error| LocalCopyError::io("modify permissions on", destination, error))?;
-    Ok(Some(mode))
+    // upstream: generator.c:2594 - fix_dir_perms = !am_root && !(file->mode &
+    // S_IWUSR): only an owner-non-writable mode is reinstated last.
+    Ok((mode & 0o200 == 0).then_some(mode))
+}
+
+/// Chmods a pre-existing directory to its during-transfer mode BEFORE its
+/// contents are written, so a restrictive destination mode (e.g. 0555) cannot
+/// fail every write into it with `EACCES`.
+///
+/// Mirrors the first-visit ordering of upstream `recv_generator()`: the
+/// directory arm rewrites `file->mode = dest_mode(...)` (generator.c:1856,
+/// `exists` judged by the pre-mkdir `statret`), `set_file_attrs()` chmods the
+/// directory to it (generator.c:1895), and the owner-`rwx` raise follows
+/// immediately (generator.c:1904-1912) - all before any of the directory's
+/// contents transfer. oc defers the strict `set_file_attrs()` chmod to
+/// [`apply_final_directory_metadata`], which is unobservable for a freshly
+/// created directory (its `create_dir` mode is already owner-writable), but a
+/// PRE-EXISTING directory keeps its on-disk bits until then, so the
+/// during-transfer mode must land here.
+///
+/// A raise failure is non-fatal, exactly as upstream's is: generator.c:1907-1910
+/// reports `failed to modify permissions on %s` at `FERROR_XFER` severity and
+/// the transfer continues (exit 23 at the end).
+#[cfg(unix)]
+pub(super) fn keep_preexisting_directory_writable(
+    context: &mut CopyContext,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    pre_transfer_meta: Option<&fs::Metadata>,
+) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let Some(pre_transfer) = pre_transfer_meta else {
+        return;
+    };
+    let metadata_options = context.metadata_options();
+    // upstream: generator.c:1904 gate - !am_root (false under --fake-super).
+    if metadata_options.fake_super_enabled() || ::metadata::am_root() {
+        return;
+    }
+    let target = ::metadata::directory_dest_mode(
+        destination,
+        metadata.permissions().mode(),
+        &metadata_options,
+        Some(pre_transfer),
+    );
+    // upstream: generator.c:1904-1906 - raise to mode | S_IRWXU when the
+    // target lacks full owner rwx; otherwise the first-visit chmod lands the
+    // target itself (set_file_attrs at generator.c:1896).
+    let during = if target & 0o700 == 0o700 {
+        target
+    } else {
+        target | 0o700
+    };
+    if pre_transfer.permissions().mode() & 0o7777 == during {
+        return;
+    }
+    if let Err(error) = fs::set_permissions(destination, fs::Permissions::from_mode(during)) {
+        // upstream: generator.c:1907-1910 - rsyserr(FERROR_XFER, ...) and the
+        // transfer continues.
+        eprintln!(
+            "rsync: failed to modify permissions on \"{}\": {}",
+            destination.display(),
+            crate::local_copy::upstream_io_error(&error)
+        );
+        context.record_io_error();
+    }
+}
+
+/// Non-Unix stub: POSIX directory write/traversal bits do not apply.
+#[cfg(not(unix))]
+pub(super) fn keep_preexisting_directory_writable(
+    _context: &mut CopyContext,
+    _destination: &Path,
+    _metadata: &fs::Metadata,
+    _pre_transfer_meta: Option<&fs::Metadata>,
+) {
 }
 
 /// Reproduces upstream's transfer-root self-lock when a `--chmod` strips the
 /// root directory's owner-execute bit.
 ///
-/// upstream: generator.c:1515-1532 - the generator chmods a directory to its
+/// upstream: generator.c:1895-1912 - the generator chmods a directory to its
 /// tweaked mode and then re-adds owner-`rwx` (`do_chmod_at(fname, mode | S_IRWXU)`)
 /// so it can write the directory's contents. The transfer root is addressed as
 /// `dst/.`, so that re-add chmod must resolve `.` *inside* `dst`; a tweak that
-/// removed owner-execute makes it fail with `EACCES` (generator.c:1514 "failed
+/// removed owner-execute makes it fail with `EACCES` (generator.c:1907-1909 "failed
 /// to modify permissions on %s") and the generator can no longer stat or create
 /// the root's contents. Nothing under it transfers and rsync exits 23.
 /// Non-root directories are addressed by name and never take this path, so the
@@ -214,7 +295,7 @@ pub(super) fn enforce_transfer_root_self_lock(
 ) -> Result<Option<LocalCopyError>, LocalCopyError> {
     use std::os::unix::fs::PermissionsExt;
 
-    // upstream: generator.c:1512 - the transfer-root owner-rwx re-add (whose
+    // upstream: generator.c:1904 - the transfer-root owner-rwx re-add (whose
     // failure is the self-lock) is guarded by `!am_root`. Under --fake-super
     // upstream sets am_root = -1, so `!am_root` is false and the strict tweaked
     // mode is never applied to the real inode: set_stat_xattr() (rsync.c:577-578)
@@ -254,7 +335,7 @@ pub(super) fn enforce_transfer_root_self_lock(
     fs::set_permissions(destination, fs::Permissions::from_mode(tweaked))
         .map_err(|error| LocalCopyError::io("modify permissions on", destination, error))?;
 
-    // upstream: generator.c:1514 do_chmod_at("dst/.", mode | S_IRWXU) - fails
+    // upstream: generator.c:1905-1906 gen_entry_chmod("dst/.", mode | S_IRWXU) - fails
     // with EACCES because `.` can no longer be resolved inside the now
     // owner-non-executable root. Trigger the identical OS error to report it.
     let dot = destination.join(".");

--- a/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
+++ b/crates/engine/src/local_copy/executor/directory/recursive/mod.rs
@@ -33,7 +33,7 @@ use deletion::{
 use destination::{check_destination_state, record_skipped_missing_destination};
 use dir_metadata::{
     DirectoryFinalize, apply_final_directory_metadata, enforce_transfer_root_self_lock,
-    record_directory_completion,
+    keep_preexisting_directory_writable, record_directory_completion,
 };
 use entry::process_planned_entry;
 
@@ -546,7 +546,7 @@ fn copy_directory_recursive_inner(
         ensure_directory(context)?;
     }
 
-    // upstream: generator.c:1503-1520 - the generator applies a directory's
+    // upstream: generator.c:1895-1912 - the generator applies a directory's
     // tweaked mode and re-adds owner-rwx BEFORE writing its contents. For the
     // transfer root ("dst/.") a --chmod that strips owner-execute makes that
     // re-add chmod fail (EACCES) and the root can no longer be entered, so none
@@ -559,6 +559,17 @@ fn copy_directory_recursive_inner(
             enforce_transfer_root_self_lock(context, destination, metadata, dir_pre_transfer)?
     {
         return Err(error);
+    }
+
+    // upstream: generator.c:1895-1912 - the strict dest_mode() chmod
+    // (set_file_attrs) and the owner-rwx raise land at the directory's FIRST
+    // visit, before any of its contents transfer. A pre-existing destination
+    // directory whose on-disk bits deny owner rwx (e.g. 0555) must be raised
+    // here or every write into it fails EACCES; apply_final_directory_metadata
+    // re-lands the strict mode after the contents and touch_up_dirs restores
+    // it last (generator.c:2594).
+    if !context.mode().is_dry_run() {
+        keep_preexisting_directory_writable(context, destination, metadata, dir_pre_transfer);
     }
 
     let mut plan = plan_directory_entries(context, &entries, relative, root_device)?;

--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -288,7 +288,19 @@ fn apply_backup_dir_attrs(
     if let Ok(meta) = fs::symlink_metadata(&source_dir)
         && meta.is_dir()
     {
-        let _ = ::metadata::apply_file_metadata_with_options(created, &meta, metadata_options);
+        // upstream: backup.c:173 set_file_attrs(backup_dir_buf, file, NULL,
+        // NULL, 0) - the synthesized file_struct carries the destination
+        // directory's stat mode VERBATIM and set_file_attrs chmods to
+        // `file->mode` with no `dest_mode()` collapse: dest_mode() runs only
+        // at generator.c:1856/1939 and receiver.c:1191, none of which sit on
+        // the backup path. A `!preserve_perms` run therefore still copies the
+        // destination directory's exact permission bits onto the backup
+        // subdirectory (measured against rsync 3.5.0: dest dir 0707, -r
+        // without -p, umask 022 -> backup dir 0707), so force the permission
+        // leg on for this one apply while every other leg keeps the caller's
+        // options.
+        let attrs_options = metadata_options.clone().preserve_permissions(true);
+        let _ = ::metadata::apply_file_metadata_with_options(created, &meta, &attrs_options);
     }
 }
 

--- a/crates/engine/src/local_copy/tests/execute_permissions.rs
+++ b/crates/engine/src/local_copy/tests/execute_permissions.rs
@@ -680,3 +680,222 @@ fn dir_no_setgid_when_parent_lacks_it() {
         "copied directory should NOT have setgid (mode {copied_mode:#o})"
     );
 }
+
+/// A fresh directory must land upstream's `dest_mode()` result, not the
+/// `create_dir` umask default.
+///
+/// Source mode 0o500 discriminates under every sane umask: `dest_mode()` gives
+/// `0o500 & (~CHMOD_BITS | dflt_perms)` = 0o500 (dflt_perms always carries the
+/// owner bits), while the pre-fix behaviour left the mkdir default
+/// (`0o777 & ~umask`, owner-writable). The file inside proves the transfer
+/// ordering: the strict 0o500 lands only after the contents are written, the
+/// during-transfer raise (generator.c:1904-1912) makes 0o700 of it, and
+/// touch_up_dirs restores 0o500 last because the owner-write bit is absent
+/// (generator.c:2594 fix_dir_perms).
+// upstream: generator.c:1856 - file->mode = dest_mode(...) runs for
+// directories even when !preserve_perms; rsync.c:481-485 masks the fresh arm.
+#[cfg(unix)]
+#[test]
+fn fresh_directory_without_perms_lands_dest_mode_not_umask_default() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if ::metadata::am_root() {
+        return; // root skips the raise/restore dance; the cells differ there.
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    let sub = source.join("sub");
+    fs::create_dir_all(&sub).expect("create source tree");
+    fs::write(sub.join("file.txt"), b"payload").expect("write file");
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o500)).expect("chmod source sub");
+
+    // Non-vacuity guard: the fixture only discriminates while the mkdir
+    // default differs from the expected dest_mode() result.
+    let probe = temp.path().join("probe");
+    fs::create_dir(&probe).expect("create probe");
+    let probe_mode = fs::metadata(&probe)
+        .expect("probe meta")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_ne!(probe_mode, 0o500, "umask makes this fixture vacuous");
+
+    let dest = temp.path().join("dst");
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let summary = plan
+        .execute_with_options(
+            LocalCopyExecution::Apply,
+            LocalCopyOptions::default().recursive(true),
+        )
+        .expect("copy succeeds");
+    assert_eq!(summary.files_copied(), 1, "the file inside must transfer");
+
+    let sub_mode = fs::metadata(dest.join("sub"))
+        .expect("dest sub meta")
+        .permissions()
+        .mode()
+        & 0o7777;
+    // Unlock before asserting so tempdir cleanup works even on failure paths.
+    let _ = fs::set_permissions(dest.join("sub"), fs::Permissions::from_mode(0o755));
+    let _ = fs::set_permissions(&sub, fs::Permissions::from_mode(0o755));
+    assert_eq!(
+        sub_mode, 0o500,
+        "a fresh dir takes dest_mode(source), not the mkdir umask default"
+    );
+}
+
+/// A pre-existing read-only destination directory must be raised to owner-rwx
+/// for the transfer and restored afterwards - without `--perms`.
+///
+/// `dest_mode()`'s exists arm keeps the directory's own 0o555
+/// (rsync.c:470-480); the raise (generator.c:1904-1912) is what lets the file
+/// land, and fix_dir_perms restores 0o555 because owner-write is absent
+/// (generator.c:2594). Measured against rsync 3.5.0: rc 0, file transferred,
+/// directory back at 0o555; the pre-fix behaviour failed the write with
+/// EACCES (exit 23) and transferred nothing.
+#[cfg(unix)]
+#[test]
+fn preexisting_readonly_subdir_without_perms_transfers_and_is_restored() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if ::metadata::am_root() {
+        return; // root writes into 0o555 regardless; the fixture cannot fail.
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    fs::create_dir_all(source.join("sub")).expect("create source tree");
+    fs::write(source.join("sub/file.txt"), b"payload").expect("write file");
+
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(dest.join("sub")).expect("create dest tree");
+    fs::set_permissions(dest.join("sub"), fs::Permissions::from_mode(0o555))
+        .expect("chmod dest sub");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().recursive(true),
+    );
+
+    let sub_mode = fs::metadata(dest.join("sub"))
+        .expect("dest sub meta")
+        .permissions()
+        .mode()
+        & 0o7777;
+    let payload = fs::read(dest.join("sub/file.txt"));
+    let _ = fs::set_permissions(dest.join("sub"), fs::Permissions::from_mode(0o755));
+
+    let summary = result.expect("copy into a read-only pre-existing dir succeeds");
+    assert_eq!(summary.files_copied(), 1);
+    assert_eq!(payload.expect("file landed").as_slice(), b"payload");
+    assert_eq!(
+        sub_mode, 0o555,
+        "the restrictive pre-existing mode must be restored after the transfer"
+    );
+}
+
+/// The transfer ROOT variant: a pre-existing 0o555 destination root must not
+/// fail the copy. Measured against rsync 3.5.0 (`-r`, fresh files): rc 0, both
+/// files land, the root is restored to 0o555.
+#[cfg(unix)]
+#[test]
+fn preexisting_readonly_dest_root_without_perms_transfers_and_is_restored() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if ::metadata::am_root() {
+        return;
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    fs::create_dir_all(&source).expect("create source");
+    fs::write(source.join("f1"), b"one").expect("write f1");
+    fs::write(source.join("f2"), b"two").expect("write f2");
+
+    let dest = temp.path().join("dst");
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::set_permissions(&dest, fs::Permissions::from_mode(0o555)).expect("chmod dest root");
+
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    let result = plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default().recursive(true),
+    );
+
+    let root_mode = fs::metadata(&dest).expect("dest meta").permissions().mode() & 0o7777;
+    let f1 = fs::read(dest.join("f1"));
+    let f2 = fs::read(dest.join("f2"));
+    let _ = fs::set_permissions(&dest, fs::Permissions::from_mode(0o755));
+
+    let summary = result.expect("copy into a read-only pre-existing root succeeds");
+    assert_eq!(summary.files_copied(), 2);
+    assert!(f1.is_ok() && f2.is_ok(), "both files must land");
+    assert_eq!(
+        root_mode, 0o555,
+        "the restrictive pre-existing root mode must be restored last"
+    );
+}
+
+/// Upstream's raise residue: an owner-writable-but-not-executable directory
+/// keeps the transient owner-rwx bits on disk, because fix_dir_perms restores
+/// only when `!(file->mode & S_IWUSR)` (generator.c:2594) and 0o644 has the
+/// owner-write bit. Measured against rsync 3.5.0: source dir 0o644 under
+/// `-rp` lands 0o744 on a fresh destination (umask 022 / 077 / 002 alike).
+/// The pre-fix behaviour restored the strict 0o644 and diverged.
+// upstream: generator.c:1904-1912 raise + generator.c:2594 restore condition.
+#[cfg(unix)]
+#[test]
+fn owner_writable_nonexec_dir_keeps_the_raise_residue_under_perms() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if ::metadata::am_root() {
+        return; // the raise is gated on !am_root; root lands 0o644 verbatim.
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let source = temp.path().join("src");
+    // The 0o644 dir stays EMPTY: without owner-x even its own entries could
+    // not be stat'd on the source side, which would add an unrelated failure.
+    fs::create_dir_all(source.join("sub")).expect("create source tree");
+    fs::set_permissions(source.join("sub"), fs::Permissions::from_mode(0o644))
+        .expect("chmod source sub");
+
+    let dest = temp.path().join("dst");
+    let mut source_operand = source.clone().into_os_string();
+    source_operand.push("/");
+    let operands = vec![source_operand, dest.clone().into_os_string()];
+    let plan = LocalCopyPlan::from_operands(&operands).expect("plan");
+
+    plan.execute_with_options(
+        LocalCopyExecution::Apply,
+        LocalCopyOptions::default()
+            .recursive(true)
+            .permissions(true),
+    )
+    .expect("copy succeeds");
+
+    let sub_mode = fs::metadata(dest.join("sub"))
+        .expect("dest sub meta")
+        .permissions()
+        .mode()
+        & 0o7777;
+    let _ = fs::set_permissions(source.join("sub"), fs::Permissions::from_mode(0o755));
+    assert_eq!(
+        sub_mode, 0o744,
+        "0o644 | S_IRWXU raise sticks: owner-write blocks the touch-up restore"
+    );
+}

--- a/crates/engine/src/local_copy/tests/unreadable_source_directory.rs
+++ b/crates/engine/src/local_copy/tests/unreadable_source_directory.rs
@@ -88,9 +88,15 @@ fn unreadable_source_directory_still_applies_its_own_metadata() {
         & 0o777;
     restore_fixture_modes(&[source.join("dropbox"), dest.join("dropbox")]);
 
+    // 0o300 is applied, then the during-transfer raise lands 0o700
+    // (generator.c:1904-1912) and touch_up_dirs never restores it because
+    // fix_dir_perms requires `!(file->mode & S_IWUSR)` (generator.c:2594) and
+    // 0o300 has the owner-write bit. Measured against rsync 3.5.0: -rp with a
+    // 0o300 source directory lands the destination directory at 0o700.
     assert_eq!(
-        dest_mode, 0o300,
-        "the unreadable source directory's own mode must reach the destination"
+        dest_mode, 0o700,
+        "the unreadable source directory's mode must reach the destination \
+         with upstream's owner-rwx raise residue"
     );
     // Its readable sibling still transfers: the failure is scoped to the frame
     // that could not be enumerated.

--- a/crates/metadata/src/apply/mod.rs
+++ b/crates/metadata/src/apply/mod.rs
@@ -145,6 +145,27 @@ pub fn apply_file_metadata_with_options(
     Ok(())
 }
 
+/// Computes the permission bits a directory ends up with BEFORE upstream's
+/// during-transfer owner-`rwx` raise - the `--chmod` tweak composed with the
+/// `dest_mode()` collapse when `!preserve_perms`.
+///
+/// `pre_transfer` is the directory's stat from BEFORE the transfer
+/// materialised it (`None` for a fresh directory). The local-copy executor and
+/// the network receiver both derive the during-transfer raise
+/// (generator.c:1904-1912) and the `touch_up_dirs` restore (generator.c:2594)
+/// from this one target value, so the two paths cannot drift.
+///
+/// See `permissions::directory_dest_mode` for the full upstream mapping.
+#[cfg(unix)]
+pub fn directory_dest_mode(
+    destination: &Path,
+    source_mode: u32,
+    options: &MetadataOptions,
+    pre_transfer: Option<&fs::Metadata>,
+) -> u32 {
+    permissions::directory_dest_mode(destination, source_mode, options, pre_transfer)
+}
+
 /// Pre-applies upstream's `dest_mode()` chmod for callers that have the
 /// pre-transfer destination stat in hand.
 ///
@@ -172,7 +193,7 @@ pub fn apply_dest_mode_pre_transfer(
 /// `am_root` is sampled through the same libc `geteuid` the chmod apply path
 /// uses, so the self-lock decision and the on-disk fixup agree under
 /// `fakeroot`. See [`crate::transfer_root_self_locks`] for the mechanism.
-/// upstream: rsync.c:set_file_attrs() new_mode + generator.c:1512 fixup.
+/// upstream: rsync.c:set_file_attrs() new_mode + generator.c:1904-1912 fixup.
 #[cfg(unix)]
 pub fn transfer_root_chmod_self_lock(
     destination: &Path,

--- a/crates/metadata/src/apply/permissions.rs
+++ b/crates/metadata/src/apply/permissions.rs
@@ -23,7 +23,7 @@ use std::os::fd::BorrowedFd;
 /// daemon chmod paths all compute one identical result (DRY). `am_root` is
 /// sampled through the same libc `geteuid` the ownership gate uses so
 /// `fakeroot`'s faked identity is honoured.
-/// upstream: generator.c:1512-1520 fixup + generator.c:2107-2145 touch_up_dirs.
+/// upstream: generator.c:1904-1912 fixup + generator.c:2565-2611 touch_up_dirs.
 #[cfg(unix)]
 fn tweak_directory_transfer_mode(mode: u32, file_type: fs::FileType) -> u32 {
     if !file_type.is_dir() {
@@ -550,7 +550,41 @@ pub(super) fn apply_permissions_with_chmod(
     {
         use std::os::unix::fs::PermissionsExt;
         let source_mode = metadata.permissions().mode();
-        if let Some(new_mode) = compute_dest_mode(
+        if metadata.file_type().is_dir() {
+            // upstream: generator.c:1856 - even when !preserve_perms the
+            // generator rewrites `file->mode = dest_mode(...)` for a
+            // directory, judging `exists` by the pre-mkdir `statret`, and
+            // set_file_attrs() (rsync.c:658) chmods the directory to it. The
+            // caller's `existing` carries that pre-transfer stat: a fresh
+            // directory takes the source mode masked by dflt_perms
+            // (rsync.c:481-485) instead of the mkdir umask default, while a
+            // pre-existing one keeps its own bits (rsync.c:470-480). The
+            // during-transfer owner-rwx raise (generator.c:1904-1912) and its
+            // touch_up_dirs restore (generator.c:2594) belong to the caller
+            // that owns transfer ordering, not to this apply.
+            let mut new_mode = directory_dest_mode(destination, source_mode, options, existing);
+            if let Ok(current_meta) = fs::metadata(destination) {
+                let current_mode = current_meta.permissions().mode();
+                // upstream: rsync.c:512-516 - a freshly-created directory that
+                // inherited S_ISGID from a setgid parent keeps that bit even
+                // though dest_mode() dropped it.
+                if existing.is_none() && current_mode & 0o2000 != 0 {
+                    new_mode |= 0o2000;
+                }
+                if (current_mode & 0o7777) != new_mode {
+                    // upstream: syscall.c:do_chmod():800-802 - when neither
+                    // --perms nor --executability is active, chmod failure is
+                    // non-fatal. upstream returns 0 so set_file_attrs()
+                    // continues.
+                    let _ = chmod_path_honoring_keep_dirlinks(
+                        destination,
+                        new_mode,
+                        options,
+                        "apply dest_mode",
+                    );
+                }
+            }
+        } else if let Some(new_mode) = compute_dest_mode(
             source_mode,
             options.destination_is_new(),
             existing,
@@ -963,7 +997,7 @@ fn intended_fake_super_mode(
 /// executor uses this to detect a transfer-root directory whose tweaked mode
 /// strips owner execute and therefore self-locks (see
 /// [`crate::transfer_root_self_locks`]).
-/// upstream: rsync.c:set_file_attrs() new_mode, pre generator.c:1512 fixup.
+/// upstream: rsync.c:set_file_attrs() new_mode, pre generator.c:1904-1912 fixup.
 #[cfg(unix)]
 pub(super) fn chmod_directory_target_mode(
     destination: &Path,
@@ -985,6 +1019,46 @@ pub(super) fn chmod_directory_target_mode(
         existing,
     );
     Ok(Some(mode & 0o7777))
+}
+
+/// The single owner of "which permission bits does a directory end up with"
+/// BEFORE upstream's during-transfer owner-`rwx` raise.
+///
+/// A directory walks the same `tweak_mode()`-then-`dest_mode()` pipeline every
+/// other type walks, so this is a thin adapter over
+/// [`chmod_tweaked_dest_mode`] supplying the two directory facts: `--chmod`
+/// DOES reach a directory (the `!S_ISLNK` gates at flist.c:1741-1742 and
+/// flist.c:996-997 pass it through, with `is_dir = true` selecting the `D`
+/// clauses), and `dest_mode()`'s `-E` tweak never fires
+/// (`S_ISREG(flist_mode)`, rsync.c:472).
+///
+/// `pre_transfer` is the destination's PRE-transfer stat - upstream judges a
+/// directory's `exists` by the pre-mkdir `statret` (generator.c:1856), so a
+/// fresh directory takes `flist_mode & (~CHMOD_BITS | dflt_perms)`
+/// (rsync.c:481-485) and a pre-existing one keeps its own bits
+/// (rsync.c:470-480). With `--perms` the (tweaked) source bits pass through.
+///
+/// The result deliberately EXCLUDES the during-transfer raise
+/// (generator.c:1904-1912) and its `touch_up_dirs` restore
+/// (generator.c:2594): those belong to the transfer-ordering owner - the
+/// local-copy executor and the network receiver each drive them from this one
+/// target value.
+#[cfg(unix)]
+pub(super) fn directory_dest_mode(
+    destination: &Path,
+    source_mode: u32,
+    options: &MetadataOptions,
+    pre_transfer: Option<&fs::Metadata>,
+) -> u32 {
+    chmod_tweaked_dest_mode(
+        options.chmod(),
+        destination,
+        source_mode,
+        true,  // S_ISDIR: --chmod `D` clauses apply
+        false, // !S_ISREG: dest_mode()'s -E tweak never fires for a dir
+        options,
+        pre_transfer,
+    ) & 0o7777
 }
 
 /// Composes the `--chmod` tweak with upstream's `dest_mode()` collapse:
@@ -1200,16 +1274,21 @@ pub(super) fn apply_permissions_from_entry(
                     );
                 }
             } else if entry.file_type().is_dir() {
-                // upstream: generator.c:1466-1467 - even when !preserve_perms
+                // upstream: generator.c:1856 - even when !preserve_perms
                 // the generator runs `file->mode = dest_mode(...)` for
-                // directories, and set_file_attrs() (rsync.c:659-660) chmods
+                // directories, and set_file_attrs() (rsync.c:658) chmods
                 // the dir to it. A new dir therefore lands the source mode
                 // masked by dflt_perms (so a source 0700 dir stays 0700 rather
                 // than the mkdir umask default); an existing dir keeps its own
                 // permission bits (pre_transfer_meta = Some -> the exists=true
                 // branch). Without this, a network-received dir was created
                 // `mkdirat(0o777)` and never re-chmod'd, landing 0o755.
-                let mut new_mode = dest_mode_for_existing_or_new(entry, pre_transfer_meta);
+                let mut new_mode = directory_dest_mode(
+                    destination,
+                    entry.permissions(),
+                    options,
+                    pre_transfer_meta,
+                );
                 let fresh_meta;
                 let current_meta = if let Some(meta) = cached_meta {
                     meta
@@ -1226,14 +1305,22 @@ pub(super) fn apply_permissions_from_entry(
                 if pre_transfer_meta.is_none() && (current_mode & 0o2000) != 0 {
                     new_mode |= 0o2000;
                 }
-                // A directory whose target mode lacks owner rwx would block the
-                // receiver from writing its contents. Upstream keeps it
-                // writable during the transfer via the dir_tweaking u+rwx grant
-                // (generator.c:1512) and restores the strict mode in
-                // touch_up_dirs; that grant is gated on --perms here, so in the
-                // !perms path leave such a directory at its umask default
-                // (owner-writable) rather than chmod'ing it non-writable.
-                if (new_mode & 0o700) == 0o700 && (current_mode & 0o7777) != (new_mode & 0o7777) {
+                // upstream: generator.c:1904-1912 - a non-root transfer raises
+                // a directory lacking full owner-rwx to `mode | S_IRWXU` at its
+                // first visit so its contents can still be written; the gate is
+                // `!am_root && (file->mode & S_IRWXU) != S_IRWXU &&
+                // dir_tweaking` with NO --perms condition (dir_tweaking =
+                // !(list_only || solo_file || dry_run), generator.c:2743).
+                // touch_up_dirs (generator.c:2594) later restores the strict
+                // mode only when `!(file->mode & S_IWUSR)`; the receiver
+                // records that restore, so the raised mode is what lands here.
+                if !options.fake_super_enabled()
+                    && !nix::unistd::geteuid().is_root()
+                    && (new_mode & 0o700) != 0o700
+                {
+                    new_mode |= 0o700;
+                }
+                if (current_mode & 0o7777) != (new_mode & 0o7777) {
                     // upstream: syscall.c:do_chmod():800-802 - when neither
                     // --perms nor --executability is active, chmod failure is
                     // non-fatal. upstream returns 0 so set_file_attrs() continues.
@@ -1661,6 +1748,90 @@ mod tests {
             symlink_pre_transfer_stat(&new, &current, Some(&obstacle)).is_none(),
             "destination_is_new wins: a brand-new destination has no \
              pre-transfer stat, whatever the caller passes"
+        );
+    }
+
+    /// `directory_dest_mode()` table pins, mirroring the symlink pins above:
+    /// which `dest_mode()` arm a directory takes, that `--chmod`'s `D` clauses
+    /// DO reach it (contrast with a link), and that the result excludes the
+    /// during-transfer owner-rwx raise.
+    ///
+    /// upstream: generator.c:1856 (`exists` judged by the pre-mkdir statret) +
+    /// rsync.c:464-486 dest_mode().
+    #[test]
+    fn directory_dest_mode_new_dir_masks_the_source_and_drops_special_bits() {
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("d");
+        let dflt = default_perms_seed(dest.parent());
+        let opts = MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false);
+
+        for source in [0o777u32, 0o750, 0o644, 0o500] {
+            let got = directory_dest_mode(&dest, 0o040000 | source, &opts, None);
+            assert_eq!(got, source & dflt, "new dir takes source & dflt_perms");
+            assert_eq!(got & !source, 0, "the mask can only remove bits");
+        }
+
+        // upstream: rsync.c:482-483 - "turn off special permissions".
+        let got = directory_dest_mode(&dest, 0o042755, &opts, None);
+        assert_eq!(got & 0o7000, 0, "setgid/setuid/sticky must not survive");
+    }
+
+    /// upstream: rsync.c:470-480 - the exists arm keeps the destination
+    /// directory's own permission bits; the raise/restore dance is the
+    /// caller's business and must not leak into this value.
+    #[test]
+    fn directory_dest_mode_existing_dir_keeps_its_own_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("d");
+        std::fs::create_dir(&dest).expect("create dir");
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o555))
+            .expect("seed dest bits");
+        let on_disk = std::fs::metadata(&dest).expect("meta");
+        let opts = MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false);
+
+        assert_eq!(
+            directory_dest_mode(&dest, 0o040755, &opts, Some(&on_disk)),
+            0o555,
+            "an existing dir keeps its own bits, not the sender's 0o755"
+        );
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755)).expect("unlock");
+    }
+
+    /// upstream: flist.c:1741-1742 gates `tweak_mode()` on `!S_ISLNK`, so a
+    /// directory IS tweaked (with `is_dir` selecting the `D` clauses), and with
+    /// `--perms` the tweaked mode passes through with no collapse
+    /// (generator.c:1856 runs only under `!preserve_perms`).
+    #[test]
+    fn directory_dest_mode_chmod_reaches_a_directory() {
+        let dir = tempdir().expect("tempdir");
+        let dest = dir.path().join("d");
+        let chmod = crate::ChmodModifiers::parse("go-rwx").expect("parse chmod");
+
+        let perms = MetadataOptions::new()
+            .preserve_permissions(true)
+            .preserve_times(false)
+            .with_chmod(Some(chmod.clone()));
+        assert_eq!(
+            directory_dest_mode(&dest, 0o040755, &perms, None),
+            0o700,
+            "--chmod=go-rwx must reach a directory under -p"
+        );
+
+        let no_perms = MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false)
+            .with_chmod(Some(chmod));
+        let dflt = default_perms_seed(dest.parent());
+        assert_eq!(
+            directory_dest_mode(&dest, 0o040755, &no_perms, None),
+            0o700 & dflt,
+            "tweak FIRST, dest_mode() collapse SECOND (flist.c:1741-1742)"
         );
     }
 }

--- a/crates/metadata/src/chmod/mod.rs
+++ b/crates/metadata/src/chmod/mod.rs
@@ -102,10 +102,10 @@ const S_IWUSR: u32 = 0o200;
 /// Final on-disk permission bits a directory carries after upstream rsync's
 /// during-transfer permission dance, given the `--chmod`-tweaked `mode`.
 ///
-/// upstream: generator.c:1512-1520 raises every directory to owner-`rwx` while
-/// its contents are written (`do_chmod_at(fname, file->mode | S_IRWXU)`), then
-/// generator.c:2107-2145 `touch_up_dirs()` restores the tweaked mode ONLY when
-/// the owner would otherwise lack write
+/// upstream: generator.c:1904-1912 raises every directory to owner-`rwx` while
+/// its contents are written (`gen_entry_chmod(fname, file, file->mode | S_IRWXU)`),
+/// then generator.c:2565-2611 `touch_up_dirs()` restores the tweaked mode ONLY
+/// when the owner would otherwise lack write
 /// (`fix_dir_perms = !am_root && !(file->mode & S_IWUSR)`). The net effect a
 /// synchronous local copy must reproduce: a tweak that leaves an owner-writable
 /// but not fully owner-`rwx` directory keeps the transient owner bits (e.g.
@@ -140,8 +140,8 @@ pub fn directory_transfer_mode(mode: u32, running_as_root: bool) -> u32 {
 /// The transfer root is addressed as `dst/.`, so upstream's during-transfer
 /// fixup `do_chmod_at("dst/.", mode | S_IRWXU)` must resolve `.` *inside* `dst`,
 /// which needs owner-execute on `dst`. When the tweaked mode strips owner
-/// execute the chmod fails with `EACCES` (generator.c:1514 "failed to modify
-/// permissions on %s") and the generator can no longer stat or create the
+/// execute the chmod fails with `EACCES` (generator.c:1907-1909 "failed to
+/// modify permissions on %s") and the generator can no longer stat or create the
 /// directory's contents, so nothing under it transfers and rsync exits 23.
 /// Non-root directories are addressed by name and never take this path.
 #[must_use]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -294,7 +294,8 @@ pub use apply::group_is_settable;
 #[cfg(unix)]
 pub use apply::{
     apply_dest_mode_pre_transfer, apply_file_metadata_with_fd,
-    apply_file_metadata_with_fd_if_changed, init_orig_umask, transfer_root_chmod_self_lock,
+    apply_file_metadata_with_fd_if_changed, directory_dest_mode, init_orig_umask,
+    transfer_root_chmod_self_lock,
 };
 pub use apply::{
     apply_directory_metadata, apply_directory_metadata_with_options, apply_file_metadata,

--- a/crates/transfer/src/disk_commit/process/tests.rs
+++ b/crates/transfer/src/disk_commit/process/tests.rs
@@ -1180,20 +1180,22 @@ fn dir_mode(path: &Path) -> u32 {
 ///
 /// `create_backup_path_parents` does
 /// `env.metadata_opts.cloned().unwrap_or_default()`, and
-/// `MetadataOptions::default()` preserves permissions - so
-/// [`make_backup_backup_dir_subdir_inherits_source_mode`], which asks for
-/// `preserve_permissions(true)`, passes identically whether the field is
-/// threaded or dropped: the default agrees with it. This cell asks for
-/// `preserve_permissions(false)`, which no default can supply, so the freshly
-/// created backup subdirectory must keep the plain `mkdir` mode instead of the
-/// destination directory's.
+/// `MetadataOptions::default()` preserves times - so
+/// [`make_backup_backup_dir_subdir_inherits_source_mode`] passes identically
+/// whether the field is threaded or dropped: the default agrees with it. This
+/// cell asks for `preserve_times(false)`, which no default can supply, so the
+/// freshly created backup subdirectory must keep its wall-clock mtime instead
+/// of the destination directory's seeded one.
+///
+/// The permission leg cannot discriminate here: upstream's backup.c:173
+/// `set_file_attrs(backup_dir_buf, file, NULL, NULL, 0)` chmods the backup
+/// subdirectory to the destination directory's mode VERBATIM regardless of
+/// `--perms` (no `dest_mode()` collapse sits on the backup path - measured
+/// against rsync 3.5.0: dest dir 0700, `-r` without `-p` -> backup dir 0700),
+/// so that verbatim copy is pinned alongside.
 ///
 /// The two cells are each other's companions: this one proves the caller's
 /// options are consulted, that one proves the attribute copy runs at all.
-///
-/// upstream: `backup.c:173` `set_file_attrs(backup_dir_buf, file, NULL, NULL, 0)`
-/// applies the run's own preserve flags to each new backup subdirectory; it does
-/// not pick its own.
 #[cfg(unix)]
 #[test]
 fn make_backup_backup_dir_parent_honours_the_supplied_metadata_options() {
@@ -1201,13 +1203,23 @@ fn make_backup_backup_dir_parent_honours_the_supplied_metadata_options() {
 
     let (_dir, dest_dir, backup_dir, file_path, inherited_mode) = backup_dir_mode_fixture();
 
+    // Seed a recognisable old mtime on the destination subdirectory; a dropped
+    // metadata_opts (default: preserve_times on) would copy it to the backup
+    // subdirectory.
+    let seeded = filetime::FileTime::from_unix_time(1_000_000_000, 0);
+    filetime::set_file_mtime(dest_dir.join("sub"), seeded).expect("seed dest sub mtime");
+
     let config = BackupConfig {
         dest_dir: dest_dir.clone(),
         backup_dir: Some(backup_dir.clone()),
         suffix: OsString::new(),
     };
     let disk_config = DiskCommitConfig {
-        metadata_opts: Some(::metadata::MetadataOptions::new().preserve_permissions(false)),
+        metadata_opts: Some(
+            ::metadata::MetadataOptions::new()
+                .preserve_permissions(false)
+                .preserve_times(false),
+        ),
         ..DiskCommitConfig::default()
     };
 
@@ -1221,12 +1233,20 @@ fn make_backup_backup_dir_parent_honours_the_supplied_metadata_options() {
         backup_sub.join("payload.bin").exists(),
         "the fixture must actually place a backup under the new subdirectory"
     );
-    let mode = dir_mode(&backup_sub);
+    let backup_mtime = filetime::FileTime::from_last_modification_time(
+        &fs::metadata(&backup_sub).expect("stat backup sub"),
+    );
     assert_ne!(
+        backup_mtime, seeded,
+        "preserve_times(false) must reach the backup-dir attribute copy; a \
+         dropped metadata_opts falls back to a default that DOES preserve times"
+    );
+    // upstream: backup.c:173 - the mode is copied verbatim even without -p.
+    let mode = dir_mode(&backup_sub);
+    assert_eq!(
         mode, inherited_mode,
-        "preserve_permissions(false) must reach the backup-dir attribute copy; \
-         a dropped metadata_opts falls back to a default that DOES preserve \
-         permissions, got {mode:o}"
+        "the backup subdirectory must inherit the destination directory's \
+         permission bits verbatim, --perms or not (backup.c:173)"
     );
 }
 

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -459,6 +459,23 @@ pub struct ReceiverContext {
     /// network transfer, so the wire path is byte-identical; set only by
     /// [`run_local_replay`](Self::run_local_replay).
     pub(in crate::receiver) local_replay: bool,
+    /// Directories raised to owner-`rwx` for the transfer whose strict
+    /// `dest_mode()` result must be reinstated by `touch_up_dirs`, as
+    /// `(path, strict permission bits)`.
+    ///
+    /// Only the `!preserve_perms` arm records here: upstream rewrites
+    /// `file->mode = dest_mode(...)` in place (generator.c:1856) so its
+    /// `touch_up_dirs` can read the collapsed mode straight off the flist,
+    /// while oc's flist keeps the sender's original mode - for a pre-existing
+    /// directory the collapsed mode (the destination's own pre-transfer bits,
+    /// rsync.c:470-480) is recoverable ONLY at first-visit time, so it is
+    /// recorded then. The `--perms` restore continues to read the flist
+    /// directly. Guarded by a `Mutex` because directory metadata application
+    /// may run from the parallel batch path.
+    ///
+    /// upstream: generator.c:1904-1912 raise + generator.c:2594 fix_dir_perms.
+    #[cfg(unix)]
+    pub(in crate::receiver) dir_perm_restores: std::sync::Mutex<Vec<(std::path::PathBuf, u32)>>,
 }
 
 impl ReceiverContext {
@@ -548,6 +565,8 @@ impl ReceiverContext {
             io_error_delete_warning_emitted: false,
             // upstream: read_batch defaults off; the network path never sets it.
             local_replay: false,
+            #[cfg(unix)]
+            dir_perm_restores: std::sync::Mutex::new(Vec::new()),
         }
     }
 

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -48,16 +48,21 @@ impl DirDestination {
 /// must be granted a temporary `u+rwx` while the receiver writes files into
 /// it, with the real mode restored afterward by `touch_up_dirs`.
 ///
-/// Mirrors upstream `generator.c:1512-1520`: when the receiver is not root,
+/// Mirrors upstream `generator.c:1904-1912`: when the receiver is not root,
 /// is not running `--fake-super`, is preserving permissions, and the target
 /// directory mode lacks full user `rwx` (`(mode & S_IRWXU) != S_IRWXU`), the
 /// generator chmods the directory to `mode | S_IRWXU` so `mkstemp()` can
 /// create temp files inside it, then sets `need_retouch_dir_perms` so the
 /// restrictive mode is reinstated at the end of the transfer
-/// (`generator.c:2122-2127`, `fix_dir_perms`). Without this, a source
+/// (`generator.c:2594`, `fix_dir_perms`). Without this, a source
 /// directory with a read-only mode (for example `0555`) leaves the
 /// destination directory unwritable and every file transfer into it fails
 /// with `mkstemp ... Permission denied`.
+///
+/// This `--perms` arm tweaks the flist entry itself, because the `-p` apply
+/// chmods to the entry's bits; the `!preserve_perms` arm instead raises inside
+/// the `dest_mode()` apply (`metadata::apply_permissions_from_entry`) and its
+/// restore is recorded via [`ReceiverContext::record_dir_perm_restore`].
 #[cfg(unix)]
 fn dir_needs_writable_transfer_mode(
     preserve_perms: bool,
@@ -67,11 +72,53 @@ fn dir_needs_writable_transfer_mode(
     preserve_perms
         && !fake_super
         && !metadata::am_root()
-        // upstream: generator.c:1512 - (file->mode & S_IRWXU) != S_IRWXU
+        // upstream: generator.c:1904 - (file->mode & S_IRWXU) != S_IRWXU
         && (real_mode & 0o700) != 0o700
 }
 
 impl ReceiverContext {
+    /// Records the strict `dest_mode()` permission bits `touch_up_dirs` must
+    /// reinstate on a `!preserve_perms` directory that the metadata apply
+    /// raises to owner-`rwx` for the transfer.
+    ///
+    /// Upstream rewrites `file->mode = dest_mode(...)` in place
+    /// (generator.c:1856), so its `touch_up_dirs` reads the collapsed mode
+    /// straight off the flist. oc's flist keeps the sender's original mode, and
+    /// for a pre-existing directory the collapsed mode (the destination's own
+    /// pre-transfer bits, rsync.c:470-480) is only recoverable now - after the
+    /// raise the on-disk owner bits are gone - so it is recorded at first-visit
+    /// time. The restore condition mirrors `fix_dir_perms = !am_root &&
+    /// !(file->mode & S_IWUSR)` (generator.c:2594); the raise condition mirrors
+    /// `(file->mode & S_IRWXU) != S_IRWXU` (generator.c:1904).
+    ///
+    /// The `--perms` arm does not record: its restore keeps reading the flist
+    /// entry directly in [`Self::touch_up_dirs`].
+    #[cfg(unix)]
+    fn record_dir_perm_restore(
+        &self,
+        dir_path: &Path,
+        entry: &FileEntry,
+        metadata_opts: &MetadataOptions,
+        pre_transfer: Option<&fs::Metadata>,
+    ) {
+        if metadata_opts.permissions() || metadata_opts.fake_super_enabled() || metadata::am_root()
+        {
+            return;
+        }
+        let target = metadata::directory_dest_mode(
+            dir_path,
+            entry.permissions(),
+            metadata_opts,
+            pre_transfer,
+        );
+        if target & 0o700 != 0o700 && target & 0o200 == 0 {
+            self.dir_perm_restores
+                .lock()
+                .expect("dir_perm_restores poisoned")
+                .push((dir_path.to_path_buf(), target));
+        }
+    }
+
     /// Classifies a directory destination, removing a conflicting symlink first
     /// when required.
     ///
@@ -511,7 +558,7 @@ impl ReceiverContext {
         } else {
             metadata_opts.clone()
         };
-        // upstream: generator.c:1512-1520 - grant a transient u+rwx to any
+        // upstream: generator.c:1904-1912 - grant a transient u+rwx to any
         // directory whose final mode is not writable by us so the receiver can
         // create temp files inside it; the real mode is restored in
         // touch_up_dirs. Captured here so the closure below stays Send.
@@ -542,7 +589,7 @@ impl ReceiverContext {
                     ) {
                         entry.set_mode(entry.mode() | 0o700);
                     }
-                    // upstream: generator.c:1465 dest_mode(..., statret == 0) -
+                    // upstream: generator.c:1856 dest_mode(..., statret == 0) -
                     // an existing dir keeps its own perms (exists=true), a new
                     // dir gets the source mode masked by dflt_perms
                     // (exists=false). Supply the pre-transfer stat only for a
@@ -556,6 +603,15 @@ impl ReceiverContext {
                     (dir_path, entry, xattr_list, pre_transfer)
                 })
                 .collect();
+        // upstream: generator.c:1904-1912 + generator.c:2594 - the
+        // !preserve_perms metadata apply raises a directory lacking owner-rwx;
+        // record which strict modes touch_up_dirs must reinstate BEFORE the
+        // raise erases the pre-transfer bits. Serial on purpose: the parallel
+        // phase below only applies, never decides.
+        #[cfg(unix)]
+        for (dir_path, entry, _, pre_transfer) in &entry_snapshots {
+            self.record_dir_perm_restore(dir_path, entry, metadata_opts, pre_transfer.as_ref());
+        }
         let dir_creation_errors: Vec<(PathBuf, String)> = failed_dir_paths
             .into_iter()
             .map(|p| {
@@ -749,7 +805,7 @@ impl ReceiverContext {
     /// for an existing dir, the attribute-diff flags computed against the
     /// pre-apply destination stat (`ITEM_REPORT_{TIME,PERMS,OWNER,GROUP}`),
     /// mirroring upstream's `itemize()` at `generator.c:1481` which runs before
-    /// `set_file_attrs` (`generator.c:1503`). Only returns `Err` for
+    /// `set_file_attrs` (`generator.c:1895`). Only returns `Err` for
     /// unrecoverable errors.
     ///
     /// Under `--dry-run` / `--list-only` the destination is left untouched: no
@@ -862,7 +918,7 @@ impl ReceiverContext {
             return Ok(None);
         }
         // upstream: generator.c:1480-1483 - itemize() runs before set_file_attrs
-        // (generator.c:1503), so compute the itemize flags from the pre-apply
+        // (generator.c:1895), so compute the itemize flags from the pre-apply
         // destination stat here. A new dir reports ITEM_LOCAL_CHANGE|ITEM_IS_NEW
         // (`cd+++++++++`); an existing dir reports the attribute-diff flags
         // (ITEM_REPORT_{TIME,PERMS,OWNER,GROUP}) so a differing root `.` mtime
@@ -946,7 +1002,7 @@ impl ReceiverContext {
         // (`run_pipelined_incremental`) decides it from `verbose_dir_name_lines`
         // against the pre-transfer stat, exactly as `run_pipelined` does, so an
         // unchanged directory stays silent (upstream names a directory only when
-        // `set_file_attrs()` changed it, generator.c:1503-1505) and the name can
+        // `set_file_attrs()` changed it, generator.c:1895-1897) and the name can
         // be interleaved with `--progress` in flist order. Naming it here also
         // ran after this call's own metadata apply, which is too late to observe
         // the pre-transfer state.
@@ -962,10 +1018,10 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:1503` - `set_file_attrs()` after the directory mkdir
-    /// - `generator.c:1465` - `dest_mode(..., statret == 0)` keeps an existing
+    /// - `generator.c:1895` - `set_file_attrs()` after the directory mkdir
+    /// - `generator.c:1856` - `dest_mode(..., statret == 0)` keeps an existing
     ///   directory's own permission bits when `--perms` is not in effect
-    /// - `generator.c:1512-1520` - transient `u+rwx` grant, undone by
+    /// - `generator.c:1904-1912` - transient `u+rwx` grant, undone by
     ///   [`Self::touch_up_dirs`]
     /// - `xattrs.c:set_xattr()` - xattrs are applied after metadata
     fn apply_incremental_dir_metadata(
@@ -977,7 +1033,7 @@ impl ReceiverContext {
         acl_cache: Option<&AclCache>,
         acl_id_map: Option<&AclIdMapper>,
     ) {
-        // upstream: generator.c:1512-1520 - grant a transient u+rwx to a
+        // upstream: generator.c:1904-1912 - grant a transient u+rwx to a
         // read-only directory so files can be written into it; the real mode
         // is restored in touch_up_dirs.
         #[cfg(unix)]
@@ -995,7 +1051,7 @@ impl ReceiverContext {
         let apply_entry = tweaked_entry.as_ref().unwrap_or(entry);
         #[cfg(not(unix))]
         let apply_entry = entry;
-        // upstream: generator.c:1465 dest_mode(..., statret == 0) - supply the
+        // upstream: generator.c:1856 dest_mode(..., statret == 0) - supply the
         // pre-transfer stat only for a dir that already existed so the !perms
         // dest_mode() apply keeps its own permission bits (exists=true) instead
         // of rewriting them; a freshly created dir (is_new) uses exists=false.
@@ -1004,6 +1060,11 @@ impl ReceiverContext {
         } else {
             fs::metadata(dir_path).ok()
         };
+        // upstream: generator.c:1904-1912 + generator.c:2594 - record the
+        // strict mode touch_up_dirs must reinstate before the !preserve_perms
+        // apply below raises the directory to owner-rwx.
+        #[cfg(unix)]
+        self.record_dir_perm_restore(dir_path, entry, metadata_opts, pre_transfer.as_ref());
         if let Err(e) = apply_metadata_with_pre_transfer_stat(
             dir_path,
             apply_entry,
@@ -1085,9 +1146,9 @@ impl ReceiverContext {
     ///
     /// # Upstream Reference
     ///
-    /// - `generator.c:2093-2146` - `touch_up_dirs(dir_flist, -1)` iterates in
+    /// - `generator.c:2565-2611` - `touch_up_dirs(dir_flist, -1)` iterates in
     ///   reverse order and repairs perms then times.
-    /// - `generator.c:2122-2127` - `fix_dir_perms = !am_root && !(mode &
+    /// - `generator.c:2594` - `fix_dir_perms = !am_root && !(mode &
     ///   S_IWUSR)` restores the real directory mode.
     /// - `generator.c:2398-2399` - `need_retouch_dir_times` gating:
     ///   `preserve_mtimes && !omit_dir_times`.
@@ -1104,16 +1165,47 @@ impl ReceiverContext {
             return;
         }
 
-        // upstream: generator.c:2271 - need_retouch_dir_times =
+        // upstream: generator.c:2744 - need_retouch_dir_times =
         // preserve_mtimes && !omit_dir_times. `effective_omit_dir_times` folds
         // in the implicit `--backup`-without-`--backup-dir` rule
         // (options.c:2342-2343, generator.c:2101), so the same predicate governs
         // both this retouch pass and the creation-time apply above.
         let retouch_times = self.config.flags.times && !self.config.effective_omit_dir_times();
 
-        // upstream: generator.c:2122 - fix_dir_perms = !am_root && !(mode &
-        // S_IWUSR); only meaningful when we preserve perms (otherwise the
-        // directory keeps its umask-derived writable mode).
+        // upstream: generator.c:2594-2599 - restore the strict dest_mode()
+        // result on the !preserve_perms directories the metadata apply raised
+        // to owner-rwx at first visit (recorded then, because the raise erases
+        // a pre-existing directory's own bits). Deepest-first so a parent's
+        // restore cannot strip the search permission a child's restore still
+        // needs.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut recorded = std::mem::take(
+                &mut *self
+                    .dir_perm_restores
+                    .lock()
+                    .expect("dir_perm_restores poisoned"),
+            );
+            recorded.sort_by(|a, b| b.0.components().count().cmp(&a.0.components().count()));
+            for (dir_path, mode) in recorded {
+                let _ = writer.maybe_send_keepalive();
+                if let Err(e) = fs::set_permissions(&dir_path, fs::Permissions::from_mode(mode)) {
+                    debug_log!(
+                        Recv,
+                        1,
+                        "touch_up_dirs: failed to restore perms on {}: {}",
+                        dir_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+
+        // upstream: generator.c:2594 - fix_dir_perms = !am_root && !(mode &
+        // S_IWUSR). This walk reads the flist mode directly, which is only the
+        // applied mode under --perms; the !preserve_perms restores were drained
+        // from the recorded list above.
         #[cfg(unix)]
         let retouch_perms =
             self.config.flags.perms && !self.config.fake_super && !metadata::am_root();
@@ -1125,7 +1217,7 @@ impl ReceiverContext {
         }
 
         // Iterate in reverse so deepest directories are touched first.
-        // upstream: generator.c:2083 - for (i = dir_flist->used - 1; i >= 0; i--)
+        // upstream: generator.c:2581 - for (i = dir_flist->used - 1; i >= 0; i--)
         for entry in self.file_list.iter().rev() {
             // upstream: generator.c:2138-2144 - poke a keepalive once the I/O
             // lull has elapsed so a remote sender does not time out while this
@@ -1143,7 +1235,7 @@ impl ReceiverContext {
                 dest_dir.join(relative_path)
             };
 
-            // upstream: generator.c:2124-2125 - restore the real mode before
+            // upstream: generator.c:2598-2599 - restore the real mode before
             // the mtime repair. Only directories that lack the user write bit
             // were tweaked, so only those are chmod'd back.
             #[cfg(unix)]
@@ -1533,7 +1625,7 @@ mod touch_up_dirs_tests {
     /// mtime with the current time. `touch_up_dirs` must re-apply the
     /// original mtime from the file list entry.
     ///
-    /// upstream: generator.c:2093-2146 - touch_up_dirs()
+    /// upstream: generator.c:2565-2611 - touch_up_dirs()
     #[test]
     fn restores_directory_mtime_after_file_writes() {
         let dir = test_support::create_tempdir();
@@ -1570,7 +1662,7 @@ mod touch_up_dirs_tests {
     /// Under `--omit-dir-times` the retouch pass must NOT re-apply the source
     /// directory mtime, leaving the directory at its (current) on-disk mtime.
     ///
-    /// upstream: generator.c:2271 - `need_retouch_dir_times = preserve_mtimes
+    /// upstream: generator.c:2744 - `need_retouch_dir_times = preserve_mtimes
     /// && !omit_dir_times`. On a remote pull the local client IS the receiver
     /// and `-O` never rides the wire (options.c:2646-2647 gates the compact
     /// 'O' on am_sender), so the receiver config must carry `omit_dir_times`
@@ -1609,7 +1701,7 @@ mod touch_up_dirs_tests {
     }
 
     /// The writable-transfer helper mirrors upstream's `dir_tweaking` gate
-    /// (`generator.c:1512`): only a non-root receiver preserving perms on a
+    /// (`generator.c:1904`): only a non-root receiver preserving perms on a
     /// directory that lacks full user `rwx` needs the transient `u+rwx`.
     #[cfg(unix)]
     #[test]
@@ -1634,7 +1726,7 @@ mod touch_up_dirs_tests {
     /// writable while the receiver creates files inside it, then be restored
     /// to its restrictive mode afterward.
     ///
-    /// upstream: generator.c:1512-1520 (grant `u+rwx`) + generator.c:2122-2127
+    /// upstream: generator.c:1904-1912 (grant `u+rwx`) + generator.c:2594
     /// (`fix_dir_perms` restore in touch_up_dirs).
     #[cfg(unix)]
     #[test]
@@ -1686,6 +1778,177 @@ mod touch_up_dirs_tests {
                 "restrictive directory mode must be restored after transfer"
             );
         }
+    }
+
+    /// The `!preserve_perms` counterpart of the test above: a fresh directory
+    /// must land upstream's `dest_mode()` result, raised to owner-rwx for the
+    /// transfer window and restored by `touch_up_dirs` only when owner-write
+    /// is absent. Entry mode 0o500 pins all three: dest_mode gives 0o500
+    /// (dflt_perms always carries the owner bits), the raise makes 0o700 of
+    /// it (generator.c:1904-1912), and fix_dir_perms restores 0o500
+    /// (generator.c:2594). Measured against rsync 3.5.0 over rsh: `-r` src
+    /// dir 0o555 -> dest 0o555, src 0o400 -> 0o400; the pre-fix receiver left
+    /// the mkdirat(0o777) umask default.
+    #[cfg(unix)]
+    #[test]
+    fn fresh_dir_without_perms_lands_dest_mode_raised_then_restored() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if metadata::am_root() {
+            return; // the raise/restore dance is gated on !am_root.
+        }
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let config = config_with_times(false);
+        assert!(!config.flags.perms, "fixture must run without --perms");
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.file_list = vec![FileEntry::new_directory("sub".into(), 0o500)];
+
+        let opts = metadata::MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false);
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        ctx.create_directories(
+            dest,
+            &opts,
+            None,
+            None,
+            &mut writer,
+            #[cfg(unix)]
+            None,
+        )
+        .expect("create_directories succeeds");
+
+        let sub = dest.join("sub");
+        let during = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            during, 0o700,
+            "during the transfer the dir carries dest_mode | S_IRWXU"
+        );
+        fs::write(sub.join("file.txt"), b"payload")
+            .expect("must be able to create files inside mid-transfer");
+        fs::remove_file(sub.join("file.txt")).expect("drop probe file");
+
+        ctx.touch_up_dirs(
+            dest,
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
+        let mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
+        let _ = fs::set_permissions(&sub, fs::Permissions::from_mode(0o755));
+        assert_eq!(
+            mode, 0o500,
+            "touch_up_dirs must reinstate the strict dest_mode() result"
+        );
+    }
+
+    /// Owner-writable-but-not-executable entry under `!preserve_perms`: the
+    /// raise fires but the restore must NOT (fix_dir_perms requires
+    /// `!(file->mode & S_IWUSR)`, generator.c:2594). Measured against rsync
+    /// 3.5.0 over rsh: `-r` src dir 0o644 -> dest 0o744.
+    #[cfg(unix)]
+    #[test]
+    fn owner_writable_dir_without_perms_keeps_the_raise_residue() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if metadata::am_root() {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times(false));
+        ctx.file_list = vec![FileEntry::new_directory("sub".into(), 0o644)];
+
+        let opts = metadata::MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false);
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        ctx.create_directories(
+            dest,
+            &opts,
+            None,
+            None,
+            &mut writer,
+            #[cfg(unix)]
+            None,
+        )
+        .expect("create_directories succeeds");
+        ctx.touch_up_dirs(
+            dest,
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
+
+        let mode = fs::metadata(dest.join("sub")).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o744,
+            "owner-write blocks the restore, so the raise residue sticks"
+        );
+    }
+
+    /// A PRE-EXISTING read-only directory under `!preserve_perms`: dest_mode's
+    /// exists arm keeps its own 0o555 (rsync.c:470-480), the raise makes it
+    /// writable for the transfer, and `touch_up_dirs` restores the recorded
+    /// 0o555 - the mode is recoverable only at first-visit time, which is
+    /// what [`ReceiverContext::record_dir_perm_restore`] exists for. Measured
+    /// against rsync 3.5.0 over rsh: pre-existing 0o555 root, `-r` -> rc 0,
+    /// files transferred, root restored to 0o555; the pre-fix receiver failed
+    /// the writes with EACCES.
+    #[cfg(unix)]
+    #[test]
+    fn preexisting_readonly_dir_without_perms_is_raised_then_restored() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if metadata::am_root() {
+            return;
+        }
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let sub = dest.join("sub");
+        fs::create_dir(&sub).expect("pre-create sub");
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o555)).expect("chmod sub");
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config_with_times(false));
+        // The sender's mode differs on purpose: the exists arm must keep the
+        // destination's own 0o555, not adopt the sender's 0o755.
+        ctx.file_list = vec![FileEntry::new_directory("sub".into(), 0o755)];
+
+        let opts = metadata::MetadataOptions::new()
+            .preserve_permissions(false)
+            .preserve_times(false);
+        let mut writer = crate::writer::ServerWriter::new_plain(Vec::new());
+        ctx.create_directories(
+            dest,
+            &opts,
+            None,
+            None,
+            &mut writer,
+            #[cfg(unix)]
+            None,
+        )
+        .expect("create_directories succeeds");
+
+        fs::write(sub.join("file.txt"), b"payload")
+            .expect("the raise must make the read-only dir writable mid-transfer");
+        fs::remove_file(sub.join("file.txt")).expect("drop probe file");
+
+        ctx.touch_up_dirs(
+            dest,
+            &mut crate::writer::ServerWriter::new_plain(Vec::new()),
+        );
+        let mode = fs::metadata(&sub).unwrap().permissions().mode() & 0o777;
+        let _ = fs::set_permissions(&sub, fs::Permissions::from_mode(0o755));
+        assert_eq!(
+            mode, 0o555,
+            "the pre-transfer bits must be restored from the recorded strict mode"
+        );
     }
 
     /// When `--times` is not set, `touch_up_dirs` must be a no-op.


### PR DESCRIPTION
## What

The directory dest-mode cluster: three coupled divergences from upstream's directory mode handling, found by task 1182's control cell and measured as 32 of 76 oracle cells diverging from real rsync 3.5.0.

1. **Fresh directories ignored `dest_mode()` composition** — created-directory modes were not routed through the one tweak-then-collapse owner, so `--chmod` tweak residues diverged (644→744 / 640→740 / 600→700 cells).
2. **A pre-existing unwritable directory was not raised before its contents** — upstream chmods the directory to `mode | S_IRWXU` BEFORE writing into it (generator.c:1904-1912, `!am_root` gated, non-fatal `FERROR_XFER` on failure) and restores the final mode afterwards; oc wrote into it as-is and failed.
3. **The restore pass ordering** — deferred final modes are drained deepest-first so a parent's restore cannot re-lock a child still being finalized.

## Fix

- `directory_dest_mode()` — a thin adapter over the one `chmod_tweaked_dest_mode()` owner from #7748, so files/dirs/links now share a single `dest_mode()` implementation.
- `keep_preexisting_directory_writable()` runs on first visit BEFORE contents, gated exactly as upstream (`!am_root`, excluded under `--fake-super`); raise failure is non-fatal, mirroring generator.c:1907-1910. Non-Unix stub.
- Receiver `dir_perm_restores` map drained deepest-first in `touch_up_dirs`.
- The existing `destination_access_error` probe changed from `read_dir` to `stat dest/.`, which also un-breaks a 0333 destination root (traversable but unreadable).

## Measured

76/76 oracle cells match real rsync 3.5.0 (was 44/76): fresh-dir 54/54 including the tweak residues; pre-existing-root 10/10 including 555→restored-rc0 and 644→untouched-rc3; subdir and remote-rsh legs all match. Mutations: A (create-mode routing) kills exactly 6 cells, B (early-raise ordering) kills exactly 8 — per-mechanism attribution, both reverted.

## Verification

- Rebased onto master past the #7766 squash; the metadata tests.rs conflict resolved by taking MASTER's side (that repair already landed); one pure test-append adjacency in permissions.rs kept both halves. Diff-of-diffs vs the pre-rebase commit is clean apart from those two seams.
- Gates at pinned 1.88.0: whole-tree rustfmt clean; clippy metadata+engine+transfer+cli `--all-targets --all-features` clean; nextest metadata+engine+transfer --lib 7889/7889 (one known APFS sparse flake retried green); the cluster's own 13 tests green; 108/108 root integration tests pre-rebase.
- Residual gaps reported, not fixed: the receiver --chmod-without-perms dir path lacks the raise (pre-existing); --relative intermediate dirs judge existence post-creation; one rc3 stderr wording difference (exit code and effects match).
