### PR TITLE
ci: make the rustdoc intra-doc link job blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,15 +241,14 @@ jobs:
   # cfg(all(target_os = "linux", feature = "io_uring")), so ubuntu +
   # --all-features is the only combination that compiles those files at all.
   #
-  # Informational: it reports the link before it lands without adding a
-  # merge-blocking context to the queue. Promote to required once it has run
-  # green for a while.
+  # Blocking: a failure here fails the workflow, so the link is repaired on
+  # the PR instead of post-merge. The context is intended to be registered as
+  # required in the branch ruleset.
   # ===========================================================================
   rustdoc-links:
-    name: rustdoc links (informational)
+    name: rustdoc links
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
 
     env:
       RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"


### PR DESCRIPTION
## What

The `rustdoc links` job loses `continue-on-error: true` and its "(informational)" label: a broken intra-doc link now fails the workflow on the PR that introduces it, instead of being discovered when Pages reddens master post-merge.

## Why now

The job's own comment promised "promote to required once it has run green for a while" - it has: the job is green on the current master lineage (verified on the last two merged waves). Four PRs (#7264, #7489, #7555, #7618) repaired this exact class post-merge before the job existed; making it blocking closes that recurrence path.

The context rename (`rustdoc links (informational)` -> `rustdoc links`) means the branch-ruleset registration should target the new name.
