### PR TITLE
fix(transfer): munge symlink targets before the --safe-links check

### DIFF
--- a/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
+++ b/crates/daemon/src/tests/chunks/daemon_munge_symlinks_push.rs
@@ -115,8 +115,11 @@ fn daemon_munge_symlinks_push_prepends_prefix() {
     assert_eq!(
         parent_link,
         std::path::Path::new("/rsyncd-munged/../escape"),
-        "parent-escape targets must carry the prefix unmodified, so the \
-         munge guard composes with `--safe-links` rather than substituting it",
+        "parent-escape targets must carry the prefix unmodified so a later \
+         munging sender can strip it and restore the original target \
+         (upstream flist.c:274-278); note `--safe-links` does not evaluate \
+         munged links individually - the prefix is absolute, so a munging \
+         receiver under --safe-links skips every symlink (generator.c:1951)",
     );
 
     let real_content =

--- a/crates/transfer/src/receiver/directory/links.rs
+++ b/crates/transfer/src/receiver/directory/links.rs
@@ -114,26 +114,35 @@ impl ReceiverContext {
 
             let relative_path = entry.path();
 
-            // upstream: flist.c:1329 - `if (sanitize_paths && !munge_symlinks
-            // && *bp) sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`.
-            // `sanitize_paths` is set for a daemon module serving a path
-            // (clientserver.c:1068), so turning munging off does not leave the
-            // received target untouched: it still cannot resolve above the
-            // module root. The two transforms are mutually exclusive upstream,
-            // which is why this runs only when munging is off.
+            // Decode-time target transforms, applied before every consumer
+            // below (the --safe-links evaluation, the quick-check comparison,
+            // and the create syscall) because upstream rewrites the target
+            // while decoding the file list and everything downstream reads the
+            // stored `F_SYMLINK(file)`:
             //
-            // Applied *before* the safe-links evaluation because upstream
-            // sanitizes during the file-list decode, so the `--safe-links`
-            // check at generator.c:1951 reads the already-sanitized
-            // `F_SYMLINK(file)`. Sanitizing after the check instead would skip
-            // entries upstream creates.
-            let sanitized: PathBuf;
-            let wire_target = if !self.config.munge_symlinks
-                && self.config.connection.is_daemon_connection
+            // - upstream: flist.c:1070,1296-1299 - a receiver running with
+            //   `munge_symlinks` (a daemon module with `munge symlinks = yes`,
+            //   or --munge-links) prepends `/rsyncd-munged/` (rsync.h:36) so
+            //   the on-disk link cannot resolve outside the module root when
+            //   followed.
+            // - upstream: flist.c:1328 - `if (sanitize_paths && !munge_symlinks
+            //   && *bp) sanitize_path(bp, bp, "", lastdir_depth, SP_DEFAULT)`.
+            //   `sanitize_paths` is live only in the daemon server process
+            //   (clientserver.c:1067-1068; a non-chroot module records its full
+            //   path length as `module_dirlen`), never in the client end of a
+            //   daemon connection, so the client of a pull stores the wire
+            //   target verbatim. Measured against rsync 3.5.0: a pull client
+            //   keeps `abs_link -> /etc/hostname` byte-for-byte.
+            let transformed: PathBuf;
+            let target: &Path = if self.config.munge_symlinks {
+                transformed = apply_symlink_munge_prefix(wire_target);
+                &transformed
+            } else if self.config.connection.is_daemon_connection
+                && !self.config.connection.client_mode
                 && !wire_target.as_os_str().is_empty()
             {
-                sanitized = sanitize_received_symlink_target(wire_target, relative_path);
-                &sanitized
+                transformed = sanitize_received_symlink_target(wire_target, relative_path);
+                &transformed
             } else {
                 wire_target
             };
@@ -141,36 +150,19 @@ impl ReceiverContext {
             // upstream: generator.c:1951 - `if (safe_symlinks && unsafe_symlink(sl, fname))`
             // skips unsafe symlinks when --safe-links is set. The check stays
             // here (not in sanitize_file_list) to preserve protocol index
-            // alignment with the sender.
-            //
-            // Note the operand differs from upstream's. oc evaluates the wire
-            // target (pre-munge); upstream evaluates the already-munged one,
-            // because it applies the prefix during file-list decode and the
-            // generator then reads `F_SYMLINK(file)`. `unsafe_symlink()`
-            // rejects every absolute target, and munging makes every target
-            // absolute, so upstream under `munge symlinks = true` with
-            // --safe-links skips every symlink - safe ones included - while oc
-            // creates the safe ones. Measured against 3.4.4 and 3.5.0.
-            // Reordering to match is a behaviour change, not a comment fix.
+            // alignment with the sender. `sl` is the decoded target, i.e. the
+            // post-munge/post-sanitize value: `unsafe_symlink()` (util1.c:1569)
+            // rejects every absolute target and munging makes every target
+            // absolute, so a munging receiver under --safe-links skips every
+            // symlink - safe ones included - and the notice quotes the munged
+            // target. Measured against rsync 3.5.0 (daemon push with
+            // `munge symlinks = yes`, client --safe-links: every link skipped).
             if self.config.flags.safe_links
-                && crate::symlink_safety::is_unsafe_symlink(wire_target.as_os_str(), relative_path)
+                && crate::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative_path)
             {
-                self.report_ignored_unsafe_symlink(writer, relative_path, wire_target);
+                self.report_ignored_unsafe_symlink(writer, relative_path, target);
                 continue;
             }
-
-            // upstream: flist.c:1122-1126 - receiver prepends `/rsyncd-munged/`
-            // to the symlink target when the daemon enabled `munge symlinks`,
-            // so the on-disk link cannot resolve outside the module root when
-            // followed. Apply once here so both the quick-check comparison and
-            // the create syscall see the prefixed form.
-            let munged: std::path::PathBuf;
-            let target: &std::path::Path = if self.config.munge_symlinks {
-                munged = apply_symlink_munge_prefix(wire_target);
-                munged.as_path()
-            } else {
-                wire_target.as_path()
-            };
 
             let link_path = dest_dir.join(relative_path);
 
@@ -454,17 +446,10 @@ impl ReceiverContext {
 
             let relative_path = entry.path();
 
-            // upstream: generator.c:1951 - skip unsafe symlinks when --safe-links.
-            if self.config.flags.safe_links
-                && crate::symlink_safety::is_unsafe_symlink(wire_target.as_os_str(), relative_path)
-            {
-                self.report_ignored_unsafe_symlink(writer, relative_path, wire_target);
-                continue;
-            }
-
-            // upstream: flist.c:1122-1126 - prepend the `/rsyncd-munged/` prefix
-            // when the daemon enabled `munge symlinks` so the on-disk link
-            // cannot resolve outside the module root when followed.
+            // upstream: flist.c:1070,1296-1299 - prepend the `/rsyncd-munged/`
+            // prefix at decode time when the daemon enabled `munge symlinks`,
+            // so the on-disk link cannot resolve outside the module root when
+            // followed.
             let munged: std::path::PathBuf;
             let target: &std::path::Path = if self.config.munge_symlinks {
                 munged = std::path::PathBuf::from(::metadata::munge_symlink(
@@ -474,6 +459,17 @@ impl ReceiverContext {
             } else {
                 wire_target.as_path()
             };
+
+            // upstream: generator.c:1951 - skip unsafe symlinks when
+            // --safe-links. Mirrors the Unix arm: the operand is the decoded
+            // (post-munge) target, so a munging receiver skips every symlink -
+            // the munge prefix itself is the absolute path the check refuses.
+            if self.config.flags.safe_links
+                && crate::symlink_safety::is_unsafe_symlink(target.as_os_str(), relative_path)
+            {
+                self.report_ignored_unsafe_symlink(writer, relative_path, target);
+                continue;
+            }
 
             let link_path = dest_dir.join(relative_path);
 
@@ -1074,11 +1070,14 @@ impl ReceiverContext {
 /// Sanitizes a received symlink target so it cannot resolve above the module
 /// root, for daemon modules that disabled `munge symlinks`.
 ///
-/// Mirrors upstream `flist.c:1329`, which applies `sanitize_path(...,
+/// Mirrors upstream `flist.c:1328`, which applies `sanitize_path(...,
 /// SP_DEFAULT)` to the target whenever `sanitize_paths && !munge_symlinks`.
 /// `sanitize_paths` is set for a daemon module with a path
-/// (`clientserver.c:1068`), so the two transforms between them leave no daemon
-/// configuration in which a peer-supplied target reaches the disk verbatim.
+/// (`clientserver.c:1067-1068`), so the two transforms between them leave no
+/// daemon configuration in which a peer-supplied target reaches the disk
+/// verbatim. It is never set in the client end of a daemon connection, so the
+/// caller gates this on `!client_mode`: a pull client stores the wire target
+/// byte-for-byte (measured against rsync 3.5.0).
 ///
 /// This rewrite is what makes an absolute target relative, so a link to
 /// `/etc/hostname` becomes the in-tree `etc/hostname` and `--safe-links` no

--- a/crates/transfer/src/receiver/tests/munge_symlinks.rs
+++ b/crates/transfer/src/receiver/tests/munge_symlinks.rs
@@ -273,3 +273,104 @@ fn receiver_writes_unmunged_target_when_disabled() {
         "without `munge symlinks`, the receiver writes the wire target verbatim",
     );
 }
+
+/// A munging receiver under `--safe-links` skips every symlink - even one
+/// whose wire target is a safe in-tree relative path - because the munge
+/// prefix is applied at decode time and the safety check reads the munged
+/// value, which is always absolute.
+///
+/// upstream: flist.c:1070,1296-1299 - the receiver prepends `SYMLINK_PREFIX`
+/// while decoding the file list; generator.c:1951 then evaluates
+/// `safe_symlinks && unsafe_symlink(sl, fname)` on that stored value, and
+/// util1.c:1569 rejects every absolute target. Measured against rsync 3.5.0:
+/// a push into a `munge symlinks = yes` module with client `--safe-links`
+/// creates no symlinks at all, and each notice quotes the munged target.
+/// Checking the pre-munge wire target instead would create the safe ones -
+/// links upstream skips.
+#[test]
+fn munging_receiver_with_safe_links_skips_even_a_safe_relative_target() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut config = munge_receiver_config();
+    config.flags.safe_links = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "rel_link".into(),
+        0o777,
+        "real_file.txt".into(),
+    )];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    assert!(
+        std::fs::symlink_metadata(dest.join("rel_link")).is_err(),
+        "the munged target `/rsyncd-munged/real_file.txt` is absolute, so \
+         --safe-links must skip it exactly as upstream does \
+         (generator.c:1951 reads the post-munge target)",
+    );
+}
+
+/// Non-vacuity control for the skip above: without `--safe-links` the very
+/// same entry is created, munged. Together the pair pins the operand of the
+/// safety check - a check on the pre-munge wire target would create the link
+/// in both tests.
+#[test]
+fn munging_receiver_without_safe_links_still_creates_the_munged_link() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut ctx = ReceiverContext::new_for_test(&handshake, munge_receiver_config());
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "rel_link".into(),
+        0o777,
+        "real_file.txt".into(),
+    )];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    let on_disk = std::fs::read_link(dest.join("rel_link")).expect("read_link");
+    assert_eq!(
+        on_disk,
+        std::path::Path::new("/rsyncd-munged/real_file.txt"),
+        "without --safe-links the munged link is created \
+         (upstream flist.c:1070,1296-1299; measured against rsync 3.5.0)",
+    );
+}
+
+/// A plain (non-munging) receiver under `--safe-links` still creates a safe
+/// relative link: the blanket skip above is the munge prefix's doing, not a
+/// property of `--safe-links` itself.
+#[test]
+fn plain_receiver_with_safe_links_creates_a_safe_relative_target() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = tmp.path();
+
+    let handshake = test_handshake();
+    let mut config = plain_receiver_config();
+    config.flags.safe_links = true;
+    let mut ctx = ReceiverContext::new_for_test(&handshake, config);
+    ctx.file_list = vec![FileEntry::new_symlink(
+        "rel_link".into(),
+        0o777,
+        "real_file.txt".into(),
+    )];
+
+    let mut writer = CapturingMsgInfoWriter;
+    ctx.create_symlinks(dest, None, &mut writer)
+        .expect("create_symlinks must succeed on a writable tempdir");
+
+    let on_disk = std::fs::read_link(dest.join("rel_link")).expect("read_link");
+    assert_eq!(
+        on_disk,
+        std::path::Path::new("real_file.txt"),
+        "an in-tree relative target is safe and must be created \
+         (generator.c:1951 / util1.c:1569)",
+    );
+}

--- a/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
+++ b/crates/transfer/src/receiver/tests/sanitize_symlink_targets.rs
@@ -6,7 +6,13 @@
 //! so the decode path strips the leading `../` that would let the stored link
 //! resolve outside the module root. The two transforms are mutually
 //! exclusive and together they leave no configuration in which a
-//! client-supplied target reaches the disk verbatim.
+//! client-supplied target reaches the daemon's disk verbatim.
+//!
+//! Both transforms belong to the daemon server process. The client end of a
+//! daemon connection stores received targets verbatim: `sanitize_paths` is
+//! never set in an upstream client (clientserver.c:1067-1068 is the only
+//! assignment), so a pull client keeps `abs_link -> /etc/hostname`
+//! byte-for-byte and its own `--safe-links` check reads that raw value.
 //!
 //! The strip is budgeted, not unconditional: upstream passes `lastdir_depth`,
 //! the depth of the entry's own directory, so a target that walks back no
@@ -148,6 +154,49 @@ fn daemon_receiver_sanitizes_an_escaping_symlink_target_when_munging_is_off() {
         "a daemon receiver with `munge symlinks = false` must sanitize the \
          received target (upstream flist.c:1329); storing `../outside` \
          verbatim lets the link resolve outside the module root",
+    );
+}
+
+#[test]
+fn the_client_end_of_a_daemon_pull_stores_the_target_verbatim() {
+    // upstream: `sanitize_paths` is set only in the daemon server process
+    // (clientserver.c:1067-1068); the client end of a daemon connection never
+    // sanitizes a received target. Measured against rsync 3.5.0: a pull
+    // client stores `abs_link -> /etc/hostname` byte-for-byte. Rewriting the
+    // target on the client corrupts the user's data and (below) defeats the
+    // client's own --safe-links evaluation.
+    let mut config = daemon_receiver_without_munging();
+    config.connection.client_mode = true;
+
+    let on_disk = create_one_symlink(config, "../outside");
+
+    assert_eq!(
+        on_disk.as_deref(),
+        Some(std::path::Path::new("../outside")),
+        "the client end of a daemon pull must store the wire target verbatim \
+         (upstream sanitize_paths is daemon-server-side only, \
+         clientserver.c:1067-1068)",
+    );
+}
+
+#[test]
+fn a_pull_clients_safe_links_check_reads_the_verbatim_target() {
+    // Why the verbatim rule above is load-bearing: sanitizing `/etc/passwd`
+    // into `etc/passwd` turns an unsafe absolute target into a safe-looking
+    // relative one, so the client's --safe-links check would pass and create
+    // a link upstream skips. Measured against rsync 3.5.0: the pull client
+    // reports `ignoring unsafe symlink` and creates nothing
+    // (generator.c:1951 / util1.c:1569 "all absolute ... are unsafe").
+    let mut config = daemon_receiver_without_munging();
+    config.connection.client_mode = true;
+    config.flags.safe_links = true;
+
+    let on_disk = create_one_symlink(config, "/etc/passwd");
+
+    assert_eq!(
+        on_disk, None,
+        "an absolute wire target must reach the --safe-links check verbatim \
+         and be skipped; sanitize-then-check created a link upstream skips",
     );
 }
 


### PR DESCRIPTION
## What

Under a daemon module with `munge symlinks = yes` and a client passing `--safe-links`, oc created symlinks both upstreams skip. Two defect mechanisms, one root: the decode-time target transforms ran AFTER (or on the wrong side of) the `--safe-links` evaluation, while upstream rewrites the target during file-list decode (flist.c:1070,1296-1299 munge; flist.c:1328 sanitize) and generator.c:1951 then reads the stored, post-transform target - `unsafe_symlink()` (util1.c:1569) rejects every absolute target, and munging makes every target absolute, so a munging receiver under `--safe-links` skips every symlink.

- **Push**: oc checked `--safe-links` against the pre-munge wire target, then munged - so a safe relative link was created as `/rsyncd-munged/...` where upstream skips it, and refusal notices quoted the wrong target.
- **Pull**: oc's *client* ran the daemon-only sanitize (upstream's `sanitize_paths` has exactly one set site, in the daemon server process - clientserver.c:1067-1068), rewriting `/etc/hostname` to `etc/hostname` and making unsafe targets look safe. Now gated on `!client_mode`; a pull client stores the wire target verbatim, as measured against real 3.5.0.

The fix applies the transform (munge, else daemon sanitize) once, before every consumer - the `--safe-links` check, the quick-check comparison, and the create syscall - on both the Unix and Windows arms. The comment that pinned the old divergence as intentional is removed, and the backwards munge-composes-with-safe-links comment in the daemon push tests is corrected (under munge, `--safe-links` never evaluates links individually).

## Measured (real rsync 3.5.0 oracle; daemon `munge symlinks = yes`, `use chroot = false`)

Three diverging cells now match upstream, notice text included: pull `--safe-links` (rel created; abs/escape/munged-abs skipped with "ignoring unsafe symlink"; munged-rel demunged and created), pull without `--safe-links` (all targets verbatim), push `--safe-links` (ALL links skipped, notices quote munged targets). Two controls unchanged and matching: push without `--safe-links` (all created munged), push `--safe-links` with `munge = no` (sanitize arm).

## Verification

- 5 new tests including the non-vacuity pair (munged-safe-rel skipped under `--safe-links` / created munged without it).
- Mutation A (check the wire target instead of the transformed one) killed by the skip pin; mutation B (drop the `!client_mode` gate) killed by both sanitize tests; both reverted, 18/18 green after.
- Gates at pinned 1.88.0: whole-tree rustfmt clean; clippy transfer+daemon `--all-targets --all-features` clean; nextest transfer --lib 2539, daemon --lib 2014. No expect-manifests touched.

## Residuals (found, not fixed)

- The Unix e2e daemon symlink tests via `start_daemon_pending_no_detach` are vacuous (assertions only run on Windows per the harness doc; verified by planted panic) - needs the planned no-detach migration.
- Local `--munge-links` diverges the other way (oc munges on write where upstream's local child demunges on read, pipe.c:134) - engine path, separate change.
- One stale citation in the engine local-copy symlink module ("clientserver.c" should be flist.c:274-278) - behaviour claim holds, left untouched.
