### PR TITLE
fix(transfer): frame server generator -vv notices as MSG_INFO

### DIFF
--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -1329,14 +1329,14 @@ impl ReceiverContext {
         // already match. Skip entirely when no preservation flags are active.
         // On a no-change scan this eliminates ownership mapping, permission
         // comparison, and timestamp construction for every file.
-        if needs_metadata_apply
+        let attrs_updated = needs_metadata_apply
             && !metadata_unchanged(
                 entry,
                 metadata_opts,
                 stat_meta,
                 self.config.file_selection.modify_window,
-            )
-        {
+            );
+        if attrs_updated {
             if let Err(e) = apply_metadata_with_cached_stat(
                 file_path,
                 entry,
@@ -1380,6 +1380,32 @@ impl ReceiverContext {
                 ) {
                     metadata_errors.push((file_path.to_path_buf(), e.to_string()));
                 }
+            }
+        }
+
+        // upstream: rsync.c:824-829 set_file_attrs() - at INFO_GTE(NAME, 2)
+        // with ATTRS_REPORT the generator reports every quick-check match:
+        // "%s is uptodate" when nothing changed, the bare name when only
+        // attributes were retouched. ATTRS_REPORT is suppressed while itemize
+        // output is active (generator.c:2727 `stdout_format_has_i ? 0 :
+        // ATTRS_REPORT`). The line is FCLIENT, so a server-side generator
+        // frames it as MSG_INFO for the client to render and count
+        // (log.c rwrite() under am_server).
+        //
+        // A client-side generator (pull) routes the line through the stamped
+        // diagnostic buffer rather than straight to stdout, so it interleaves
+        // in production order with the `delta-transmission` notice the same
+        // generator emitted at setup (upstream prints that first, at
+        // generator.c:2763, before the per-file loop reaches rsync.c:824).
+        // Writing directly to stdout here would jump the queue and invert the
+        // two, since the setup notice is buffered.
+        if !emit_itemize && logging::info_gte(logging::InfoFlag::Name, 2) {
+            let name = entry.path().to_string_lossy();
+            let suffix = if attrs_updated { "" } else { " is uptodate" };
+            if self.config.connection.client_mode {
+                info_log!(Name, 2, "{name}{suffix}");
+            } else {
+                let _ = writer.send_msg_info(format!("{name}{suffix}\n").as_bytes());
             }
         }
     }
@@ -2819,5 +2845,225 @@ mod skip_notice_tests {
 
         let lines = run(cfg(), 2, files(), dest);
         assert_eq!(lines, vec!["typed exists (type change)\n".to_owned()]);
+    }
+}
+
+/// Quick-check "is uptodate" reporting: upstream's generator reports every
+/// quick-check match at `INFO_GTE(NAME, 2)` through `set_file_attrs()`'s
+/// `ATTRS_REPORT` (rsync.c:824-829), and a server-side generator frames the
+/// line as `MSG_INFO` so the far-end client renders it and counts its bytes
+/// in `received` (log.c:330-346). These tests pin the exact text, the NAME
+/// gate, and the itemize suppression (generator.c:2727).
+#[cfg(test)]
+mod uptodate_notice_tests {
+    use std::io;
+    use std::path::Path;
+
+    use logging::{InfoFlag, VerbosityConfig};
+    use metadata::MetadataOptions;
+    use protocol::ProtocolVersion;
+    use protocol::flist::FileEntry;
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::receiver::stats::TransferStats;
+    use crate::role::ServerRole;
+
+    /// Records every `MSG_INFO` frame a server-mode receiver emits.
+    #[derive(Default)]
+    struct CaptureWriter {
+        lines: Vec<String>,
+    }
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl crate::writer::MsgInfoSender for CaptureWriter {
+        fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
+            self.lines.push(String::from_utf8_lossy(data).into_owned());
+            Ok(())
+        }
+    }
+
+    fn handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    fn server_config() -> ServerConfig {
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            ..Default::default()
+        };
+        config.connection.client_mode = false;
+        config
+    }
+
+    /// Whole-second mtime pinned on both the seeded destination file and the
+    /// flist entry, so the quick-check matches on every filesystem regardless
+    /// of sub-second timestamp granularity.
+    const SEED_MTIME: i64 = 1_700_000_000;
+
+    /// Seeds `dest/<name>` with `size` bytes and returns a matching flist
+    /// entry whose size and mtime satisfy the quick-check.
+    fn uptodate_entry(dest: &Path, name: &str, size: usize) -> FileEntry {
+        let path = dest.join(name);
+        std::fs::write(&path, vec![b'x'; size]).expect("seed dest file");
+        let stamp = filetime::FileTime::from_unix_time(SEED_MTIME, 0);
+        filetime::set_file_mtime(&path, stamp).expect("pin dest mtime");
+        let mut entry = FileEntry::new_file(name.into(), size as u64, 0o644);
+        entry.set_mtime(SEED_MTIME, 0);
+        entry
+    }
+
+    /// Runs the candidate pass at a given `--info=name` level and returns the
+    /// captured `MSG_INFO` lines.
+    fn run(
+        config: ServerConfig,
+        name_level: u8,
+        files: Vec<FileEntry>,
+        dest: &Path,
+    ) -> Vec<String> {
+        let mut cfg = VerbosityConfig::default();
+        cfg.info.set(InfoFlag::Name, name_level);
+        logging::init(cfg);
+
+        let hs = handshake();
+        let mut ctx = ReceiverContext::new_for_test(&hs, config);
+        ctx.file_list = files;
+
+        let mut writer = CaptureWriter::default();
+        let opts = MetadataOptions::default();
+        let mut errs = Vec::new();
+        let mut stats = TransferStats::default();
+        let _ = ctx.build_files_to_transfer(
+            &mut writer,
+            dest,
+            #[cfg(unix)]
+            None,
+            &opts,
+            None,
+            &mut errs,
+            &mut stats,
+            None,
+            None,
+        );
+        writer.lines
+    }
+
+    /// upstream: rsync.c:828 - at NAME2 every quick-check match is reported as
+    /// `"%s is uptodate"`, framed as `MSG_INFO` by a server generator so the
+    /// client both prints it and counts its bytes. A stale file (mtime
+    /// mismatch) transfers instead and must NOT be reported uptodate.
+    #[test]
+    fn uptodate_notice_at_name2_frames_msg_info() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let fresh = uptodate_entry(dest, "same", 30);
+        let mut stale = uptodate_entry(dest, "stale", 30);
+        stale.set_mtime(1, 0);
+
+        let lines = run(server_config(), 2, vec![fresh, stale], dest);
+        assert_eq!(lines, vec!["same is uptodate\n".to_owned()]);
+    }
+
+    /// upstream: rsync.c:825-828 - the two arms are distinct: a quick-check
+    /// match whose attributes were retouched reports the bare name (`updated`),
+    /// while an untouched one reports `"is uptodate"`. Reporting "uptodate" for
+    /// a file whose permissions just changed would tell the operator nothing
+    /// happened when something did.
+    #[cfg(unix)]
+    #[test]
+    fn retouched_attrs_report_bare_name_not_uptodate() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let entry = uptodate_entry(dest, "perms", 30);
+        // Source mode is 0o644 (uptodate_entry); make the destination differ so
+        // the metadata apply fires while size and mtime still quick-check.
+        std::fs::set_permissions(dest.join("perms"), std::fs::Permissions::from_mode(0o600))
+            .expect("skew dest permissions");
+
+        let lines = run(server_config(), 2, vec![entry], dest);
+        assert_eq!(lines, vec!["perms\n".to_owned()]);
+    }
+
+    /// upstream: rsync.c:824 - the report is gated on `INFO_GTE(NAME, 2)`;
+    /// at `-v` (NAME1) and below, quiet transfers must stay byte-identical.
+    #[test]
+    fn uptodate_notice_silent_below_name2() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let entry = || vec![uptodate_entry(dest, "same", 30)];
+
+        assert!(run(server_config(), 1, entry(), dest).is_empty());
+        assert!(run(server_config(), 0, entry(), dest).is_empty());
+    }
+
+    /// A client-side generator (pull) must route the line through the stamped
+    /// diagnostic buffer, NOT frame it and NOT write it straight to stdout.
+    /// Framing would send generator chatter to the server; writing directly to
+    /// stdout would jump ahead of the buffered `delta-transmission` notice and
+    /// invert upstream's order (generator.c:2763 before rsync.c:824).
+    #[test]
+    fn client_mode_routes_uptodate_through_event_buffer() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let files = vec![uptodate_entry(dest, "same", 30)];
+
+        let mut config = server_config();
+        config.connection.client_mode = true;
+        let framed = run(config, 2, files, dest);
+        assert!(
+            framed.is_empty(),
+            "a pulling client must not frame the notice: {framed:?}"
+        );
+
+        let buffered: Vec<String> = logging::drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                logging::DiagnosticEvent::Info { message, .. } => Some(message),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            buffered.iter().any(|m| m == "same is uptodate"),
+            "client-side notice must reach the stamped buffer: {buffered:?}"
+        );
+    }
+
+    /// upstream: generator.c:2727 - `maybe_ATTRS_REPORT` is zeroed while
+    /// itemize output is active (`stdout_format_has_i`), so `-i -vv` must not
+    /// add uptodate lines on top of the itemize rows.
+    #[test]
+    fn uptodate_notice_suppressed_by_itemize() {
+        let dir = test_support::create_tempdir();
+        let dest = dir.path();
+        let files = vec![uptodate_entry(dest, "same", 30)];
+
+        let mut config = server_config();
+        config.flags.info_flags.itemize = true;
+        let lines = run(config, 2, files, dest);
+        assert!(
+            !lines.iter().any(|l| l.contains("is uptodate")),
+            "itemize mode must suppress ATTRS_REPORT: {lines:?}"
+        );
     }
 }

--- a/crates/transfer/src/receiver/transfer/setup/context.rs
+++ b/crates/transfer/src/receiver/transfer/setup/context.rs
@@ -50,6 +50,36 @@ fn merge_chmod(
 }
 
 impl ReceiverContext {
+    /// Reports the delta-transmission status once per run, gated on
+    /// `DEBUG_GTE(FLIST, 1)` (first active at `-vv`).
+    ///
+    /// `whole_file` is forced on for local transfers and `--whole-file`;
+    /// otherwise the rolling-checksum delta path is used. A server-side
+    /// generator frames the line as `MSG_INFO` so the client renders it and
+    /// counts its bytes; a client-side generator emits it locally.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:2763-2767` - the `DEBUG_GTE(FLIST, 1)` gate and both
+    ///   message texts
+    /// - `log.c:330-346` - `rwrite()` under `am_server` frames FINFO as
+    ///   `MSG_INFO` instead of writing it locally
+    fn emit_delta_transmission_notice<W: crate::writer::MsgInfoSender + ?Sized>(
+        &self,
+        writer: &mut W,
+    ) {
+        let status = if self.config.flags.whole_file {
+            "disabled for local transfer or --whole-file"
+        } else {
+            "enabled"
+        };
+        if self.config.connection.client_mode {
+            debug_log!(Flist, 1, "delta-transmission {}", status);
+        } else if logging::debug_gte(logging::DebugFlag::Flist, 1) {
+            let _ = writer.send_msg_info(format!("delta-transmission {status}\n").as_bytes());
+        }
+    }
+
     /// Common setup for all transfer modes.
     ///
     /// Activates input multiplex, reads filter list if needed, receives the
@@ -75,20 +105,7 @@ impl ReceiverContext {
         // setup_transfer).
         debug_log!(Genr, 1, "generator starting pid={}", std::process::id());
 
-        // upstream: generator.c:2290-2295 - the generator prints the
-        // delta-transmission status once, gated on DEBUG_GTE(FLIST, 1) (first
-        // active at -vv). whole_file is forced on for local transfers and
-        // --whole-file; otherwise the rolling-checksum delta path is used.
-        debug_log!(
-            Flist,
-            1,
-            "delta-transmission {}",
-            if self.config.flags.whole_file {
-                "disabled for local transfer or --whole-file"
-            } else {
-                "enabled"
-            }
-        );
+        self.emit_delta_transmission_notice(writer);
 
         // Parallel receive-side delta apply is unconditionally compiled (PFF-7).
         debug_log!(Recv, 1, "parallel receive-delta path active");
@@ -1482,5 +1499,127 @@ mod files_from_forwarding_framing_tests {
         assert_eq!(len as usize, expected.len(), "framed length mismatch");
         assert_eq!(bytes[3], MSG_DATA_TAG, "high byte must be the MSG_DATA tag");
         assert_eq!(&bytes[4..], expected.as_slice(), "framed payload mismatch");
+    }
+}
+
+/// Delta-transmission notice routing: upstream prints the line locally on a
+/// client generator but frames it as `MSG_INFO` on a server generator, so the
+/// far-end client both renders it and counts its bytes in `received`
+/// (upstream: generator.c:2763-2767, log.c:330-346).
+#[cfg(test)]
+mod delta_transmission_notice_tests {
+    use std::io;
+
+    use logging::{DiagnosticEvent, VerbosityConfig, drain_events};
+    use protocol::ProtocolVersion;
+
+    use crate::config::ServerConfig;
+    use crate::handshake::HandshakeResult;
+    use crate::receiver::ReceiverContext;
+    use crate::role::ServerRole;
+
+    /// Captures `MSG_INFO` payloads so the tests can assert the framed bytes.
+    #[derive(Default)]
+    struct CaptureWriter {
+        infos: Vec<String>,
+    }
+
+    impl crate::writer::MsgInfoSender for CaptureWriter {
+        fn send_msg_info(&mut self, data: &[u8]) -> io::Result<()> {
+            self.infos.push(String::from_utf8_lossy(data).into_owned());
+            Ok(())
+        }
+    }
+
+    fn handshake() -> HandshakeResult {
+        HandshakeResult {
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            buffered: Vec::new(),
+            compat_exchanged: false,
+            client_args: None,
+            io_timeout: None,
+            negotiated_algorithms: None,
+            compat_flags: None,
+            checksum_seed: 0,
+        }
+    }
+
+    fn context(client_mode: bool, whole_file: bool) -> ReceiverContext {
+        let mut config = ServerConfig {
+            role: ServerRole::Receiver,
+            protocol: ProtocolVersion::try_from(32u8).unwrap(),
+            ..Default::default()
+        };
+        config.connection.client_mode = client_mode;
+        config.flags.whole_file = whole_file;
+        ReceiverContext::new_for_test(&handshake(), config)
+    }
+
+    fn init_verbosity(flist_level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.flist = flist_level;
+        logging::init(cfg);
+        let _ = drain_events();
+    }
+
+    /// A server generator at `DEBUG_GTE(FLIST, 1)` must put the notice on the
+    /// wire: the far-end client renders it AND counts its frame in `received`
+    /// (the -vv byte-accounting parity this fix restores).
+    #[test]
+    fn server_mode_frames_notice_as_msg_info() {
+        init_verbosity(1);
+        let mut writer = CaptureWriter::default();
+        context(false, false).emit_delta_transmission_notice(&mut writer);
+        assert_eq!(
+            writer.infos,
+            vec!["delta-transmission enabled\n".to_owned()]
+        );
+
+        let mut writer = CaptureWriter::default();
+        context(false, true).emit_delta_transmission_notice(&mut writer);
+        assert_eq!(
+            writer.infos,
+            vec!["delta-transmission disabled for local transfer or --whole-file\n".to_owned()]
+        );
+    }
+
+    /// Below the gate (default verbosity) nothing crosses the wire - the
+    /// notice must not inflate quiet transfers.
+    #[test]
+    fn server_mode_is_silent_below_flist_gate() {
+        init_verbosity(0);
+        let mut writer = CaptureWriter::default();
+        context(false, false).emit_delta_transmission_notice(&mut writer);
+        assert!(
+            writer.infos.is_empty(),
+            "gated notice leaked: {:?}",
+            writer.infos
+        );
+    }
+
+    /// A client generator (pull) owns its stdout: the notice stays a local
+    /// debug emission and never becomes a frame, since framing it would send
+    /// generator chatter TO the server.
+    #[test]
+    fn client_mode_emits_locally_not_framed() {
+        init_verbosity(1);
+        let mut writer = CaptureWriter::default();
+        context(true, false).emit_delta_transmission_notice(&mut writer);
+        assert!(
+            writer.infos.is_empty(),
+            "client mode must not frame: {:?}",
+            writer.infos
+        );
+        let local: Vec<String> = drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug { message, .. } => Some(message),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            local.iter().any(|m| m == "delta-transmission enabled"),
+            "client-side local emission missing: {local:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

A server-side generator never put its `-vv` notices on the wire, so the far-end client neither rendered them nor counted their bytes. Upstream's `rwrite()` frames an `FCLIENT`/`FINFO` line as `MSG_INFO` when `am_server` (`log.c:330-346`); oc emitted locally in both roles, which on a server generator means emitting into nothing.

Two sites, one owner each, role-split rather than patched:

- **`delta-transmission {status}`** (`generator.c:2763-2767`, `DEBUG_GTE(FLIST, 1)`, first active at `-vv`) - extracted into `emit_delta_transmission_notice`. Client generator logs locally; server generator frames `MSG_INFO`. The drifted citation (`generator.c:2290-2295`) is corrected in the same commit.
- **`%s is uptodate` / bare name** (`rsync.c:824-829` via `set_file_attrs()`'s `ATTRS_REPORT` at `INFO_GTE(NAME, 2)`, suppressed under itemize per `generator.c:2727`) - the quick-check match report. The existing `needs_metadata_apply && !metadata_unchanged(..)` condition is bound as `attrs_updated` so the same value that decides whether attributes were retouched also decides the wording, instead of a second predicate that could disagree.

A client-side generator routes through the stamped diagnostic buffer rather than straight to stdout, so the per-file line interleaves in production order behind the setup notice the same generator buffered earlier - writing direct to stdout inverts the two.

## Measured (`received` / `sent`, 8 cells, both directions, mixed pairs included)

`-vv` push `received` **15 -> 149** against upstream's 172. `-v` pull now matches upstream's 142 exactly. The five non-verbose cells are unchanged, as intended - this is a `-vv`/`-v` reporting gap, not an accounting rewrite.

## Gap 1 (MSG_STATS) - premise refuted, and it is NOT a wire bug

`MSG_STATS` appears **zero times in all 80 captures, including pure upstream-to-upstream**. The C explains it: at `main.c:1085` the receiver's `f_out` is reassigned to `error_pipe[1]`, so the `NDX_DONE` + `MSG_STATS` at `main.c:1098-1099` travels the **fork-internal pipe to the generator**, never the socket, and `io.c:1690` rejects the tag unless `am_generator`. oc is not fork-split there, so there is nothing to send and no divergence to fix. The wire-visible equivalent is the varlong stats block (`main.c:353-359`), which oc already sends. **Do not reopen this as a wire frame.**

## Residuals, named rather than left as "close enough"

- **`-vv` push, 23 bytes** = 18 wire + 5 counting boundary. Upstream's `s2c` carries `DATA 12` + `DATA 11` where oc sends 5x`DATA 1` (18 B of framing), and the two sides leave 5 vs 10 bytes uncounted at the tail. Mechanism: the `|| INFO_GTE(NAME, 2)` clause of upstream's itemize wire gate (`generator.c:588`) makes the generator write an NDX+`iflags` row for *every* file at `-vv` even when `iflags == 0`; oc suppresses the row when nothing is significant.
- **`-vv` pull, 84 bytes** = 57 + 31 - 4. Upstream additionally carries `INFO 53` `total: matches=0 hash_hits=0 false_alarms=0 data=0` (the sender-side `match_report()`, `sender.c:815` -> `match.c:480-489`, framed because `am_server`) plus the same `generator.c:588` rows; oc's flist framing accounts for -4.

Neither is chased here, deliberately. `generator.c:588` changes what the generator puts on the socket per file and feeds the peer's `read_ndx_and_attrs`/`maybe_log_item` - that is itemize gating, not accounting. The `total:` line needs cumulative `matches`/`hash_hits`/`false_alarms` plumbed to the wire sender; they are per-scan locals today, and the existing emitter is **local-path only**, so oc prints no `total:` line on a wire pull at all - an output-parity gap as well as a byte one. Both are separate tasks with their own oracles.

## Verification

8 mutations, each killed by the named test: emission dropped, itemize suppression dropped, NAME gate 2->1, `attrs_updated` arms inverted, server emits locally, FLIST debug gate dropped, client frames instead of emitting, client bypasses the event buffer.

Gates at the pinned toolchain: whole-tree rustfmt clean (3428 files); clippy `-p transfer --all-targets --all-features` clean; `nextest -p transfer --lib` 2547 passed; full `-p transfer` 2938 passed / 3 skipped. No expect-manifest touched, no testsuite row flipped.

⚠ Scope of the new tests: they assert emission through a capture writer, which proves routing and text but not frame-header bytes on a real socket. The wire-level evidence is the harness decode in the table above, not the unit tests.
