### PR TITLE
chore(unsafe): deny unsafe_code in the crates that lacked the gate

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -355,6 +355,7 @@
 //! - [`parallel`] module for concurrent computation (always compiled)
 //! - [`RollingChecksum`] for sliding window checksum details
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]

--- a/crates/checksums/src/simd_batch/md4/mod.rs
+++ b/crates/checksums/src/simd_batch/md4/mod.rs
@@ -213,6 +213,7 @@ impl Md4Dispatcher {
 
     /// AVX-512 batched digest implementation.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_avx512<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(16);
@@ -256,6 +257,7 @@ impl Md4Dispatcher {
 
     /// AVX2 batched digest implementation.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_avx2<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(8);
@@ -291,6 +293,7 @@ impl Md4Dispatcher {
 
     /// SSE2 batched digest implementation.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_sse2<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);
@@ -322,6 +325,7 @@ impl Md4Dispatcher {
 
     /// NEON batched digest implementation.
     #[cfg(target_arch = "aarch64")]
+    #[allow(unsafe_code)]
     fn digest_batch_neon<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);

--- a/crates/checksums/src/simd_batch/md4/simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx2.rs
@@ -40,6 +40,7 @@ const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 /// `_mm256_srlv_epi32` and OR. Variable shifts let the shift amount be
 /// a runtime value.
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
     _mm256_or_si256(
         _mm256_sllv_epi32(x, _mm256_set1_epi32(n)),
@@ -58,6 +59,7 @@ unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
 /// Caller must ensure AVX2 is available; verify at runtime with
 /// `is_x86_feature_detected!("avx2")` before calling.
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -214,6 +216,7 @@ pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md4/simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx512.rs
@@ -51,6 +51,7 @@ struct Aligned512([u32; 16]);
 /// Invoking this on a CPU without these features triggers an illegal-
 /// instruction fault.
 #[cfg(target_arch = "x86_64")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -148,6 +149,7 @@ pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
 /// this triggers an illegal-instruction fault.
 #[cfg(target_arch = "x86_64")]
 #[inline(never)]
+#[allow(unsafe_code)]
 unsafe fn process_block_avx512(
     state_a: &mut Aligned512,
     state_b: &mut Aligned512,
@@ -396,6 +398,7 @@ unsafe fn process_block_avx512(
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md4/simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/neon.rs
@@ -57,6 +57,7 @@ macro_rules! rotl_const {
 /// (ARMv8-A baseline), so this is always satisfied on 64-bit ARM.
 #[cfg(target_arch = "aarch64")]
 #[allow(unsafe_op_in_unsafe_fn)]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -258,6 +259,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md4/simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/sse2.rs
@@ -74,6 +74,7 @@ macro_rules! rotl {
 /// Caller must ensure SSE2 is available; SSE2 is part of the x86_64
 /// baseline so this is always satisfied on 64-bit Intel/AMD.
 #[target_feature(enable = "sse2")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -275,6 +276,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md5_dispatcher.rs
+++ b/crates/checksums/src/simd_batch/md5_dispatcher.rs
@@ -318,6 +318,7 @@ impl Dispatcher {
     ///
     /// Processes inputs in batches of 16 using AVX-512 SIMD.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_avx512<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(16);
@@ -361,6 +362,7 @@ impl Dispatcher {
 
     /// AVX2 batched digest implementation.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_avx2<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(8);
@@ -398,6 +400,7 @@ impl Dispatcher {
     ///
     /// Processes inputs in batches of 4 using SSE2 SIMD.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_sse2<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);
@@ -431,6 +434,7 @@ impl Dispatcher {
     ///
     /// Processes inputs in batches of 4 using SSSE3 SIMD.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_ssse3<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);
@@ -464,6 +468,7 @@ impl Dispatcher {
     ///
     /// Processes inputs in batches of 4 using SSE4.1 SIMD with blendv optimization.
     #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
     fn digest_batch_sse41<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);
@@ -497,6 +502,7 @@ impl Dispatcher {
     ///
     /// Processes inputs in batches of 4 using NEON SIMD.
     #[cfg(target_arch = "aarch64")]
+    #[allow(unsafe_code)]
     fn digest_batch_neon<T: AsRef<[u8]>>(&self, inputs: &[T]) -> Vec<Digest> {
         let mut results = Vec::with_capacity(inputs.len());
         let chunks = inputs.chunks(4);

--- a/crates/checksums/src/simd_batch/md5_simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx2.rs
@@ -108,6 +108,7 @@ const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 ///
 /// Requires AVX2; enforced by the `#[target_feature]` attribute.
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
     _mm256_or_si256(
         _mm256_sllv_epi32(x, _mm256_set1_epi32(n)),
@@ -126,6 +127,7 @@ unsafe fn rotl(x: __m256i, n: i32) -> __m256i {
 /// Caller must ensure AVX2 is available; verify at runtime with
 /// `is_x86_feature_detected!("avx2")` before calling.
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -285,6 +287,7 @@ pub unsafe fn digest_x8(inputs: &[&[u8]; 8]) -> [Digest; 8] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::md5_scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md5_simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/neon.rs
@@ -115,6 +115,7 @@ macro_rules! rotl_const {
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[allow(unsafe_op_in_unsafe_fn)]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -324,6 +325,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::md5_scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md5_simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse2.rs
@@ -159,6 +159,7 @@ macro_rules! rotl {
 /// Caller must ensure SSE2 is available. SSE2 is part of the x86_64 baseline,
 /// so this is always satisfied on 64-bit Intel/AMD platforms.
 #[target_feature(enable = "sse2")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -392,6 +393,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::md5_scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md5_simd/sse41.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse41.rs
@@ -153,6 +153,7 @@ macro_rules! rotl {
 /// `is_x86_feature_detected!("sse4.1")` before calling.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse4.1")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -368,6 +369,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::md5_scalar;
     use super::*;

--- a/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
@@ -153,6 +153,7 @@ macro_rules! rotl {
 /// `is_x86_feature_detected!("ssse3")` before calling.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "ssse3")]
+#[allow(unsafe_code)]
 pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
@@ -370,6 +371,7 @@ pub unsafe fn digest_x4(inputs: &[&[u8]; 4]) -> [Digest; 4] {
 }
 
 #[cfg(test)]
+#[allow(unsafe_code)]
 mod tests {
     use super::super::super::md5_scalar;
     use super::*;

--- a/crates/flist/src/batched_stat/dir_stat.rs
+++ b/crates/flist/src/batched_stat/dir_stat.rs
@@ -47,6 +47,7 @@ impl DirectoryStatBatch {
     /// # Errors
     ///
     /// Returns an error if the file cannot be stat'd.
+    #[allow(unsafe_code)]
     pub fn stat_relative(&self, name: &OsString, follow_symlinks: bool) -> io::Result<FstatResult> {
         use std::ffi::CString;
         use std::os::unix::ffi::OsStrExt;
@@ -92,6 +93,7 @@ impl DirectoryStatBatch {
     ///
     /// Returns an error if the file cannot be stat'd.
     #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+    #[allow(unsafe_code)]
     pub fn statx_relative(
         &self,
         name: &OsString,

--- a/crates/flist/src/batched_stat/statx_support.rs
+++ b/crates/flist/src/batched_stat/statx_support.rs
@@ -14,6 +14,7 @@ use super::types::StatxResult;
 /// The result is cached after the first call using a probe syscall.
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
 #[must_use]
+#[allow(unsafe_code)]
 pub fn has_statx_support() -> bool {
     use std::sync::atomic::{AtomicU8, Ordering};
 
@@ -125,6 +126,7 @@ pub fn statx_size_and_mtime<P: AsRef<Path>>(
 /// The `dir_fd` parameter enables directory-relative lookups (AT_FDCWD for
 /// absolute paths, or an open directory fd for relative paths).
 #[cfg(all(target_os = "linux", not(target_env = "musl")))]
+#[allow(unsafe_code)]
 fn statx_with_mask(
     dir_fd: i32,
     path: &Path,

--- a/crates/flist/src/lib.rs
+++ b/crates/flist/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/crates/test-support/src/lib.rs
+++ b/crates/test-support/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 

--- a/crates/windows-gnu-eh/src/lib.rs
+++ b/crates/windows-gnu-eh/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::undocumented_unsafe_blocks)]
@@ -86,6 +87,7 @@ mod windows_gnu {
     const SYM_DEREGISTER: &[u8] = b"__deregister_frame_info\0";
 
     #[link(name = "kernel32")]
+    #[allow(unsafe_code)]
     unsafe extern "system" {
         fn GetModuleHandleA(lpModuleName: *const c_char) -> *mut c_void;
         fn LoadLibraryA(lpLibFileName: *const c_char) -> *mut c_void;
@@ -93,6 +95,7 @@ mod windows_gnu {
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     unsafe fn ensure_function(cache: &AtomicUsize, symbol: &[u8]) -> Option<*mut ()> {
         let mut state = cache.load(Ordering::Acquire);
         loop {
@@ -127,6 +130,7 @@ mod windows_gnu {
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     unsafe fn resolve_symbol(symbol: &[u8]) -> *mut c_void {
         debug_assert!(!symbol.is_empty() && symbol[symbol.len() - 1] == 0);
 
@@ -142,6 +146,7 @@ mod windows_gnu {
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     unsafe fn load_from_library(library: &[u8], symbol: &[u8]) -> *mut c_void {
         debug_assert!(!library.is_empty() && library[library.len() - 1] == 0);
 
@@ -165,6 +170,7 @@ mod windows_gnu {
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     unsafe fn resolve_register() -> Option<RegisterFrameInfo> {
         // SAFETY: SYM_REGISTER is a static NUL-terminated byte literal satisfying ensure_function's precondition.
         let ptr = match unsafe { ensure_function(&REGISTER_FRAME_INFO, SYM_REGISTER) } {
@@ -176,6 +182,7 @@ mod windows_gnu {
     }
 
     #[inline(always)]
+    #[allow(unsafe_code)]
     unsafe fn resolve_deregister() -> Option<DeregisterFrameInfo> {
         // SAFETY: SYM_DEREGISTER is a static NUL-terminated byte literal satisfying ensure_function's precondition.
         let ptr = match unsafe { ensure_function(&DEREGISTER_FRAME_INFO, SYM_DEREGISTER) } {
@@ -188,6 +195,7 @@ mod windows_gnu {
 
     /// Forwards `rsbegin`'s registration hook to libunwind.
     #[unsafe(no_mangle)]
+    #[allow(unsafe_code)]
     pub unsafe extern "C" fn ___register_frame_info(eh_frame: *const u8, object: *mut c_void) {
         // SAFETY: resolve_register has no preconditions beyond those satisfied by static symbol constants.
         if let Some(register) = unsafe { resolve_register() } {
@@ -200,6 +208,7 @@ mod windows_gnu {
 
     /// Forwards `rsbegin`'s deregistration hook to libunwind.
     #[unsafe(no_mangle)]
+    #[allow(unsafe_code)]
     pub unsafe extern "C" fn ___deregister_frame_info(eh_frame: *const u8) {
         // SAFETY: resolve_deregister has no preconditions beyond those satisfied by static symbol constants.
         if let Some(deregister) = unsafe { resolve_deregister() } {

--- a/tools/dhat-profile/src/main.rs
+++ b/tools/dhat-profile/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(unsafe_code)]
+
 //! Dhat heap profiling harness for oc-rsync.
 //!
 //! This standalone tool profiles heap allocations using dhat.


### PR DESCRIPTION
## What

The unsafe-code policy assumes crate-level `#![deny(unsafe_code)]` plus narrow per-function `#[allow]`. Five workspace members had no deny at all, so for them there was **no gate** - `checksums` most consequentially. This installs the gate. It moves no code and removes no unsafe.

Gated: `checksums`, `flist`, `test-support`, `windows-gnu-eh`, and `tools/dhat-profile` (found during the census; zero unsafe, so its deny is free). Deliberately out of scope: `engine` already denies production unsafe via `#![cfg_attr(not(test), deny(unsafe_code))]`, and `fast_io` is an unsafe-owner crate by charter.

+49/-0 across 18 files: **5** `#![deny(unsafe_code)]`, **43** `#[allow(unsafe_code)]`, and one blank line. Every allow is an outer per-item attribute; there is no `#![allow(unsafe_code)]` anywhere, which is what keeps the gate from being defeated by its own annotations.

## Two filed numbers were wrong

The task row said `checksums` holds 54 production blocks. The gate needed **22** production annotations - 10 `digest_batch_*` dispatch fns plus 12 `unsafe fn` declarations. The rest of the raw count is intrinsic call sites *inside* those fns (covered by the enclosing per-fn allow) and 13 sites already covered by pre-existing file-level allows in `rolling/checksum/{neon,x86}.rs` and `md5_simd/avx512.rs`. `flist`'s "8" is likewise 4 functions.

## Granularity, stated rather than hidden

Production sites take per-**function** allows. The nine SIMD backends' `#[cfg(test)] mod tests` take **one** allow on the mod item rather than 28 per-fn annotations - `--all-targets` reaches those in-crate test mods so the crate deny does cover them, and they are `cfg(test)` by construction so the allow cannot mask production unsafe. The three pre-existing file-level allows were left alone rather than churning ten functions in `x86.rs`, so the crate now mixes granularities. That is a deliberate choice, not an oversight.

## Non-vacuity, per crate, on the right target

Plant -> fail -> revert -> green, for all five: `flist` in `statx()`, `checksums` in `digest_batch_scalar`, `test-support` in `create_tempdir`, `dhat-profile` in `main`, `windows-gnu-eh` in `windows_gnu::force_link`. Each failure named its own crate's `lib.rs` deny line.

**A real blindness fell out of the flist proof, and it generalises.** With the same planted unsafe block, the host (aarch64-macOS) check **passed** while `--target aarch64-unknown-linux-gnu` **failed** - `statx()` is Linux-gated, so a host-only build cannot see that arm at all. Every cfg-gated arm was therefore verified on its own target: `x86_64-apple-darwin --all-targets` for the sse2/ssse3/sse41/avx2/avx512 backends including their test mods, `x86_64-pc-windows-gnu` for windows-gnu-eh, `aarch64-unknown-linux-gnu` for flist. Same class as the toolchain lesson from #7655.

`wasm32` arms are unverified by compilation (no target installed), so the two spurious annotations a script had added there were **removed** after confirming by inspection that both `digest_batch_wasm` fns contain no unsafe - nothing is annotated on faith.

## Verification

Pinned toolchain 1.88.0: whole-tree rustfmt clean (3428 files); clippy on all five crates `--all-targets --all-features --no-deps -D warnings` clean; `nextest --all-features --lib` on the four lib crates 692 passed / 1 skipped.

Not done, deliberately: no relocation to `fast_io` (tasks 1081-1084 - the +49/-0 diff is the proof nothing moved); integration-test crate roots untouched (`checksums/tests/simd_audit_guard_page.rs` has unsafe but is a separate crate root the lib deny cannot reach, and needs nothing).

This is the prerequisite gate for the two-owner rule and the SIMD relocation.
