### PR TITLE
feat(matching): wire --debug=deltasum to the real delta scans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4264,6 +4264,7 @@ dependencies = [
  "getrandom 0.4.3",
  "libc",
  "logging",
+ "matching",
  "metadata",
  "platform",
  "proptest",

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -152,8 +152,9 @@ impl<'a> CopyContext<'a> {
         // which the statement is actually true.
         matching::trace_deltasum::trace_recv_mapped(&relative.display(), total_size);
 
-        // upstream: match.c:126 - `n = offset - last_match`, so the `match at`
-        // line needs the end of the previous match, not the write cursor.
+        // upstream: match.c:135 - the `match at` line reports `n`, the gap since
+        // the previous match, so this tracks the end of that match rather than
+        // the write cursor.
         let mut last_match = 0u64;
 
         let mut destination_reader = Some(fs::File::open(destination).map_err(|error| {

--- a/crates/engine/src/local_copy/context_impl/delta_transfer.rs
+++ b/crates/engine/src/local_copy/context_impl/delta_transfer.rs
@@ -128,6 +128,34 @@ impl<'a> CopyContext<'a> {
             let _ = fast_io::mark_file_sparse(writer);
         }
 
+        // A local copy runs both roles in one process, so upstream prints both
+        // role's DELTASUM lines. The generator half (basis geometry and the
+        // per-chunk sums) is emitted where the signature is built
+        // (`executor::file::comparison::build_delta_signature`); these are the
+        // sender-half milestones for this file.
+        // Order matches upstream's local run, which is a real sender talking to
+        // a real receiver over a socketpair: sender.c:760-763, :768-769, then
+        // match.c:436-437, then match.c:180-182, :199-202.
+        matching::trace_deltasum::trace_send_files_mapped(&source.display(), total_size);
+        matching::trace_deltasum::trace_calling_match_sums(&source.display());
+        matching::trace_deltasum::trace_built_hash_table();
+        matching::trace_deltasum::trace_hash_search_start(index.block_length(), total_size);
+        matching::trace_deltasum::trace_hash_search_params(
+            index.block_length(),
+            total_size,
+            index.block_count() as u64,
+        );
+        // upstream: receiver.c:498-501 - the receiver half maps the same basis.
+        // Upstream prints this only once its receiver process reaches
+        // `receive_data()`, i.e. AFTER the sender's counters; oc's fused loop
+        // opens the basis here, before the scan, so this is the position at
+        // which the statement is actually true.
+        matching::trace_deltasum::trace_recv_mapped(&relative.display(), total_size);
+
+        // upstream: match.c:126 - `n = offset - last_match`, so the `match at`
+        // line needs the end of the previous match, not the write cursor.
+        let mut last_match = 0u64;
+
         let mut destination_reader = Some(fs::File::open(destination).map_err(|error| {
             LocalCopyError::io(
                 "read existing destination",
@@ -233,10 +261,27 @@ impl<'a> CopyContext<'a> {
             }
 
             let digest = rolling.digest();
+            // upstream: match.c:210-213 - the per-offset rolling sum.
+            let scan_offset = total_bytes.saturating_add(pending_literals.len() as u64);
+            matching::trace_deltasum::trace_scan_offset(scan_offset, digest.sum2(), digest.sum1());
             if let Some(block_index) =
                 index.find_match_window_counted(digest, &window, &mut scratch, &mut probe)
             {
                 file_matches = file_matches.saturating_add(1);
+                // upstream: match.c:258-262 then :133-138
+                matching::trace_deltasum::trace_potential_match(
+                    scan_offset,
+                    block_index as u64,
+                    digest.value(),
+                );
+                matching::trace_deltasum::trace_match(
+                    scan_offset,
+                    last_match,
+                    index.block(block_index).index(),
+                    index.block(block_index).len(),
+                    scan_offset.saturating_sub(last_match),
+                );
+                last_match = scan_offset + index.block(block_index).len() as u64;
                 if !pending_literals.is_empty() {
                     let flushed_len = pending_literals.len();
                     if inplace_mode {
@@ -259,6 +304,7 @@ impl<'a> CopyContext<'a> {
                         &mut compressed_progress,
                         source,
                         destination,
+                        total_bytes,
                     )?;
                     let literal_written = if sparse {
                         flushed_len as u64
@@ -277,6 +323,20 @@ impl<'a> CopyContext<'a> {
                 let block_len = block.len();
                 let matched = MatchedBlock::new(block, index.block_length());
                 let basis_offset = matched.offset();
+
+                // upstream: receiver.c:609-614 - the receiver half reports
+                // every matched block it applies: the basis offset it reads
+                // from, the output offset it lands at, and ` (seek)` when the
+                // in-place fast path means the bytes are already correct. The
+                // local loop performs exactly this copy, so the line is a
+                // statement about work it really does.
+                matching::trace_deltasum::trace_recv_chunk(
+                    block.index(),
+                    block_len,
+                    basis_offset,
+                    total_bytes,
+                    inplace_mode && basis_offset == output_position,
+                );
 
                 // upstream: receiver.c:624-629. The skip-fast-path only fires
                 // when basis offset == output position. For any other matched
@@ -442,6 +502,30 @@ impl<'a> CopyContext<'a> {
             // counts the shrunk-window tail probe the same as any other.
             file_matches = file_matches.saturating_add(1);
             probe.hash_hits = probe.hash_hits.saturating_add(1);
+            // upstream: match.c:258-262 then :133-138 - the short final block is
+            // reported like any other match, with its own shorter length. Its
+            // source offset is the scan cursor: everything before it has either
+            // been emitted or is sitting in `pending_literals`.
+            {
+                let tail_offset = total_bytes.saturating_add(pending_literals.len() as u64);
+                let tail_block = index.block(block_index);
+                matching::trace_deltasum::trace_potential_match(
+                    tail_offset,
+                    block_index as u64,
+                    rolling.digest().value(),
+                );
+                matching::trace_deltasum::trace_match(
+                    tail_offset,
+                    last_match,
+                    tail_block.index(),
+                    tail_block.len(),
+                    tail_offset.saturating_sub(last_match),
+                );
+                // The tail block is the last match the scan can make, so nothing
+                // reads this again; assigned so the invariant "last_match is the
+                // end of the most recent match" holds at every exit.
+                let _ = last_match;
+            }
             if !pending_literals.is_empty() {
                 let flushed_len = pending_literals.len();
                 if inplace_mode {
@@ -464,6 +548,7 @@ impl<'a> CopyContext<'a> {
                     &mut compressed_progress,
                     source,
                     destination,
+                    total_bytes,
                 )?;
                 let literal_written = if sparse {
                     flushed_len as u64
@@ -480,6 +565,16 @@ impl<'a> CopyContext<'a> {
             let block_len = block.len();
             let matched = MatchedBlock::new(block, index.block_length());
             let basis_offset = matched.offset();
+
+            // upstream: receiver.c:609-614 - as in the main loop, the applied
+            // short final block is reported with its true length.
+            matching::trace_deltasum::trace_recv_chunk(
+                block.index(),
+                block_len,
+                basis_offset,
+                total_bytes,
+                inplace_mode && basis_offset == output_position,
+            );
 
             if inplace_mode && basis_offset == output_position {
                 consume_matched_in_place(
@@ -564,6 +659,7 @@ impl<'a> CopyContext<'a> {
                 &mut compressed_progress,
                 source,
                 destination,
+                total_bytes,
             )?;
             total_bytes = total_bytes.saturating_add(flushed_len as u64);
             let literal_written = if sparse {
@@ -629,6 +725,19 @@ impl<'a> CopyContext<'a> {
             total_size.saturating_sub(initial_bytes),
         );
 
+        // upstream: match.c:441-442, :468-471 - the scan-complete marker and the
+        // per-file counters. The local loop writes the reconstructed file
+        // directly, so it never computes or transfers a whole-file checksum:
+        // upstream's `sending file_sum` (match.c:465) and `got file_sum`
+        // (receiver.c:672) have no analogue here and are deliberately absent
+        // rather than faked.
+        matching::trace_deltasum::trace_done_hash_search();
+        matching::trace_deltasum::trace_match_counters(
+            probe.false_alarms,
+            probe.hash_hits,
+            file_matches,
+        );
+
         // upstream: match.c:433-435 folds the per-file counters into the run
         // totals after match_sums() returns; do the same so the end-of-run
         // `-vv` `total:` line reports cumulative figures.
@@ -666,11 +775,18 @@ impl<'a> CopyContext<'a> {
         compressed_progress: &mut u64,
         source: &Path,
         destination: &Path,
+        output_offset: u64,
     ) -> Result<usize, LocalCopyError> {
         if chunk.is_empty() {
             return Ok(0);
         }
         self.enforce_timeout()?;
+
+        // upstream: receiver.c:552-555 - a local transfer runs a real receiver
+        // over a socketpair, so it reports every literal run it applies. This
+        // fused loop writes the same run at the same output offset, so it is the
+        // one place the local path can say it honestly.
+        matching::trace_deltasum::trace_data_recv(chunk.len(), output_offset);
 
         // Capture LITERAL operation to the batch delta buffer if active.
         // upstream: token.c:simple_send_token() - literals are written as

--- a/crates/engine/src/local_copy/executor/file/comparison.rs
+++ b/crates/engine/src/local_copy/executor/file/comparison.rs
@@ -165,6 +165,40 @@ pub(crate) fn build_delta_signature(
         Err(_) => return Ok(None),
     };
 
+    // A local copy plays the generator role too, so upstream prints the
+    // generator's DELTASUM lines for the basis it just checksummed. This is the
+    // local counterpart of `receiver::basis::generate_basis_signature`.
+    //
+    // upstream: generator.c:2358-2361 `gen mapped`, :765-770 the geometry
+    // `sum_sizes_sqroot()` chose, :817-822 one line per generated chunk. The
+    // `generating and sending sums for %d` line (generator.c:2363) has NO local
+    // analogue: nothing is sent, and the local executor carries no wire file
+    // index to name - upstream's local run has one only because it really does
+    // drive a generator over a socketpair. Naming a fabricated index here would
+    // be inventing output, so the line is deliberately absent.
+    //
+    // The name is the basis path as this executor holds it. Upstream prints
+    // `fnamecmp`, which is relative because upstream chdir'd into the
+    // destination root; the local executor never chdirs, so the spelling is
+    // whatever the operand resolved to.
+    matching::trace_deltasum::trace_gen_mapped(&destination.display(), length);
+    matching::trace_deltasum::trace_sum_geometry(
+        layout.block_count(),
+        layout.remainder(),
+        layout.block_length().get() as usize,
+        layout.strong_sum_length().get(),
+        length,
+    );
+    let block_length = u64::from(layout.block_length().get());
+    for (position, block) in signature.blocks().iter().enumerate() {
+        matching::trace_deltasum::trace_gen_chunk(
+            position as u64,
+            position as u64 * block_length,
+            block.len(),
+            block.rolling().value(),
+        );
+    }
+
     match DeltaSignatureIndex::from_signature(&signature, SignatureAlgorithm::Md4) {
         Some(index) => Ok(Some(index)),
         None => Ok(None),

--- a/crates/matching/src/generator.rs
+++ b/crates/matching/src/generator.rs
@@ -12,7 +12,6 @@
 use std::io::{self, Cursor, Read};
 
 use checksums::{RollingChecksum, RollingDigest};
-use logging::debug_log;
 use rayon::prelude::*;
 
 #[cfg(feature = "tracing")]
@@ -21,6 +20,7 @@ use tracing::instrument;
 use crate::index::{DeltaSignatureIndex, MatchedBlocks};
 use crate::ring_buffer::RingBuffer;
 use crate::script::{DeltaScript, DeltaToken};
+use crate::trace_deltasum;
 
 /// Default buffer size used by [`DeltaGenerator::generate`].
 const DEFAULT_BUFFER_LEN: usize = 128 * 1024;
@@ -41,6 +41,23 @@ const CHUNK_SIZE: usize = 32 * 1024;
 /// parallelism. The effective floor is the larger of this and 64 basis blocks.
 /// See `docs/design/intra-file-parallelism.md`.
 const MIN_PARALLEL_CHUNK_BYTES: usize = 1024 * 1024;
+
+/// Per-scan counters backing the `--debug=deltasum` per-file line and the
+/// sender's run totals.
+///
+/// upstream: match.c:363-366 zeroes `false_alarms`/`hash_hits`/`matches` at the
+/// top of `match_sums()`; match.c:472-475 folds them into the run totals that
+/// `match_report()` prints. `hash_hits`/`false_alarms` carry oc-native
+/// semantics (see [`crate::ProbeCounters`]).
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ScanCounters {
+    /// Confirmed block matches emitted as `Copy` tokens.
+    pub matches: u64,
+    /// Hash-probe attempts that reached the index (bithash positives).
+    pub hash_hits: u64,
+    /// Probe attempts that produced no confirmed match.
+    pub false_alarms: u64,
+}
 
 /// Emits a coalesced `DeltaToken::Copy` covering an open seq-match run.
 ///
@@ -263,6 +280,15 @@ pub struct DeltaGenerator {
     /// byte-identical - only the unsafe seek-backwards read is avoided. `false`
     /// (default) leaves the scan byte-for-byte unchanged.
     updating_basis_file: bool,
+    /// Source length, when the caller knows it, for the `--debug=deltasum`
+    /// scan-start lines.
+    ///
+    /// Upstream scans a `map_file()`d source whose length it always has, and
+    /// prints it as `len=` in both `hash search` lines (match.c:180-182,
+    /// :199-202). oc scans a `Read` stream, so the length has to arrive from
+    /// the caller. `None` suppresses those two lines rather than inventing a
+    /// number; every production caller sets it.
+    source_len: Option<u64>,
     /// Test-only knob disabling the matched-block pruning bitmap so the
     /// property tests can compare prune-on against prune-off output. The
     /// production path always prunes; see `docs/design/zsync-prune.md`.
@@ -278,9 +304,24 @@ impl DeltaGenerator {
             buffer_len: DEFAULT_BUFFER_LEN,
             consecutive_match_needed: 1,
             updating_basis_file: false,
+            source_len: None,
             #[cfg(any(test, feature = "bench-internal"))]
             prune_matched: true,
         }
+    }
+
+    /// Records the source length so the `--debug=deltasum` scan-start lines can
+    /// print upstream's `len=` field.
+    ///
+    /// Purely diagnostic: the scan itself never reads this value, so setting it
+    /// cannot change a token, a counter, or a wire byte.
+    ///
+    /// upstream: match.c:180-182, :199-202 print `len` from `map_file()`'s
+    /// known source length.
+    #[must_use]
+    pub const fn with_source_len(mut self, len: u64) -> Self {
+        self.source_len = Some(len);
+        self
     }
 
     /// Overrides the buffer length used when reading from the input stream.
@@ -373,6 +414,21 @@ impl DeltaGenerator {
         reader: R,
         index: &DeltaSignatureIndex,
     ) -> io::Result<DeltaScript> {
+        self.generate_counted(reader, index)
+            .map(|(script, _)| script)
+    }
+
+    /// Like [`Self::generate`], additionally returning the per-scan
+    /// [`ScanCounters`] the caller needs for the `--debug=deltasum` per-file
+    /// counter line and the sender's run totals.
+    ///
+    /// upstream: match.c:363-366 (per-file counters), match.c:472-475 (run
+    /// total accumulation).
+    pub fn generate_counted<R: Read>(
+        &self,
+        reader: R,
+        index: &DeltaSignatureIndex,
+    ) -> io::Result<(DeltaScript, ScanCounters)> {
         // The gated scan only matches full-length blocks, so it can form a run
         // of `needed` only when the basis holds at least `needed` full blocks.
         // With fewer (e.g. one full block plus a short tail) every match is
@@ -436,7 +492,7 @@ impl DeltaGenerator {
         index: &DeltaSignatureIndex,
         prune_matched: bool,
         tail_match: bool,
-    ) -> io::Result<DeltaScript> {
+    ) -> io::Result<(DeltaScript, ScanCounters)> {
         let block_len = index.block_length();
         let mut window = RingBuffer::with_capacity(block_len);
         let mut pending_literals = Vec::with_capacity(block_len);
@@ -449,6 +505,15 @@ impl DeltaGenerator {
         let mut false_alarms = 0u64;
         let mut matches = 0u64;
         let mut offset = 0u64;
+        // upstream: match.c:126 `n = offset - last_match` - the literal-byte
+        // count the `match at` line reports, so the trace needs the end of the
+        // previous match, not just the current cursor.
+        let mut last_match = 0u64;
+        // upstream prints `sum=%.8x k=%ld` and the level-3 `hash search`
+        // parameter line once, right after the first window's checksum is
+        // computed (match.c:190-202). oc computes that checksum inside the
+        // scan loop, so the emission rides the first full window.
+        let mut first_window = true;
 
         // upstream: match.c - `want_i` tracks the expected next block index
         // for adjacent-match hinting. After a confirmed match at block `i`,
@@ -478,21 +543,12 @@ impl DeltaGenerator {
         let mut buffer_pos = 0usize;
         let mut buffer_len = 0usize;
 
-        debug_log!(
-            Deltasum,
-            2,
-            "hash search b={} len={}",
-            block_len,
-            index.block_length()
-        );
-
-        debug_log!(
-            Deltasum,
-            3,
-            "hash search s->blength={} buffer_len={}",
-            block_len,
-            self.buffer_len
-        );
+        // upstream: match.c:180-182 - the scan-start line, before the first
+        // window checksum. The level-3 companion (`s->blength`/`count`) waits
+        // for that checksum, exactly as upstream orders them.
+        if let Some(source_len) = self.source_len {
+            trace_deltasum::trace_hash_search_start(block_len, source_len);
+        }
 
         loop {
             if buffer_pos == buffer_len {
@@ -534,14 +590,22 @@ impl DeltaGenerator {
 
             let digest = rolling.digest();
 
-            debug_log!(
-                Deltasum,
-                4,
-                "offset={} sum={:04x}{:04x}",
-                offset,
-                digest.sum1(),
-                digest.sum2()
-            );
+            if first_window {
+                first_window = false;
+                // upstream: match.c:192-193 then :199-202 - the initial window
+                // checksum, then the scan parameters, in that order.
+                trace_deltasum::trace_initial_sum(digest.value(), window.len());
+                if let Some(source_len) = self.source_len {
+                    trace_deltasum::trace_hash_search_params(
+                        block_len,
+                        source_len,
+                        index.block_count() as u64,
+                    );
+                }
+            }
+
+            // upstream: match.c:210-213
+            trace_deltasum::trace_scan_offset(offset, digest.sum2(), digest.sum1());
 
             // upstream: match.c:144-190 - try want_i hint before hash probe.
             // The want_i hint deliberately bypasses the matched-block bitmap:
@@ -585,14 +649,23 @@ impl DeltaGenerator {
                 loop {
                     matches += 1;
 
-                    debug_log!(
-                        Deltasum,
-                        3,
-                        "potential match at {} i={} sum={:08x}",
+                    // upstream: match.c:258-262
+                    trace_deltasum::trace_potential_match(
                         offset,
-                        match_idx,
-                        rolling.digest().value()
+                        match_idx as u64,
+                        rolling.digest().value(),
                     );
+                    // upstream: match.c:133-138 `matched()` - `n` is the
+                    // literal run this match terminates, which is exactly the
+                    // gap since the previous match ended.
+                    trace_deltasum::trace_match(
+                        offset,
+                        last_match,
+                        index.block(match_idx).index(),
+                        index.block(match_idx).len(),
+                        offset.saturating_sub(last_match),
+                    );
+                    last_match = offset + index.block(match_idx).len() as u64;
 
                     if !pending_literals.is_empty() {
                         // Adjacency invariant: literals between runs always
@@ -772,14 +845,26 @@ impl DeltaGenerator {
                     };
                     if let Some(tail_idx) = tail_hit {
                         matches += 1;
-                        debug_log!(
-                            Deltasum,
-                            3,
-                            "potential match at {} i={} len={}",
+                        // upstream: match.c:258-262 then :133-138 - the short
+                        // final block is matched and emitted like any other,
+                        // just with its own shorter length.
+                        trace_deltasum::trace_potential_match(
                             offset,
-                            tail_idx,
-                            tail_len
+                            tail_idx as u64,
+                            RollingDigest::from_bytes(window.as_slice()).value(),
                         );
+                        trace_deltasum::trace_match(
+                            offset,
+                            last_match,
+                            index.block(tail_idx).index(),
+                            tail_len,
+                            offset.saturating_sub(last_match),
+                        );
+                        // The tail block is the last thing the scan can match,
+                        // so nothing reads `last_match` again; kept assigned so
+                        // the invariant "last_match is the end of the most
+                        // recent match" holds at every exit.
+                        let _ = last_match;
                         if !pending_literals.is_empty() {
                             literal_bytes += pending_literals.len() as u64;
                             total_bytes += pending_literals.len() as u64;
@@ -822,25 +907,28 @@ impl DeltaGenerator {
             tokens.push(DeltaToken::Literal(pending_literals));
         }
 
-        debug_log!(Deltasum, 2, "done hash search");
-        debug_log!(
-            Deltasum,
-            2,
-            "false_alarms={} hash_hits={} matches={}",
-            false_alarms,
-            hash_hits,
-            matches
-        );
+        // upstream: match.c:441-442. The per-file counter line is NOT emitted
+        // here: upstream prints it at match.c:468-471, AFTER `sending file_sum`
+        // and the checksum trailer (match.c:465-466). The counters therefore
+        // travel out through `ScanCounters` and the caller that writes that
+        // trailer emits the line, which is what keeps the three lines in
+        // upstream's order.
+        trace_deltasum::trace_done_hash_search();
 
         // Nothing is printed at DELTASUM level 1 here. upstream's only level-1
-        // delta diagnostic is match_report()'s `total:` line (match.c:439-448),
+        // delta diagnostic is match_report()'s `total:` line (match.c:479-487),
         // which the sender emits ONCE for the whole run - not once per file -
-        // from a single place (sender.c:491). oc renders that one line from the
-        // client summary; a per-file line here would both invent output
-        // upstream never prints and land dead-last through the deferred
-        // diagnostic flush.
+        // from a single place (sender.c:815). The run totals travel out through
+        // `ScanCounters` so the driver can print that line once.
 
-        Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
+        Ok((
+            DeltaScript::new(tokens, total_bytes, literal_bytes),
+            ScanCounters {
+                matches,
+                hash_hits,
+                false_alarms,
+            },
+        ))
     }
 
     /// Consecutive-match (zsync `seq_matches=2`) gated delta scan.
@@ -868,7 +956,7 @@ impl DeltaGenerator {
         &self,
         mut reader: R,
         index: &DeltaSignatureIndex,
-    ) -> io::Result<DeltaScript> {
+    ) -> io::Result<(DeltaScript, ScanCounters)> {
         let block_len = index.block_length();
         let mut window = RingBuffer::with_capacity(block_len);
         let mut pending_literals = Vec::with_capacity(block_len);
@@ -887,6 +975,25 @@ impl DeltaGenerator {
         // Source cursor (window-start offset), tracked so the in-place guard can
         // compare each candidate's basis offset against the write position.
         let mut offset = 0u64;
+        // Counters for the per-file `--debug=deltasum` line. `matches` counts
+        // blocks the scan CONFIRMED, including one later demoted to a literal
+        // by the consecutive-match rule - the confirmation is what upstream's
+        // counter records (match.c:238 `matches++` sits at the accepted-block
+        // site, before any emission decision).
+        let mut hash_hits = 0u64;
+        let mut false_alarms = 0u64;
+        let mut matches = 0u64;
+        let mut last_match = 0u64;
+
+        // upstream: match.c:180-182
+        if let Some(source_len) = self.source_len {
+            trace_deltasum::trace_hash_search_start(block_len, source_len);
+            trace_deltasum::trace_hash_search_params(
+                block_len,
+                source_len,
+                index.block_count() as u64,
+            );
+        }
 
         // Flushes accumulated literal bytes as a single token, keeping the
         // total/literal accounting in step. Returns nothing; mutates in place.
@@ -930,14 +1037,18 @@ impl DeltaGenerator {
             }
 
             let digest = rolling.digest();
+            // upstream: match.c:210-213
+            trace_deltasum::trace_scan_offset(offset, digest.sum2(), digest.sum1());
             let (first, second) = window.as_slices();
             // upstream: match.c:211 - under --inplace, suppress a candidate whose
             // basis offset precedes the write cursor so it demotes to a literal.
+            hash_hits += 1;
             let matched = index
                 .find_match_slices_filtered(digest, first, second, Some(&matched_blocks))
                 .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset));
 
             let Some(mut match_idx) = matched else {
+                false_alarms += 1;
                 continue;
             };
 
@@ -964,6 +1075,21 @@ impl DeltaGenerator {
                     lone_src.extend_from_slice(s1);
                     lone_src.extend_from_slice(s2);
                 }
+                matches += 1;
+                // upstream: match.c:258-262 then :133-138
+                trace_deltasum::trace_potential_match(
+                    offset,
+                    match_idx as u64,
+                    rolling.digest().value(),
+                );
+                trace_deltasum::trace_match(
+                    offset,
+                    last_match,
+                    basis_idx,
+                    block_len,
+                    offset.saturating_sub(last_match),
+                );
+                last_match = offset + block_len as u64;
                 run.push(basis_idx);
 
                 matched_blocks.mark_matched(match_idx);
@@ -1002,12 +1128,16 @@ impl DeltaGenerator {
                     rolling.update(s);
                 }
                 let adj_digest = rolling.digest();
+                hash_hits += 1;
                 let adj = index
                     .find_match_slices_filtered(adj_digest, f, s, Some(&matched_blocks))
                     .filter(|&idx| self.basis_offset_ok(index, block_len, idx, offset));
                 match adj {
                     Some(next_idx) => match_idx = next_idx,
-                    None => break,
+                    None => {
+                        false_alarms += 1;
+                        break;
+                    }
                 }
             }
 
@@ -1044,7 +1174,18 @@ impl DeltaGenerator {
         }
         flush_pending!();
 
-        Ok(DeltaScript::new(tokens, total_bytes, literal_bytes))
+        // upstream: match.c:441-442. As in `generate_with_prune`, the counter
+        // line belongs to the caller that writes the checksum trailer.
+        trace_deltasum::trace_done_hash_search();
+
+        Ok((
+            DeltaScript::new(tokens, total_bytes, literal_bytes),
+            ScanCounters {
+                matches,
+                hash_hits,
+                false_alarms,
+            },
+        ))
     }
 
     /// Generates a [`DeltaScript`] by scanning `source` in parallel across up
@@ -1104,6 +1245,24 @@ impl DeltaGenerator {
         index: &DeltaSignatureIndex,
         max_chunks: usize,
     ) -> io::Result<DeltaScript> {
+        self.generate_chunked_counted(source, index, max_chunks)
+            .map(|(script, _)| script)
+    }
+
+    /// Like [`Self::generate_chunked`], additionally returning the summed
+    /// per-stripe [`ScanCounters`].
+    ///
+    /// Counters are summed across stripes, so they describe the same work the
+    /// sequential scan would have done. The per-match `--debug=deltasum` trace
+    /// lines, however, are emitted on the rayon workers, whose thread-local
+    /// diagnostic buffers are never drained - see this module's note on the
+    /// parallel path in `trace_deltasum`.
+    pub fn generate_chunked_counted(
+        &self,
+        source: &[u8],
+        index: &DeltaSignatureIndex,
+        max_chunks: usize,
+    ) -> io::Result<(DeltaScript, ScanCounters)> {
         // The consecutive-match extension needs a single sequential pass to
         // reason about cross-range block adjacency, so route it through the
         // gated scan rather than the parallel range split. This path is only
@@ -1125,7 +1284,7 @@ impl DeltaGenerator {
         // know a stripe-local cursor, so route the guarded scan through the
         // sequential path, which tracks the true global offset.
         if self.updating_basis_file {
-            return self.generate(Cursor::new(source), index);
+            return self.generate_counted(Cursor::new(source), index);
         }
 
         let block_len = index.block_length();
@@ -1142,7 +1301,7 @@ impl DeltaGenerator {
 
         if chunks <= 1 || block_len == 0 {
             // Too small to split usefully - keep the pruned sequential path.
-            return self.generate(Cursor::new(source), index);
+            return self.generate_counted(Cursor::new(source), index);
         }
 
         // Pruning is disabled per stripe, so no worker writes the shared
@@ -1173,20 +1332,26 @@ impl DeltaGenerator {
         // claim the basis's short final block; a stripe that stops at a boundary
         // would otherwise place that block mid-file, where upstream's
         // `l = MIN(blength, len-offset)` test (`match.c:222-224`) never admits it.
-        let scripts: Vec<io::Result<DeltaScript>> = ranges
+        let scripts: Vec<io::Result<(DeltaScript, ScanCounters)>> = ranges
             .par_iter()
             .map(|&(s, e)| {
                 self.generate_with_prune(Cursor::new(&source[s..e]), index, false, e == n)
             })
             .collect();
 
+        let mut counters = ScanCounters::default();
+
         // Lift every worker `Copy` to an absolute source offset. Literals are
         // ignored: [`merge_copy_runs`] regenerates them from `source`, so a
         // stripe boundary can never drop or duplicate a literal byte.
         let mut runs: Vec<CopyRun> = Vec::new();
         for (&(scan_start, _), script) in ranges.iter().zip(scripts) {
+            let (script, stripe_counters) = script?;
+            counters.matches += stripe_counters.matches;
+            counters.hash_hits += stripe_counters.hash_hits;
+            counters.false_alarms += stripe_counters.false_alarms;
             let mut local_off = 0u64;
-            for token in script?.into_tokens() {
+            for token in script.into_tokens() {
                 let token_len = token.byte_len() as u64;
                 if let DeltaToken::Copy {
                     index: basis_index,
@@ -1221,7 +1386,7 @@ impl DeltaGenerator {
             }
         }
 
-        Ok(merge_copy_runs(source, runs, block_len))
+        Ok((merge_copy_runs(source, runs, block_len), counters))
     }
 }
 

--- a/crates/matching/src/lib.rs
+++ b/crates/matching/src/lib.rs
@@ -30,12 +30,13 @@ mod index;
 pub mod optimized_search;
 mod ring_buffer;
 mod script;
+pub mod trace_deltasum;
 
 pub use fuzzy::{
     FUZZY_LEVEL_1, FUZZY_LEVEL_2, FuzzyMatch, FuzzyMatcher, trace_fuzzy_basis_selected,
     trace_fuzzy_distance, trace_fuzzy_size_mtime_match,
 };
-pub use generator::{DeltaGenerator, generate_delta};
+pub use generator::{DeltaGenerator, ScanCounters, generate_delta};
 pub use index::{
     DeltaSignatureIndex, HASH_KEY_BITS, HashtableRole, MatchedBlocks, ProbeCounters,
     trace_hashtable_created, trace_hashtable_destroyed, trace_hashtable_growing,

--- a/crates/matching/src/trace_deltasum.rs
+++ b/crates/matching/src/trace_deltasum.rs
@@ -1,0 +1,457 @@
+//! `--debug=DELTASUM` producer emissions for the delta-transfer pipeline.
+//!
+//! Mirrors upstream rsync's `DEBUG_GTE(DELTASUM, n)` output byte-for-byte so
+//! diagnostics align across implementations. Every upstream format string has
+//! exactly ONE owner function here; the sender scan (this crate), the network
+//! sender/receiver/generator drivers (`transfer`), and the local fused
+//! delta loop (`engine::local_copy`) all emit through these functions instead
+//! of holding their own copies of the text.
+//!
+//! # Upstream Reference
+//!
+//! - `match.c` - sender hash-search trace (levels 2-4) and the run totals.
+//! - `sender.c` - per-file receive_sums / map / match_sums milestones.
+//! - `generator.c` - signature generation geometry and per-chunk sums.
+//! - `receiver.c` - basis map, literal/match application, file_sum receipt.
+//!
+//! Upstream forwards only `--info` words to the remote server
+//! (`options.c:3117-3120` builds the server's output option from `info_words`
+//! alone), so DELTASUM output is CLIENT-side only: a pull prints the
+//! generator+receiver lines, a push prints the sender lines, and a local copy
+//! prints both sets. The server-side roles stay silent unless the server
+//! itself was invoked with `--debug=deltasum`.
+//!
+//! # Measured fidelity, against upstream 3.5.0 (`--debug=deltasum{,2,3}`)
+//!
+//! Fixture: a 256 KB pseudo-random file, 100 bytes overwritten in a backdated
+//! basis, `--no-whole-file -t` so the delta path engages.
+//!
+//! - **Wire pull** (client = generator + receiver): byte-identical at all three
+//!   levels, including all 755 lines at level 3.
+//! - **Wire push** (client = sender): identical at all three levels except the
+//!   two counter lines, whose `hash_hits`/`false_alarms` values differ by the
+//!   oc-native counter semantics documented on [`trace_match_counters`].
+//!   `matches` and `data` agree exactly (1132 of 1134 level-3 lines identical).
+//! - **Local copy**: every line oc emits matches upstream's text exactly, and
+//!   the set of emitted lines is a subset of upstream's apart from the same two
+//!   counter lines plus the two spelling/geometry residuals below. The ORDER
+//!   differs: see the local notes.
+//!
+//! # Known no-analogue sites and residual divergences
+//!
+//! - `match.c:210-213` (level 4 `offset=... sum=...`) is emitted by the
+//!   sequential scan only; the opt-in parallel chunked scan
+//!   (`DeltaGenerator::generate_chunked`) runs its stripes on rayon workers
+//!   whose thread-local diagnostic buffers are not collected, so per-match
+//!   trace lines from those stripes are not printed. Counters still reach the
+//!   merged [`crate::DeltaScript`].
+//! - The local fused delta loop writes the reconstructed file directly and
+//!   never computes or transfers a whole-file checksum, so it has no analogue
+//!   for `sending file_sum` (match.c:465) or `got file_sum` (receiver.c:672).
+//! - The local path has no analogue for the sender's `receive_sums()` block
+//!   trace (`chunk[%d] len=%d offset=%s sum1=%08x`, sender.c:382-386): nothing
+//!   is received: the one in-process signature index serves both roles. Upstream
+//!   prints those 375 lines locally only because its local run really does drive
+//!   two processes over a socketpair. Nor does it have one for `generating and
+//!   sending sums for %d` (generator.c:2363) - the local executor carries no
+//!   wire file index, and naming a fabricated one would be inventing output.
+//! - **Local ordering**: upstream's local run emits every sender line, then its
+//!   receiver process drains the delta and emits `recv mapped` plus all its
+//!   `chunk[..] of size ..` lines as a trailing block. oc's local loop is fused,
+//!   so it emits `recv mapped` where it opens the basis and each `chunk[..] of
+//!   size ..` where it actually copies that block - interleaved with the scan.
+//!   The lines are individually byte-identical; only their interleaving differs,
+//!   and it differs because the work really is interleaved.
+//! - **Local `gen mapped` spelling**: upstream prints `fnamecmp`, relative
+//!   because it chdir'd into the destination root. The local executor never
+//!   chdirs, so it prints the path the operand resolved to.
+//! - **Local `s2length`**: upstream reports `s2length=2` for this fixture, oc
+//!   `s2length=16`. That is a pre-existing difference in the local path's
+//!   signature geometry (`build_delta_signature` asks for a full 16-byte strong
+//!   sum), surfaced - not caused - by this trace. Changing it would change local
+//!   block matching, so it is reported rather than adjusted here.
+
+use logging::debug_log;
+
+/// Level 2 `hash search b=%ld len=%s` - scan start with block length and the
+/// source length the scan was sized from.
+///
+/// upstream: match.c:180-182 `hash_search()`.
+#[inline]
+pub fn trace_hash_search_start(block_length: usize, source_len: u64) {
+    debug_log!(Deltasum, 2, "hash search b={block_length} len={source_len}");
+}
+
+/// Level 3 `hash search s->blength=%ld len=%s count=%s` - scan parameters.
+///
+/// upstream: match.c:199-202 `hash_search()`.
+#[inline]
+pub fn trace_hash_search_params(block_length: usize, source_len: u64, count: u64) {
+    debug_log!(
+        Deltasum,
+        3,
+        "hash search s->blength={block_length} len={source_len} count={count}"
+    );
+}
+
+/// Level 3 `sum=%.8x k=%ld` - the initial window checksum over the first `k`
+/// source bytes.
+///
+/// upstream: match.c:192-193 `hash_search()`.
+#[inline]
+pub fn trace_initial_sum(sum: u32, k: usize) {
+    debug_log!(Deltasum, 3, "sum={sum:08x} k={k}");
+}
+
+/// Level 4 `offset=%s sum=%04x%04x` - per-offset rolling sum during the scan.
+///
+/// upstream: match.c:210-213 `hash_search()`.
+#[inline]
+pub fn trace_scan_offset(offset: u64, s2: u16, s1: u16) {
+    debug_log!(Deltasum, 4, "offset={offset} sum={s2:04x}{s1:04x}");
+}
+
+/// Level 3 `potential match at %s i=%ld sum=%08x` - a weak-checksum candidate.
+///
+/// upstream: match.c:258-262 `hash_search()`. Upstream prints every chain
+/// candidate whose weak sum and length match, BEFORE the strong-checksum
+/// verify; oc's index probe confirms the strong checksum internally, so this
+/// fires only for confirmed candidates and `i` is the confirmed block index
+/// rather than an arbitrary chain entry.
+#[inline]
+pub fn trace_potential_match(offset: u64, i: u64, sum: u32) {
+    debug_log!(
+        Deltasum,
+        3,
+        "potential match at {offset} i={i} sum={sum:08x}"
+    );
+}
+
+/// Level 2 `match at %s last_match=%s j=%d len=%ld n=%ld` - an emitted block
+/// match: `j` is the basis block index, `len` its length, `n` the literal
+/// bytes accumulated since the previous token.
+///
+/// upstream: match.c:133-138 `matched()` (printed only for `i >= 0`).
+#[inline]
+pub fn trace_match(offset: u64, last_match: u64, j: u64, len: usize, n: u64) {
+    debug_log!(
+        Deltasum,
+        2,
+        "match at {offset} last_match={last_match} j={j} len={len} n={n}"
+    );
+}
+
+/// Level 2 `built hash table` - the signature hash index is ready.
+///
+/// upstream: match.c:436-437 `match_sums()`.
+#[inline]
+pub fn trace_built_hash_table() {
+    debug_log!(Deltasum, 2, "built hash table");
+}
+
+/// Level 2 `done hash search` - the scan over the source completed.
+///
+/// upstream: match.c:441-442 `match_sums()`.
+#[inline]
+pub fn trace_done_hash_search() {
+    debug_log!(Deltasum, 2, "done hash search");
+}
+
+/// Level 2 `sending file_sum` - the sender is about to write the whole-file
+/// checksum trailer.
+///
+/// upstream: match.c:465-466 `match_sums()`.
+#[inline]
+pub fn trace_sending_file_sum() {
+    debug_log!(Deltasum, 2, "sending file_sum");
+}
+
+/// Level 2 `false_alarms=%d hash_hits=%d matches=%d` - per-file scan counters,
+/// printed after the file's checksum trailer.
+///
+/// upstream: match.c:468-471 `match_sums()`. Counter semantics are oc-native
+/// (see [`crate::ProbeCounters`]): `hash_hits` counts bithash-prefilter
+/// positives and `false_alarms` counts prefilter positives that produced no
+/// confirmed match, where upstream counts bucket hits and strong-sum rejects.
+#[inline]
+pub fn trace_match_counters(false_alarms: u64, hash_hits: u64, matches: u64) {
+    debug_log!(
+        Deltasum,
+        2,
+        "false_alarms={false_alarms} hash_hits={hash_hits} matches={matches}"
+    );
+}
+
+/// Level 1 `total: matches=%d  hash_hits=%d  false_alarms=%d data=%s` - the
+/// once-per-run sender totals (note the double spaces).
+///
+/// upstream: match.c:479-487 `match_report()`, called after `send_files()`
+/// finishes (sender.c:815). The LOCAL copy path renders this line directly
+/// from the client summary (`cli::frontend::progress::render`) to keep
+/// upstream's position between the name list and the summary trailer; this
+/// function is the owner for the network sender drivers only.
+#[inline]
+pub fn trace_match_totals(matches: u64, hash_hits: u64, false_alarms: u64, data: u64) {
+    debug_log!(
+        Deltasum,
+        1,
+        "total: matches={matches}  hash_hits={hash_hits}  false_alarms={false_alarms} data={data}"
+    );
+}
+
+/// Level 3 `count=%s n=%ld rem=%ld` - the sender's view of the received sum
+/// header.
+///
+/// upstream: sender.c:348-350 `receive_sums()`.
+#[inline]
+pub fn trace_receive_sums_head(count: u64, block_length: usize, remainder: u32) {
+    debug_log!(
+        Deltasum,
+        3,
+        "count={count} n={block_length} rem={remainder}"
+    );
+}
+
+/// Level 3 `chunk[%d] len=%d offset=%s sum1=%08x` - one received signature
+/// block on the sender.
+///
+/// upstream: sender.c:382-386 `receive_sums()`.
+#[inline]
+pub fn trace_receive_sums_chunk(i: u64, len: usize, offset: u64, sum1: u32) {
+    debug_log!(
+        Deltasum,
+        3,
+        "chunk[{i}] len={len} offset={offset} sum1={sum1:08x}"
+    );
+}
+
+/// Level 2 `send_files mapped %s%s%s of size %s` - the sender opened its
+/// source for scanning.
+///
+/// upstream: sender.c:760-763 `send_files()` (the `%s%s%s` is
+/// path/slash/fname; oc passes the joined path).
+#[inline]
+pub fn trace_send_files_mapped(path: &dyn std::fmt::Display, size: u64) {
+    debug_log!(Deltasum, 2, "send_files mapped {path} of size {size}");
+}
+
+/// Level 2 `calling match_sums %s%s%s` - the sender is entering the delta
+/// scan for this file.
+///
+/// upstream: sender.c:768-769 `send_files()`.
+#[inline]
+pub fn trace_calling_match_sums(path: &dyn std::fmt::Display) {
+    debug_log!(Deltasum, 2, "calling match_sums {path}");
+}
+
+/// Level 3 `gen mapped %s of size %s` - the generator opened the basis it
+/// will checksum.
+///
+/// upstream: generator.c:2358-2361 `recv_generator()`.
+#[inline]
+pub fn trace_gen_mapped(path: &dyn std::fmt::Display, size: u64) {
+    debug_log!(Deltasum, 3, "gen mapped {path} of size {size}");
+}
+
+/// Level 2 `generating and sending sums for %d` - the generator is producing
+/// the signature for file index `ndx`.
+///
+/// upstream: generator.c:2363-2364 `recv_generator()`.
+#[inline]
+pub fn trace_generating_sums(ndx: i32) {
+    debug_log!(Deltasum, 2, "generating and sending sums for {ndx}");
+}
+
+/// Level 2 `count=%s rem=%ld blength=%ld s2length=%d flength=%s` - the
+/// signature geometry chosen for a basis.
+///
+/// upstream: generator.c:765-770 `sum_sizes_sqroot()`.
+#[inline]
+pub fn trace_sum_geometry(
+    count: u64,
+    remainder: u32,
+    block_length: usize,
+    s2length: u8,
+    flength: u64,
+) {
+    debug_log!(
+        Deltasum,
+        2,
+        "count={count} rem={remainder} blength={block_length} s2length={s2length} flength={flength}"
+    );
+}
+
+/// Level 3 `chunk[%s] offset=%s len=%ld sum1=%08lx` - one generated signature
+/// block on the generator.
+///
+/// upstream: generator.c:817-822 `generate_and_send_sums()`.
+#[inline]
+pub fn trace_gen_chunk(i: u64, offset: u64, len: usize, sum1: u32) {
+    debug_log!(
+        Deltasum,
+        3,
+        "chunk[{i}] offset={offset} len={len} sum1={sum1:08x}"
+    );
+}
+
+/// Level 2 `recv mapped %s of size %s` - the receiver opened the basis it
+/// will copy matched blocks from.
+///
+/// upstream: receiver.c:498-501 `receive_data()`.
+#[inline]
+pub fn trace_recv_mapped(path: &dyn std::fmt::Display, size: u64) {
+    debug_log!(Deltasum, 2, "recv mapped {path} of size {size}");
+}
+
+/// Level 3 `data recv %d at %s` - a literal run arrived at output offset
+/// `offset`.
+///
+/// upstream: receiver.c:552-555 `receive_data()`.
+#[inline]
+pub fn trace_data_recv(len: usize, offset: u64) {
+    debug_log!(Deltasum, 3, "data recv {len} at {offset}");
+}
+
+/// Level 3 `chunk[%d] of size %ld at %s offset=%s%s` - a matched block is
+/// applied from basis offset `offset2` at output offset `offset`; `seek` adds
+/// upstream's ` (seek)` marker for the in-place skip fast path.
+///
+/// upstream: receiver.c:609-614 `receive_data()`.
+#[inline]
+pub fn trace_recv_chunk(i: u64, len: usize, offset2: u64, offset: u64, seek: bool) {
+    debug_log!(
+        Deltasum,
+        3,
+        "chunk[{i}] of size {len} at {offset2} offset={offset}{}",
+        if seek { " (seek)" } else { "" }
+    );
+}
+
+/// Level 2 `got file_sum` - the receiver consumed the sender's whole-file
+/// checksum trailer.
+///
+/// upstream: receiver.c:671-673 `receive_data()`.
+#[inline]
+pub fn trace_got_file_sum() {
+    debug_log!(Deltasum, 2, "got file_sum");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logging::{DebugFlag, DiagnosticEvent, VerbosityConfig, drain_events, init};
+
+    fn setup(level: u8) {
+        let mut cfg = VerbosityConfig::default();
+        cfg.debug.deltasum = level;
+        init(cfg);
+        let _ = drain_events();
+    }
+
+    fn messages() -> Vec<String> {
+        drain_events()
+            .into_iter()
+            .filter_map(|event| match event {
+                DiagnosticEvent::Debug {
+                    flag: DebugFlag::Deltasum,
+                    message,
+                    ..
+                } => Some(message),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Pins every format string byte-for-byte against upstream 3.5.0 output
+    /// captured from `--debug=deltasum3` runs (match.c / sender.c /
+    /// generator.c / receiver.c, see per-fn citations).
+    #[test]
+    fn formats_match_upstream() {
+        setup(4);
+        trace_hash_search_start(700, 262144);
+        trace_hash_search_params(700, 262144, 375);
+        trace_initial_sum(0x760c_feda, 700);
+        trace_scan_offset(3, 0xf16c, 0xfc9a);
+        trace_potential_match(0, 320, 0x760c_feda);
+        trace_match(700, 700, 1, 700, 0);
+        trace_built_hash_table();
+        trace_done_hash_search();
+        trace_sending_file_sum();
+        trace_match_counters(0, 377, 374);
+        trace_match_totals(374, 377, 0, 700);
+        trace_receive_sums_head(375, 700, 344);
+        trace_receive_sums_chunk(0, 700, 0, 0x760c_feda);
+        trace_send_files_mapped(&"/src/a.bin", 262144);
+        trace_calling_match_sums(&"/src/a.bin");
+        trace_gen_mapped(&"a.bin", 262144);
+        trace_generating_sums(0);
+        trace_sum_geometry(375, 344, 700, 2, 262144);
+        trace_gen_chunk(1, 700, 700, 0xf164_ff4a);
+        trace_recv_mapped(&"a.bin", 262144);
+        trace_data_recv(700, 99400);
+        trace_recv_chunk(374, 344, 261800, 261800, false);
+        trace_recv_chunk(5, 700, 3500, 3500, true);
+        trace_got_file_sum();
+
+        let msgs = messages();
+        let expected = [
+            "hash search b=700 len=262144",
+            "hash search s->blength=700 len=262144 count=375",
+            "sum=760cfeda k=700",
+            "offset=3 sum=f16cfc9a",
+            "potential match at 0 i=320 sum=760cfeda",
+            "match at 700 last_match=700 j=1 len=700 n=0",
+            "built hash table",
+            "done hash search",
+            "sending file_sum",
+            "false_alarms=0 hash_hits=377 matches=374",
+            "total: matches=374  hash_hits=377  false_alarms=0 data=700",
+            "count=375 n=700 rem=344",
+            "chunk[0] len=700 offset=0 sum1=760cfeda",
+            "send_files mapped /src/a.bin of size 262144",
+            "calling match_sums /src/a.bin",
+            "gen mapped a.bin of size 262144",
+            "generating and sending sums for 0",
+            "count=375 rem=344 blength=700 s2length=2 flength=262144",
+            "chunk[1] offset=700 len=700 sum1=f164ff4a",
+            "recv mapped a.bin of size 262144",
+            "data recv 700 at 99400",
+            "chunk[374] of size 344 at 261800 offset=261800",
+            "chunk[5] of size 700 at 3500 offset=3500 (seek)",
+            "got file_sum",
+        ];
+        assert_eq!(msgs, expected, "DELTASUM formats drifted from upstream");
+    }
+
+    /// Every emission must respect its upstream level gate: nothing below its
+    /// own level, everything at it.
+    #[test]
+    fn level_gates_match_upstream() {
+        setup(1);
+        trace_hash_search_start(1, 1);
+        trace_built_hash_table();
+        trace_got_file_sum();
+        trace_data_recv(1, 0);
+        assert!(messages().is_empty(), "level-2/3 lines leaked at level 1");
+
+        setup(1);
+        trace_match_totals(0, 0, 0, 0);
+        assert_eq!(messages().len(), 1, "the total line is level 1");
+
+        setup(2);
+        trace_data_recv(1, 0);
+        trace_potential_match(0, 0, 0);
+        trace_initial_sum(0, 0);
+        assert!(messages().is_empty(), "level-3 lines leaked at level 2");
+
+        setup(3);
+        trace_scan_offset(0, 0, 0);
+        assert!(
+            messages().is_empty(),
+            "the level-4 offset line leaked at level 3"
+        );
+        setup(4);
+        trace_scan_offset(0, 0, 0);
+        assert_eq!(messages().len(), 1);
+    }
+}

--- a/crates/matching/tests/deltasum_emissions.rs
+++ b/crates/matching/tests/deltasum_emissions.rs
@@ -129,29 +129,58 @@ fn level_1_scan_emits_nothing() {
     );
 }
 
-/// At `-vvv` (DELTASUM level 2) the per-file counter line must survive, with
-/// upstream's exact wording and field order.
+/// At `-vvv` (DELTASUM level 2) the scan reports its milestones but NOT the
+/// per-file counter line.
 ///
-/// upstream: match.c:428-431 - `false_alarms=%d hash_hits=%d matches=%d`, note
-/// the single spaces and the order, which is deliberately the REVERSE of the
-/// `total:` line's `matches / hash_hits / false_alarms`.
+/// upstream orders the three level-2 lines `done hash search` (match.c:441),
+/// `sending file_sum` (match.c:465), `false_alarms=... hash_hits=...
+/// matches=...` (match.c:468) - the counters come AFTER the checksum trailer.
+/// The scan does not write that trailer, so it cannot own the line without
+/// printing it in the wrong place; it hands the numbers back through
+/// `ScanCounters` and the driver that writes the trailer emits them. MEASURED:
+/// emitting the counters from the scan put them one line ahead of
+/// `sending file_sum` on a `--debug=deltasum2` push, against upstream 3.5.0.
 #[test]
-fn level_2_scan_emits_upstream_per_file_counter_line() {
+fn level_2_scan_emits_milestones_but_not_the_counter_line() {
     init_deltasum(2);
     scan();
 
     let msgs = deltasum_messages();
-    let counters = msgs
-        .iter()
-        .find(|m| m.starts_with("false_alarms="))
-        .unwrap_or_else(|| panic!("missing per-file counter line, got: {msgs:?}"));
-    let fields: Vec<&str> = counters.split(' ').collect();
-    assert_eq!(fields.len(), 3, "unexpected field count in {counters:?}");
-    assert!(fields[0].starts_with("false_alarms="), "{counters:?}");
-    assert!(fields[1].starts_with("hash_hits="), "{counters:?}");
-    assert!(fields[2].starts_with("matches="), "{counters:?}");
+    assert!(
+        msgs.iter().any(|m| m == "done hash search"),
+        "missing the scan-complete milestone, got: {msgs:?}"
+    );
+    assert!(
+        !msgs.iter().any(|m| m.starts_with("false_alarms=")),
+        "the per-file counter line must follow `sending file_sum`, which only \
+         the trailer-writing driver can order correctly; got: {msgs:?}"
+    );
     assert!(
         !msgs.iter().any(|m| m.starts_with("total:")),
         "the run-total line is never emitted per file, got: {msgs:?}"
+    );
+}
+
+/// The counters the scan hands back are the ones the driver prints, so a scan
+/// that matched a block and left a literal run must report both.
+///
+/// upstream: match.c:472-475 - the same three values fold into the run totals.
+#[test]
+fn scan_counters_describe_the_work_done() {
+    init_deltasum(0);
+    let basis = basis_bytes();
+    let index = build_index(&basis);
+    let source = source_bytes();
+    let (script, counters) = DeltaGenerator::new()
+        .with_source_len(source.len() as u64)
+        .generate_counted(std::io::Cursor::new(source.as_slice()), &index)
+        .expect("delta scan");
+    assert!(
+        script.literal_bytes() > 0 && script.total_bytes() > script.literal_bytes(),
+        "fixture must produce both a match and a literal run"
+    );
+    assert!(
+        counters.matches > 0,
+        "the confirmed block match must be counted, got {counters:?}"
     );
 }

--- a/crates/transfer/Cargo.toml
+++ b/crates/transfer/Cargo.toml
@@ -18,6 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 protocol = { path = "../protocol" }
 metadata = { path = "../metadata", default-features = false }
 engine = { path = "../engine", default-features = false }
+matching = { path = "../matching" }
 signature = { path = "../signature" }
 filters = { path = "../filters" }
 compress = { path = "../compress" }

--- a/crates/transfer/src/generator/delta.rs
+++ b/crates/transfer/src/generator/delta.rs
@@ -335,15 +335,22 @@ impl<R: Read> Read for ScanSource<R> {
 pub fn generate_delta_from_signature<R: Read>(
     source: R,
     config: DeltaGeneratorConfig<'_>,
-) -> io::Result<DeltaScript> {
+    source_len: u64,
+) -> io::Result<(DeltaScript, matching::ScanCounters)> {
     let needed = consecutive_match_needed(&config);
     let updating_basis_file = config.updating_basis_file;
     let index = build_signature_index(config)?;
 
+    // upstream: match.c:436-437 - `match_sums()` announces the table it just
+    // built, immediately before entering `hash_search()`. oc builds the index
+    // here, so this is the equivalent position.
+    matching::trace_deltasum::trace_built_hash_table();
+
     let generator = DeltaGenerator::new()
         .with_consecutive_match_needed(needed)
-        .with_updating_basis_file(updating_basis_file);
-    generator.generate(source, &index).map_err(|e| {
+        .with_updating_basis_file(updating_basis_file)
+        .with_source_len(source_len);
+    generator.generate_counted(source, &index).map_err(|e| {
         io::Error::other(format!(
             "delta generation failed: {e} {}{}",
             error_location!(),
@@ -392,7 +399,7 @@ pub fn generate_delta_from_signature_chunked(
     source: &[u8],
     config: DeltaGeneratorConfig<'_>,
     max_chunks: usize,
-) -> io::Result<DeltaScript> {
+) -> io::Result<(DeltaScript, matching::ScanCounters)> {
     // Carry the negotiated consecutive-match threshold onto the parallel path:
     // when the mutual CAP_CONSECUTIVE_MATCH bit is set the receiver has halved
     // the strong-sum length, so the sender must apply seq_matches=2 gating here
@@ -402,15 +409,19 @@ pub fn generate_delta_from_signature_chunked(
     let updating_basis_file = config.updating_basis_file;
     let index = build_signature_index(config)?;
 
+    // upstream: match.c:436-437
+    matching::trace_deltasum::trace_built_hash_table();
+
     let generator = DeltaGenerator::new()
         .with_consecutive_match_needed(needed)
-        .with_updating_basis_file(updating_basis_file);
+        .with_updating_basis_file(updating_basis_file)
+        .with_source_len(source.len() as u64);
     let result = if index.has_duplicate_blocks() {
         // Duplicate-content basis: the prune-off parallel scan would diverge
         // from the pruned sequential wire bytes, so keep the sequential path.
-        generator.generate(io::Cursor::new(source), &index)
+        generator.generate_counted(io::Cursor::new(source), &index)
     } else {
-        generator.generate_chunked(source, &index, max_chunks)
+        generator.generate_chunked_counted(source, &index, max_chunks)
     };
 
     result.map_err(|e| {
@@ -1789,8 +1800,10 @@ mod tests {
         let mut config = delta_config(sig_blocks, BLOCK_LEN, 16, false);
         config.remainder = REMAINDER;
 
-        let script =
-            generate_delta_from_signature(io::Cursor::new(basis.clone()), config).expect("delta");
+        let basis_len = basis.len() as u64;
+        let (script, _) =
+            generate_delta_from_signature(io::Cursor::new(basis.clone()), config, basis_len)
+                .expect("delta");
 
         let short_copies: Vec<usize> = script
             .tokens()
@@ -1835,7 +1848,8 @@ mod tests {
         source.extend_from_slice(&block0);
 
         // Guard inactive: the backward match survives as a Copy (non-monotonic).
-        let off = generate_delta_from_signature(
+        let source_len = source.len() as u64;
+        let (off, _) = generate_delta_from_signature(
             io::Cursor::new(source.clone()),
             delta_config(
                 wire_signature(&basis, block_len, strong_len),
@@ -1843,6 +1857,7 @@ mod tests {
                 strong_len,
                 false,
             ),
+            source_len,
         )
         .expect("delta (guard off)");
         assert!(
@@ -1851,7 +1866,7 @@ mod tests {
         );
 
         // Guard active: the backward Copy is demoted to a literal (monotonic).
-        let on = generate_delta_from_signature(
+        let (on, _) = generate_delta_from_signature(
             io::Cursor::new(source.clone()),
             delta_config(
                 wire_signature(&basis, block_len, strong_len),
@@ -1859,6 +1874,7 @@ mod tests {
                 strong_len,
                 true,
             ),
+            source_len,
         )
         .expect("delta (guard on)");
         assert!(

--- a/crates/transfer/src/generator/protocol_io.rs
+++ b/crates/transfer/src/generator/protocol_io.rs
@@ -1096,12 +1096,24 @@ where
     R: Read,
     F: FnMut() -> io::Result<()>,
 {
+    // upstream: sender.c:348-350 - `receive_sums()` reports the header it just
+    // read, before the block loop, and does so even for an empty signature.
+    matching::trace_deltasum::trace_receive_sums_head(
+        u64::from(sum_head.count),
+        sum_head.blength as usize,
+        sum_head.remainder,
+    );
+
     if sum_head.is_empty() {
         // No basis file (count=0), whole-file transfer - no blocks to read
         return Ok(Vec::new());
     }
 
     let mut blocks = Vec::with_capacity(sum_head.count as usize);
+    // upstream: sender.c:377-380 - the per-block offset the trace reports is
+    // the running sum of block lengths, with the remainder applying to the
+    // last block only.
+    let mut block_offset = 0u64;
 
     for i in 0..sum_head.count {
         // Read rolling checksum (4 bytes LE)
@@ -1112,6 +1124,22 @@ where
         // Read strong checksum (s2length bytes)
         let mut strong_sum = vec![0u8; sum_head.s2length as usize];
         reader.read_exact(&mut strong_sum)?;
+
+        // upstream: sender.c:109-110 - the last block takes the remainder when
+        // it is non-zero; every other block spans a full blength.
+        let block_len = if i + 1 == sum_head.count && sum_head.remainder != 0 {
+            sum_head.remainder as usize
+        } else {
+            sum_head.blength as usize
+        };
+        // upstream: sender.c:382-386
+        matching::trace_deltasum::trace_receive_sums_chunk(
+            u64::from(i),
+            block_len,
+            block_offset,
+            rolling_sum,
+        );
+        block_offset += block_len as u64;
 
         blocks.push(SignatureBlock {
             index: i,

--- a/crates/transfer/src/generator/transfer/transfer_loop.rs
+++ b/crates/transfer/src/generator/transfer/transfer_loop.rs
@@ -416,6 +416,11 @@ impl GeneratorContext {
         // another append delta, so track which entries have been sent once.
         let mut sent_files = SentFileTracker::default();
         let mut bytes_sent = 0u64;
+        // upstream: match.c:472-475 - total_matches / total_hash_hits /
+        // total_false_alarms accumulate across every file, and match_report()
+        // (match.c:479-487) prints them once after send_files() returns
+        // (sender.c:815).
+        let mut run_scan_counters = matching::ScanCounters::default();
         // upstream: match.c stats.matched_data / stats.literal_data accumulated
         // per token as the sender emits the delta stream.
         let mut matched_data = 0u64;
@@ -1123,7 +1128,12 @@ impl GeneratorContext {
                 // path has no io::Error to catch - a bad page raises SIGBUS -
                 // so it is left alone.
                 let mut scan_source = source_reader.map(|r| ScanSource::new(r, file_size));
-                let delta_script = match source_mmap.as_ref() {
+                // upstream: sender.c:760-763 then :768-769 - the source map and
+                // the match_sums() entry are announced per file, before the
+                // scan runs.
+                matching::trace_deltasum::trace_send_files_mapped(&source_path_display, file_size);
+                matching::trace_deltasum::trace_calling_match_sums(&source_path_display);
+                let (delta_script, scan_counters) = match source_mmap.as_ref() {
                     Some(mmap) => generate_delta_from_signature_chunked(
                         mmap.as_slice(),
                         config,
@@ -1134,8 +1144,14 @@ impl GeneratorContext {
                             .as_mut()
                             .expect("sequential reader opened when mmap is absent"),
                         config,
+                        file_size,
                     )?,
                 };
+                // upstream: match.c:472-475 - the per-file counters fold into
+                // the run totals that match_report() prints once at the end.
+                run_scan_counters.matches += scan_counters.matches;
+                run_scan_counters.hash_hits += scan_counters.hash_hits;
+                run_scan_counters.false_alarms += scan_counters.false_alarms;
                 read_error = scan_source.and_then(ScanSource::into_read_error);
 
                 self.write_ndx_attrs_and_sum_head(
@@ -1197,7 +1213,18 @@ impl GeneratorContext {
                     if read_error.is_some() {
                         poison_file_checksum(&mut checksum_buf, result.checksum_len);
                     }
+                    // upstream: match.c:465-466 - announced immediately before
+                    // the whole-file checksum trailer goes on the wire, and
+                    // match.c:468-471 - the per-file counters follow it. This
+                    // ordering is why the scan hands its counters back instead
+                    // of printing them itself.
+                    matching::trace_deltasum::trace_sending_file_sum();
                     cw.write_all(&checksum_buf[..result.checksum_len])?;
+                    matching::trace_deltasum::trace_match_counters(
+                        scan_counters.false_alarms,
+                        scan_counters.hash_hits,
+                        scan_counters.matches,
+                    );
                     matched_data += result.matched_data;
                     literal_data += result.literal_data;
                     sent_bytes(cw.bytes_written(), divert_xfer)
@@ -1406,6 +1433,18 @@ impl GeneratorContext {
 
         // upstream: sender.c:485-486 - if (io_error != save_io_error &&
         // protocol_version >= 30) send_msg_int(MSG_IO_ERROR, io_error);
+        // upstream: sender.c:815 match_report() - the once-per-run delta totals,
+        // printed after the send loop has finished every file. `data` is
+        // `stats.literal_data` (match.c:486), the cumulative literal-byte count.
+        // Upstream prints it whether or not any delta ran, leaving the counters
+        // at zero for a whole-file transfer.
+        matching::trace_deltasum::trace_match_totals(
+            run_scan_counters.matches,
+            run_scan_counters.hash_hits,
+            run_scan_counters.false_alarms,
+            literal_data,
+        );
+
         // Emitted immediately before NDX_DONE so a remote receiver learns of
         // vanished/unreadable source files and reports exit 24/23. MSG_NO_SEND
         // only skips the file; it does not carry the exit-code bits.

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -84,6 +84,13 @@ impl BasisFileResult {
 /// to generate its signature (protocol version, checksum algorithm, length).
 #[derive(Debug)]
 pub struct BasisFileConfig<'a> {
+    /// Wire file index of the entry being requested.
+    ///
+    /// Diagnostic only: it names the file in the generator's `generating and
+    /// sending sums for %d` trace and never affects the signature or the wire.
+    ///
+    /// upstream: generator.c:2363-2364.
+    pub ndx: i32,
     /// Target file path in destination.
     pub file_path: &'a std::path::Path,
     /// Destination directory base.
@@ -188,7 +195,14 @@ impl std::fmt::Debug for InplaceBackupSpec<'_> {
 /// needed to generate a file signature, reducing parameter count and improving
 /// maintainability.
 #[derive(Debug, Clone, Copy)]
-struct SignatureGenerationConfig {
+struct SignatureGenerationConfig<'a> {
+    /// Wire file index, named by the `generating and sending sums for %d`
+    /// trace. upstream: generator.c:2363-2364.
+    ndx: i32,
+    /// Flist-relative name of the target, the spelling upstream's `gen mapped`
+    /// trace prints (upstream works in `fnamecmp`, relative to the destination
+    /// root it chdir'd into). upstream: generator.c:2358-2361.
+    relative_name: &'a std::path::Path,
     /// Protocol version for signature layout calculation.
     protocol: ProtocolVersion,
     /// Checksum truncation length.
@@ -201,10 +215,12 @@ struct SignatureGenerationConfig {
     block_size: Option<NonZeroU32>,
 }
 
-impl SignatureGenerationConfig {
+impl<'a> SignatureGenerationConfig<'a> {
     /// Extracts signature generation config from a BasisFileConfig.
-    fn from_basis_config(config: &BasisFileConfig<'_>) -> Self {
+    fn from_basis_config(config: &BasisFileConfig<'a>) -> Self {
         Self {
+            ndx: config.ndx,
+            relative_name: config.relative_path,
             protocol: config.protocol,
             checksum_length: config.checksum_length,
             checksum_algorithm: config.checksum_algorithm,
@@ -446,7 +462,7 @@ fn generate_basis_signature(
     basis_path: PathBuf,
     fnamecmp_type: protocol::FnameCmpType,
     xname: Option<Vec<u8>>,
-    config: SignatureGenerationConfig,
+    config: SignatureGenerationConfig<'_>,
 ) -> BasisFileResult {
     // Cap the per-file strong-sum length by the negotiated transfer checksum's
     // digest width. `sum_sizes_sqroot()` clamps s2length to
@@ -525,6 +541,21 @@ fn generate_basis_signature(
     // basis and falls back to a whole-file transfer.
     // upstream: fileio.c:214-217 comment + map_ptr() deliberately use read(2)
     // instead of mmap(2) on basis files for exactly this reason.
+    // upstream: generator.c:2358-2361, :2363-2364, then :765-770 - the generator
+    // names the basis it mapped, announces the file it is producing sums for,
+    // and then reports the geometry `sum_sizes_sqroot()` chose. All three
+    // precede the per-chunk sums below, and that order is the reason this whole
+    // group lives here rather than split across the request writer.
+    matching::trace_deltasum::trace_gen_mapped(&config.relative_name.display(), basis_size);
+    matching::trace_deltasum::trace_generating_sums(config.ndx);
+    matching::trace_deltasum::trace_sum_geometry(
+        layout.block_count(),
+        layout.remainder(),
+        layout.block_length().get() as usize,
+        layout.strong_sum_length().get(),
+        basis_size,
+    );
+
     let reader = std::io::BufReader::with_capacity(MAX_MAP_SIZE, basis_file);
     let signature = compute_basis_signature(
         reader,
@@ -535,13 +566,29 @@ fn generate_basis_signature(
     );
 
     match signature {
-        Ok(sig) => BasisFileResult {
-            signature: Some(sig),
-            basis_path: Some(basis_path),
-            fnamecmp_type,
-            xname,
-            backup_notice: None,
-        },
+        Ok(sig) => {
+            // upstream: generator.c:817-822 - one line per generated chunk,
+            // emitted as `generate_and_send_sums()` walks the basis. oc
+            // computes the whole signature first (possibly in parallel), so the
+            // trace is replayed here in block order rather than interleaved
+            // with the hashing; the values and their order are identical.
+            let block_length = layout.block_length().get() as u64;
+            for (position, block) in sig.blocks().iter().enumerate() {
+                matching::trace_deltasum::trace_gen_chunk(
+                    position as u64,
+                    position as u64 * block_length,
+                    block.len(),
+                    block.rolling().value(),
+                );
+            }
+            BasisFileResult {
+                signature: Some(sig),
+                basis_path: Some(basis_path),
+                fnamecmp_type,
+                xname,
+                backup_notice: None,
+            }
+        }
         Err(_) => BasisFileResult::EMPTY,
     }
 }
@@ -1081,6 +1128,8 @@ mod tests {
         }
 
         let cfg = SignatureGenerationConfig {
+            ndx: 0,
+            relative_name: std::path::Path::new("a.bin"),
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
@@ -1150,6 +1199,8 @@ mod tests {
         }
 
         let cfg = SignatureGenerationConfig {
+            ndx: 0,
+            relative_name: std::path::Path::new("a.bin"),
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
@@ -1209,6 +1260,7 @@ mod tests {
         let rel = std::path::Path::new("file.bin");
         let partial_rel = std::path::Path::new(".rsync-partial");
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir,
             relative_path: rel,
@@ -1264,6 +1316,7 @@ mod tests {
 
         let dest_file = dest_dir.join("file.bin");
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir,
             relative_path: std::path::Path::new("file.bin"),
@@ -1308,6 +1361,7 @@ mod tests {
 
         let dest_file = dest_dir.join("data.txt");
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir,
             relative_path: std::path::Path::new("data.txt"),
@@ -1386,6 +1440,7 @@ mod tests {
             ),
         ];
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir: &dest_dir,
             relative_path: std::path::Path::new("file.bin"),
@@ -1459,6 +1514,7 @@ mod tests {
             ref_dir.clone(),
         )];
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir: &dest_dir,
             relative_path: std::path::Path::new("data.txt"),
@@ -1521,6 +1577,7 @@ mod tests {
 
         let dest_file = dest_dir.join("data.txt");
         let config = BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir,
             relative_path: std::path::Path::new("data.txt"),
@@ -1582,6 +1639,7 @@ mod tests {
 
         let dest_file = dest_dir.join("file.bin");
         let make_config = |checksum_length: NonZeroU8| BasisFileConfig {
+            ndx: 0,
             file_path: &dest_file,
             dest_dir,
             relative_path: std::path::Path::new("file.bin"),
@@ -1669,6 +1727,8 @@ mod tests {
         };
 
         let base = SignatureGenerationConfig {
+            ndx: 0,
+            relative_name: std::path::Path::new("a.bin"),
             protocol: ProtocolVersion::NEWEST,
             checksum_length: NonZeroU8::new(16).unwrap(),
             checksum_algorithm: SignatureAlgorithm::Md4,
@@ -1686,6 +1746,8 @@ mod tests {
             | protocol::CompatibilityFlags::CHECKSUM_SEED_FIX;
         assert_eq!(
             strong_len(SignatureGenerationConfig {
+                ndx: 0,
+                relative_name: std::path::Path::new("a.bin"),
                 compat_flags: Some(no_cap),
                 block_size: None,
                 ..base
@@ -1699,6 +1761,8 @@ mod tests {
             | protocol::CompatibilityFlags::CONSECUTIVE_MATCH;
         assert_eq!(
             strong_len(SignatureGenerationConfig {
+                ndx: 0,
+                relative_name: std::path::Path::new("a.bin"),
                 compat_flags: Some(with_cap),
                 block_size: None,
                 ..base
@@ -1735,6 +1799,8 @@ mod tests {
                 f.flush().expect("flush");
             }
             let cfg = SignatureGenerationConfig {
+                ndx: 0,
+                relative_name: std::path::Path::new("a.bin"),
                 protocol: ProtocolVersion::NEWEST,
                 checksum_length: NonZeroU8::new(phase_len).unwrap(),
                 checksum_algorithm: algo,
@@ -1837,6 +1903,8 @@ mod tests {
 
         let sign = |block_size: Option<NonZeroU32>| {
             let cfg = SignatureGenerationConfig {
+                ndx: 0,
+                relative_name: std::path::Path::new("a.bin"),
                 protocol: ProtocolVersion::NEWEST,
                 checksum_length: NonZeroU8::new(16).unwrap(),
                 checksum_algorithm: SignatureAlgorithm::Md4,
@@ -1886,6 +1954,7 @@ mod tests {
         inplace_backup: Option<InplaceBackupSpec<'a>>,
     ) -> BasisFileConfig<'a> {
         BasisFileConfig {
+            ndx: 0,
             file_path: dest_file,
             dest_dir,
             relative_path: rel,

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -852,23 +852,30 @@ impl ReceiverContext {
         }
     }
 
-    /// Builds a [`BasisFileConfig`] for a single file, pulling shared state from `self`.
+    /// Builds a [`BasisFileConfig`] for a single file, pulling shared state from
+    /// `self` and the per-entry fields from `file_entry`.
+    ///
+    /// `relative_path`, `target_size` and `target_mtime` are all read off the
+    /// one flist entry, so the entry is passed instead of its three projections:
+    /// they cannot then disagree, and the signature stays within the argument
+    /// budget now that the wire NDX rides along for the generator's
+    /// `generating and sending sums for %d` trace.
     pub(in crate::receiver) fn build_basis_file_config<'a>(
         &'a self,
+        ndx: i32,
         file_path: &'a std::path::Path,
         dest_dir: &'a std::path::Path,
-        relative_path: &'a std::path::Path,
-        target_size: u64,
-        target_mtime: i64,
+        file_entry: &'a protocol::flist::FileEntry,
         checksum_length: NonZeroU8,
         checksum_algorithm: signature::SignatureAlgorithm,
     ) -> BasisFileConfig<'a> {
         BasisFileConfig {
+            ndx,
             file_path,
             dest_dir,
-            relative_path,
-            target_size,
-            target_mtime,
+            relative_path: file_entry.path(),
+            target_size: file_entry.size(),
+            target_mtime: file_entry.mtime(),
             fuzzy_level: self.config.flags.fuzzy_level,
             reference_directories: &self.config.reference_directories,
             partial_dir: self.config.partial_dir.as_deref(),

--- a/crates/transfer/src/receiver/transfer/pipeline.rs
+++ b/crates/transfer/src/receiver/transfer/pipeline.rs
@@ -651,13 +651,24 @@ impl ReceiverContext {
                             .parallel_thresholds
                             .for_op(crate::parallel_io::ParallelOp::Signature);
 
+                        // The generator's `generating and sending sums for %d`
+                        // trace names the same wire NDX the request carries.
+                        // Resolve it here, before the parallel map: the closures
+                        // below deliberately capture only locals so they never
+                        // borrow `self` across rayon workers.
+                        let batch_ndxs: Vec<i32> = batch
+                            .iter()
+                            .map(|&(file_idx, ..)| self.flat_to_wire_ndx(file_idx))
+                            .collect();
+
                         // Ordering: wire protocol requires file requests in file-list index order.
                         // Preserved by par_iter().map().collect() + sequential zip/send loop below.
                         // Violation sends signatures for wrong files, corrupting delta transfer.
                         let sig_results: Vec<_> = if batch.len() >= sig_threshold {
                             batch
                                 .par_iter()
-                                .map(|(_, file_entry, file_path, base_iflags)| {
+                                .zip(batch_ndxs.par_iter())
+                                .map(|((_, file_entry, file_path, base_iflags), &ndx)| {
                                     // A metadata-only record transfers no data,
                                     // so no basis search is needed.
                                     if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0
@@ -665,6 +676,7 @@ impl ReceiverContext {
                                         return crate::receiver::basis::BasisFileResult::EMPTY;
                                     }
                                     let basis_config = BasisFileConfig {
+                                        ndx,
                                         file_path,
                                         dest_dir,
                                         relative_path: file_entry.path(),
@@ -687,12 +699,14 @@ impl ReceiverContext {
                         } else {
                             batch
                                 .iter()
-                                .map(|(_, file_entry, file_path, base_iflags)| {
+                                .zip(batch_ndxs.iter())
+                                .map(|((_, file_entry, file_path, base_iflags), &ndx)| {
                                     if base_iflags & crate::generator::ItemFlags::ITEM_TRANSFER == 0
                                     {
                                         return crate::receiver::basis::BasisFileResult::EMPTY;
                                     }
                                     let basis_config = BasisFileConfig {
+                                        ndx,
                                         file_path,
                                         dest_dir,
                                         relative_path: file_entry.path(),
@@ -1286,6 +1300,7 @@ impl ReceiverContext {
             // send a real sum head so the sender can diff against the receiver's
             // basis (empty when no basis exists, driving a whole-file batch).
             let basis_config = BasisFileConfig {
+                ndx: self.flat_to_wire_ndx(file_idx),
                 file_path,
                 dest_dir: &setup.dest_dir,
                 relative_path: file_entry.path(),

--- a/crates/transfer/src/receiver/transfer/sync.rs
+++ b/crates/transfer/src/receiver/transfer/sync.rs
@@ -203,11 +203,10 @@ impl ReceiverContext {
             // The basis search must precede the iflags write so a
             // --partial-dir resume basis can set ITEM_BASIS_TYPE_FOLLOWS.
             let basis_config = self.build_basis_file_config(
+                ndx,
                 &file_path,
                 &dest_dir,
-                relative_path,
-                file_entry.size(),
-                file_entry.mtime(),
+                file_entry,
                 checksum_length,
                 checksum_algorithm,
             );

--- a/crates/transfer/src/transfer_ops/request.rs
+++ b/crates/transfer/src/transfer_ops/request.rs
@@ -207,6 +207,13 @@ pub fn send_file_request_xattr<W: Write + ?Sized>(
         Some(ref sig) => SumHead::from_signature(sig),
         None => SumHead::empty(),
     };
+    // The `generating and sending sums for %d` line is NOT emitted here.
+    // Upstream prints it (generator.c:2363) between `gen mapped` and the
+    // geometry line that `sum_sizes_sqroot()` produces, i.e. while the basis is
+    // being checksummed - which in oc is `receiver::basis`, the owner of all
+    // four generator-half DELTASUM lines. Emitting it at this point put it after
+    // every `chunk[..]` line instead of before them (MEASURED against upstream
+    // 3.5.0 on a `--debug=deltasum2` pull).
     sum_head.write(writer)?;
 
     // upstream: generator.c:787-788 - in append mode, generator skips writing

--- a/crates/transfer/src/transfer_ops/streaming.rs
+++ b/crates/transfer/src/transfer_ops/streaming.rs
@@ -155,9 +155,23 @@ pub fn process_file_response_streaming<R: Read>(
     });
 
     let mut basis_map = if let Some(ref path) = header.basis_path {
-        Some(MapFile::open(path).map_err(|e| {
+        let map = MapFile::open(path).map_err(|e| {
             io::Error::new(e.kind(), format!("failed to open basis file {path:?}: {e}"))
-        })?)
+        })?;
+        // upstream: receiver.c:498-501 - `receive_data()` names the basis it
+        // mapped, and its size, before consuming the first token. Upstream's
+        // `fname_r` is the flist-relative name (it chdir'd into the destination
+        // root), so print that spelling rather than the absolute path. The size
+        // is the signature's file length: the basis this delta was built against.
+        let _ = path;
+        matching::trace_deltasum::trace_recv_mapped(
+            &ctx.wire_basis.entry_relative_path.display(),
+            header
+                .signature
+                .as_ref()
+                .map_or(0, |sig| sig.layout().file_size()),
+        );
+        Some(map)
     } else {
         None
     };
@@ -184,9 +198,14 @@ pub fn process_file_response_streaming<R: Read>(
 
             if matches!(next_delta, DeltaToken::End) {
                 total_bytes = len as u64;
+                // upstream: receiver.c:552-555 - the coalesced single-literal
+                // file is still one literal token arriving at offset 0.
+                matching::trace_deltasum::trace_data_recv(len, 0);
                 let checksum_len = checksum_verifier.digest_len();
                 let mut expected_checksum = [0u8; ChecksumVerifier::MAX_DIGEST_LEN];
                 reader.read_exact(&mut expected_checksum[..checksum_len])?;
+                // upstream: receiver.c:671-673
+                matching::trace_deltasum::trace_got_file_sum();
 
                 file_tx
                     .send(FileMessage::WholeFile {
@@ -213,6 +232,8 @@ pub fn process_file_response_streaming<R: Read>(
 
             // Not a single-chunk file - send Begin + first Chunk,
             // then continue the regular loop starting with the peeked token.
+            // upstream: receiver.c:552-555 - this first literal lands at 0.
+            matching::trace_deltasum::trace_data_recv(len, 0);
             file_tx.send(FileMessage::Begin(begin_msg)).map_err(|_| {
                 io::Error::new(io::ErrorKind::BrokenPipe, "disk commit thread disconnected")
             })?;

--- a/crates/transfer/src/transfer_ops/token_loop.rs
+++ b/crates/transfer/src/transfer_ops/token_loop.rs
@@ -116,6 +116,8 @@ pub(super) fn process_remaining_tokens<R: Read>(
                     send_abort(file_tx, format!("failed to read checksum: {e}"));
                     return Err(e);
                 }
+                // upstream: receiver.c:671-673
+                matching::trace_deltasum::trace_got_file_sum();
 
                 file_tx
                     .send(FileMessage::Commit {
@@ -149,6 +151,10 @@ pub(super) fn process_remaining_tokens<R: Read>(
                     }
                 };
                 let len = buf.len() as u64;
+
+                // upstream: receiver.c:552-555 - the literal's length and the
+                // output offset it lands at, before it is written.
+                matching::trace_deltasum::trace_data_recv(len as usize, total_bytes);
 
                 file_tx.send(FileMessage::Chunk(buf)).map_err(|_| {
                     io::Error::new(
@@ -210,7 +216,19 @@ pub(super) fn process_remaining_tokens<R: Read>(
                     // (receiver.c:392-403), so a temp holding nothing but basis
                     // copies is unlinked on abort (cleanup.c:159, :199-200)
                     // rather than renamed over a complete destination.
-                    let msg = if updating_basis && offset == total_bytes {
+                    let seek = updating_basis && offset == total_bytes;
+                    // upstream: receiver.c:609-614 - the ` (seek)` suffix marks
+                    // the in-place skip, where the basis bytes are already
+                    // correct at the output offset.
+                    matching::trace_deltasum::trace_recv_chunk(
+                        block_idx as u64,
+                        bytes_to_copy,
+                        offset,
+                        total_bytes,
+                        seek,
+                    );
+
+                    let msg = if seek {
                         FileMessage::SkipMatched(buf)
                     } else {
                         FileMessage::MatchedChunk(buf)

--- a/crates/transfer/tests/fuzzy_level2_basis_search.rs
+++ b/crates/transfer/tests/fuzzy_level2_basis_search.rs
@@ -63,6 +63,7 @@ fn fuzzy_level2_finds_basis_in_reference_directory() {
     )];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir_a,
         relative_path,
@@ -125,6 +126,7 @@ fn fuzzy_level1_does_not_search_reference_directories() {
     )];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir_a,
         relative_path,
@@ -184,6 +186,7 @@ fn fuzzy_level2_selects_best_match_across_reference_dirs() {
     ];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir,
         relative_path,
@@ -242,6 +245,7 @@ fn fuzzy_level2_generates_valid_signature_from_basis() {
     )];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir,
         relative_path,
@@ -303,6 +307,7 @@ fn fuzzy_level0_skips_search() {
     )];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir,
         relative_path,
@@ -354,6 +359,7 @@ fn whole_file_bypasses_fuzzy_search() {
     )];
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &file_path,
         dest_dir: &dest_dir,
         relative_path,
@@ -407,6 +413,7 @@ fn fuzzy_basis_selection_emits_debug_fuzzy_line() {
     let _ = drain_events();
 
     let config = BasisFileConfig {
+        ndx: 0,
         file_path: &target_path,
         dest_dir: &dest_dir,
         relative_path,

--- a/tests/debug_deltasum_live.rs
+++ b/tests/debug_deltasum_live.rs
@@ -1,0 +1,329 @@
+//! Live-binary non-vacuity guard for `--debug=deltasum`.
+//!
+//! `--debug=deltasum` was parsed and accepted for a long time while emitting
+//! NOTHING from the delta scan. A unit test on the trace helpers cannot catch
+//! that: the helpers were fine, they simply had no caller on the path the binary
+//! actually takes. The previous attempt at this fix wired the flag at the
+//! obvious site and was PROVABLY INERT, because the local copy path does not
+//! traverse the network delta scanner.
+//!
+//! So these tests run the real binary over a real delta fixture and assert on
+//! its stdout. They are the only check here that can distinguish "the emission
+//! is wired" from "the format string exists".
+//!
+//! They live in the ROOT package, not in `crates/cli`, and resolve the binary
+//! through `CARGO_BIN_EXE_oc-rsync`. That is load-bearing: `oc-rsync` is defined
+//! by this package, so cargo rebuilds it before these tests run and the env var
+//! names that fresh artifact. MEASURED - an earlier revision of this file lived
+//! in `crates/cli/tests/` and located the binary by walking up from
+//! `current_exe()`. `cargo nextest run -p cli` does not build the root package,
+//! so those tests silently graded whatever `target/debug/oc-rsync` happened to
+//! be on disk: a mutation that made the level gate always-true left all seven
+//! of them GREEN while the real binary printed 2588 lines at level 1.
+//!
+//! Upstream reference for every asserted line: `match.c` (hash search and the
+//! run totals), `sender.c` (`receive_sums`/`send_files` milestones),
+//! `generator.c` (signature geometry and per-chunk sums), `receiver.c` (basis
+//! map, literal/match application, file_sum receipt).
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Block length the 256 KB fixture's signature layout selects, and the count of
+/// blocks it yields. Pinned so the asserted lines carry real geometry.
+const FIXTURE_LEN: usize = 262_144;
+
+/// The `oc-rsync` cargo just built for this test run.
+///
+/// `CARGO_BIN_EXE_oc-rsync` is a COMPILE-time variable, so `env!` (not
+/// `std::env::var`) is what binds it, and cargo guarantees the named artifact is
+/// up to date before the test starts.
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_oc-rsync"))
+}
+
+/// Deterministic pseudo-random bytes (xorshift64), so the delta has real
+/// literal runs instead of the long self-similar matches a constant fill gives.
+fn pseudo_random(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed | 1;
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 24) as u8
+        })
+        .collect()
+}
+
+/// Builds `src/a.bin` and a mutated, backdated `dst/a.bin` so the quick-check
+/// cannot skip the file and the delta scan has both matches and a literal run.
+fn fixture(root: &Path) -> (PathBuf, PathBuf) {
+    let src_dir = root.join("src");
+    let dst_dir = root.join("dst");
+    fs::create_dir_all(&src_dir).expect("src dir");
+    fs::create_dir_all(&dst_dir).expect("dst dir");
+
+    let data = pseudo_random(FIXTURE_LEN, 0x5eed_1234);
+    let src = src_dir.join("a.bin");
+    fs::write(&src, &data).expect("write src");
+
+    let mut mutated = data;
+    mutated[100_000..100_100].fill(b'X');
+    let dst = dst_dir.join("a.bin");
+    fs::write(&dst, &mutated).expect("write dst");
+
+    // Backdate the basis: rsync's quick-check skips a same-size, same-mtime
+    // file, which would make every assertion here vacuous.
+    let old = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(946_684_800);
+    filetime::set_file_mtime(&dst, filetime::FileTime::from_system_time(old))
+        .expect("backdate basis");
+
+    (src, dst)
+}
+
+/// Runs the binary with `--debug=<word>` on the local delta fixture.
+fn run_local(root: &Path, word: &str) -> String {
+    let (src, dst) = fixture(root);
+    let out = Command::new(binary())
+        .arg("--no-whole-file")
+        .arg(format!("--debug={word}"))
+        .arg("-t")
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .expect("run oc-rsync");
+    assert!(
+        out.status.success(),
+        "transfer failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A stand-in `ssh` that drops the host argument and execs the rest locally, so
+/// a wire transfer runs over a real pipe pair without needing a daemon or sshd.
+fn fake_rsh(root: &Path) -> PathBuf {
+    let path = root.join("fake-rsh.sh");
+    let mut f = fs::File::create(&path).expect("create rsh");
+    f.write_all(b"#!/bin/sh\nshift\nexec \"$@\"\n")
+        .expect("write rsh");
+    drop(f);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).expect("chmod rsh");
+    }
+    path
+}
+
+/// Runs a wire transfer in the given direction over the fake rsh.
+#[cfg(unix)]
+fn run_wire(root: &Path, word: &str, push: bool) -> String {
+    let (src, dst) = fixture(root);
+    let rsh = fake_rsh(root);
+    let bin = binary();
+    let mut cmd = Command::new(&bin);
+    cmd.arg("--no-whole-file")
+        .arg(format!("--debug={word}"))
+        .arg("-t")
+        .arg("-e")
+        .arg(&rsh)
+        .arg(format!("--rsync-path={}", bin.display()));
+    if push {
+        cmd.arg(&src).arg(format!("fake:{}", dst.display()));
+    } else {
+        cmd.arg(format!("fake:{}", src.display())).arg(&dst);
+    }
+    let out = cmd.output().expect("run oc-rsync over fake rsh");
+    assert!(
+        out.status.success(),
+        "transfer failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn assert_contains(haystack: &str, needle: &str, cell: &str) {
+    assert!(
+        haystack.contains(needle),
+        "{cell}: expected a line containing {needle:?}, got:\n{haystack}"
+    );
+}
+
+/// The whole point of the task: the flag must produce delta-scan output from the
+/// LOCAL path, which is a fused loop that the network delta scanner never runs.
+///
+/// upstream: match.c:180-182 `hash search`, :133-138 `match at`, :441-442
+/// `done hash search`, :468-471 the counters.
+#[test]
+fn local_delta_scan_emits_deltasum2() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_local(tmp.path(), "deltasum2");
+
+    assert_contains(&out, "built hash table", "local L2");
+    assert_contains(&out, "calling match_sums ", "local L2");
+    assert_contains(&out, "send_files mapped ", "local L2");
+    assert_contains(
+        &out,
+        &format!("hash search b=700 len={FIXTURE_LEN}"),
+        "local L2",
+    );
+    assert_contains(&out, "match at 0 last_match=0 j=0 len=700 n=0", "local L2");
+    assert_contains(&out, "done hash search", "local L2");
+    assert_contains(&out, "false_alarms=", "local L2");
+    assert_contains(&out, "total: matches=", "local L2");
+}
+
+/// Level 3 adds the generator's per-chunk sums and the receiver's per-block
+/// application, both of which the local fused loop really performs.
+///
+/// upstream: generator.c:817-822 `chunk[%s] offset=...`, receiver.c:609-614
+/// `chunk[%d] of size %ld at %s offset=%s`, :552-555 `data recv %d at %s`.
+#[test]
+fn local_delta_scan_emits_deltasum3_chunk_detail() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_local(tmp.path(), "deltasum3");
+
+    assert_contains(&out, "gen mapped ", "local L3");
+    assert_contains(&out, "chunk[0] offset=0 len=700 sum1=", "local L3");
+    assert_contains(&out, "chunk[0] of size 700 at 0 offset=0", "local L3");
+    assert_contains(&out, "data recv ", "local L3");
+    assert_contains(&out, "potential match at 0 i=0 sum=", "local L3");
+}
+
+/// Level 1 is the run-total line only. It must appear, and the per-offset and
+/// per-chunk detail must NOT: a level gate that is wired but always-true is as
+/// wrong as one that never fires.
+///
+/// upstream: match.c:479-487 `match_report()` prints only `total:` at
+/// DEBUG_GTE(DELTASUM, 1).
+#[test]
+fn local_deltasum1_is_the_total_line_only() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_local(tmp.path(), "deltasum");
+
+    assert_contains(&out, "total: matches=", "local L1");
+    // Checked per line, not as a substring: the `total:` line legitimately
+    // carries a `false_alarms=` field of its own, so a naive `contains` would
+    // pass for the wrong reason.
+    for line in out.lines() {
+        for forbidden in [
+            "hash search b=",
+            "done hash search",
+            "false_alarms=",
+            "match at ",
+            "chunk[",
+        ] {
+            assert!(
+                !line.starts_with(forbidden),
+                "local L1: {forbidden:?} is level >= 2 and must not appear at level 1, \
+                 but the line {line:?} does. Full output:\n{out}"
+            );
+        }
+    }
+}
+
+/// The network SENDER path is a different scanner from the local one, so it
+/// needs its own live assertion.
+///
+/// upstream: sender.c:348-350 `count=/n=/rem=`, :760-763 `send_files mapped`,
+/// :768-769 `calling match_sums`, match.c:465-466 `sending file_sum`.
+#[cfg(unix)]
+#[test]
+fn wire_push_sender_emits_deltasum2() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_wire(tmp.path(), "deltasum2", true);
+
+    assert_contains(&out, "send_files mapped ", "push L2");
+    assert_contains(&out, "calling match_sums ", "push L2");
+    assert_contains(&out, "built hash table", "push L2");
+    assert_contains(
+        &out,
+        &format!("hash search b=700 len={FIXTURE_LEN}"),
+        "push L2",
+    );
+    assert_contains(&out, "match at 0 last_match=0 j=0 len=700 n=0", "push L2");
+    assert_contains(&out, "done hash search", "push L2");
+    assert_contains(&out, "sending file_sum", "push L2");
+    assert_contains(&out, "total: matches=", "push L2");
+
+    // Ordering is load-bearing: upstream prints the per-file counters AFTER the
+    // checksum trailer announcement, which is why the scan hands its counters
+    // back rather than printing them itself (match.c:465-471).
+    let sending = out.find("sending file_sum").expect("sending file_sum");
+    let counters = out.find("false_alarms=").expect("counter line");
+    assert!(
+        sending < counters,
+        "push L2: `sending file_sum` must precede the counter line, got:\n{out}"
+    );
+}
+
+/// The client PULL path runs the generator and the receiver, a third distinct
+/// set of emission sites.
+///
+/// upstream: generator.c:2358-2361 `gen mapped`, :2363-2364 `generating and
+/// sending sums`, :765-770 the geometry, receiver.c:498-501 `recv mapped`,
+/// :671-673 `got file_sum`.
+#[cfg(unix)]
+#[test]
+fn wire_pull_generator_and_receiver_emit_deltasum2() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_wire(tmp.path(), "deltasum2", false);
+
+    assert_contains(&out, "generating and sending sums for 0", "pull L2");
+    assert_contains(&out, "recv mapped a.bin of size ", "pull L2");
+    assert_contains(&out, "got file_sum", "pull L2");
+    assert_contains(
+        &out,
+        &format!("count=375 rem=344 blength=700 s2length=2 flength={FIXTURE_LEN}"),
+        "pull L2",
+    );
+
+    // upstream prints `generating and sending sums` BEFORE the geometry line
+    // that sum_sizes_sqroot() produces (generator.c:2363 then :765).
+    let announce = out.find("generating and sending sums").expect("announce");
+    let geometry = out.find("count=375 rem=").expect("geometry");
+    assert!(
+        announce < geometry,
+        "pull L2: the announce must precede the geometry line, got:\n{out}"
+    );
+}
+
+/// Level 3 on the pull adds the generator's per-chunk sums and the receiver's
+/// per-block application.
+#[cfg(unix)]
+#[test]
+fn wire_pull_emits_deltasum3_chunk_detail() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let out = run_wire(tmp.path(), "deltasum3", false);
+
+    assert_contains(&out, "gen mapped a.bin of size ", "pull L3");
+    assert_contains(&out, "chunk[0] offset=0 len=700 sum1=", "pull L3");
+    assert_contains(&out, "chunk[0] of size 700 at 0 offset=0", "pull L3");
+}
+
+/// `--debug=deltasum` must stay inert when it is not asked for: a producer that
+/// ignores its gate would flood every ordinary `-t` transfer.
+#[test]
+fn no_deltasum_output_without_the_flag() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (src, dst) = fixture(tmp.path());
+    let out = Command::new(binary())
+        .arg("--no-whole-file")
+        .arg("-t")
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .expect("run oc-rsync");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for forbidden in ["hash search", "match at ", "total: matches=", "chunk["] {
+        assert!(
+            !stdout.contains(forbidden),
+            "{forbidden:?} leaked without --debug=deltasum, got:\n{stdout}"
+        );
+    }
+}

--- a/tools/ci/citation_drift_baseline.json
+++ b/tools/ci/citation_drift_baseline.json
@@ -2,7 +2,7 @@
   "_1_what": "Per-crate suspected-drift counts accepted by `citation_drift_audit.py --ratchet`. The gate fails only when a crate RISES above its number here.",
   "_2_lowering_is_mandatory": "A number above zero is an accepted debt, not a passing grade. If you FIX citations in a crate, you MUST lower its number in the SAME commit. Skip that and the ratchet keeps accepting the old count, and the next real regression in that crate slips through under your unclaimed headroom.",
   "_3_raising_needs_a_reason": "Raise a number only for a confirmed false positive - a comment citing a range or a definition while quoting a construct that lives at the range end or at a use site. Say which citation and why in the commit message. Never raise one to make a red gate go green.",
-  "_4_engine_and_transfer": "engine=1 and transfer=6 are the deferred half of the 3.4.4 sweep, excluded to avoid colliding with concurrent edits in those crates. They are UNREVIEWED - nobody has confirmed they are false positives. Whoever sweeps them lowers these two numbers in the same commit.",
+  "_4_engine_and_transfer": "engine is now 0; transfer=4 is what remains of the deferred half of the 3.4.4 sweep, excluded to avoid colliding with concurrent edits in that crate. Those 4 are UNREVIEWED - nobody has confirmed they are false positives. Whoever sweeps them lowers the number in the same commit.",
   "_5_350_flip": "Pinned source moved 3.4.4 -> 3.5.0 (task U350-7e). 439 citations were retargeted by ordinal mapping - same anchor, same occurrence index in both versions - plus 122 range ENDs shifted by the same delta. Drift fell 453 -> 14 of 495 anchored citations. Every one of the 14 left is an anchor matching MORE THAN ONE upstream line, so the tool cannot localise it and its verdict is not evidence. They are accepted as false positives, NOT as unfixed drift. Fixing them means giving the comment a distinctive anchor, not moving a correct line number.",
   "_5_regenerate": "python3 tools/ci/citation_drift_audit.py --write-baseline [crate ...]  (merges, so a crate subset will not drop the others or these notes)",
   "bandwidth": 0,
@@ -21,5 +21,5 @@
   "protocol": 0,
   "rsync_io": 0,
   "signature": 0,
-  "transfer": 6
+  "transfer": 4
 }


### PR DESCRIPTION
## What

`--debug=deltasum` was parsed and emitted nothing from the delta scan on every path. This wires it to upstream's 23 `DEBUG_GTE(DELTASUM, n)` sites, enumerated from the 3.5.0 source: `match.c` (hash-search trace levels 2-4 plus the run totals), `sender.c` (per-file `receive_sums`/map/`match_sums` milestones), `generator.c` (signature geometry and per-chunk sums), `receiver.c` (basis map, literal/match application, `file_sum` receipt). None in `token.c`.

One new owner module, `crates/matching/src/trace_deltasum.rs`: **every upstream format string has exactly one owner function**, and the sender scan, the three network driver roles and the local fused delta loop all emit through it rather than holding their own copies.

Recorded in the module doc, with the citation, because it explains the whole shape of the output: upstream forwards only `--info` words to the server (`options.c:3117-3120` builds the server's output option from `info_words` alone), so DELTASUM is **client-side only** - a pull prints generator+receiver lines, a push prints sender lines, a local copy prints both, and server roles stay silent unless the server was itself invoked with the flag.

## Measured against upstream 3.5.0

256 KB fixture, 100 bytes overwritten in a backdated basis, `--no-whole-file -t`:

| cell | upstream L1/L2/L3 | oc before | oc after |
|---|---|---|---|
| wire pull | 0 / 4 / 755 | 0 / 0 / 0 | **0 / 4 / 755, byte-identical** |
| wire push | 1 / 382 / 1134 | 0 / 3 / 378 | 1 / 382 / 1134 |
| local | 1 / 386 / 1889 | 1 / 1 / 1 | 1 / 382 / 1509 |

Pull is byte-identical at all three levels. Push is identical except the two counter lines - `matches` and `data` match exactly, while `hash_hits`/`false_alarms` carry oc's own prefilter semantics (bithash positives) against upstream's bucket-hit/strong-reject. Local emits upstream's text on every line it emits; its residuals are ordering plus four lines with no local analogue.

## Two orderings that had to be measured rather than assumed

Per-file counters must follow `sending file_sum`, so the scan returns a `ScanCounters` value instead of printing. And `generating and sending sums` must precede the geometry line, which moved all four generator lines into `basis.rs` (requiring a diagnostic-only `ndx` on `BasisFileConfig`).

## No-analogue residuals, documented not faked

Local has no `sending file_sum`/`got file_sum` (no whole-file checksum on that path), no sender `receive_sums` chunk trace (one in-process index serves both roles), and no `generating and sending sums` - there is no wire ndx locally, and the number was not fabricated. Local also interleaves receiver lines where upstream's separate receiver process trails them, and `gen mapped` prints the resolved path where upstream had chdir'd. The parallel chunked scan's rayon-worker lines are not drained.

## Two pre-existing findings, reported not touched

Local requests a full 16-byte strong sum (`s2length=16`) where upstream uses `2`; changing it would alter local block matching, so it is reported rather than adjusted here. And the `hash_hits`/`false_alarms` semantic difference above is oc's prefilter design, not a defect in this wiring.

## Verification

Three mutations, each killed by a named test, none over-killing: level gate forced true, sender milestones unwired, local `match at` unwired. `crates/logging/` has zero diff.

⚠ **Mutation A first ran GREEN, and that exposed a defect in the test design rather than in the code.** Located under `crates/cli/tests/` and resolving the binary via `current_exe()`, `nextest -p cli` never rebuilds the root `bin` package - so the tests graded a stale binary while the real one printed 2588 lines at level 1. Moved to `tests/debug_deltasum_live.rs` using `env!("CARGO_BIN_EXE_oc-rsync")`; the mutation then killed correctly. This is the "cargo does not rebuild" trap in a new guise and is written into the test's module doc.

Gates at the pinned toolchain: whole-tree rustfmt clean (3430 files); clippy `-D warnings` clean on matching/transfer/engine/bin/cli; nextest matching 383, transfer --lib 2539, engine --lib 4840, fuzzy_level2 7, debug_deltasum_live 7. No expect-manifest edits.
