### PR TITLE
fix(tests): gate fake_rsh to unix so the Windows test build compiles

### DIFF
--- a/tests/debug_deltasum_live.rs
+++ b/tests/debug_deltasum_live.rs
@@ -27,6 +27,7 @@
 //! map, literal/match application, file_sum receipt).
 
 use std::fs;
+#[cfg(unix)]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -105,6 +106,13 @@ fn run_local(root: &Path, word: &str) -> String {
 
 /// A stand-in `ssh` that drops the host argument and execs the rest locally, so
 /// a wire transfer runs over a real pipe pair without needing a daemon or sshd.
+///
+/// Gated to the same platforms as its only caller, `run_wire`. The script it
+/// writes is `#!/bin/sh` and needs the exec bit, so it is unix-only in substance
+/// as well as in reach; leaving it ungated made it a zero-caller function on
+/// Windows, which `-D warnings` turns into a build failure of this whole test
+/// binary rather than a lint.
+#[cfg(unix)]
 fn fake_rsh(root: &Path) -> PathBuf {
     let path = root.join("fake-rsh.sh");
     let mut f = fs::File::create(&path).expect("create rsh");


### PR DESCRIPTION
## What

`run_wire` in `tests/debug_deltasum_live.rs` is `#[cfg(unix)]` and is the only caller of `fake_rsh`, which was left ungated. On Windows the caller compiles out, `fake_rsh` drops to zero callers, `dead_code` fires, and `-D warnings` turns it into a compile error that takes down the whole test binary:

```
error: function `fake_rsh` is never used
 --> tests\debug_deltasum_live.rs:108:4
note: `-D dead-code` implied by `-D warnings`
error: could not compile `bin` (test "debug_deltasum_live") due to 1 previous error
```

The workspace test build fails, so `Windows ACL/xattr` goes red. This is on master, from #7782, and it reddens every open PR regardless of what that PR touches.

## The fix

Gate `fake_rsh` to match its sole caller. The gate is substantive, not mechanical: the script it writes is `#!/bin/sh` and needs the exec bit, so the function is unix-only in substance as well as in reach. `use std::io::Write` is used only by that function's `write_all`, so it is gated with it — leaving the import behind would just swap `dead_code` for `unused_imports`.

## Verification

A/B against the real Windows target with CI's `-D warnings`. `cargo check --target x86_64-pc-windows-msvc` type-checks without needing a Windows C toolchain to link, so the lint pass genuinely runs:

| arm | result |
|---|---|
| base (master's file) | `error: function \`fake_rsh\` is never used` — exit 101 |
| fixed | zero errors, zero warnings — exit 0 |

The base arm reproducing CI's exact error is what makes this a measurement rather than an inference.

The unix arm still compiles clean in the workspace on the pinned 1.88.0 (`cargo check --tests -p bin --test debug_deltasum_live`).

⚠ Method note, recorded because it nearly produced a false green: a first attempt type-checked the file standalone with `rustc`. That aborted at name resolution (the file uses `tempfile` and `filetime` by full path, with no `use` line) and so never reached the lint pass — it reported the *same* clean-of-dead-code result on the unfixed file. An instrument that cannot fail on the base arm proves nothing; the numbers above come from the replacement that resolves the dev-dependencies.
