### PR TITLE
refactor(checksums): one owner for the SIMD batch input cap

### DIFF
--- a/crates/checksums/src/simd_batch/md4/simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx2.rs
@@ -7,7 +7,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::super::Digest;
+use super::super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD4 initial state constants broadcast to 8 lanes.
 const INIT_A: u32 = 0x6745_2301;
@@ -30,9 +30,6 @@ const S3: [i32; 4] = [3, 9, 11, 15];
 /// Message word indices for each round.
 const M2: [usize; 16] = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15];
 const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
 /// 32-bit rotate-left for AVX2 using variable-shift intrinsics.
 ///

--- a/crates/checksums/src/simd_batch/md4/simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/avx512.rs
@@ -8,7 +8,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::asm;
 
-use super::super::super::Digest;
+use super::super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD4 initial state constants (RFC 1320).
 const INIT_A: u32 = 0x6745_2301;
@@ -56,7 +56,7 @@ pub unsafe fn digest_x16(inputs: &[&[u8]; 16]) -> [Digest; 16] {
     let max_len = inputs.iter().map(|i| i.len()).max().unwrap_or(0);
 
     // Fall back to scalar for inputs that would require excessive padding allocations.
-    if max_len > 1024 * 1024 {
+    if max_len > MAX_INPUT_SIZE {
         return std::array::from_fn(|i| super::super::scalar::digest(inputs[i]));
     }
 

--- a/crates/checksums/src/simd_batch/md4/simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/neon.rs
@@ -5,7 +5,7 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
-use super::super::super::Digest;
+use super::super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD4 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -29,9 +29,6 @@ const K: [u32; 3] = [
 const M2: [usize; 16] = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15];
 /// Message word indices for round 3.
 const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
 /// 32-bit rotate-left for NEON; shift amount must be a const generic.
 ///

--- a/crates/checksums/src/simd_batch/md4/simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/sse2.rs
@@ -8,7 +8,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::super::Digest;
+use super::super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD4 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -27,9 +27,6 @@ const K: [u32; 3] = [
 const M2: [usize; 16] = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15];
 /// Message word indices for round 3.
 const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// Rotate-left helper for SSE2 (requires a compile-time shift constant).
 ///

--- a/crates/checksums/src/simd_batch/md4/simd/wasm.rs
+++ b/crates/checksums/src/simd_batch/md4/simd/wasm.rs
@@ -5,7 +5,7 @@
 #[cfg(target_arch = "wasm32")]
 use std::arch::wasm32::*;
 
-use super::super::super::Digest;
+use super::super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD4 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -24,8 +24,6 @@ const K: [u32; 3] = [
 const M2: [usize; 16] = [0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15];
 /// Message word indices for round 3.
 const M3: [usize; 16] = [0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15];
-
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// 32-bit rotate-left for WASM SIMD; shift may be a runtime value.
 ///

--- a/crates/checksums/src/simd_batch/md5_simd/avx2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx2.rs
@@ -12,7 +12,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants broadcast to 8 lanes.
 const INIT_A: u32 = 0x6745_2301;
@@ -94,9 +94,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-/// Maximum input size supported (can be increased if needed).
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
 /// 32-bit rotate-left for AVX2 using variable-shift intrinsics.
 ///

--- a/crates/checksums/src/simd_batch/md5_simd/avx512.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/avx512.rs
@@ -17,7 +17,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::asm;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants (RFC 1321).
 const INIT_A: u32 = 0x6745_2301;
@@ -92,9 +92,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-/// Inputs larger than this fall back to scalar to cap padding allocations.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024; // 1MB per input
 
 /// 64-byte aligned 16x u32 storage for ZMM register loads/stores.
 ///

--- a/crates/checksums/src/simd_batch/md5_simd/neon.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/neon.rs
@@ -10,7 +10,7 @@
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -85,9 +85,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// Macro for compile-time rotate left on NEON.
 ///

--- a/crates/checksums/src/simd_batch/md5_simd/sse2.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse2.rs
@@ -13,7 +13,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -88,9 +88,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// Rotate-left helper for SSE2 (requires a compile-time shift constant).
 ///

--- a/crates/checksums/src/simd_batch/md5_simd/sse41.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/sse41.rs
@@ -11,7 +11,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -86,8 +86,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// Rotate left macros for compile-time constants.
 macro_rules! rotl {

--- a/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/ssse3.rs
@@ -11,7 +11,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -86,8 +86,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// Rotate left macros for compile-time constants.
 macro_rules! rotl {

--- a/crates/checksums/src/simd_batch/md5_simd/wasm.rs
+++ b/crates/checksums/src/simd_batch/md5_simd/wasm.rs
@@ -10,7 +10,7 @@
 #[cfg(target_arch = "wasm32")]
 use std::arch::wasm32::*;
 
-use super::super::Digest;
+use super::super::{Digest, MAX_INPUT_SIZE};
 
 /// MD5 initial state constants.
 const INIT_A: u32 = 0x6745_2301;
@@ -85,9 +85,6 @@ const K: [u32; 64] = [
     0x2ad7_d2bb,
     0xeb86_d391,
 ];
-
-/// Maximum input size supported.
-const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
 
 /// 32-bit rotate-left for WASM SIMD; shift may be a runtime value.
 ///

--- a/crates/checksums/src/simd_batch/mod.rs
+++ b/crates/checksums/src/simd_batch/mod.rs
@@ -28,6 +28,23 @@ pub use md5_dispatcher::Backend;
 /// Also used for MD4 (same output size).
 pub type Digest = [u8; 16];
 
+/// Largest per-input length any SIMD batch backend will hash in-lane.
+///
+/// Every backend pads each lane into a freshly allocated 64-byte-block
+/// multiple, so the transient allocation is bounded by lanes x this cap
+/// (16 MiB on the widest, AVX-512 16-lane path). Batches whose longest input
+/// exceeds the cap fall back to the scalar digest instead.
+///
+/// This is the single owner for the bound: MD4 and MD5, every architecture.
+/// Upstream rsync has no multi-buffer MD4/MD5, so there is no upstream
+/// counterpart to mirror - the value is an oc-side allocation-tuning choice.
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
+const MAX_INPUT_SIZE: usize = 1_024 * 1_024;
+
 /// Compute MD5 digests for multiple inputs in parallel.
 ///
 /// Uses SIMD instructions when available to process multiple hashes
@@ -75,4 +92,63 @@ pub fn simd_available() -> bool {
 #[allow(dead_code)] // REASON: public API exercised by simd_parity_tests
 pub fn parallel_lanes() -> usize {
     active_backend().lanes()
+}
+
+#[cfg(all(
+    test,
+    any(
+        target_arch = "x86_64",
+        target_arch = "aarch64",
+        target_arch = "wasm32"
+    )
+))]
+mod max_input_size_tests {
+    use super::{MAX_INPUT_SIZE, digest_batch};
+
+    /// The cap exists to bound the transient padding allocation, so its value
+    /// must stay compatible with how the backends allocate: each lane is padded
+    /// to a whole 64-byte MD4/MD5 block, and the widest backend runs 16 lanes.
+    /// Changing the value changes the worst-case burst these hot paths take.
+    #[test]
+    fn cap_bounds_the_worst_case_padded_allocation() {
+        assert_eq!(MAX_INPUT_SIZE, 1_024 * 1_024);
+        assert_eq!(
+            MAX_INPUT_SIZE % 64,
+            0,
+            "cap must be a whole number of 64-byte hash blocks"
+        );
+        assert_eq!(
+            MAX_INPUT_SIZE * 16,
+            16 * 1_024 * 1_024,
+            "AVX-512 runs 16 lanes, so the worst-case burst is 16x the cap"
+        );
+    }
+
+    /// Both sides of the cap must produce identical digests: below it the SIMD
+    /// kernel runs, above it every backend bails to the scalar reference. A
+    /// backend that read a different bound than the scalar oracle assumes would
+    /// still have to agree here, which is what makes the shared owner safe.
+    #[test]
+    fn digests_agree_with_scalar_on_both_sides_of_the_cap() {
+        for len in [MAX_INPUT_SIZE, MAX_INPUT_SIZE + 1] {
+            let long = vec![0xA5u8; len];
+            let inputs: [&[u8]; 2] = [&long, b"short"];
+
+            let md5_batch = digest_batch(&inputs);
+            let md4_batch = super::md4::digest_batch(&inputs);
+
+            for (i, input) in inputs.iter().enumerate() {
+                assert_eq!(
+                    md5_batch[i],
+                    super::md5_scalar::digest(input),
+                    "md5 lane {i} diverged at len {len}"
+                );
+                assert_eq!(
+                    md4_batch[i],
+                    super::md4::scalar::digest(input),
+                    "md4 lane {i} diverged at len {len}"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
The 1 MiB per-input cap that decides whether a SIMD batch backend hashes
in-lane or bails to the scalar digest was written out **twelve** times across
`crates/checksums/src/simd_batch/` — eleven named `const MAX_INPUT_SIZE`
declarations plus one bare literal at `md4/simd/avx512.rs:59`
(`if max_len > 1024 * 1024`) that a grep for the constant name cannot see.

There is now one owner in `simd_batch/mod.rs`, cfg-gated to the three
architectures that have SIMD backends, consumed by all twelve former sites.

## Why the bound exists

Stated in the doc comment, because it was nowhere before: every backend pads
each lane into a freshly allocated 64-byte-block multiple, so the transient
allocation is bounded by lanes x cap — 16 MiB on the widest, AVX-512 16-lane
path.

Upstream has no multi-buffer MD4/MD5 at all (its only checksum SIMD is
`get_checksum1`, the Adler rolling sum), so there is no upstream counterpart to
mirror and the doc says so rather than inventing a citation. The one 1 MiB
constant in upstream's SIMD source, `simd-checksum-x86_64.cpp:512 BLOCK_LEN`, is
a benchmark-harness buffer and unrelated.

## The bound was untested

Mutating both live aarch64 copies on the base tree killed **0 of 1158** tests.
Two tests now cover it:

- `cap_bounds_the_worst_case_padded_allocation` — pins the value against the
  allocation reasoning that justifies it (whole 64-byte blocks; 16-lane worst
  case), so a change to the value has to confront why.
- `digests_agree_with_scalar_on_both_sides_of_the_cap` — at `MAX_INPUT_SIZE` and
  `MAX_INPUT_SIZE + 1`, MD4 and MD5 batch digests must equal the scalar
  reference. This is what makes a shared owner safe: a backend reading a
  different bound than the scalar oracle assumes would still have to agree here.

## Codegen neutrality

Proven past the test suite: LLVM IR diff is 18659 lines both sides, 22 differing
— the module ID and `core::panic::Location` line numbers shifting by exactly 3,
the three deleted lines per file.

## Gates

rustfmt 3430 files clean (whole-tree checker), clippy
`-p checksums --all-targets --all-features` clean, nextest 1160/1160 (1158
before plus the 2 new).

Host limitation, stated rather than implied: aarch64-apple-darwin executes only
the NEON path. SSE2/SSSE3/SSE4.1/AVX2/AVX-512 are type-checked but not run
locally, and wasm32 is not compiled — CI covers those.
