### PR TITLE
fix(daemon): split glob segments on / only, never on backslash

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
+++ b/crates/daemon/src/daemon/sections/module_access/client_args/path_resolution.rs
@@ -290,36 +290,12 @@ fn resolve_sender_sources(
         // re-append.
         // upstream flist.c tests `fbuf[len-1] == '/'` only - a trailing `\` is
         // part of the NAME on Unix, not a dotdir marker.
-        sources.push(join_module_relative(module_path, trimmed));
+        push_expanded_source(module_path, trimmed, &mut sources);
     }
     if all_empty {
         return vec![module_root_dotdir(module_path)];
     }
-    // upstream: util1.c:804 `glob_expand_module()` runs each module-relative
-    // positional through `glob_expand()` (util1.c:755) which in turn calls
-    // POSIX `glob(3)` to expand shell metacharacters (`*`, `?`, `[...]`)
-    // against the on-disk module tree. Without this expansion, a request
-    // like `rsync rsync://host/mod/f*` walks a literal path `<module>/f*`
-    // that does not exist, the sender returns 0 entries, and the server
-    // sits in `recv_filter_list -> read_int(0)` waiting for the receiver's
-    // phase-transition NDX while the receiver is still waiting for the
-    // file list - a wire-level deadlock that surfaces as the upstream
-    // `daemon` testsuite timing out on subtest 4 (test-from/f*) and
-    // subtest 5 (test-from/f* with -U).
-    //
-    // Upstream behaviour, mirrored here:
-    //   * Only positionals containing a glob metacharacter are expanded.
-    //     Plain paths fall straight through.
-    //   * A pattern that matches nothing is preserved verbatim, matching
-    //     `glob_expand()`'s `glob.argc == save_argc` branch at util1.c:786
-    //     (the literal arg surfaces downstream as a normal `link_stat`
-    //     failure instead of a silent drop).
-    //   * Expansion is rooted at the module path so the resulting absolute
-    //     paths land inside the module's tree, the same containment
-    //     guarantee that the chroot / Landlock allowlist enforces. The
-    //     `..` collapse above the loop runs before this, so a pattern
-    //     reaching the globber is already confined to the module root.
-    expand_sender_source_globs(module_path, sources)
+    sources
 }
 
 /// Returns the module root path with a trailing `/` appended (idempotent).
@@ -364,66 +340,95 @@ fn join_module_relative(module_path: &std::path::Path, tail: &str) -> std::path:
     std::path::PathBuf::from(buf)
 }
 
-/// Returns `true` if `name` contains a shell glob metacharacter recognised
-/// by `glob(3)`.
+/// Returns `true` if `tail` contains a shell glob metacharacter recognised
+/// by upstream's daemon glob.
 ///
-/// upstream: util1.c:743 - `wildcard_chars[] = "*?["` is the metaset.
-fn path_has_glob_metachar(name: &std::ffi::OsStr) -> bool {
-    name.as_encoded_bytes()
-        .iter()
-        .any(|&b| matches!(b, b'*' | b'?' | b'['))
+/// upstream: util1.c:754 - `strpbrk(arg, "*?[")` is the metaset. None of the
+/// three bytes can be a separator, so testing the whole tail decides exactly
+/// the same set of positionals as testing each segment would.
+fn tail_has_glob_metachar(tail: &str) -> bool {
+    tail.bytes().any(|b| matches!(b, b'*' | b'?' | b'['))
 }
 
-/// Expands each source path under `module_path` that contains a glob
-/// metacharacter via a single-component walk. Mirrors upstream's
-/// `glob_expand()` (util1.c:755) with the simpler subset rsync's daemon
-/// path actually receives: each positional is a relative path joined to
-/// the module root, so we expand component-by-component. A pattern that
-/// matches nothing is left in place so the sender surfaces the normal
-/// link_stat error instead of silently dropping the arg.
-fn expand_sender_source_globs(
+/// Expands one module-relative positional into `out`, glob-expanding it when
+/// it carries a metacharacter and otherwise passing `joined` straight through.
+///
+/// upstream: util1.c:881 `glob_expand_module()` runs each module-relative
+/// positional through `glob_expand()` (util1.c:832), whose `glob_match()`
+/// (util1.c:733) walks the arg one `/`-separated segment at a time and matches
+/// each segment against the directory's entries with `wildmatch()`. Without
+/// this expansion, a request like `rsync rsync://host/mod/f*` walks a literal
+/// path `<module>/f*` that does not exist, the sender returns 0 entries, and
+/// the server sits in `recv_filter_list -> read_int(0)` waiting for the
+/// receiver's phase-transition NDX while the receiver is still waiting for the
+/// file list - a wire-level deadlock that surfaced as the upstream `daemon`
+/// testsuite timing out on subtest 4 (test-from/f*) and subtest 5 (the same
+/// with -U).
+///
+/// Upstream behaviour, mirrored here:
+///   * Only positionals containing a glob metacharacter are expanded
+///     (util1.c:754). Plain paths fall straight through.
+///   * A pattern that matches nothing is preserved verbatim, matching
+///     `glob_expand()`'s `glob.argc == save_argc` branch at util1.c:864
+///     (the literal arg surfaces downstream as a normal `link_stat`
+///     failure instead of a silent drop).
+///   * Expansion is rooted at the module path so the resulting absolute
+///     paths land inside the module's tree, the same containment
+///     guarantee that the chroot / Landlock allowlist enforces. The
+///     `..` collapse in the caller runs before this, so a pattern
+///     reaching the globber is already confined to the module root.
+fn push_expanded_source(
     module_path: &std::path::Path,
-    sources: Vec<std::path::PathBuf>,
-) -> Vec<std::path::PathBuf> {
-    let mut out = Vec::with_capacity(sources.len());
-    for path in sources {
-        match path.strip_prefix(module_path) {
-            Ok(rel)
-                if rel.components().any(
-                    |c| matches!(c, std::path::Component::Normal(s) if path_has_glob_metachar(s)),
-                ) =>
-            {
-                let matches = expand_relative_glob(module_path, rel);
-                if matches.is_empty() {
-                    out.push(path);
-                } else {
-                    out.extend(matches);
-                }
-            }
-            _ => out.push(path),
-        }
+    tail: &str,
+    out: &mut Vec<std::path::PathBuf>,
+) {
+    let joined = join_module_relative(module_path, tail);
+    if !tail_has_glob_metachar(tail) {
+        out.push(joined);
+        return;
     }
-    out
+    let matches = expand_relative_glob(module_path, tail);
+    if matches.is_empty() {
+        out.push(joined);
+    } else {
+        out.extend(matches);
+    }
 }
 
-/// Expands a relative path that may contain glob metacharacters in any
-/// component, rooted at `base`. Returns the matching absolute paths.
-fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<std::path::PathBuf> {
+/// Expands a module-relative wire tail that may carry glob metacharacters in
+/// any segment, rooted at `base`. Returns the matching absolute paths.
+///
+/// ⚠ Segments are split on `/` and ONLY on `/`, on every platform.
+///
+/// upstream: util1.c:749 - `glob_match()` finds each segment boundary with
+/// `strchr(arg, '/')`; there is no `\` arm, and `wildmatch()` itself is
+/// byte-oriented with a single explicit `'/'` check (lib/wildmatch.c:101-102).
+/// A `\` in the pattern is wildmatch's ESCAPE character (lib/wildmatch.c:86
+/// outside a class, :154 inside one), so consuming it as a separator destroys
+/// the escape and silently changes which files the daemon serves.
+///
+/// This must therefore NOT walk `std::path::Component`s: `Path::components()`
+/// splits on `\` as well as `/` on Windows, which is precisely that
+/// conflation. There, `mod/a\*` was split into the segments `a` and `*` and
+/// served every entry of the directory `a`, where upstream matches the single
+/// segment `a\*` and serves only the file literally named `a*`. Upstream has
+/// no platform-conditional separator handling here, so neither does this.
+fn expand_relative_glob(base: &std::path::Path, tail: &str) -> Vec<std::path::PathBuf> {
     let mut current = vec![base.to_path_buf()];
-    for component in rel.components() {
-        let segment = match component {
-            std::path::Component::Normal(s) => s,
-            // RootDir / Prefix should not appear in a stripped relative path,
-            // and `..` was already rejected by the caller. CurDir is a no-op.
-            std::path::Component::CurDir => continue,
-            _ => return Vec::new(),
-        };
+    for segment in tail.split('/') {
+        // upstream: util1.c:749 - consecutive slashes leave an empty span,
+        // and a `.` segment addresses the directory already reached.
+        if segment.is_empty() || segment == "." {
+            continue;
+        }
+        if segment == ".." {
+            // The caller's `collapse_module_relative` has already folded these
+            // away; a survivor would climb out of the module, so refuse the
+            // expansion and let the caller keep the literal arg.
+            return Vec::new();
+        }
         let mut next = Vec::new();
-        if path_has_glob_metachar(segment) {
-            let pattern = match segment.to_str() {
-                Some(s) => s,
-                None => return Vec::new(),
-            };
+        if tail_has_glob_metachar(segment) {
             for dir in &current {
                 let entries = match std::fs::read_dir(dir) {
                     Ok(it) => it,
@@ -437,7 +442,7 @@ fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<st
                         // any name (this is wildmatch, not POSIX glob(3), so
                         // there is no leading-dot special case). read_dir()
                         // never yields `.`/`..`, so no explicit skip is needed.
-                        if glob_match_segment(pattern, name_str) {
+                        if glob_match_segment(segment, name_str) {
                             next.push(dir.join(&name));
                         }
                     }
@@ -467,6 +472,11 @@ fn expand_relative_glob(base: &std::path::Path, rel: &std::path::Path) -> Vec<st
 /// only the literal name `a*` and `[\]]` is a class holding `]`. A segment
 /// never contains `/`, so wildmatch's slash-restricted `*`/`?` semantics
 /// reduce to plain single-segment globbing here.
+///
+/// This is the ONE owner of pattern interpretation on the daemon glob path;
+/// [`expand_relative_glob`] only decides where the segment boundaries are, and
+/// it draws them on `/` alone so a `\` always arrives here as the escape byte
+/// upstream's `wildmatch()` expects rather than as a separator.
 fn glob_match_segment(pattern: &str, name: &str) -> bool {
     filters::wildmatch(pattern.as_bytes(), name.as_bytes())
 }

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -5116,12 +5116,16 @@ mod module_access_tests {
         assert_eq!(sources, vec![module_path.join("ab.txt")]);
     }
 
-    // Unix-only for the FIXTURE, not for the behaviour: a Windows filesystem
-    // cannot hold a file named `]x`. The pattern now reaches the matcher
-    // intact on every platform - `expand_relative_glob` splits segments on `/`
-    // alone (upstream util1.c:749) - and the Windows arm of that is pinned by
-    // `resolve_sender_sources_glob_backslash_is_escape_not_separator_windows`.
-    #[cfg(unix)]
+    // Runs on EVERY platform, unlike the two escape tests above: `[`, `]` and
+    // `x` are all legal in a Windows filename, so the fixture is
+    // representable there and this is a live Windows assertion rather than a
+    // reasoned one.
+    //
+    // It was `#[cfg(unix)]` while `expand_relative_glob` walked
+    // `std::path::Component`s, because on Windows that split `[\]]*` at the
+    // `\` into the segments `[` and `]]*` and the pattern never reached the
+    // matcher intact. Splitting on `/` alone (upstream util1.c:749) closes
+    // that, so the gate comes off and the Windows CI cell now executes it.
     #[test]
     fn resolve_sender_sources_glob_class_with_escaped_bracket() {
         // upstream: lib/wildmatch.c:154-161 - inside a `[...]` class a `\`

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -5116,11 +5116,11 @@ mod module_access_tests {
         assert_eq!(sources, vec![module_path.join("ab.txt")]);
     }
 
-    // Unix-only: the fixture `]x` is representable on Windows, but there the
-    // pattern's `\` escape collides with std::path treating `\` as a
-    // separator in the resolve pipeline, so `[\]]*` never reaches the
-    // matcher intact (same class as the peer-dest separator fix in
-    // module_access; the Windows arm is a pre-existing platform gap).
+    // Unix-only for the FIXTURE, not for the behaviour: a Windows filesystem
+    // cannot hold a file named `]x`. The pattern now reaches the matcher
+    // intact on every platform - `expand_relative_glob` splits segments on `/`
+    // alone (upstream util1.c:749) - and the Windows arm of that is pinned by
+    // `resolve_sender_sources_glob_backslash_is_escape_not_separator_windows`.
     #[cfg(unix)]
     #[test]
     fn resolve_sender_sources_glob_class_with_escaped_bracket() {
@@ -5149,6 +5149,67 @@ mod module_access_tests {
         let args = vec![".".to_owned(), "mod/missing/file".to_owned()];
         let sources = resolve_sender_sources(module_path, &args, "mod", false);
         assert_eq!(sources, vec![module_path.join("missing/file")]);
+    }
+
+    #[test]
+    fn resolve_sender_sources_glob_expands_a_nested_segment() {
+        // upstream: util1.c:749 - `glob_match()` peels one `/`-separated
+        // segment per recursion, so a metacharacter in a LATER segment expands
+        // against the directory the earlier literal segments reached. Runs on
+        // every platform: `/` is a separator everywhere, so this pins that
+        // moving off `Path::components()` did not cost multi-segment globbing.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::create_dir(module_path.join("d1")).expect("d1");
+        std::fs::write(module_path.join("d1").join("f1"), b"1").expect("f1");
+        std::fs::write(module_path.join("d1").join("other"), b"o").expect("other");
+
+        let args = vec![".".to_owned(), "mod/d1/f*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
+        assert_eq!(sources, vec![module_path.join("d1").join("f1")]);
+    }
+
+    // The Windows arm of the backslash-escape rule. It needs no odd fixture
+    // name, so unlike the three `#[cfg(unix)]` escape tests above it is
+    // expressible on a Windows filesystem.
+    //
+    // ⚠ This test is compile-checked from the development host via
+    // `cargo check -p daemon --all-targets --target x86_64-pc-windows-msvc`;
+    // it is executed only by the `Windows (stable)` CI cell.
+    #[cfg(windows)]
+    #[test]
+    fn resolve_sender_sources_glob_backslash_is_escape_not_separator_windows() {
+        // upstream: util1.c:749 `glob_match()` finds segment boundaries with
+        // `strchr(arg, '/')` and has no `\` arm on any platform, while
+        // lib/wildmatch.c:86 makes `\` escape the following pattern byte. So
+        // `a\*` is ONE segment denoting the literal name `a*`. A Windows
+        // filesystem cannot hold a file named `a*`, so upstream matches
+        // nothing and `glob_expand()` preserves the literal arg
+        // (util1.c:864, the `glob.argc == save_argc` branch).
+        //
+        // `Path::components()` splits on `\` as well as `/` on Windows, so the
+        // previous implementation read `a\*` as the segments `a` and `*`,
+        // descended into the directory `a` and served every entry it held -
+        // files the client never named. That is the escape/separator
+        // conflation this pins closed.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module_path = tmp.path();
+        std::fs::create_dir(module_path.join("a")).expect("dir a");
+        std::fs::write(module_path.join("a").join("x"), b"x").expect("a/x");
+
+        let args = vec![".".to_owned(), "mod/a\\*".to_owned()];
+        let sources = resolve_sender_sources(module_path, &args, "mod", false);
+
+        let literal = std::path::PathBuf::from(format!("{}/a\\*", module_path.display()));
+        assert_eq!(
+            sources,
+            vec![literal],
+            "an unmatched escaped pattern must survive verbatim"
+        );
+        assert!(
+            !sources.contains(&module_path.join("a").join("x")),
+            "the `\\` escape was consumed as a path separator and leaked <mod>/a/x"
+        );
     }
 
     // UTS-3.b.5 - cross-platform parity for daemon sub-path resolution.


### PR DESCRIPTION
The daemon's glob expander found segment boundaries by walking
`std::path::Path::components()`. On Windows that splits on `\` as well as `/`,
and `\` is `wildmatch`'s **escape** character — so the escape was consumed as a
separator before the matcher ever saw it.

Upstream has no such conflation and no platform arm at all:

- `glob_match()` finds every boundary with `strchr(arg, '/')` (`util1.c:749`).
  There is no `\` case anywhere in the function.
- `wildmatch()` is byte-oriented with a single explicit `'/'` check
  (`lib/wildmatch.c:101-102`); `\` escapes the next pattern byte outside a class
  (`:86`) and inside one (`:154`).

Segmentation now splits on `/` and only `/`, on every platform, operating on the
`/`-separated wire tail rather than on `std::path`. `wildmatch()` stays the
single owner of pattern interpretation — the expander only decides where
segments end. That division is now stated in both functions' docs, since it is
exactly what went wrong.

## Reachability — stated plainly

`oc-rsync` **refuses to start in daemon mode on non-Unix**
(`crates/cli/src/frontend/server/daemon.rs:210`), and this expander is on the
daemon path only. So the Windows misbehaviour is **not reachable in a shipped
configuration today**; this is a faithfulness and code-health fix that also
removes a platform-conditional behaviour upstream does not have, ahead of any
future daemon-on-Windows work.

What it *does* change on every platform: the `strip_prefix(module_path)`
round-trip is gone (the joined path was rebuilt only to be re-split), and empty
and `.` segments are skipped explicitly rather than incidentally.

## The mutation is the evidence

The defect could not be executed on this host, so it was demonstrated by
emulating Windows' rule on a platform that can run:

- **A** — `split('/')` → `split(['/', '\\'])`, which *is* `components()`'
  Windows behaviour: **3 kills**, exactly the three escape tests. This is the
  load-bearing evidence.
- **B** — no segmentation at all: **1 kill**, the new nested-glob test.
  Non-vacuous.
- **Unix regression delta: 0 kills.** The fix is a provable no-op where
  `components()` already split on `/` alone — which is also why the Unix suite
  could never have been the gate for this.

## Test gating

`resolve_sender_sources_glob_class_with_escaped_bracket` was `#[cfg(unix)]` with
a comment naming this exact conflation as an accepted platform gap. `[`, `]` and
`x` are all legal in a Windows filename, so the gate comes off and the
`Windows (stable)` cell now executes it. A second, Windows-only test pins the
`mod/a\*` case, whose fixture (`a*`) is not representable on NTFS: it asserts
both that the unmatched pattern survives verbatim and that `<mod>/a/x` is **not**
served.

The other two escape tests stay Unix-only for a real reason — their fixtures are
named `a*` and `a\b.txt`.

## Gates

Pinned 1.88.0: `check_rustfmt_all.py` clean (3430 files) · clippy `-p daemon
--all-targets -D warnings` clean · nextest `-p daemon --lib` 1907/1907 ·
citation drift audit exit 0.

`cargo check -p daemon --all-targets --target x86_64-pc-windows-gnu` is clean, so
the new `#[cfg(windows)]` test type-checks. (`-msvc` cannot be checked from
macOS — `zstd-sys` compiles C.) Four stale upstream line citations refreshed in
the same commit.
