### PR TITLE
docs: repair the three rustdoc links the doc gate reports

### DIFF
--- a/crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs
@@ -175,7 +175,7 @@ pub(super) fn anchor_parent<'a>(
     }
 }
 
-/// Returns `true` when [`anchor_parent`] resolves a multi-component path's
+/// Returns `true` when `anchor_parent` resolves a multi-component path's
 /// parent beneath the sandbox root on this host, and `false` when it degrades
 /// to the caller's path-based fallback.
 ///

--- a/crates/fast_io/src/pinned_root.rs
+++ b/crates/fast_io/src/pinned_root.rs
@@ -54,7 +54,7 @@
 //! Keeping `O_PATH` also means the platform where the anchored stat already
 //! works issues the same syscall it did before, so this change cannot move it.
 //!
-//! [`open_o_path`](crate::pinned_root::open_o_path) stays Linux-only
+//! `open_o_path` stays Linux-only
 //! regardless: a Landlock rule needs the directory as a descriptor, and
 //! there is no portable stand-in for that.
 //!

--- a/crates/transfer/src/receiver/basis.rs
+++ b/crates/transfer/src/receiver/basis.rs
@@ -160,7 +160,7 @@ pub struct BasisFileConfig<'a> {
 /// naming configuration plus the sandbox environment the copy is confined by.
 ///
 /// Constructed only inside the crate (the fields feed
-/// [`crate::disk_commit::make_backup_copy`], whose environment type is
+/// `crate::disk_commit::make_backup_copy`, whose environment type is
 /// crate-private); external callers of [`find_basis_file_with_config`] pass
 /// `None`.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Three intra-doc links the rustdoc job reports as broken:

- `crates/fast_io/src/dir_sandbox/at_syscalls/nested.rs`
- `crates/fast_io/src/pinned_root.rs`
- `crates/transfer/src/receiver/basis.rs`

One line each, no behaviour touched.

The rustdoc-links job is currently `continue-on-error: true` (ci.yml:242), so
these were reported and discarded rather than blocking. Making that job blocking
and required is a separate change — this one just empties the list it reports so
the flip has nothing pending behind it.

Rebased onto current master; the commit replays clean and its footprint is
exactly the three lines.
