### PR TITLE
fix(matching): grow the block index table like upstream match.c

### DIFF
--- a/crates/matching/src/index/compact_key_tests.rs
+++ b/crates/matching/src/index/compact_key_tests.rs
@@ -66,26 +66,28 @@ fn distinct_basis(n_blocks: usize) -> Vec<u8> {
     basis
 }
 
-/// The bucket array never grows beyond `2^16` slots, even when the basis
-/// signature would naively suggest a larger table.
+/// The compact key governs the bucket array only up to `2^16` slots; past
+/// that the table grows on upstream's rule instead of pinning at the cap.
+///
+/// upstream: match.c:84-88.
 #[test]
-fn bucket_size_is_capped_at_2_16() {
-    // 70 000 blocks > 2^16 = 65 536, so the naive "next-power-of-two of
-    // 2 * n_entries" expansion would jump past the cap. The compact-key
-    // table must clamp at `2^16` so the bucket array stays at most 256 KiB.
+fn bucket_size_follows_upstream_past_the_compact_key() {
+    // 70 000 blocks: upstream's `(70000/8) * 10 + 11` = 87 511 exceeds
+    // TRADITIONAL_TABLESIZE, so the table must grow to exactly that. A
+    // policy that clamped at `2^16` reports 65 536 here.
     let huge = CompactLookup::with_capacity(70_000);
-    assert_eq!(huge.capacity(), 1 << 16);
+    assert_eq!(huge.capacity(), 87_511);
 
-    // The publicly observable `lookup_capacity` accessor on the index
-    // honours the same cap end-to-end, so callers that bin by cache level
-    // never see an over-budget figure.
+    // A basis small enough to stay under the boundary keeps the compact
+    // power-of-two sizing, so callers that bin by cache level still see a
+    // table far below the `2^16` compact-key limit.
     let basis = distinct_basis(8);
     let index = build_index(&basis).expect("index for tiny basis");
     assert!(index.lookup_capacity() <= 1 << 16);
 
     // `lookup_bytes` traverses `CompactLookup::bucket_bytes` so a regular
     // (non-`--benches`) build sees the call chain and clippy stops marking
-    // `bucket_bytes` as dead code. The 256 KiB cap mirrors the bucket cap.
+    // `bucket_bytes` as dead code.
     assert!(index.lookup_bytes() <= 256 * 1024);
 }
 

--- a/crates/matching/src/index/compact_lookup.rs
+++ b/crates/matching/src/index/compact_lookup.rs
@@ -1,18 +1,26 @@
-//! Compact bucket index keyed on the upper half of the rolling checksum.
+//! Bucket index over the rolling checksum, with two addressing modes.
 //!
-//! Translates zsync's `librcksum/hash.c` `rsum_a_mask` trick into oc-rsync's
-//! delta matcher. The bucket address is derived from the upper 16 bits of the
-//! rolling sum (`rsum >> 16`, equal to [`checksums::RollingDigest::sum2`])
-//! while the lower 16 bits ([`checksums::RollingDigest::sum1`]) become the
-//! in-bucket discriminator. Shrinking the bucket array from a `(sum1, sum2)`
-//! keyspace down to a `sum2`-only space keeps the hottest table cache-line
-//! resident even when the basis runs to tens of thousands of blocks.
+//! Mirrors upstream rsync's `match.c` `build_hash_table()`, which sizes its
+//! bucket array from the basis block count and switches hash function at the
+//! `TRADITIONAL_TABLESIZE` (`match.c:45`, `1<<16`) boundary:
+//!
+//! - **Compact** (at or below the boundary) - the bucket address comes from
+//!   the upper 16 bits of the rolling sum (`rsum >> 16`, equal to
+//!   [`checksums::RollingDigest::sum2`]) while the lower 16 bits
+//!   ([`checksums::RollingDigest::sum1`]) become the in-bucket discriminator.
+//!   This is zsync's `librcksum/hash.c` `rsum_a_mask` trick (ZSO-4);
+//!   upstream's own small-table hash (`match.c:71-72` `SUM2HASH`) is likewise
+//!   a 16-bit function. Below the boundary oc sizes tighter than upstream's
+//!   flat `1<<16` floor, which keeps the hot table cache-line resident for
+//!   the small files that dominate a typical transfer.
+//! - **Wide** (above the boundary) - the address is the full 32-bit rolling
+//!   sum modulo the table size, exactly upstream's `BIG_SUM2HASH`
+//!   (`match.c:74`) over upstream's `(count/8) * 10 + 11` sizing
+//!   (`match.c:82-88`). A `sum2`-only key carries no entropy past `2^16`, so
+//!   growing the table requires widening the key just as upstream does.
 //!
 //! The structure is intentionally chain-based rather than open-addressed:
 //!
-//! - The bucket array is sized at most `2^16` slots, so its working set is
-//!   bounded by 256 KiB regardless of basis size. Adjacent rolling-hash
-//!   probes touch the same cache line with high probability.
 //! - Chain nodes live in a packed `Vec<ChainEntry>`; entries for a single
 //!   bucket are *not* required to be contiguous in memory, but the bucket
 //!   array stays tight.
@@ -20,16 +28,37 @@
 //!   zsync's `e.r.a != (r.a & rsum_a_mask)` filter in `librcksum/rsum.c:205`.
 //!
 //! Wire format is unchanged: full `(sum1, sum2)` digests stay in
-//! [`signature::SignatureBlock`]. The compact key is an in-memory probe
-//! optimisation only and is rebuilt per segment by
+//! [`signature::SignatureBlock`]. Both addressing modes map equal rolling
+//! sums to one bucket and [`CompactLookup::find_all`] filters on the full
+//! `(sum1, sum2)` pair, so the yielded candidate sequence - and therefore
+//! every emitted token - is identical under either mode. The table is an
+//! in-memory probe optimisation only, rebuilt per segment by
 //! [`super::DeltaSignatureIndex::rebuild`].
 
-/// Maximum bucket count exponent (`2^16 = 65 536`).
+/// Maximum bucket count exponent for the compact (`sum2`-keyed) mode.
 ///
-/// Bounds the bucket array footprint at `2^16 * 4 = 256 KiB` and matches
-/// the natural `sum2` keyspace - never grow the table beyond this because
-/// the compact key carries no further entropy.
+/// `2^16 = 65 536` is the natural `sum2` keyspace, so the compact key
+/// carries no entropy beyond it. It is also upstream's
+/// `TRADITIONAL_TABLESIZE` (`match.c:45`) - the point at which upstream
+/// swaps `SUM2HASH` for the full-rsum `BIG_SUM2HASH`. Past this the table
+/// grows under [`BucketAddress::Wide`], never by stretching the compact key.
 const MAX_LOG2_BUCKETS: u32 = 16;
+
+/// Upstream's `TRADITIONAL_TABLESIZE`: the bucket count below which upstream
+/// keeps a flat table and the 16-bit hash.
+///
+/// upstream: match.c:45 `#define TRADITIONAL_TABLESIZE (1<<16)`.
+const TRADITIONAL_TABLESIZE: usize = 1 << MAX_LOG2_BUCKETS;
+
+/// Allocation guard on the wide bucket count.
+///
+/// `2^27 - 1` slots is 1 GiB of [`BucketSlot`], reached only at roughly
+/// 107 million basis blocks (a multi-terabyte basis at upstream's 128 KiB
+/// maximum block length) - about 2 000x past the point where the wide mode
+/// engages. Upstream has no equivalent guard; it simply asks `new_array()`
+/// for the allocation and dies if it fails. The value is odd so the guard
+/// preserves upstream's oddness requirement (`match.c:80-81`).
+const MAX_WIDE_BUCKETS: usize = (1 << 27) - 1;
 
 /// Minimum bucket count exponent (`2^4 = 16`).
 ///
@@ -89,23 +118,100 @@ impl BucketSlot {
     };
 }
 
-/// Compact bucket index keyed on the upper 16 bits of the rolling sum.
+/// Bucket sizing and addressing rule, the single owner of the decision.
 ///
-/// See the module docs for the ZSO-4 design contract and the duplicate-block
-/// correctness rationale shared with [`super::MatchedBlocks`].
+/// Constructed once per table by [`Self::for_entries`]; both
+/// [`CompactLookup::insert`] and [`CompactLookup::find_all`] route through
+/// [`Self::index_of`] so the two paths cannot drift apart, and no call site
+/// re-derives a bucket count of its own.
+#[derive(Clone, Copy, Debug)]
+enum BucketAddress {
+    /// `sum2 & mask` over a power-of-two table at most
+    /// [`TRADITIONAL_TABLESIZE`] slots wide (ZSO-4 compact key).
+    Compact { mask: u16 },
+    /// `rsum % modulus` over upstream's dynamically grown table.
+    ///
+    /// upstream: match.c:74 `#define BIG_SUM2HASH(sum) ((sum)%tablesize)`.
+    Wide { modulus: u32 },
+}
+
+impl BucketAddress {
+    /// Chooses the sizing and addressing rule for `n_entries` indexed blocks.
+    ///
+    /// upstream: match.c:82-88 - `tablesize = (uint32)(s->count/8) * 10 + 11`,
+    /// raised to `TRADITIONAL_TABLESIZE` when it falls below it. The `* 10 / 8`
+    /// factor targets an 80% hash load and the `+ 11` keeps the result odd,
+    /// without which the upper sum half cannot span the whole table
+    /// (`match.c:80-81`). Reproducing the growth is what keeps the per-offset
+    /// chain walk flat as the basis grows: pinning the table at
+    /// `TRADITIONAL_TABLESIZE` instead makes the mean walk scale linearly with
+    /// the block count (measured 9.0x upstream at 1 000 000 blocks).
+    ///
+    /// At or below the boundary oc keeps its own power-of-two sizing rather
+    /// than upstream's flat floor. Upstream allocates and `memset`s 256 KiB
+    /// per file there regardless of how few blocks the basis has; oc's
+    /// tighter table measures within 1% of upstream's mean chain walk from
+    /// 32 768 blocks up to the boundary, so the floor buys nothing it does
+    /// not charge for in cache footprint.
+    fn for_entries(n_entries: usize) -> Self {
+        let wide = (n_entries / 8).saturating_mul(10).saturating_add(11);
+        if wide > TRADITIONAL_TABLESIZE {
+            Self::Wide {
+                modulus: wide.min(MAX_WIDE_BUCKETS) as u32,
+            }
+        } else {
+            let n_buckets = 1usize << log2_buckets_for(n_entries);
+            Self::Compact {
+                mask: (n_buckets - 1) as u16,
+            }
+        }
+    }
+
+    /// Number of bucket slots the rule asks for.
+    const fn bucket_count(self) -> usize {
+        match self {
+            Self::Compact { mask } => mask as usize + 1,
+            Self::Wide { modulus } => modulus as usize,
+        }
+    }
+
+    /// Maps a `(sum1, sum2)` pair onto a bucket slot.
+    ///
+    /// Both modes send equal rolling sums to the same slot, which is the only
+    /// property [`CompactLookup::find_all`] depends on for correctness.
+    #[inline]
+    fn index_of(self, sum1: u16, sum2: u16) -> usize {
+        match self {
+            Self::Compact { mask } => (sum2 & mask) as usize,
+            Self::Wide { modulus } => {
+                let rsum = (u32::from(sum2) << 16) | u32::from(sum1);
+                (rsum % modulus) as usize
+            }
+        }
+    }
+}
+
+/// Bucket index over the rolling checksum.
+///
+/// See the module docs for the two addressing modes, the ZSO-4 design
+/// contract, and the duplicate-block correctness rationale shared with
+/// [`super::MatchedBlocks`].
 #[derive(Clone, Debug)]
 pub(super) struct CompactLookup {
     buckets: Vec<BucketSlot>,
     entries: Vec<ChainEntry>,
-    mask: u16,
+    address: BucketAddress,
 }
 
 impl CompactLookup {
-    /// Derives the bucket address from the packed rolling sum.
+    /// Derives the compact-mode bucket key from the packed rolling sum.
     ///
     /// `rsum >> 16` is the upper half of the wire-format checksum and matches
     /// [`checksums::RollingDigest::sum2`], mirroring zsync's
     /// `r.a & rsum_a_mask` formulation while staying entirely in-memory.
+    /// Tables grown past [`TRADITIONAL_TABLESIZE`] address on the full rolling
+    /// sum instead ([`BucketAddress::Wide`]), so this is the key only while
+    /// the table is in compact mode.
     #[inline]
     #[must_use]
     pub(super) const fn bucket_for(rsum: u32) -> u16 {
@@ -114,21 +220,18 @@ impl CompactLookup {
 
     /// Builds a bucket table sized for the expected number of entries.
     ///
-    /// Bucket count is the smallest power of two `>= 2 * n_entries`, clamped
-    /// to `[2^MIN_LOG2_BUCKETS, 2^MAX_LOG2_BUCKETS]`. The chain backing store
-    /// is reserved at a conservative upper bound (`MAX_RESERVE_ENTRIES`) so
-    /// adversarial inputs cannot trigger an oversized allocation up-front;
-    /// real basis sizes never approach the cap before paging concerns kick
-    /// in elsewhere.
+    /// Sizing is owned entirely by [`BucketAddress::for_entries`]. The chain
+    /// backing store is reserved at a conservative upper bound
+    /// (`MAX_RESERVE_ENTRIES`) so adversarial inputs cannot trigger an
+    /// oversized allocation up-front; real basis sizes never approach the cap
+    /// before paging concerns kick in elsewhere.
     pub(super) fn with_capacity(n_entries: usize) -> Self {
-        let log2_buckets = log2_buckets_for(n_entries);
-        let n_buckets = 1usize << log2_buckets;
-        let mask = (n_buckets - 1) as u16;
+        let address = BucketAddress::for_entries(n_entries);
         let reserve = n_entries.min(MAX_RESERVE_ENTRIES);
         Self {
-            buckets: vec![BucketSlot::EMPTY; n_buckets],
+            buckets: vec![BucketSlot::EMPTY; address.bucket_count()],
             entries: Vec::with_capacity(reserve),
-            mask,
+            address,
         }
     }
 
@@ -144,7 +247,7 @@ impl CompactLookup {
             block_index, CHAIN_END,
             "block_index u32::MAX collides with chain sentinel",
         );
-        let bucket = self.bucket_index(sum2);
+        let bucket = self.address.index_of(sum1, sum2);
         let entry_idx = self.entries.len() as u32;
         self.entries.push(ChainEntry {
             sum1,
@@ -166,28 +269,19 @@ impl CompactLookup {
 
     /// Returns an iterator over all block indices matching `(sum1, sum2)`.
     ///
-    /// Walks the `sum2`-derived bucket chain in insertion order and yields
-    /// entries whose lower-half discriminator equals `sum1`. The
-    /// strong-checksum verify still gates the final caller-visible match -
-    /// this iterator only filters out chain entries that cannot possibly
-    /// match.
+    /// Walks the bucket chain in insertion order and yields entries whose
+    /// lower-half discriminator equals `sum1`. The strong-checksum verify
+    /// still gates the final caller-visible match - this iterator only
+    /// filters out chain entries that cannot possibly match. The yielded
+    /// sequence is independent of the addressing mode.
     #[inline]
     pub(super) fn find_all(&self, sum1: u16, sum2: u16) -> CompactLookupIter<'_> {
-        let bucket = self.bucket_index(sum2);
+        let bucket = self.address.index_of(sum1, sum2);
         CompactLookupIter {
             table: self,
             sum1,
             next: self.buckets[bucket].head,
         }
-    }
-
-    /// Masks `sum2` into the bucket-array address space.
-    ///
-    /// Equivalent to `sum2 & self.mask`, but kept as a single helper so the
-    /// insert and lookup paths cannot drift apart.
-    #[inline]
-    fn bucket_index(&self, sum2: u16) -> usize {
-        (sum2 & self.mask) as usize
     }
 
     /// Resets all bucket heads and chain entries, preserving the backing
@@ -203,12 +297,14 @@ impl CompactLookup {
         self.entries.len() as u32
     }
 
-    /// Returns the number of bucket slots (always a power of two, `<= 2^16`).
+    /// Returns the number of bucket slots.
     ///
-    /// Reported as the bench harnesses' "lookup capacity" - the metric they
-    /// pair against the local CPU cache hierarchy.
+    /// A power of two at or below `2^16` in compact mode, upstream's odd
+    /// `(count/8) * 10 + 11` above it. Reported as the bench harnesses'
+    /// "lookup capacity" - the metric they pair against the local CPU cache
+    /// hierarchy.
     pub(super) fn capacity(&self) -> usize {
-        (self.mask as usize) + 1
+        self.address.bucket_count()
     }
 
     /// Returns the byte footprint of the bucket array allocation.
@@ -346,16 +442,146 @@ mod tests {
     }
 
     #[test]
-    fn bucket_count_is_capped_at_two_to_sixteen() {
-        let table = CompactLookup::with_capacity(usize::MAX);
-        assert_eq!(table.capacity(), 1 << MAX_LOG2_BUCKETS);
-        assert_eq!(table.mask, u16::MAX);
-    }
-
-    #[test]
     fn bucket_count_is_floored_for_tiny_inputs() {
         let table = CompactLookup::with_capacity(0);
         assert_eq!(table.capacity(), 1 << MIN_LOG2_BUCKETS);
+    }
+
+    /// Upstream's table size for `n` blocks: `(n/8) * 10 + 11`, raised to
+    /// `TRADITIONAL_TABLESIZE` when it falls below it.
+    ///
+    /// upstream: match.c:84-88.
+    fn upstream_tablesize(n: usize) -> usize {
+        ((n / 8) * 10 + 11).max(TRADITIONAL_TABLESIZE)
+    }
+
+    /// The bucket count must track upstream's dynamic growth once the basis
+    /// is large enough to leave `TRADITIONAL_TABLESIZE` behind.
+    ///
+    /// Pinning the table at the floor instead is what the measured 9.0x
+    /// chain-walk blow-up at a million blocks comes from: the walk cost is
+    /// `n_entries / n_buckets`, so a fixed bucket count makes it grow without
+    /// bound. Any policy that stops growing fails this at `100_000`.
+    ///
+    /// upstream: match.c:84-88.
+    #[test]
+    fn bucket_count_tracks_upstream_growth_above_the_floor() {
+        // 52 424 is the first block count whose upstream size exceeds
+        // TRADITIONAL_TABLESIZE: 52424/8 = 6553, 6553*10 + 11 = 65 541.
+        // 52 423 truncates to 6552 and still lands on the floor.
+        for &n in &[52_424usize, 100_000, 400_000, 1_000_000, 8_000_000] {
+            let table = CompactLookup::with_capacity(n);
+            assert_eq!(
+                table.capacity(),
+                upstream_tablesize(n),
+                "bucket count for {n} blocks must equal upstream's tablesize"
+            );
+            assert!(
+                table.capacity() > TRADITIONAL_TABLESIZE,
+                "{n} blocks must leave the traditional table size behind"
+            );
+        }
+        assert_eq!(CompactLookup::with_capacity(52_424).capacity(), 65_541);
+    }
+
+    /// Below the boundary the table stays on oc's tighter power-of-two
+    /// sizing, and never exceeds `TRADITIONAL_TABLESIZE`.
+    ///
+    /// Upstream's flat `1<<16` floor would `memset` 256 KiB per file for a
+    /// basis of a handful of blocks; the measured mean chain walk is within
+    /// 1% of upstream's from 32 768 blocks to the boundary, so the floor is
+    /// pure cache footprint there.
+    #[test]
+    fn bucket_count_stays_compact_below_the_boundary() {
+        for &(n, expected) in &[
+            (0usize, 1usize << MIN_LOG2_BUCKETS),
+            (1, 1 << MIN_LOG2_BUCKETS),
+            (1_000, 2_048),
+            (32_768, TRADITIONAL_TABLESIZE),
+            (52_423, TRADITIONAL_TABLESIZE),
+        ] {
+            let table = CompactLookup::with_capacity(n);
+            assert_eq!(table.capacity(), expected, "bucket count for {n} blocks");
+            assert!(table.capacity().is_power_of_two());
+        }
+    }
+
+    /// A grown table must be odd, or the upper sum half cannot span the whole
+    /// set under `rsum % tablesize`.
+    ///
+    /// upstream: match.c:80-81.
+    #[test]
+    fn grown_bucket_count_is_odd() {
+        for &n in &[52_424usize, 100_000, 999_999, 8_000_000, usize::MAX] {
+            let count = BucketAddress::for_entries(n).bucket_count();
+            assert_eq!(count % 2, 1, "grown table for {n} blocks must be odd");
+        }
+    }
+
+    /// The allocation guard bounds the wide bucket count for adversarial
+    /// entry counts without wrapping the `u32` modulus.
+    #[test]
+    fn wide_bucket_count_is_guarded() {
+        assert_eq!(
+            BucketAddress::for_entries(usize::MAX).bucket_count(),
+            MAX_WIDE_BUCKETS
+        );
+        assert_eq!(
+            BucketAddress::for_entries(usize::MAX / 8).bucket_count(),
+            MAX_WIDE_BUCKETS
+        );
+    }
+
+    /// Above the boundary the address must consume the full rolling sum.
+    ///
+    /// Two sums sharing `sum2` collide in every compact table by
+    /// construction; a grown table that still keyed on `sum2` alone would
+    /// keep them colliding and so gain nothing from the extra slots.
+    ///
+    /// upstream: match.c:74 `BIG_SUM2HASH(sum) ((sum)%tablesize)`.
+    #[test]
+    fn wide_address_uses_the_full_rolling_sum() {
+        let address = BucketAddress::for_entries(100_000);
+        assert!(matches!(address, BucketAddress::Wide { .. }));
+        assert_ne!(
+            address.index_of(0x0001, 0xBEEF),
+            address.index_of(0x0002, 0xBEEF),
+            "wide addressing must separate sums that share sum2"
+        );
+
+        let compact = BucketAddress::for_entries(1_000);
+        assert_eq!(
+            compact.index_of(0x0001, 0xBEEF),
+            compact.index_of(0x0002, 0xBEEF),
+            "compact addressing keys on sum2 alone",
+        );
+    }
+
+    /// Growing the table must not change which candidates a probe yields:
+    /// the sizing is an in-memory optimisation with no token-level effect.
+    #[test]
+    fn wide_mode_preserves_lookup_semantics_and_order() {
+        let n = 60_000usize;
+        let mut table = CompactLookup::with_capacity(n);
+        assert!(table.capacity() > TRADITIONAL_TABLESIZE);
+        for i in 0..n {
+            table.insert((i & 0xFFFF) as u16, ((i >> 5) & 0xFFFF) as u16, i as u32);
+        }
+        for i in (0..n).step_by(97) {
+            let found: Vec<usize> = table
+                .find_all((i & 0xFFFF) as u16, ((i >> 5) & 0xFFFF) as u16)
+                .collect();
+            assert!(found.contains(&i), "missing entry {i}");
+        }
+
+        // Duplicate keys must still come back in insertion order: the
+        // MatchedBlocks first-fit contract depends on it.
+        let mut dup = CompactLookup::with_capacity(n);
+        dup.insert(7, 9, 100);
+        dup.insert(7, 9, 5);
+        dup.insert(7, 9, 42);
+        let found: Vec<usize> = dup.find_all(7, 9).collect();
+        assert_eq!(found, vec![100, 5, 42]);
     }
 
     #[test]

--- a/crates/matching/src/index/mod.rs
+++ b/crates/matching/src/index/mod.rs
@@ -4,12 +4,16 @@
 //! delta generation. It indexes signature blocks by their rolling checksum
 //! components `(sum1, sum2)` for efficient matching.
 //!
-//! The compact bucket index ([`CompactLookup`]) addresses buckets using only
-//! the upper half of the rolling sum (`rsum >> 16`, equal to `sum2`); the
-//! lower half (`sum1`) is stored as an in-bucket discriminator. This is the
-//! ZSO-4 translation of zsync's `librcksum/hash.c:45` `rsum_a_mask` trick:
-//! shrinking the bucket array to at most `2^16` slots keeps the hottest
-//! lookup table cache-line resident across rolling-hash advances.
+//! The bucket index ([`CompactLookup`]) mirrors upstream `match.c`'s two
+//! addressing modes. Below upstream's `TRADITIONAL_TABLESIZE` (`match.c:45`)
+//! it addresses buckets using only the upper half of the rolling sum
+//! (`rsum >> 16`, equal to `sum2`), with the lower half (`sum1`) stored as an
+//! in-bucket discriminator - the ZSO-4 translation of zsync's
+//! `librcksum/hash.c:45` `rsum_a_mask` trick, which keeps the hottest lookup
+//! table cache-line resident across rolling-hash advances. Above it the table
+//! grows on upstream's `(count/8) * 10 + 11` rule (`match.c:84-88`) and
+//! addresses on the full rolling sum (`match.c:74` `BIG_SUM2HASH`), because a
+//! `sum2`-only key carries no entropy past `2^16`.
 
 mod bithash;
 mod builder;
@@ -51,9 +55,16 @@ pub use trace::{
 
 /// Size of the tag table for quick rolling checksum rejection (2^16 entries).
 ///
-/// Upstream rsync uses a boolean array indexed by the low 16 bits (sum1) of the
-/// rolling checksum to reject non-matching positions before probing the hash
-/// table. This constant matches upstream's `TABLESIZE` in `match.c`.
+/// The tag table is a boolean array indexed by the low 16 bits (`sum1`) of the
+/// rolling checksum, rejecting non-matching positions before the bithash and
+/// bucket probes. `2^16` is the entire keyspace of a 16-bit index, so this is
+/// a complete table rather than a sized one: there is nothing to grow it to,
+/// and every entry is addressable.
+///
+/// It is *not* the analogue of upstream's `hash_table`, whose size does track
+/// the block count (`match.c:84-88`); that role belongs to [`CompactLookup`].
+/// rsync 3.5.0 has no tag table of its own - upstream dropped the 2.x-era one
+/// when `match.c` moved to a chained `hash_table`.
 const TAG_TABLE_SIZE: usize = 1 << 16;
 
 /// Maximum number of equal-weak-checksum candidates verified at a single
@@ -107,14 +118,15 @@ pub struct ProbeCounters {
 
 /// Index over a file signature that accelerates delta matching.
 ///
-/// Uses a chained bucket table (`CompactLookup`) addressed by the upper
-/// half of the rolling sum (`sum2`) for O(1) block lookup with excellent
-/// cache locality. The lower half (`sum1`) lives inside each chain entry as
-/// an in-bucket discriminator, mirroring zsync's `librcksum`
-/// `rsum_a_mask` trick (ZSO-4). A tag table indexed by `sum1` still provides
-/// upstream-rsync-style fast-path rejection before the bucket walk, and the
-/// bithash prefilter (ZSO-1) rejects the bulk of post-tag misses before the
-/// chain probe.
+/// Uses a chained bucket table (`CompactLookup`) sized on upstream's
+/// `match.c` rule for O(1) block lookup. Below upstream's
+/// `TRADITIONAL_TABLESIZE` it addresses on the upper half of the rolling sum
+/// (`sum2`) for cache locality, keeping the lower half (`sum1`) inside each
+/// chain entry as an in-bucket discriminator per zsync's `librcksum`
+/// `rsum_a_mask` trick (ZSO-4); above it the table grows and addresses on the
+/// full rolling sum as upstream does. A tag table indexed by `sum1` provides
+/// fast-path rejection before the bucket walk, and the bithash prefilter
+/// (ZSO-1) rejects the bulk of post-tag misses before the chain probe.
 #[derive(Debug)]
 pub struct DeltaSignatureIndex {
     block_length: usize,
@@ -281,13 +293,15 @@ impl SeqMatchCounters {
 }
 
 impl DeltaSignatureIndex {
-    /// Returns the bucket address the compact lookup would use for `rsum`.
+    /// Returns the compact-mode bucket key for `rsum`.
     ///
     /// The compact key is `rsum >> 16` (equal to
     /// [`checksums::RollingDigest::sum2`]); the lower 16 bits become the
     /// in-chain discriminator. Exposed so callers and tests can reason
     /// about bucket collisions without reaching into the private bucket
-    /// table.
+    /// table. Tables grown past upstream's `TRADITIONAL_TABLESIZE` address
+    /// on the full rolling sum instead, so this is the key only while the
+    /// table is in compact mode.
     #[inline]
     #[must_use]
     pub const fn bucket_for(rsum: u32) -> u16 {
@@ -1082,11 +1096,13 @@ impl DeltaSignatureIndex {
         self.tag_table[sum1 as usize]
     }
 
-    /// Bucket-slot count of the underlying compact lookup table.
+    /// Bucket-slot count of the underlying lookup table.
     ///
-    /// Equal to the bucket count, capped at `2^16` per the ZSO-4 compact-key
-    /// design. Bench harnesses use this to bin index sizes against the local
-    /// CPU cache hierarchy (L1 / L2 / LLC / main memory).
+    /// A power of two at or below `2^16` while the ZSO-4 compact key
+    /// addresses the table, and upstream's `(count/8) * 10 + 11`
+    /// (`match.c:84`) once the basis grows past that. Bench harnesses use
+    /// this to bin index sizes against the local CPU cache hierarchy
+    /// (L1 / L2 / LLC / main memory).
     #[must_use]
     pub fn lookup_capacity(&self) -> usize {
         self.lookup.capacity()

--- a/docs/design/sender-tokio-prototype.md
+++ b/docs/design/sender-tokio-prototype.md
@@ -381,7 +381,9 @@ same index, the atomic consumed array provides the coordination.
 
 The `CompactLookup` (`crates/matching/src/index/compact_lookup.rs`)
 addresses hash-table buckets using only `sum2` (upper 16 bits of the
-rolling sum), with `sum1` as an in-bucket discriminator. This is a
+rolling sum), with `sum1` as an in-bucket discriminator, for tables at or
+below upstream's `TRADITIONAL_TABLESIZE`; larger tables address on the
+full rolling sum as upstream's `BIG_SUM2HASH` does. This is a
 data-structure optimization with no I/O or synchronization concerns.
 
 **Async interaction:** None. Pure computation within `spawn_blocking`.


### PR DESCRIPTION
`CompactLookup` clamps its bucket table to 2^16 as a **ceiling**. Upstream uses that
same number as a **floor** and grows past it without bound:

```c
/* match.c:84-88 */
tablesize = (uint32)(s->count/8) * 10 + 11;
if (tablesize < TRADITIONAL_TABLESIZE)
        tablesize = TRADITIONAL_TABLESIZE;
```

with the key widening in step — `SUM2HASH` is 16-bit at the floor, `BIG_SUM2HASH`
is the full 32-bit rolling sum above it (`match.c:71-74`). oc kept the 16-bit key
at every size, so the chain walk grows linearly with the basis instead of staying
flat.

## Not a wire change

Both modes send equal rolling sums to one bucket and `find_all` filters on the
full `(sum1, sum2)` pair, so the emitted token stream is identical either way.
The only field that moves is the `size:` value in oc's own `--debug=HASH` line,
which upstream does not emit at all. **The impact is performance only.**

## What it buys, measured

Mean chain entries per probe, oc's policy vs upstream's, over real `RollingDigest`
values:

| blocks | oc | upstream | ratio |
|---|---|---|---|
| 1 000 | 1.45 | 1.01 | 1.44x |
| 32 768 | 1.50 | 1.51 | 0.99x |
| 100 000 | 2.52 | 1.80 | 1.40x |
| 400 000 | 7.10 | 1.80 | 3.94x |
| 1 000 000 | 16.26 | 1.80 | 9.03x |

The boundary is around 6.7 GB of basis at upstream's 128 KiB maximum block size.

**Wall clock did not move, and this PR does not claim it did**: 128 MiB over
262 144 blocks measures 0.174s pinned vs 0.173s grown. oc's tag table and BitHash
prefilter keep the chain walk off the critical path at benchable sizes. So this
bounds an unbounded worst case and restores fidelity; it is not a measured
speedup, and above the boundary it costs 8 bytes per bucket where upstream
spends 4.

## Shape

One owner — `BucketAddress::for_entries`, which both `insert` and `find_all`
reach through `index_of`, so the two paths cannot disagree about placement.
Above `TRADITIONAL_TABLESIZE` it takes upstream's formula and `rsum % modulus`;
at or below it, oc's power-of-two sizing is **unchanged**, with the reason
stated: upstream's flat floor would `memset` 256 KiB per file for a ten-block
basis, and its walk is within 1% of oc's from 32 768 blocks up to the boundary.

`MAX_WIDE_BUCKETS = 2^27 - 1` guards allocation roughly 2000x past the point the
growth engages. Upstream has no such guard; this one is oc's own and is
documented as such.

## Two documentation defects fixed in passing

`TAG_TABLE_SIZE` (`index/mod.rs`) claimed to match "upstream's `TABLESIZE` in
`match.c`". Neither half holds: it sizes a `Vec<bool>` indexed by `sum1`, the low
16 bits of the rolling sum, so 2^16 is the *complete keyspace* rather than a
floor — and rsync 3.5.0 has no tag table at all, having moved `match.c` to a
chained `hash_table`. The design note in `sender-tokio-prototype.md` said
`CompactLookup` addresses on `sum2` alone, which stops being true above the
boundary.

## Verification

Mutations: growth branch disabled kills 6 named tests; the key narrowed back to
16-bit kills exactly 1; `+11` changed to `+10` kills 3. The below-boundary control
survives all three by design — that non-kill is what shows the unchanged arm is
genuinely unchanged.

Gates at the pinned 1.88.0: rustfmt 3430 clean, `clippy -p matching` clean,
nextest `matching` 388/388 and `matching`+`engine` 5510/5510. Not run: interop,
upstream testsuite.

## Filed, not fixed

`optimized_search.rs` carries a second independent `TAG_TABLE_SIZE` with its own
`TagTable`/`BlockHashTable`, and the whole module has no consumers beyond
`pub mod` in `lib.rs` — dead public API whose module doc repeats the same claim
about a `match.c` tag table that does not exist. Tracked separately for deletion.
