### PR TITLE
docs: pin the confinement rule on path-keyed stat caches

### DIFF
--- a/crates/flist/BATCHED_STAT.md
+++ b/crates/flist/BATCHED_STAT.md
@@ -136,14 +136,32 @@ The `BatchedStatCache` uses `Arc<fs::Metadata>` to enable cheap cloning while ma
 
 ```rust
 pub struct BatchedStatCache {
-    cache: Arc<Mutex<HashMap<PathBuf, Arc<fs::Metadata>>>>,
+    shards: Arc<[Mutex<HashMap<PathBuf, Arc<fs::Metadata>>>; SHARD_COUNT]>,
 }
 ```
 
 This design:
-- Allows thread-safe sharing via `Arc<Mutex<_>>`
+- Allows thread-safe sharing via a 16-shard array of `Mutex<HashMap<_>>`
 - Avoids cloning large metadata structures via `Arc<fs::Metadata>`
 - Enables reference-counted cleanup when entries are no longer needed
+
+### Cache lifetime and confinement
+
+The cache is keyed on a **path string** and has no invalidation trigger: only
+`clear()` empties it, and nothing here observes filesystem mutation. An entry is
+therefore authoritative for the cache's whole lifetime, and a hit answers for
+whatever the path denoted at fill time.
+
+This type is currently unreached. It must not be wired into any walk that
+crosses a confinement boundary without first being re-keyed onto a resolved
+handle (a held directory fd plus a single component), because a path-keyed hit
+reopens the TOCTOU window that the per-component resolver exists to close.
+`DirectoryStatBatch` already has the safe shape. The contract is stated in
+`docs/design/path-confinement-resolver-api.md` section 5.
+
+Upstream rsync has no counterpart: `flist.c`'s `lastdir` interns a directory
+*name*, not a `STRUCT_STAT`, and every upstream hashtable is keyed on integers
+(`(dev, ino)`, `gnum`, `fs_dev`) rather than on a path.
 
 ### Parallel Execution
 

--- a/crates/flist/src/batched_stat/cache.rs
+++ b/crates/flist/src/batched_stat/cache.rs
@@ -23,6 +23,45 @@ type StatShard = Mutex<HashMap<PathBuf, Arc<fs::Metadata>>>;
 /// Uses sharded locking (16 independent `Mutex<HashMap>` shards) to reduce
 /// contention under parallel stat workloads. Paths are routed to shards via
 /// a fast hash of their byte representation.
+///
+/// # Confinement constraint
+///
+/// **This type is unreached, and it must not be wired as written.** It is keyed
+/// on a path *string*, so a hit returns the metadata the path denoted when the
+/// entry was filled, not the metadata it denotes now. There is no invalidation
+/// hook and no generation counter: nothing here observes filesystem mutation,
+/// so an entry stays authoritative for the cache's whole lifetime.
+///
+/// Wiring it into a walk that crosses a confinement boundary would reopen the
+/// TOCTOU window the per-component resolver exists to close. An attacker who
+/// replaces a path component with a symlink between the fill and the hit gets
+/// the pre-swap answer back, and on a miss the re-resolve
+/// (`fs::metadata`/`fs::symlink_metadata` on an absolute path) walks the
+/// mutated path with the process's full authority rather than through the
+/// per-component ownership walk.
+///
+/// Any future wiring must key on a resolved handle - a held directory fd plus a
+/// single component - rather than on a path. The sibling `DirectoryStatBatch`
+/// already has that shape: it holds the directory open and issues `fstatat`
+/// relative to that fd, so a component swapped after the open cannot redirect
+/// the lookup. See `docs/design/path-confinement-resolver-api.md` section 5,
+/// which states the contract this type would breach.
+///
+/// # Upstream
+///
+/// Upstream has no counterpart to re-key against: there is no pathname-keyed
+/// stat cache anywhere in rsync's file-list build. `flist.c:1547-1556`'s
+/// `lastdir` interns a directory *name* (a `char *`) and a derived component
+/// count, never a `STRUCT_STAT`; `make_file()` destructures each stat into
+/// scalar `file_struct` fields and drops it. Every hashtable upstream keeps is
+/// keyed on integers, not paths - `(dev, ino)` in `hlink.c:74-84`, `gnum`,
+/// `fs_dev`, an xattr-content checksum - and the one path-shaped cache
+/// (`syscall.c:3540-3548`) holds open dirfds, which upstream's own comment
+/// argues are race-safe precisely because an fd pins an inode where a resolved
+/// path snapshot does not. Where a stale snapshot would be dangerous upstream
+/// re-stats and diffs against the flist value (`sender.c:428`, `failed_op =
+/// "re-lstat"`). An oc-invented cache with no upstream analogue is a design
+/// decision, not an inherited one.
 #[derive(Debug)]
 pub struct BatchedStatCache {
     shards: Arc<[StatShard; SHARD_COUNT]>,

--- a/crates/flist/src/batched_stat/mod.rs
+++ b/crates/flist/src/batched_stat/mod.rs
@@ -10,6 +10,16 @@
 //! - **Modern syscalls** using `statx` on Linux 4.11+ for better performance
 //! - **Caching** to avoid redundant syscalls for already-stat'd paths
 //!
+//! # Confinement
+//!
+//! The two fetchers here have opposite safety properties, and the difference is
+//! load-bearing. `DirectoryStatBatch` holds a directory fd and issues `fstatat`
+//! against it, so it re-resolves a single component under a pinned inode.
+//! `BatchedStatCache` is keyed on a path string and never invalidates, so a hit
+//! can answer for a path that has since been swapped. Nothing reaches either
+//! type today; see the confinement constraint on `BatchedStatCache` before
+//! wiring it anywhere.
+//!
 //! # Performance
 //!
 //! On large directory trees, batched metadata fetching can provide 2-4x speedup

--- a/crates/metadata/src/stat_cache.rs
+++ b/crates/metadata/src/stat_cache.rs
@@ -23,6 +23,32 @@ use std::path::{Path, PathBuf};
 /// This cache is designed for short-lived, sequential metadata operations
 /// where the same paths may be stat'd multiple times in quick succession.
 /// It's particularly effective during permission and ownership updates.
+///
+/// # Confinement constraint
+///
+/// **This type is unreached and must not be wired as written.** It is keyed on
+/// a path *string*, so a hit answers for whatever the path denoted at fill
+/// time. `invalidate()` exists but is caller-driven: nothing here observes
+/// filesystem mutation, so a caller that forgets one `invalidate()` silently
+/// keeps a stale answer.
+///
+/// That matters more here than for a plain lookup cache, because the values
+/// gate privileged syscalls. `mode_matches` and `ownership_matches` are
+/// quick-checks that *skip* a `chmod`/`chown` when the cached mode or owner
+/// already matches. A stale hit therefore turns into a silently omitted
+/// permission fix, and a hit for a path swapped to point elsewhere applies (or
+/// withholds) an ownership decision computed for a different inode.
+///
+/// The live applier does **not** use this type. It threads a plain
+/// `Option<&fs::Metadata>` down the call chain, so the stat it consults belongs
+/// to the operation in flight rather than to a map with an unbounded lifetime.
+/// That mirrors upstream, which passes a `stat_x *` into `set_file_attrs()` and
+/// re-stats where staleness would be dangerous (`sender.c:428`, `failed_op =
+/// "re-lstat"`). Upstream keeps no pathname-keyed metadata cache at all.
+///
+/// Any future wiring must key on a resolved handle - a held fd, or an anchor
+/// plus a single component - not on a path. See
+/// `docs/design/path-confinement-resolver-api.md` section 5.
 #[derive(Debug)]
 pub struct MetadataCache {
     cache: HashMap<PathBuf, CachedMetadata>,

--- a/docs/design/path-confinement-resolver-api.md
+++ b/docs/design/path-confinement-resolver-api.md
@@ -276,9 +276,33 @@ confinement decision lives in the *act of resolving*, not in the value returned.
 
 Any cache that survives across a resolution must therefore key on a **resolved
 handle** (an fd, or an anchor plus a single component) rather than on a path string.
-`crates/flist`'s `BatchedStatCache` (`HashMap<PathBuf, Arc<fs::Metadata>>`) is the
-concrete instance to watch: it is currently unreached, and wiring it without
-re-keying would breach this contract (task 656).
+There are **two** concrete instances to watch, both currently unreached, and wiring
+either without re-keying would breach this contract (task 656):
+
+1. `crates/flist`'s `BatchedStatCache` (`HashMap<PathBuf, Arc<fs::Metadata>>`). It
+   has no invalidation hook at all. It sits behind the non-default `parallel`
+   feature in a crate that reaches the product only as an unused `pub use` in
+   `core`, so it is not compiled into a default build.
+2. `crates/metadata`'s `MetadataCache` (`HashMap<PathBuf, CachedMetadata>`,
+   `stat_cache.rs`). This one is the sharper hazard despite being smaller: it is a
+   `pub mod` of a crate that *is* in the default dependency graph, and its
+   `mode_matches`/`ownership_matches` helpers gate whether a `chmod`/`chown` is
+   skipped, so a stale hit becomes an omitted permission fix rather than merely a
+   wrong readback. Its `invalidate()` is caller-driven and so does not satisfy the
+   contract on its own.
+
+The live metadata applier is **not** an instance: it threads an
+`Option<&fs::Metadata>` through a single operation, which is the same shape as
+upstream's `stat_x *` argument to `set_file_attrs()`.
+
+Neither cache has an upstream counterpart. Upstream keeps no pathname-keyed stat
+cache in the file-list build: `flist.c:1547-1556`'s `lastdir` interns a directory
+*name* plus a derived component count, `make_file()` destructures each stat into
+scalar `file_struct` fields and drops it, and every upstream hashtable is keyed on
+integers (`(dev, ino)` in `hlink.c:74-84`, `gnum`, `fs_dev`, an xattr-content
+checksum). The one path-shaped cache, `syscall.c:3540-3548`, holds open **dirfds**;
+upstream's own comment there argues its safety comes from an fd pinning an inode,
+which is exactly the distinction this section draws.
 
 ## 6. Explicitly out of scope
 


### PR DESCRIPTION
This started as "drop an unused dependency" and the premise did not survive contact.

## The filed premise is refuted

`flist` is **not** an unused dependency of `core`. `crates/core/src/lib.rs:67` has
`pub use ::flist;`, a genuine compile-time use. Proven by deleting the manifest line
and building, not by reading:

```
error[E0432]: unresolved import `flist`
  --> crates/core/src/lib.rs:67:9
   |
67 | pub use ::flist;
   |         ^^^^^^^ no external crate `flist`
help: consider importing this module instead
   |
67 | pub use protocol::flist;
```

That compiler hint also explains how the finding arose: `protocol::flist` is a
*module*, `flist` is a *crate*, and the product uses the former throughout. The
probe was reverted — the manifest and `Cargo.lock` are untouched here.

Dropping the dep needs the re-export removed first, which is an API change and a
separate decision. Nothing in this PR does that.

## What the investigation actually found

`BatchedStatCache` is `HashMap<PathBuf, Arc<fs::Metadata>>` with **no invalidation
hook** — only `clear()`, and nothing observes filesystem mutation. A hit answers for
whatever the path denoted at fill time, for the cache's whole lifetime.

Wiring that across a confinement boundary reopens the exact TOCTOU window the
per-component resolver exists to close: swap a component for a symlink between fill
and hit and you get the pre-swap answer. On a *miss* the re-resolve runs
`fs::metadata` on an absolute path with the process's full authority, bypassing the
ownership walk entirely.

The sharpest evidence is in the same module. `DirectoryStatBatch` holds the directory
open (`_dir_file: fs::File`) and issues `fstatat(dir_fd, name, AT_SYMLINK_NOFOLLOW)`
— an anchor plus a single component, and it caches nothing. Two types, one module,
opposite safety properties.

## Upstream has no counterpart

Verified in the pinned 3.5.0 source. `flist.c:1547-1556`'s `lastdir` interns a
directory *name* and a derived component count, never a `STRUCT_STAT`; `make_file()`
destructures each stat into scalar `file_struct` fields and drops it. Every upstream
hashtable is keyed on **integers** — `(dev, ino)` in `hlink.c:74-84`, `gnum`,
`fs_dev`, an xattr-content checksum. The one path-shaped cache (`syscall.c:3540-3548`)
holds open **dirfds**, and upstream's own comment argues its safety comes from an fd
pinning an inode. Where staleness would bite, upstream re-stats and diffs
(`sender.c:428`, `failed_op = "re-lstat"`).

So this is an oc-invented cache with no upstream analogue — a design decision, now
stated rather than silently retained.

## A second instance, in a live crate

`crates/metadata/src/stat_cache.rs::MetadataCache` has the same
`HashMap<PathBuf, …>` shape and also zero constructors outside its own tests, but it
is a `pub mod` of a crate that **is** in the default dependency graph. It is the
sharper hazard: `mode_matches`/`ownership_matches` gate whether a `chmod`/`chown` is
**skipped**, so a stale hit becomes a silently omitted permission fix rather than
merely a wrong readback. Its `invalidate()` is caller-driven, so one forgotten call
suffices.

**Containment checked, and the live applier is clean:** `apply/ownership.rs:615` and
`apply/permissions.rs:1216` thread a plain `Option<&fs::Metadata>` through one
operation — the same shape as upstream's `stat_x *` into `set_file_attrs()`. No live
path-keyed cache exists today.

## Why document rather than delete

Deletion is defensible, but several `docs/audits/*.md` cite these files by line
number, so removing them invalidates measurement records. The constraint is recorded
at the code sites a future wirer will actually read — a design doc alone would never
be seen by someone editing `cache.rs`. The design doc now names **both** instances,
and a stale struct in `BATCHED_STAT.md` showing one `Arc<Mutex<HashMap>>` where the
code has a 16-shard array is corrected.

## Scope

Documentation only; no behavioural code touched, so there is no mutation result to
report and none is claimed. `batched_stat` sits behind the non-default `parallel`
feature, which `core` does not request — it is not in a default build at all.

Gates at the pinned 1.88.0: rustfmt 3431 files clean; `clippy -p flist -p core -p
metadata --all-targets --all-features` clean; `nextest -p flist -p core -p metadata
--all-features` 4016 passed / 0 failed / 70 skipped; `cargo doc -p flist -p metadata`
clean. macOS only — not built on Linux or Windows, though the change is
comments and markdown.
