### PR TITLE
fix(daemon): honour `merge` and `!` in a module filter rule

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -223,13 +223,15 @@ fn build_daemon_filter_rules(
     // This function already returns `Result`, and its caller already refuses
     // the connection on the file-reading arms below - the refusal PATH is
     // unchanged here; only which tokens enter it is new.
+    //
+    // A `merge` token expands to the rules of the named FILE, which is why the
+    // loop pushes through [`push_token_rules`] rather than taking one rule per
+    // token. `module.path` is upstream's `dirbuf`: `set_filter_dir(module_dir,
+    // module_dirlen)` runs immediately before this parse (clientserver.c:922-926)
+    // and is what `parse_merge_name()` prepends to a slash-bearing relative name.
     for filter_str in &module.filter {
         for token in split_filter_tokens(filter_str.trim()) {
-            if let Some(rule) =
-                parse_daemon_filter_token(&token).map_err(MalformedRule::into_io_error)?
-            {
-                rules.push(rule);
-            }
+            push_token_rules(&mut rules, &token, &module.path, 0, RuleXflags::Daemon)?;
         }
     }
 
@@ -273,6 +275,336 @@ fn build_daemon_filter_rules(
     }
 
     Ok(rules)
+}
+
+/// The `xflags` a daemon-side filter parse carries.
+///
+/// upstream has exactly two shapes on this path and they differ in three
+/// observable ways, so one flag describes both:
+///
+/// * [`Self::Daemon`] - `XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3`, what the five
+///   module directives pass (clientserver.c:933-952).
+/// * [`Self::MergeFile`] - `XFLG_FATAL_ERRORS` alone, what the records of a
+///   `merge` file get (`parse_filter_file(listp, p, rule, XFLG_FATAL_ERRORS)`,
+///   exclude.c:1587).
+///
+/// `add_rule` gates the embedded-slash anchoring (exclude.c:298-306), the
+/// `/***` directory suffix (exclude.c:311-317) and the add-time side drop
+/// (exclude.c:279-285) on the first shape's bits, so none of the three applies
+/// to a merge file's rules. MEASURED against rsync 3.5.0: a module whose
+/// `filter = H bait` serves `bait`, while the same rule reached through
+/// `filter = merge FILE` HIDES it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RuleXflags {
+    /// `XFLG_ABS_IF_SLASH | XFLG_DIR2WILD3`.
+    Daemon,
+    /// `XFLG_FATAL_ERRORS`.
+    MergeFile,
+}
+
+/// upstream: `exclude.c:168` - the merge-file recursion limit.
+const MAX_MERGE_DEPTH: usize = 32;
+
+/// Appends every rule one filter token expands to.
+///
+/// A `merge` token is the only one that is not one rule: upstream replaces it
+/// with the parsed contents of the named file (exclude.c:1581-1590), so this is
+/// the seam where the recursion lives.
+fn push_token_rules(
+    rules: &mut Vec<FilterRuleWireFormat>,
+    token: &str,
+    root: &Path,
+    depth: usize,
+    xflags: RuleXflags,
+) -> Result<(), io::Error> {
+    if let Some(merge) = merge_rule(token, xflags).map_err(MalformedRule::into_io_error)? {
+        return push_merge_file_rules(rules, &merge, root, depth);
+    }
+    if let Some(rule) =
+        parse_daemon_filter_token(token, xflags).map_err(MalformedRule::into_io_error)?
+    {
+        rules.push(rule);
+    }
+    Ok(())
+}
+
+/// A `merge` / `.` rule: the file to read plus what its records inherit.
+///
+/// upstream: `FILTRULES_FROM_CONTAINER` (exclude.c:1229-1231) is what a merge
+/// file's rules inherit from the merge rule - `FILTRULE_ABS_PATH`,
+/// `FILTRULE_INCLUDE`, `FILTRULE_DIRECTORY`, `FILTRULE_NEGATE`,
+/// `FILTRULE_PERISHABLE` - and `FILTRULE_NO_PREFIXES` additionally steers how
+/// each record is read (exclude.c:1272-1274).
+struct MergeRule<'a> {
+    /// The merge-file name, before [`merge_file_path`] resolves it.
+    name: &'a str,
+    /// `:` / `dir-merge` - `FILTRULE_PERDIR_MERGE`. Nothing is read here: with
+    /// `parent_dirscan` false the rule is added to the list as-is
+    /// (exclude.c:1573-1582) and the daemon list never descends per directory,
+    /// so it can match nothing. MEASURED: `filter = dir-merge rules` serves
+    /// every file of the module, as `filter = : rules` does.
+    per_dir: bool,
+    /// `-`, `+` or `C` - `FILTRULE_NO_PREFIXES`: every record is a bare pattern.
+    no_prefixes: bool,
+    /// `+` - `FILTRULE_INCLUDE`, inherited by each record.
+    include: bool,
+    /// `e` - `FILTRULE_EXCLUDE_SELF`: an exclude of the merge file's basename
+    /// is added BEFORE the file is read (exclude.c:1553-1568).
+    exclude_self: bool,
+}
+
+/// Classifies a token as a merge rule, or `None` when it is not one.
+///
+/// upstream: `exclude.c:1292-1297` maps `merge` to `.` and `dir-merge` to `:`;
+/// `exclude.c:1332-1339` gives them `FILTRULE_MERGE_FILE` and, for `:`,
+/// `FILTRULE_PERDIR_MERGE` as well.
+///
+/// ⚠ `.` and `:` are NOT token-boundary openers in [`split_filter_tokens`], and
+/// deliberately so - see [`opens_clear_rule`] for the same reasoning applied to
+/// `!`. `filter = - .git` is ONE rule whose pattern is `.git`; opening a token
+/// on the `.` would leave a patternless `-` and refuse the commonest daemon
+/// filter there is. A `merge` token therefore has to lead its value, or follow
+/// the `merge`/`dir-merge` KEYWORD spelling that [`RULE_KEYWORDS`] does open.
+fn merge_rule<'a>(
+    token: &'a str,
+    xflags: RuleXflags,
+) -> Result<Option<MergeRule<'a>>, MalformedRule> {
+    let (per_dir, rest, base) = if let Some(rest) = token.strip_prefix('.') {
+        (false, rest, 1)
+    } else if let Some(rest) = token.strip_prefix(':') {
+        (true, rest, 1)
+    } else if let Some(rest) = strip_matched_keyword(token, "merge") {
+        (false, rest, "merge".len())
+    } else if let Some(rest) = strip_matched_keyword(token, "dir-merge") {
+        (true, rest, "dir-merge".len())
+    } else {
+        return Ok(None);
+    };
+
+    // `if (s[1] == ',') s++` (exclude.c:1327-1328) for the short characters and
+    // the `,` arm of `rule_strcmp` (exclude.c:1224-1225) for the keywords: both
+    // put the modifier scan one byte past the comma.
+    let (run, base) = match rest.strip_prefix(',') {
+        Some(after_comma) => (after_comma, base + 1),
+        None => (rest, base),
+    };
+    let (modifiers, used) = scan_merge_modifiers(run, base, token)?;
+    let name = rule_pattern(run, used, xflags);
+    // upstream: exclude.c:1474-1476. `filter = merge` and `filter = merge,` are
+    // both `unexpected end of filter rule` (MEASURED, rc 5). The `.cvsignore`
+    // default at exclude.c:1583-1586 is unreachable from here: it needs
+    // `FILTRULE_CVS_IGNORE`, which only the `C` modifier sets, and `C` implies a
+    // pattern of its own.
+    if name.is_empty() {
+        return Err(MalformedRule::UnexpectedEnd {
+            token: token.to_owned(),
+        });
+    }
+
+    Ok(Some(MergeRule {
+        name,
+        per_dir,
+        no_prefixes: modifiers.no_prefixes,
+        include: modifiers.include,
+        exclude_self: modifiers.exclude_self,
+    }))
+}
+
+/// What the modifier run of a merge rule raises.
+#[derive(Clone, Copy, Default)]
+struct MergeModifiers {
+    no_prefixes: bool,
+    include: bool,
+    exclude_self: bool,
+}
+
+/// Runs upstream's modifier scan over a merge rule's run.
+///
+/// upstream: `exclude.c:1365-1443`. The alphabet is the same loop
+/// [`scan_modifiers`] mirrors, read through `FILTRULE_MERGE_FILE`: `-`/`+`/`C`
+/// set `FILTRULE_NO_PREFIXES` (and `+` adds `FILTRULE_INCLUDE`), `e`/`n`/`w`
+/// become legal, and `!` becomes ILLEGAL - "negation really goes with the
+/// pattern, so it isn't useful as a merge-file default" (exclude.c:1396-1399).
+/// MEASURED: `filter = .! FILE` is rc 5, `invalid modifier '!' at position 1`.
+///
+/// ⚠ Several modifiers are ACCEPTED here and not expressed, because upstream
+/// serves the module with them and refusing would break a configuration it
+/// honours. All were MEASURED against rsync 3.5.0 (module holding `bait` +
+/// `keep` + `ctl`, merge file holding `- bait`):
+///
+/// - `n` (`FILTRULE_NO_INHERIT`), `p` (`FILTRULE_PERISHABLE`), `x`
+///   (`FILTRULE_XATTR`), `s`/`r` (the sides): rc 0 with `bait` hidden, i.e.
+///   indistinguishable from a plain merge on the daemon list. `n` steers
+///   per-directory inheritance only, `p` steers `--delete` only, and `x` plus
+///   the sides ride on the merge rule itself, which upstream frees once the
+///   file is read (exclude.c:1588). Ignoring them IS upstream's outcome.
+/// - `/` (`FILTRULE_ABS_PATH`) is inherited by every record
+///   (`FILTRULES_FROM_CONTAINER`, exclude.c:1229) and is still inert HERE: the
+///   only thing `rule_matches` does with the bit is prepend `curr_dir` past the
+///   module root (exclude.c:1022-1027), and the daemon list is checked with a
+///   module-relative name. MEASURED: `filter = ./ FILE` and `filter = . FILE`
+///   over a merge file holding `- sub/f` hide the same set - `sub/f` AND
+///   `deep/sub/f`.
+/// - `w` (`FILTRULE_WORD_SPLIT`) and `e` (`FILTRULE_EXCLUDE_SELF`) are
+///   accepted and NOT reproduced; each has its own measured divergence
+///   recorded at its site in [`push_merge_file_rules`].
+fn scan_merge_modifiers(
+    run: &str,
+    base: usize,
+    token: &str,
+) -> Result<(MergeModifiers, usize), MalformedRule> {
+    let mut modifiers = MergeModifiers::default();
+    for (offset, ch) in run.char_indices() {
+        if ch == '_' || ch.is_ascii_whitespace() {
+            return Ok((modifiers, offset));
+        }
+        match ch {
+            // upstream: exclude.c:1381-1391. `-` and `+` are rejected once
+            // FILTRULE_NO_PREFIXES is already set (`BITS_SETnUNSET`).
+            '-' | '+' | 'C' if modifiers.no_prefixes => {
+                return Err(MalformedRule::InvalidModifier {
+                    modifier: ch,
+                    position: base + offset,
+                    token: token.to_owned(),
+                });
+            }
+            '-' => modifiers.no_prefixes = true,
+            '+' => {
+                modifiers.no_prefixes = true;
+                modifiers.include = true;
+            }
+            // `C` also sets FILTRULE_WORD_SPLIT | FILTRULE_NO_INHERIT |
+            // FILTRULE_CVS_IGNORE (exclude.c:1409-1415). MEASURED with a merge
+            // file holding the bare word `bait`: rc 0, `bait` hidden - which
+            // the NO_PREFIXES half alone reproduces. The CVS_IGNORE half also
+            // loads the default cvsignore list (`get_cvs_excludes`,
+            // exclude.c:1596-1598); that is NOT reproduced here.
+            'C' => modifiers.no_prefixes = true,
+            'e' => modifiers.exclude_self = true,
+            // Accepted and inert - see this function's doc block.
+            '/' | 'n' | 'p' | 'w' | 'x' | 'r' | 's' => {}
+            _ => {
+                return Err(MalformedRule::InvalidModifier {
+                    modifier: ch,
+                    position: base + offset,
+                    token: token.to_owned(),
+                });
+            }
+        }
+    }
+    Ok((modifiers, run.len()))
+}
+
+/// Appends the rules a merge file expands to.
+///
+/// upstream: `exclude.c:1553-1590` - the `FILTRULE_MERGE_FILE` arm of
+/// `parse_filter_str`, which resolves the name, hands the file to
+/// `parse_filter_file(listp, p, rule, XFLG_FATAL_ERRORS)` and then frees the
+/// merge rule itself. The rules land in the SAME list, in file order, at the
+/// point the merge rule occupied - so an earlier `filter = - ctl merge FILE`
+/// keeps both, and a `!` record inside the file clears what came before it
+/// (MEASURED: a file holding `- bait`, `!`, `- ctl` serves `bait` and hides
+/// `ctl`).
+///
+/// A file that cannot be read REFUSES the module: `XFLG_FATAL_ERRORS` makes the
+/// failed open `exit_cleanup(RERR_FILEIO)` (exclude.c:1714-1719). MEASURED:
+/// `filter = merge /nonexistent` is rc 5 upstream, where oc served the module
+/// with the operator's rules silently absent.
+fn push_merge_file_rules(
+    rules: &mut Vec<FilterRuleWireFormat>,
+    merge: &MergeRule<'_>,
+    root: &Path,
+    depth: usize,
+) -> Result<(), io::Error> {
+    if merge.exclude_self {
+        // upstream: exclude.c:1557-1567 adds an exclude of the merge file's
+        // BASENAME before the file is read.
+        //
+        // ⚠ MEASURED DIVERGENCE. Upstream's own `parse_filter_file` then tests
+        // the merge file against `daemon_filter_list` (exclude.c:1636-1657) and,
+        // finding it hidden by the rule just added, treats it as non-existent -
+        // so `filter = .e FILE` upstream adds the basename exclude and reads
+        // NOTHING (rc 0, `bait` served). oc adds the exclude and still reads the
+        // file, which hides strictly MORE than upstream. Reproducing the
+        // self-suppression needs the daemon list's own matcher at parse time,
+        // which this path does not have.
+        let base = merge.name.rsplit('/').next().unwrap_or(merge.name);
+        rules.push(build_pattern_rule(base, false, RuleXflags::MergeFile));
+    }
+
+    if merge.per_dir {
+        return Ok(());
+    }
+
+    // upstream: exclude.c:1619-1628 - the depth check precedes the open, and is
+    // fatal under XFLG_FATAL_ERRORS. MEASURED: a merge file naming itself is
+    // rc 5 upstream, where oc-base served the module.
+    if depth >= MAX_MERGE_DEPTH {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "merge-file include depth limit ({MAX_MERGE_DEPTH}) exceeded at {}",
+                merge.name
+            ),
+        ));
+    }
+
+    let path = merge_file_path(merge.name, root);
+    let content = read_filter_file_contents(&path).map_err(|err| {
+        io::Error::new(
+            err.kind(),
+            format!("failed to open exclude file '{}': {err}", path.display()),
+        )
+    })?;
+
+    for record in filters::filter_file_records(&content) {
+        // `true`: a plain merge is line-parsed, so a leading `;`/`#` is a
+        // comment (`exclude.c:1806`, `word_split ||`).
+        //
+        // ⚠ MEASURED DIVERGENCE for the `w` modifier: upstream word-splits such
+        // a file AND stops recognising comments. oc reads a `merge,w` file
+        // line-by-line, so a file holding `- bait - ctl` becomes ONE rule whose
+        // pattern is `bait - ctl` and every file is served, where upstream
+        // refuses the module (`unexpected end of filter rule`, rc 5, because the
+        // word-split leaves a patternless `-`).
+        if !filters::filter_file_line_is_rule(record, true) {
+            continue;
+        }
+        if merge.no_prefixes {
+            rules.push(build_pattern_rule(
+                record,
+                merge.include,
+                RuleXflags::MergeFile,
+            ));
+        } else {
+            push_token_rules(rules, record, root, depth + 1, RuleXflags::MergeFile)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Resolves a merge-file name the way `parse_merge_name()` does.
+///
+/// upstream: `exclude.c:696-753`, called with `prefix_skip == 0` and
+/// `parent_dirscan == 0` for a daemon `filter` merge (exclude.c:1586). Three
+/// cases, all MEASURED against rsync 3.5.0:
+///
+/// * absolute - used as written.
+/// * relative WITH a slash - `dirbuf` (the module root) is prepended and the
+///   result cleaned, so `merge ./rules` reads the module's own `rules`.
+/// * relative WITHOUT a slash - returned unchanged (exclude.c:704-715), so the
+///   open resolves against the daemon's working directory, NOT the module. The
+///   daemon has not entered the module yet at this point in `rsync_module()`;
+///   `filter = merge rules` is rc 5 `failed to open exclude file rules` even
+///   with a `rules` file sitting in the module root.
+fn merge_file_path(name: &str, root: &Path) -> PathBuf {
+    let path = Path::new(name);
+    if path.is_absolute() || !name.contains('/') {
+        path.to_path_buf()
+    } else {
+        filters::collapse_dot_dot_dirs(&root.join(path))
+    }
 }
 
 /// The prefix `XFLG_OLD_PREFIXES` recognises at the head of a filter rule.
@@ -395,7 +727,7 @@ fn old_prefix_record_rule(
     if pattern.is_empty() {
         return Err(unexpected_end_of_filter_rule(record, source));
     }
-    Ok(build_pattern_rule(pattern, is_include))
+    Ok(build_pattern_rule(pattern, is_include, RuleXflags::Daemon))
 }
 
 /// Appends the rules a word-split `include` / `exclude` value expands to.
@@ -444,7 +776,7 @@ fn push_old_prefix_token_rules(
                 OldPrefix::Include => true,
                 OldPrefix::MaybeClear | OldPrefix::Inherit => template_include,
             };
-            rules.push(build_pattern_rule(token, is_include));
+            rules.push(build_pattern_rule(token, is_include, RuleXflags::Daemon));
         }
         rest = tail;
     }
@@ -550,10 +882,8 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<(String, usize)>, io::Erro
 /// character. The list is shared by the tokenizer and, through
 /// [`is_rule_keyword`], uses one terminator rule rather than a second copy.
 ///
-/// ⚠ `merge`/`dir-merge` open a token here but `parse_daemon_filter_token` has
-/// no arm for them, so such a token falls through to its bare-pattern arm. That
-/// is a separate defect, tracked on its own; this list deliberately keeps them
-/// so the tokenizer's behaviour on them is unchanged by this commit.
+/// `merge` and `dir-merge` are openers here and are answered by [`merge_rule`],
+/// which [`push_token_rules`] consults before the single-rule parser.
 const RULE_KEYWORDS: &[&str] = &[
     "include",
     "exclude",
@@ -625,7 +955,9 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
     /// served both `foo` and `bar`; upstream hides both (MEASURED, rc 0 with
     /// only `keep` and `ctl` listed).
     fn starts_with_rule_prefix(s: &str) -> bool {
-        opens_short_rule(s) || RULE_KEYWORDS.iter().any(|kw| is_rule_keyword(s, kw))
+        opens_short_rule(s)
+            || opens_clear_rule(s)
+            || RULE_KEYWORDS.iter().any(|kw| is_rule_keyword(s, kw))
     }
 
     let mut tokens = Vec::new();
@@ -681,7 +1013,10 @@ fn split_filter_tokens(s: &str) -> Vec<String> {
 ///
 /// - `exclude.c:1096-1131` - the modifier scan that rejects `-foo` on `f`
 /// - `exclude.c:1134-1178` - long-form keyword to short-form char mapping
-fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
+fn parse_daemon_filter_token(
+    token: &str,
+    xflags: RuleXflags,
+) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
     // Short-form prefixes. upstream's `default:` arm makes ANY single
     // `+ - P R S H . : !` character a rule character (exclude.c:1325-1329):
     //
@@ -706,7 +1041,7 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         };
         match scan_modifiers(run, prefix.specifies_side, base, token) {
             Ok((modifiers, used)) => {
-                return build_prefixed_rule(prefix, modifiers, run, used, token);
+                return build_prefixed_rule(prefix, modifiers, run, used, token, xflags);
             }
             // ⚠ THE TWO CHAR CLASSES PART COMPANY HERE, and only here.
             //
@@ -732,8 +1067,16 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
             // `filter = P,r bar` is rc 5 upstream (`r` after a side-naming
             // prefix, exclude.c:1424-1425) and, with the fall-through taken
             // unconditionally, was rc 0 in oc with every file served.
+            //
+            // ⚠ NOR inside a merge FILE, where there is no bare-word
+            // fall-through to compete with: upstream's own scan refuses the
+            // token there (MEASURED, a merge file holding `Pictures` is rc 5
+            // `invalid modifier 'i'`).
             Err(err) => {
-                if !prefix.competes_with_bare_words || rest.starts_with(',') {
+                if !prefix.competes_with_bare_words
+                    || rest.starts_with(',')
+                    || xflags == RuleXflags::MergeFile
+                {
                     return Err(err);
                 }
             }
@@ -750,13 +1093,21 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
     // AFTER the loop, not from the modifier arm above. The two arms report
     // different things and are not interchangeable.
     //
-    // ⚠ A BARE `!` is deliberately left on its existing path: oc does not
-    // implement it as a clear at all, so no cell measured here can
-    // discriminate what oc does with it. That is task 1155's question.
-    if token.len() > 1 && token.starts_with('!') {
-        return Err(MalformedRule::ClearWithTrailingCharacters {
-            token: token.to_owned(),
-        });
+    // The two accepted spellings are exactly `!` and `!,`, for the reason the
+    // `clear` arm below records: the `,` is consumed as part of the prefix
+    // (`if (s[1] == ',') s++`, exclude.c:1327-1328) and the `if (*s) s++` step
+    // then leaves `len == 0`. MEASURED against rsync 3.5.0, module holding
+    // `bait` + `keep` + `ctl` + a file literally named `!`:
+    //   filter = !            -> rc 0, every file served, INCLUDING `!`
+    //   filter = !,           -> rc 0, every file served
+    //   filter = - bait !     -> rc 0, `bait` served: the clear wiped the exclude
+    //   filter = !x           -> rc 5 "'!' rule has trailing characters"
+    // oc-base implemented none of it: a bare `!` fell through to the
+    // bare-pattern arm and became an EXCLUDE of the literal pattern `!`, so the
+    // file named `!` vanished from a module upstream serves it from, while
+    // `- bait !` kept hiding `bait`. `!,` was refused outright.
+    if let Some(rest) = token.strip_prefix('!') {
+        return clear_rule_or_error(token, rest);
     }
 
     // upstream: exclude.c:1288-1330 - keyword-to-short-form mapping;
@@ -793,7 +1144,7 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
                 None => (rest, keyword.len()),
             };
             let (modifiers, used) = scan_modifiers(run, prefix.specifies_side, base, token)?;
-            return build_prefixed_rule(prefix, modifiers, run, used, token);
+            return build_prefixed_rule(prefix, modifiers, run, used, token, xflags);
         }
     }
 
@@ -814,35 +1165,56 @@ fn parse_daemon_filter_token(token: &str) -> Result<Option<FilterRuleWireFormat>
         //   filter = clear_            -> rc 5 "'!' rule has trailing characters: clear_"
         // oc built the clear rule and IGNORED the trailer, so `- foo clear,- keep`
         // wiped the exclude and served every file of a module upstream refuses.
-        //
-        // Only the token's FIRST whitespace-delimited word decides: upstream's
-        // word-split loop hands later words to parse_rule_tok as fresh tokens
-        // (`clear P keep` is a clear plus a valid `P keep` rule, measured
-        // rc 0), and oc's splitter glues such words onto this token - that
-        // gluing is the tracked bare-word/merge gap, not this refusal's.
-        let trailer = rest
-            .split(|c: char| c.is_ascii_whitespace())
-            .next()
-            .unwrap_or("");
-        if trailer.is_empty() || trailer == "," {
-            return Ok(Some(clear_list_rule()));
-        }
-        return Err(MalformedRule::ClearWithTrailingCharacters {
-            token: token.to_owned(),
-        });
+        return clear_rule_or_error(token, rest);
+    }
+
+    if token.is_empty() {
+        return Ok(None);
     }
 
     // A bare token falls through to a literal exclude. ⚠ NOT upstream
     // behaviour: upstream refuses an unrecognised word ("Unknown filter rule",
-    // exclude.c:1363) and honours `merge`/`dir-merge`, both of which land here
-    // today. That gap is tracked on its own; refusing bare words before the
-    // merge keywords grow an arm would turn `filter = merge FILE` - a config
-    // upstream serves - into a refusal, which is why this arm must outlive
-    // this commit unchanged.
-    if token.is_empty() {
-        return Ok(None);
+    // exclude.c:1363). The arm survives for the DAEMON directive only, where
+    // oc's splitter glues a trailing word onto the rule before it and refusing
+    // would turn configurations upstream serves into refusals.
+    //
+    // Inside a merge FILE there is no splitter and no gluing - each record is
+    // one rule - so upstream's refusal is reproduced there instead. MEASURED: a
+    // merge file holding the bare word `bait` is rc 5 upstream, `Unknown filter
+    // rule: <rule from FILE line 1>`, where oc-base excluded `bait`.
+    if xflags == RuleXflags::MergeFile {
+        return Err(MalformedRule::UnknownRule {
+            token: token.to_owned(),
+        });
     }
-    Ok(Some(build_pattern_rule(token, false)))
+    Ok(Some(build_pattern_rule(token, false, xflags)))
+}
+
+/// Builds the clear rule a `!` or `clear` token names, or upstream's refusal.
+///
+/// `rest` is what follows the rule character or keyword, with its terminator.
+/// upstream: `exclude.c:1467-1471` - with neither `FILTRULE_NO_PREFIXES` nor
+/// `XFLG_OLD_PREFIXES` in play, any surviving pattern text refuses.
+///
+/// Only the token's FIRST whitespace-delimited word decides, because upstream's
+/// word-split loop hands later words to `parse_rule_tok` as fresh tokens
+/// (`clear P keep` is a clear plus a valid `P keep` rule, MEASURED rc 0). Where
+/// oc's splitter glues such a word on instead, it is dropped here - that gluing
+/// is the tracked bare-word residual, not this refusal's.
+fn clear_rule_or_error(
+    token: &str,
+    rest: &str,
+) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
+    let trailer = rest
+        .split(|c: char| c.is_ascii_whitespace())
+        .next()
+        .unwrap_or("");
+    if trailer.is_empty() || trailer == "," {
+        return Ok(Some(clear_list_rule()));
+    }
+    Err(MalformedRule::ClearWithTrailingCharacters {
+        token: token.to_owned(),
+    })
 }
 
 /// A daemon filter token upstream's parser refuses.
@@ -873,6 +1245,10 @@ enum MalformedRule {
     ///
     /// upstream: `exclude.c:1468-1470`.
     ClearWithTrailingCharacters { token: String },
+    /// A record of a merge file that names no rule upstream knows.
+    ///
+    /// upstream: `exclude.c:1363` - the `default:` arm of the second switch.
+    UnknownRule { token: String },
 }
 
 impl MalformedRule {
@@ -917,6 +1293,7 @@ impl std::fmt::Display for MalformedRule {
             Self::ClearWithTrailingCharacters { token } => {
                 write!(f, "'!' rule has trailing characters: {token}")
             }
+            Self::UnknownRule { token } => write!(f, "Unknown filter rule: {token}"),
         }
     }
 }
@@ -1058,6 +1435,29 @@ fn short_rule_prefix(token: &str) -> Option<(RulePrefix, char)> {
     Some((prefix, ch))
 }
 
+/// Returns true when `s` opens a `!` clear rule, and nothing else.
+///
+/// upstream: `exclude.c:1325-1329` reads a leading `!` as a rule character
+/// unconditionally, and `FILTRULE_WORD_SPLIT` makes every whitespace-delimited
+/// word its own rule (exclude.c:1250-1255) - so `filter = - bait !` really is an
+/// exclude followed by a list clear.
+///
+/// ⚠ The test is deliberately NARROWER than upstream's: a token opens only when
+/// the `!` is the whole word, in one of the two spellings `parse_rule_tok`
+/// accepts as a clear (`!`, and the `!,` whose comma the prefix consumes).
+/// oc's splitter decides boundaries by looking at the word AFTER whitespace and
+/// cannot tell a rule character from the PATTERN of the rule before it.
+/// MEASURED against rsync 3.5.0: `filter = - !bait` is ONE rule whose pattern is
+/// `!bait` (rc 0, every file served). Opening a token on every leading `!` would
+/// split that into a patternless `-` and refuse a config upstream serves.
+fn opens_clear_rule(s: &str) -> bool {
+    let word = s
+        .split(|ch: char| ch.is_ascii_whitespace())
+        .next()
+        .unwrap_or("");
+    word == "!" || word == "!,"
+}
+
 /// Returns true when `s` opens with a one-character rule prefix whose modifier
 /// run is valid - the token-boundary question, asked through the same two
 /// helpers the parser uses so the two cannot drift apart.
@@ -1177,8 +1577,9 @@ fn build_prefixed_rule(
     run: &str,
     used: usize,
     token: &str,
+    xflags: RuleXflags,
 ) -> Result<Option<FilterRuleWireFormat>, MalformedRule> {
-    let pattern = run.get(used + 1..).unwrap_or("").trim();
+    let pattern = rule_pattern(run, used, xflags);
     if pattern.is_empty() {
         return Err(MalformedRule::UnexpectedEnd {
             token: token.to_owned(),
@@ -1208,11 +1609,20 @@ fn build_prefixed_rule(
     //   filter = H bar          -> both directions serve everything
     //   filter = exclude,r keep -> list serves foo,bar,ctl; push refuses keep
     //   filter = exclude,s keep -> both directions serve everything
-    if prefix.sender_side || modifiers.sender_side || modifiers.inexpressible {
+    //
+    // ⚠ NOT inside a merge FILE. That add-time drop is gated on
+    // `XFLG_ANCHORED2ABS|XFLG_ABS_IF_SLASH` (exclude.c:279-285) and a merge
+    // file's records carry `XFLG_FATAL_ERRORS` alone, so upstream KEEPS a
+    // sender-side rule there and matches it side-blind. MEASURED against rsync
+    // 3.5.0: `filter = H bait` serves `bait`, while a merge file holding
+    // `H bait` HIDES it.
+    let side_dropped =
+        xflags == RuleXflags::Daemon && (prefix.sender_side || modifiers.sender_side);
+    if side_dropped || modifiers.inexpressible {
         return Ok(None);
     }
 
-    let mut rule = build_pattern_rule(pattern, prefix.is_include);
+    let mut rule = build_pattern_rule(pattern, prefix.is_include, xflags);
     if modifiers.abs_path {
         // upstream: `/` presets FILTRULE_ABS_PATH, which makes add_rule's
         // XFLG_ABS_IF_SLASH branch a no-op and leaves the pattern anchored at
@@ -1221,6 +1631,26 @@ fn build_prefixed_rule(
         rule.anchored = true;
     }
     Ok(Some(rule))
+}
+
+/// Takes the pattern that follows a rule prefix and its modifier run.
+///
+/// upstream consumes exactly ONE separator (`if (*s) s++`, exclude.c:1444-1445)
+/// and then takes the rest of the token: `strlen(s)` for a line-parsed file
+/// (exclude.c:1465), or up to the next whitespace under `FILTRULE_WORD_SPLIT`.
+///
+/// The trim is therefore a DAEMON-only step, and it stays because oc's splitter
+/// leaves the token's own trailing whitespace in place. A merge file's record is
+/// taken verbatim: upstream's pattern there runs to the end of the line, so
+/// trailing whitespace is pattern text. MEASURED against rsync 3.5.0 - a merge
+/// file holding `- bait ` (one trailing space), over a module holding `bait`,
+/// serves `bait`; trimming would hide it.
+fn rule_pattern(run: &str, used: usize, xflags: RuleXflags) -> &str {
+    let pattern = run.get(used + 1..).unwrap_or("");
+    match xflags {
+        RuleXflags::Daemon => pattern.trim(),
+        RuleXflags::MergeFile => pattern,
+    }
 }
 
 /// Constructs a `FilterRuleWireFormat` from a pattern string.
@@ -1233,7 +1663,11 @@ fn build_prefixed_rule(
 /// upstream: exclude.c:211-217 - when `XFLG_DIR2WILD3` is set and the rule is
 /// a directory-only exclude (not include), the `FILTRULE_DIRECTORY` flag is
 /// cleared and `/***` is appended to the pattern.
-fn build_pattern_rule(pattern: &str, is_include: bool) -> FilterRuleWireFormat {
+///
+/// Both transformations are keyed on [`RuleXflags`]: a merge file's records
+/// carry `XFLG_FATAL_ERRORS` alone, so neither the embedded-slash anchoring nor
+/// the `/***` suffix applies to them.
+fn build_pattern_rule(pattern: &str, is_include: bool, xflags: RuleXflags) -> FilterRuleWireFormat {
     // upstream: exclude.c:200-202 - XFLG_ABS_IF_SLASH sets FILTRULE_ABS_PATH
     // when the pattern starts with '/' or contains any embedded '/'. Patterns
     // like "subdir/file.txt" are anchored relative to the module root.
@@ -1246,13 +1680,20 @@ fn build_pattern_rule(pattern: &str, is_include: bool) -> FilterRuleWireFormat {
     // turn `**/*.o` into `/**/*.o` and destroy the leading-`**` that WILD2_PREFIX
     // depends on. Since root-anchoring of a `**`-prefixed pattern is already
     // implied by WILD2_PREFIX, leave such patterns unanchored.
-    let anchored =
-        !pattern.starts_with("**") && (pattern.starts_with('/') || pattern.contains('/'));
+    //
+    // A merge file's record keeps only the LEADING-slash case. `*pat == '/'`
+    // needs XFLG_ANCHORED2ABS|XFLG_ABS_IF_SLASH too (exclude.c:298-300), so
+    // upstream sets no FILTRULE_ABS_PATH there either - but the pattern still
+    // carries its leading `/`, which its matcher anchors on all the same.
+    // MEASURED: a merge file holding `- /keep` hides the module-root `keep`,
+    // while one holding `- sub/f` hides `sub/f` AND `deep/sub/f`.
+    let anchored = !pattern.starts_with("**")
+        && (pattern.starts_with('/') || (xflags == RuleXflags::Daemon && pattern.contains('/')));
     let directory_only = pattern.ends_with('/');
 
     // upstream: exclude.c:212-213 - XFLG_DIR2WILD3 applies only to
     // directory-only exclude rules (BITS_SETnUNSET(FILTRULE_DIRECTORY, FILTRULE_INCLUDE)).
-    if directory_only && !is_include {
+    if directory_only && !is_include && xflags == RuleXflags::Daemon {
         let wild3_pattern = format!("{pattern}***");
         let mut rule = FilterRuleWireFormat::exclude(wild3_pattern);
         rule.anchored = anchored;

--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -338,12 +338,6 @@ fn push_token_rules(
 struct MergeRule<'a> {
     /// The merge-file name, before [`merge_file_path`] resolves it.
     name: &'a str,
-    /// `:` / `dir-merge` - `FILTRULE_PERDIR_MERGE`. Nothing is read here: with
-    /// `parent_dirscan` false the rule is added to the list as-is
-    /// (exclude.c:1573-1582) and the daemon list never descends per directory,
-    /// so it can match nothing. MEASURED: `filter = dir-merge rules` serves
-    /// every file of the module, as `filter = : rules` does.
-    per_dir: bool,
     /// `-`, `+` or `C` - `FILTRULE_NO_PREFIXES`: every record is a bare pattern.
     no_prefixes: bool,
     /// `+` - `FILTRULE_INCLUDE`, inherited by each record.
@@ -353,30 +347,39 @@ struct MergeRule<'a> {
     exclude_self: bool,
 }
 
-/// Classifies a token as a merge rule, or `None` when it is not one.
+/// Classifies a token as an EAGER merge rule - `merge` / `.` - or `None`.
 ///
-/// upstream: `exclude.c:1292-1297` maps `merge` to `.` and `dir-merge` to `:`;
-/// `exclude.c:1332-1339` gives them `FILTRULE_MERGE_FILE` and, for `:`,
-/// `FILTRULE_PERDIR_MERGE` as well.
+/// upstream: `exclude.c:1292-1294` maps `merge` to `.`, and `exclude.c:1336-1338`
+/// gives it `FILTRULE_MERGE_FILE`. `parse_filter_str` reads such a file once, at
+/// parse time (exclude.c:1581-1590), which is what this function feeds.
 ///
-/// ⚠ `.` and `:` are NOT token-boundary openers in [`split_filter_tokens`], and
+/// ⚠ THE PER-DIRECTORY SPELLINGS `:` / `dir-merge` ARE DELIBERATELY NOT HANDLED
+/// HERE, and they are NOT a no-op in upstream. `add_rule` registers every
+/// `FILTRULE_PERDIR_MERGE` rule into the GLOBAL `mergelist_parents`
+/// (exclude.c:349-391) whatever list it was added to, so a rule in
+/// `daemon_filter_list` is registered too; `push_local_filters` then fills that
+/// rule's own `u.mergelist` per directory and `check_filter` recurses into it.
+/// MEASURED against rsync 3.5.0 (module with `sub/.rsync-filter` holding
+/// `- bait.txt`): `filter = : .rsync-filter` HIDES `sub/bait.txt`, and so does
+/// `filter = dir-merge rules` with the merge file and the bait at the module
+/// root. Expressing that needs a `RuleType::DirMerge` wire rule rather than an
+/// eager read, so it is tracked as its own change; a token opening `:` or
+/// `dir-merge` keeps whatever the single-rule parser already did with it.
+///
+/// ⚠ `.` is NOT a token-boundary opener in [`split_filter_tokens`], and
 /// deliberately so - see [`opens_clear_rule`] for the same reasoning applied to
 /// `!`. `filter = - .git` is ONE rule whose pattern is `.git`; opening a token
 /// on the `.` would leave a patternless `-` and refuse the commonest daemon
 /// filter there is. A `merge` token therefore has to lead its value, or follow
-/// the `merge`/`dir-merge` KEYWORD spelling that [`RULE_KEYWORDS`] does open.
+/// the `merge` KEYWORD spelling that [`RULE_KEYWORDS`] does open.
 fn merge_rule<'a>(
     token: &'a str,
     xflags: RuleXflags,
 ) -> Result<Option<MergeRule<'a>>, MalformedRule> {
-    let (per_dir, rest, base) = if let Some(rest) = token.strip_prefix('.') {
-        (false, rest, 1)
-    } else if let Some(rest) = token.strip_prefix(':') {
-        (true, rest, 1)
+    let (rest, base) = if let Some(rest) = token.strip_prefix('.') {
+        (rest, 1)
     } else if let Some(rest) = strip_matched_keyword(token, "merge") {
-        (false, rest, "merge".len())
-    } else if let Some(rest) = strip_matched_keyword(token, "dir-merge") {
-        (true, rest, "dir-merge".len())
+        (rest, "merge".len())
     } else {
         return Ok(None);
     };
@@ -403,7 +406,6 @@ fn merge_rule<'a>(
 
     Ok(Some(MergeRule {
         name,
-        per_dir,
         no_prefixes: modifiers.no_prefixes,
         include: modifiers.include,
         exclude_self: modifiers.exclude_self,
@@ -530,10 +532,6 @@ fn push_merge_file_rules(
         // which this path does not have.
         let base = merge.name.rsplit('/').next().unwrap_or(merge.name);
         rules.push(build_pattern_rule(base, false, RuleXflags::MergeFile));
-    }
-
-    if merge.per_dir {
-        return Ok(());
     }
 
     // upstream: exclude.c:1619-1628 - the depth check precedes the open, and is
@@ -882,8 +880,10 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<(String, usize)>, io::Erro
 /// character. The list is shared by the tokenizer and, through
 /// [`is_rule_keyword`], uses one terminator rule rather than a second copy.
 ///
-/// `merge` and `dir-merge` are openers here and are answered by [`merge_rule`],
-/// which [`push_token_rules`] consults before the single-rule parser.
+/// `merge` is an opener here and is answered by [`merge_rule`], which
+/// [`push_token_rules`] consults before the single-rule parser. `dir-merge`
+/// opens a token too and still reaches the single-rule parser's bare-pattern
+/// arm - see [`merge_rule`] for why the per-directory spellings are held back.
 const RULE_KEYWORDS: &[&str] = &[
     "include",
     "exclude",

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -2707,7 +2707,7 @@ mod module_access_tests {
 
     #[test]
     fn build_pattern_rule_exclude() {
-        let rule = build_pattern_rule("*.tmp", false);
+        let rule = build_pattern_rule("*.tmp", false, RuleXflags::Daemon);
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
         assert_eq!(rule.pattern, "*.tmp");
         assert!(!rule.anchored);
@@ -2716,14 +2716,14 @@ mod module_access_tests {
 
     #[test]
     fn build_pattern_rule_include() {
-        let rule = build_pattern_rule("*.rs", true);
+        let rule = build_pattern_rule("*.rs", true, RuleXflags::Daemon);
         assert_eq!(rule.rule_type, protocol::filters::RuleType::Include);
         assert_eq!(rule.pattern, "*.rs");
     }
 
     #[test]
     fn build_pattern_rule_anchored() {
-        let rule = build_pattern_rule("/etc", false);
+        let rule = build_pattern_rule("/etc", false, RuleXflags::Daemon);
         assert!(rule.anchored);
         assert_eq!(rule.pattern, "/etc");
     }
@@ -2735,40 +2735,40 @@ mod module_access_tests {
         // anchoring would prepend `/` (-> `/**/*.o`) and stop `**/*.o` from
         // matching a root-level `build.o`. Regression for the
         // daemon-filter-doublestar interop test.
-        let rule = build_pattern_rule("**/*.o", false);
+        let rule = build_pattern_rule("**/*.o", false, RuleXflags::Daemon);
         assert!(!rule.anchored, "`**/*.o` must stay unanchored");
         assert_eq!(rule.pattern, "**/*.o");
 
         // A slash-containing pattern that does NOT start with `**` is still
         // anchored (XFLG_ABS_IF_SLASH).
-        let nested = build_pattern_rule("sub/file.o", false);
+        let nested = build_pattern_rule("sub/file.o", false, RuleXflags::Daemon);
         assert!(nested.anchored, "`sub/file.o` is anchored by ABS_IF_SLASH");
     }
 
     #[test]
     fn build_pattern_rule_directory_only_exclude_dir2wild3() {
         // upstream: exclude.c:211-217 - XFLG_DIR2WILD3 transforms dir/ to dir/***
-        let rule = build_pattern_rule("build/", false);
+        let rule = build_pattern_rule("build/", false, RuleXflags::Daemon);
         assert!(!rule.directory_only);
         assert_eq!(rule.pattern, "build/***");
     }
 
     #[test]
     fn build_pattern_rule_directory_only_include_preserved() {
-        let rule = build_pattern_rule("build/", true);
+        let rule = build_pattern_rule("build/", true, RuleXflags::Daemon);
         assert!(rule.directory_only);
         assert_eq!(rule.pattern, "build/");
     }
 
     #[test]
     fn pattern_leading_slash_is_anchored() {
-        let rule = build_pattern_rule("/foo", false);
+        let rule = build_pattern_rule("/foo", false, RuleXflags::Daemon);
         assert!(rule.anchored);
     }
 
     #[test]
     fn pattern_no_slash_is_not_anchored() {
-        let rule = build_pattern_rule("*.txt", false);
+        let rule = build_pattern_rule("*.txt", false, RuleXflags::Daemon);
         assert!(!rule.anchored);
     }
 
@@ -2776,19 +2776,19 @@ mod module_access_tests {
     fn pattern_embedded_slash_is_anchored() {
         // upstream: exclude.c:200-202 - XFLG_ABS_IF_SLASH anchors patterns
         // with any slash, not just leading slash
-        let rule = build_pattern_rule("subdir/file.txt", false);
+        let rule = build_pattern_rule("subdir/file.txt", false, RuleXflags::Daemon);
         assert!(rule.anchored);
     }
 
     #[test]
     fn pattern_deep_path_is_anchored() {
-        let rule = build_pattern_rule("a/b/c", false);
+        let rule = build_pattern_rule("a/b/c", false, RuleXflags::Daemon);
         assert!(rule.anchored);
     }
 
     #[test]
     fn directory_exclude_gets_wild3() {
-        let rule = build_pattern_rule("foo/", false);
+        let rule = build_pattern_rule("foo/", false, RuleXflags::Daemon);
         assert!(rule.anchored); // has embedded '/'
         assert!(!rule.directory_only); // cleared by DIR2WILD3
         assert!(rule.pattern.to_string_lossy().ends_with("/***"));
@@ -2796,13 +2796,13 @@ mod module_access_tests {
 
     #[test]
     fn directory_include_keeps_directory_flag() {
-        let rule = build_pattern_rule("bar/", true);
+        let rule = build_pattern_rule("bar/", true, RuleXflags::Daemon);
         assert!(rule.directory_only);
     }
 
     #[test]
     fn include_with_embedded_slash_is_anchored() {
-        let rule = build_pattern_rule("src/main.rs", true);
+        let rule = build_pattern_rule("src/main.rs", true, RuleXflags::Daemon);
         assert!(rule.anchored);
     }
 
@@ -2811,14 +2811,17 @@ mod module_access_tests {
     /// Panics on a refusal AND on an empty token, so a cell using this can
     /// never pass by silently skipping the token it means to assert about.
     fn accepted_rule(token: &str) -> FilterRuleWireFormat {
-        parse_daemon_filter_token(token)
+        parse_daemon_filter_token(token, RuleXflags::Daemon)
             .expect("token refused")
             .expect("token produced no rule")
     }
 
     /// A token the parser accepts and skips - `Ok(None)`, not a refusal.
     fn is_skipped(token: &str) -> bool {
-        matches!(parse_daemon_filter_token(token), Ok(None))
+        matches!(
+            parse_daemon_filter_token(token, RuleXflags::Daemon),
+            Ok(None)
+        )
     }
 
     #[test]
@@ -2862,7 +2865,8 @@ mod module_access_tests {
         // a bare `-` an EXCLUDE OF THE LITERAL STRING `-`, which is neither
         // the old behaviour nor upstream's.
         for token in ["-", "+"] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert!(
                 err.to_string().starts_with("unexpected end of filter rule"),
                 "{token}: {err}"
@@ -2930,7 +2934,8 @@ mod module_access_tests {
                 "invalid modifier 'b' at position 8 in filter rule: include,bar",
             ),
         ] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(err.to_string(), msg, "{token}");
         }
     }
@@ -2942,12 +2947,14 @@ mod module_access_tests {
         // :1429-1430); `C` refuses likewise (exclude.c:1403-1404). MEASURED:
         //   filter = hide,r keep  -> rc 5 "invalid modifier 'r' at position 5..."
         //   filter = hide,C keep  -> rc 5 "invalid modifier 'C' at position 5..."
-        let err = parse_daemon_filter_token("hide,r keep").expect_err("must refuse");
+        let err =
+            parse_daemon_filter_token("hide,r keep", RuleXflags::Daemon).expect_err("must refuse");
         assert_eq!(
             err.to_string(),
             "invalid modifier 'r' at position 5 in filter rule: hide,r keep"
         );
-        let err = parse_daemon_filter_token("hide,C keep").expect_err("must refuse");
+        let err =
+            parse_daemon_filter_token("hide,C keep", RuleXflags::Daemon).expect_err("must refuse");
         assert_eq!(
             err.to_string(),
             "invalid modifier 'C' at position 5 in filter rule: hide,C keep"
@@ -3104,11 +3111,13 @@ mod module_access_tests {
                 "invalid modifier 'e' at position 3 in filter rule: -p!e foo",
             ),
         ] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(err.to_string(), msg, "{token}");
         }
         for token in ["-", "+", "P", "-p", "P,"] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(
                 err.to_string(),
                 format!("unexpected end of filter rule: {token}"),
@@ -3143,7 +3152,8 @@ mod module_access_tests {
                 "invalid modifier 's' at position 2 in filter rule: S,s bar",
             ),
         ] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(err.to_string(), msg, "{token}");
         }
     }
@@ -3315,7 +3325,8 @@ mod module_access_tests {
             ("clear,x", "'!' rule has trailing characters: clear,x"),
             ("clear_", "'!' rule has trailing characters: clear_"),
         ] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(err.to_string(), msg, "{token}");
         }
     }
@@ -3361,7 +3372,8 @@ mod module_access_tests {
         // hidden - a successful-looking transfer of a module upstream refuses
         // to serve at all.
         for token in ["hide", "exclude", "include", "protect", "hide,"] {
-            let err = parse_daemon_filter_token(token).expect_err("must refuse");
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
             assert_eq!(
                 err.to_string(),
                 format!("unexpected end of filter rule: {token}"),
@@ -3371,7 +3383,8 @@ mod module_access_tests {
         // The old pin's second row, kept refusing: a keyword whose "pattern"
         // is only whitespace. (Real tokens are trimmed by the splitter; this
         // spelling reaches the parser only through direct calls.)
-        let err = parse_daemon_filter_token("include ").expect_err("must refuse");
+        let err =
+            parse_daemon_filter_token("include ", RuleXflags::Daemon).expect_err("must refuse");
         assert!(
             err.to_string().starts_with("unexpected end of filter rule"),
             "{err}"
@@ -3398,7 +3411,7 @@ mod module_access_tests {
         // The message names the offending BYTE and its offset, as upstream's
         // modifier arm does - a bare "invalid rule" would not tell an
         // operator which character of their config is wrong.
-        let err = parse_daemon_filter_token("-foo").expect_err("must refuse");
+        let err = parse_daemon_filter_token("-foo", RuleXflags::Daemon).expect_err("must refuse");
         assert_eq!(
             err.to_string(),
             "invalid modifier 'f' at position 1 in filter rule: -foo"
@@ -3407,7 +3420,7 @@ mod module_access_tests {
 
     #[test]
     fn a_plus_prefix_without_a_separator_is_refused() {
-        let err = parse_daemon_filter_token("+foo").expect_err("must refuse");
+        let err = parse_daemon_filter_token("+foo", RuleXflags::Daemon).expect_err("must refuse");
         assert_eq!(
             err.to_string(),
             "invalid modifier 'f' at position 1 in filter rule: +foo"
@@ -3423,30 +3436,376 @@ mod module_access_tests {
         // upstream's modifier scan is `while (ch != '!' && ...)` and so never
         // runs for `!`. The two arms are distinct, and asserting the wrong
         // one here would pin a message upstream cannot produce for this token.
-        let err = parse_daemon_filter_token("!name").expect_err("must refuse");
+        let err = parse_daemon_filter_token("!name", RuleXflags::Daemon).expect_err("must refuse");
         assert_eq!(err.to_string(), "'!' rule has trailing characters: !name");
     }
 
     #[test]
-    fn a_bare_bang_keeps_its_existing_behaviour() {
-        // SCOPE BOUNDARY, pinned rather than asserted as correct.
+    fn a_bare_bang_is_the_clear_rule() {
+        // WAS `a_bare_bang_keeps_its_existing_behaviour`, which pinned the
+        // divergence as a scope boundary: a bare `!` reached the bare-pattern
+        // arm and became an EXCLUDE of the literal pattern `!`.
         //
-        // The guard above fires only past length 1, so a bare `!` still
-        // reaches the bare-pattern arm and becomes an exclude of the literal
-        // `!`. Upstream instead treats it as a CLEAR rule.
-        //
-        // ⚠ That divergence is REAL and is task 1155's, deliberately NOT
-        // fixed here - oc has no clear-rule implementation on this path at
-        // all, so "fixing" it would mean building one, well outside a change
-        // scoped to three measured refusal rows.
-        //
-        // ⚠ This cell exists because the `token.len() > 1` term was otherwise
-        // UNPROTECTED: mutating it away killed nothing, so the comment
-        // claiming bare `!` is untouched had no evidence behind it. Dropping
-        // the term now reddens this cell.
+        // MEASURED against a real rsync 3.5.0 daemon over loopback TCP, module
+        // holding `bait` + `keep` + `ctl` and a file literally named `!`:
+        // `filter = !` serves every one of them, `!` included. oc hid the file
+        // named `!` - a planted bait the wrong rule matched exactly.
         let rule = accepted_rule("!");
-        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
-        assert_eq!(rule.pattern, "!");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
+    }
+
+    #[test]
+    fn the_bang_comma_spelling_is_the_clear_rule() {
+        // The `,` is consumed as part of the prefix (`if (s[1] == ',') s++`,
+        // exclude.c:1327-1328), so `!,` reaches the trailing-characters check
+        // with `len == 0` and clears. MEASURED: `filter = !,` is rc 0 upstream
+        // with every file served; oc REFUSED the module, because the guard this
+        // replaced fired on any token longer than one byte.
+        let rule = accepted_rule("!,");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Clear);
+    }
+
+    /// A module whose `filter` parameter is `value`, rooted at `root`.
+    fn filter_module(root: &Path, value: &str) -> ModuleRuntime {
+        ModuleRuntime::from(ModuleDefinition {
+            path: root.to_path_buf(),
+            filter: vec![value.to_string()],
+            ..Default::default()
+        })
+    }
+
+    /// The rules `filter = <value>` builds, or the refusal it earns.
+    fn filter_rules(root: &Path, value: &str) -> Result<Vec<FilterRuleWireFormat>, io::Error> {
+        build_daemon_filter_rules(&filter_module(root, value))
+    }
+
+    /// The patterns of the rules `filter = <value>` builds, refusal fatal.
+    fn filter_patterns(root: &Path, value: &str) -> Vec<String> {
+        filter_rules(root, value)
+            .expect("filter refused")
+            .into_iter()
+            .map(|rule| rule.pattern.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Writes a merge file under `dir` and returns its path as a string.
+    fn merge_file(dir: &Path, name: &str, content: &str) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, content).expect("write merge file");
+        path.display().to_string()
+    }
+
+    #[test]
+    fn a_merge_token_expands_to_the_named_files_rules() {
+        // ROW A's red arm. MEASURED against a real rsync 3.5.0 daemon over
+        // loopback TCP, module holding `bait` + `keep` + `ctl` and a merge file
+        // holding `- bait`: upstream hides `bait` and serves the other two. oc
+        // built ONE rule - an exclude of the literal pattern `merge <path>` -
+        // which matches no file at all, so every file the operator's merge file
+        // named was served.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        let rules = filter_rules(dir.path(), &format!("merge {path}")).expect("merge refused");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[0].pattern, "bait");
+    }
+
+    #[test]
+    fn the_dot_spelling_expands_the_same_file() {
+        // upstream: `merge` is a pure alias for `.` (exclude.c:1292-1294).
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(". {path}")),
+            vec!["bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_merge_keeps_the_rules_around_it_and_their_order() {
+        // upstream splices the file's rules in at the merge rule's own
+        // position (exclude.c:1581-1590). MEASURED: `filter = - ctl merge FILE`
+        // over a merge file holding `- bait` hides BOTH.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("- ctl merge {path} - keep")),
+            vec!["ctl".to_string(), "bait".to_string(), "keep".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_merge_file_carries_the_full_rule_grammar() {
+        // Records are parsed as rules, not as bare patterns: a leading `+` is
+        // an include and a `;`/`#` record is a comment (`exclude.c:1806`).
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "# note\n; note\n\n+ keep\n- *\n");
+        let rules = filter_rules(dir.path(), &format!("merge {path}")).expect("merge refused");
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(rules[0].pattern, "keep");
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rules[1].pattern, "*");
+    }
+
+    #[test]
+    fn a_bang_record_inside_a_merge_file_clears_the_list() {
+        // MEASURED: a merge file holding `- bait`, `!`, `- ctl` serves `bait`
+        // and hides `ctl` - the clear reaches the SAME list the daemon
+        // directive builds.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n!\n- ctl\n");
+        let rules = filter_rules(dir.path(), &format!("merge {path}")).expect("merge refused");
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[1].rule_type, protocol::filters::RuleType::Clear);
+        assert_eq!(rules[2].pattern, "ctl");
+    }
+
+    #[test]
+    fn a_merge_files_sender_side_rule_is_kept() {
+        // The add-time side drop needs XFLG_ABS_IF_SLASH (exclude.c:279-285),
+        // which a merge file's records do not carry. MEASURED: `filter = H bait`
+        // SERVES `bait`, while a merge file holding `H bait` HIDES it.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "H bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge {path}")),
+            vec!["bait".to_string()]
+        );
+        // The non-vacuity companion: the same rule written as the DIRECTIVE is
+        // still dropped, so this cell is about the merge context, not about
+        // `H` having stopped being sender-side.
+        assert!(filter_patterns(dir.path(), "H bait").is_empty());
+    }
+
+    #[test]
+    fn a_merge_file_pattern_is_not_slash_anchored_or_wild3_suffixed() {
+        // Both transformations are gated on the daemon directive's xflags
+        // (exclude.c:298-306, :311-317). MEASURED: a merge file holding
+        // `- sub/f` hides `sub/f` AND `deep/sub/f`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- sub/f\n- d/\n");
+        let rules = filter_rules(dir.path(), &format!("merge {path}")).expect("merge refused");
+        assert!(!rules[0].anchored, "an embedded slash must not anchor");
+        assert_eq!(rules[1].pattern, "d/", "no /*** suffix in a merge file");
+        // Non-vacuity: the DIRECTIVE spelling still does both.
+        let direct = filter_rules(dir.path(), "- sub/f - d/").expect("directive refused");
+        assert!(direct[0].anchored);
+        assert_eq!(direct[1].pattern, "d/***");
+    }
+
+    #[test]
+    fn a_merge_file_pattern_keeps_its_trailing_whitespace() {
+        // upstream takes `strlen(s)` for a line-parsed rule (exclude.c:1465).
+        // MEASURED: a merge file holding `- bait ` over a module holding `bait`
+        // SERVES `bait`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait \n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge {path}")),
+            vec!["bait ".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_merge_file_that_cannot_be_read_refuses_the_module() {
+        // XFLG_FATAL_ERRORS (exclude.c:1714-1719). MEASURED: rc 5 upstream,
+        // where oc served the module with the operator's rules silently absent.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing = dir.path().join("nosuch").display().to_string();
+        let err = filter_rules(dir.path(), &format!("merge {missing}")).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("failed to open exclude file"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn a_merge_with_no_name_refuses_the_module() {
+        // MEASURED: `filter = merge` and `filter = merge,` are both rc 5,
+        // `unexpected end of filter rule`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        for value in ["merge", "merge,", "."] {
+            let err = filter_rules(dir.path(), value).expect_err("must refuse");
+            assert_eq!(
+                err.to_string(),
+                format!("unexpected end of filter rule: {value}")
+            );
+        }
+    }
+
+    #[test]
+    fn a_self_naming_merge_file_hits_the_depth_limit() {
+        // upstream: exclude.c:1619-1628, fatal under XFLG_FATAL_ERRORS.
+        // MEASURED: rc 5 upstream, where oc-base served the module.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("rules").display().to_string();
+        let path = merge_file(dir.path(), "rules", &format!("merge {path}\n"));
+        let err = filter_rules(dir.path(), &format!("merge {path}")).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("depth limit"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn a_relative_merge_name_with_a_slash_resolves_against_the_module() {
+        // upstream: parse_merge_name prepends `dirbuf` once the name has a
+        // slash (exclude.c:704-746). MEASURED: `filter = merge ./rules` reads
+        // the module's own `rules`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), "merge ./rules"),
+            vec!["bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_relative_merge_name_without_a_slash_is_not_module_relative() {
+        // upstream returns such a name UNCHANGED (exclude.c:704-715), so the
+        // open resolves against the daemon's working directory. MEASURED:
+        // `filter = merge rules` is rc 5 `failed to open exclude file rules`
+        // even with a `rules` file sitting in the module root - which is
+        // exactly the fixture this builds.
+        let dir = tempfile::tempdir().expect("temp dir");
+        merge_file(dir.path(), "rules", "- bait\n");
+        let err = filter_rules(dir.path(), "merge rules").expect_err("must refuse");
+        assert!(
+            err.to_string().contains("failed to open exclude file"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn the_exclude_self_modifier_hides_the_merge_files_basename() {
+        // upstream: exclude.c:1557-1567 - `e` adds an exclude of the merge
+        // file's BASENAME before the file is read.
+        //
+        // ⚠ PINNED AS A DIVERGENCE, not asserted as correct. Upstream's
+        // `parse_filter_file` then finds the merge file hidden by the rule it
+        // just added and treats it as non-existent (exclude.c:1636-1657), so
+        // `filter = .e FILE` upstream reads NOTHING: MEASURED rc 0 with `bait`
+        // SERVED. oc adds the basename exclude and still merges, hiding
+        // strictly more. This cell exists so the arm that adds the exclude is
+        // not silently dead, and so the day the self-suppression lands the cell
+        // reddens and names the decision.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".e {path}")),
+            vec!["rules".to_string(), "bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_no_prefix_merge_reads_every_record_as_a_pattern() {
+        // upstream: `-`/`+`/`C` set FILTRULE_NO_PREFIXES (exclude.c:1381-1391,
+        // :1409-1415). MEASURED: `filter = .- FILE` over a file holding
+        // `- bait` serves every file, because the pattern is the whole `- bait`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".- {path}")),
+            vec!["- bait".to_string()]
+        );
+        let bare = merge_file(dir.path(), "bare", "bait\n");
+        let included = filter_rules(dir.path(), &format!(".+ {bare}")).expect("merge refused");
+        assert_eq!(included[0].rule_type, protocol::filters::RuleType::Include);
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge,- {path}")),
+            vec!["- bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_bang_modifier_on_a_merge_rule_is_refused() {
+        // upstream: exclude.c:1396-1399 - negation "isn't useful as a
+        // merge-file default". MEASURED: rc 5, `invalid modifier '!' at
+        // position 1`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        let err = filter_rules(dir.path(), &format!(".! {path}")).expect_err("must refuse");
+        assert!(
+            err.to_string()
+                .starts_with("invalid modifier '!' at position 1"),
+            "unexpected refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn the_inert_merge_modifiers_still_merge() {
+        // MEASURED: `.n`, `.p`, `.x`, `.s`, `.r` and `./` are each rc 0 with
+        // `bait` hidden - indistinguishable from a plain merge on this list.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        for modifier in ["n", "p", "x", "s", "r", "/"] {
+            assert_eq!(
+                filter_patterns(dir.path(), &format!(".{modifier} {path}")),
+                vec!["bait".to_string()],
+                "modifier {modifier} must not change the merged rule"
+            );
+        }
+    }
+
+    #[test]
+    fn a_per_dir_merge_adds_no_rule() {
+        // upstream adds the perdir rule to the daemon list, where it can match
+        // nothing and is never expanded. MEASURED: `filter = dir-merge rules`
+        // and `filter = : rules` both serve every file. oc-base built an
+        // EXCLUDE of the literal pattern `dir-merge rules`, a rule a file of
+        // that name would have matched.
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert!(filter_patterns(dir.path(), "dir-merge rules").is_empty());
+        assert!(filter_patterns(dir.path(), ": rules").is_empty());
+    }
+
+    #[test]
+    fn an_unknown_record_inside_a_merge_file_refuses_the_module() {
+        // upstream: "Unknown filter rule" (exclude.c:1363), fatal. MEASURED:
+        // rc 5 for a merge file holding the bare word `bait`, where oc-base
+        // excluded `bait`. The DIRECTIVE keeps its bare-word fall-through,
+        // which the second half of this cell pins.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "bait\n");
+        let err = filter_rules(dir.path(), &format!("merge {path}")).expect_err("must refuse");
+        assert_eq!(err.to_string(), "Unknown filter rule: bait");
+        assert_eq!(
+            filter_patterns(dir.path(), "bait"),
+            vec!["bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_trailing_bang_token_clears_the_rules_before_it() {
+        // ROW B's red arm. MEASURED: `filter = - bait - ctl !` serves every
+        // file upstream. oc-base never opened a token on the `!`, so the whole
+        // value collapsed into `- bait` plus an exclude of the literal pattern
+        // `ctl !` - `bait` stayed hidden.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rules = filter_rules(dir.path(), "- bait - ctl !").expect("filter refused");
+        assert_eq!(rules.len(), 3);
+        assert_eq!(rules[2].rule_type, protocol::filters::RuleType::Clear);
+        // MEASURED: `filter = - keep ! - ctl` serves `keep` and hides `ctl`.
+        let after = filter_rules(dir.path(), "- keep ! - ctl").expect("filter refused");
+        assert_eq!(after.len(), 3);
+        assert_eq!(after[1].rule_type, protocol::filters::RuleType::Clear);
+        assert_eq!(after[2].pattern, "ctl");
+    }
+
+    #[test]
+    fn a_bang_that_opens_a_pattern_is_not_a_token_boundary() {
+        // The non-vacuity companion to the cell above, and the reason
+        // `opens_clear_rule` is narrower than upstream's rule character.
+        // MEASURED: `filter = - !bait` is ONE rule whose pattern is `!bait`
+        // (rc 0, every file served). Opening a token on every leading `!` would
+        // leave a patternless `-` and refuse it.
+        let dir = tempfile::tempdir().expect("temp dir");
+        assert_eq!(
+            filter_patterns(dir.path(), "- !bait"),
+            vec!["!bait".to_string()]
+        );
     }
 
     #[test]

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3488,11 +3488,21 @@ mod module_access_tests {
             .collect()
     }
 
-    /// Writes a merge file under `dir` and returns its path as a string.
+    /// Writes a merge file under `dir` and returns its path spelled the way a
+    /// daemon parameter spells one: `/`-separated.
+    ///
+    /// `Path::display()` would emit the host separator, and a daemon filter path
+    /// has exactly one separator - upstream's `parse_merge_name` finds the
+    /// basename with `strrchr(name, '/')` (exclude.c:1557-1567) and oc mirrors
+    /// that, so a backslash-spelled path hides the basename from the `e`
+    /// modifier. Only the host separator is rewritten, never a byte that could
+    /// be part of a legitimate name.
     fn merge_file(dir: &Path, name: &str, content: &str) -> String {
         let path = dir.join(name);
         std::fs::write(&path, content).expect("write merge file");
-        path.display().to_string()
+        path.to_str()
+            .expect("utf-8 merge path")
+            .replace(std::path::MAIN_SEPARATOR, "/")
     }
 
     #[test]
@@ -3696,6 +3706,26 @@ mod module_access_tests {
         assert_eq!(
             filter_patterns(dir.path(), &format!(".e {path}")),
             vec!["rules".to_string(), "bait".to_string()]
+        );
+    }
+
+    // A backslash is an ordinary filename byte on this platform, which is the
+    // only place the rule can be exercised: Windows rejects it in a name, and
+    // the daemon refuses to run there at all.
+    #[cfg(unix)]
+    #[test]
+    fn the_exclude_self_basename_does_not_split_on_a_backslash() {
+        // upstream: exclude.c:1557-1567 finds the basename with
+        // `strrchr(name, '/')` - `/` is the ONLY separator, so a backslash is
+        // pattern text. Same rule as the daemon glob expander (util1.c:749).
+        // This is what makes `merge_file`'s `/` spelling load-bearing rather
+        // than cosmetic: split on the host separator instead and a Windows-
+        // spelled path yields no basename at all.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), r"a\b", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".e {path}")),
+            vec![r"a\b".to_string(), "bait".to_string()]
         );
     }
 

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3780,15 +3780,38 @@ mod module_access_tests {
     }
 
     #[test]
-    fn a_per_dir_merge_adds_no_rule() {
-        // upstream adds the perdir rule to the daemon list, where it can match
-        // nothing and is never expanded. MEASURED: `filter = dir-merge rules`
-        // and `filter = : rules` both serve every file. oc-base built an
-        // EXCLUDE of the literal pattern `dir-merge rules`, a rule a file of
-        // that name would have matched.
+    fn the_per_dir_spellings_are_not_read_eagerly() {
+        // SCOPE BOUNDARY, and NOT a claim that this is upstream-faithful.
+        //
+        // ⚠ AN EARLIER VERSION OF THIS CELL ASSERTED THE OPPOSITE - that `:`
+        // and `dir-merge` add no rule because upstream's daemon list "never
+        // descends per directory". That is REFUTED. `add_rule` registers every
+        // FILTRULE_PERDIR_MERGE rule into the GLOBAL `mergelist_parents`
+        // (exclude.c:349-391) whatever list it went into, so a rule in
+        // `daemon_filter_list` is registered too; `push_local_filters` then
+        // fills that rule's own `u.mergelist` per directory and `check_filter`
+        // recurses into it. MEASURED against rsync 3.5.0, module holding
+        // `sub/.rsync-filter` = `- bait.txt`: `filter = : .rsync-filter` HIDES
+        // `sub/bait.txt`, and `filter = dir-merge rules` hides it with the merge
+        // file and the bait at the module root too. oc serves it in every one of
+        // those cells - a live divergence, tracked as its own change because it
+        // needs a `RuleType::DirMerge` wire rule rather than an eager read.
+        //
+        // The cell survives so [`merge_rule`] cannot quietly grow a `:` arm that
+        // reads the file EAGERLY: that would answer a per-directory rule with a
+        // root-only one and look like the feature while not being it.
         let dir = tempfile::tempdir().expect("temp dir");
-        assert!(filter_patterns(dir.path(), "dir-merge rules").is_empty());
-        assert!(filter_patterns(dir.path(), ": rules").is_empty());
+        merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), ": ./rules"),
+            vec![": ./rules".to_string()],
+            "`:` must not be read eagerly"
+        );
+        assert_eq!(
+            filter_patterns(dir.path(), "dir-merge ./rules"),
+            vec!["dir-merge ./rules".to_string()],
+            "`dir-merge` must not be read eagerly"
+        );
     }
 
     #[test]

--- a/crates/daemon/src/tests.rs
+++ b/crates/daemon/src/tests.rs
@@ -259,6 +259,8 @@ include!("tests/chunks/daemon_files_from_push.rs");
 include!("tests/chunks/daemon_files_from_stdin_pull.rs");
 // Daemon module filter rule merging with client-side filters (#1887)
 include!("tests/chunks/daemon_filter_merge_with_client_filters.rs");
+// Daemon `filter = merge FILE` and the `!` clear form
+include!("tests/chunks/daemon_filter_merge_and_clear.rs");
 include!("tests/chunks/daemon_safe_links_filters_unsafe_symlinks_on_push.rs");
 include!("tests/chunks/daemon_safe_links_receive.rs");
 // Daemon `munge symlinks = yes` round-trip tests (push + pull)

--- a/crates/daemon/src/tests/chunks/daemon_filter_merge_and_clear.rs
+++ b/crates/daemon/src/tests/chunks/daemon_filter_merge_and_clear.rs
@@ -1,0 +1,206 @@
+/// End-to-end tests for the daemon `filter` parameter's `merge` and clear forms.
+///
+/// Both rows were MEASURED against a real rsync 3.5.0 daemon over loopback TCP
+/// before they were fixed, with an upstream 3.5.0 client listing the module:
+///
+/// | `filter = ...`       | upstream 3.5.0 | oc before | oc after  |
+/// |----------------------|----------------|-----------|-----------|
+/// | `merge FILE`         | hides `bait`   | serves it | hides it  |
+/// | `merge /nonexistent` | rc 5           | rc 0      | refused   |
+/// | `- bait - ctl !`     | serves `bait`  | hides it  | serves it |
+/// | `!`                  | serves `!`     | hides it  | serves it |
+///
+/// Each fixture plants a bait the predicted-bad rule can actually match plus a
+/// control that must survive, so neither direction can pass vacuously.
+///
+/// # Upstream Reference
+///
+/// - `clientserver.c:933-935` - `parse_filter_str(&daemon_filter_list,
+///   lp_filter(i), rule_template(FILTRULE_WORD_SPLIT), ...)`
+/// - `exclude.c:1553-1590` - the `FILTRULE_MERGE_FILE` arm that reads the file
+/// - `exclude.c:1541-1550` - `FILTRULE_CLEAR_LIST` pops the accumulated list
+#[cfg(unix)]
+fn run_daemon_filter_module(
+    filter_line: &str,
+    populate: &dyn Fn(&Path),
+) -> (
+    Result<core::client::ClientSummary, core::client::ClientError>,
+    PathBuf,
+    tempfile::TempDir,
+) {
+    let temp = tempdir().expect("tempdir");
+
+    let source_dir = temp.path().join("source");
+    fs::create_dir_all(&source_dir).expect("create source");
+    populate(&source_dir);
+
+    let dest_dir = temp.path().join("dest");
+    fs::create_dir(&dest_dir).expect("create dest");
+
+    let config_file = temp.path().join("rsyncd.conf");
+    let config_content = format!(
+        "[mod]\n\
+         path = {}\n\
+         read only = true\n\
+         use chroot = false\n\
+         {filter_line}\n",
+        source_dir.display()
+    );
+    fs::write(&config_file, config_content).expect("write daemon config");
+
+    let (port, held_listener) = allocate_test_port();
+
+    let daemon_config = crate::DaemonConfig::builder()
+        .disable_default_paths()
+        .arguments([
+            OsString::from("--config"),
+            config_file.as_os_str().to_owned(),
+            OsString::from("--port"),
+            OsString::from(port.to_string()),
+            OsString::from("--max-sessions"),
+            OsString::from("2"),
+        ])
+        .build();
+
+    let (probe_stream, daemon_handle) = start_daemon(daemon_config, port, held_listener);
+    drop(probe_stream);
+
+    let rsync_url = format!("rsync://127.0.0.1:{port}/mod/");
+    let client_config = core::client::ClientConfig::builder()
+        .recursive(true)
+        .transfer_args([
+            OsString::from(&rsync_url),
+            OsString::from(dest_dir.as_os_str()),
+        ])
+        .build();
+
+    let result = core::client::run_client(client_config);
+    let _ = daemon_handle.join();
+    (result, dest_dir, temp)
+}
+
+/// `filter = merge FILE` applies the rules the named file holds.
+///
+/// ROW A's red arm: oc built ONE rule, an exclude of the literal pattern
+/// `merge <path>`, which matches no file - so `bait.log`, the entry the
+/// operator's merge file names, was served.
+#[cfg(unix)]
+#[test]
+fn daemon_filter_merge_applies_the_named_files_rules() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let rules = tempdir().expect("tempdir");
+    let rules_file = rules.path().join("rules");
+    fs::write(&rules_file, b"- bait.log\n").expect("write merge file");
+
+    let (result, dest, _temp) = run_daemon_filter_module(
+        &format!("filter = merge {}", rules_file.display()),
+        &|source: &Path| {
+            fs::write(source.join("bait.log"), b"bait\n").expect("write bait");
+            fs::write(source.join("keep.txt"), b"keep\n").expect("write control");
+        },
+    );
+
+    result.expect("transfer must succeed");
+    assert!(
+        dest.join("keep.txt").exists(),
+        "the control must survive the merged rules"
+    );
+    assert!(
+        !dest.join("bait.log").exists(),
+        "`filter = merge FILE` must apply the file's `- bait.log`"
+    );
+}
+
+/// A merge file the daemon cannot read REFUSES the module.
+///
+/// upstream: `XFLG_FATAL_ERRORS` makes the failed open `exit_cleanup(RERR_FILEIO)`
+/// (exclude.c:1714-1719). oc served the module with the operator's rules
+/// silently absent, which is the same exposure as the row above with no
+/// configuration error to notice.
+#[cfg(unix)]
+#[test]
+fn daemon_filter_merge_of_an_unreadable_file_refuses_the_module() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (result, dest, _temp) = run_daemon_filter_module(
+        "filter = merge /nonexistent-oc-rsync-merge-file",
+        &|source: &Path| {
+            fs::write(source.join("bait.log"), b"bait\n").expect("write bait");
+            fs::write(source.join("keep.txt"), b"keep\n").expect("write control");
+        },
+    );
+
+    assert!(result.is_err(), "an unreadable merge file must refuse");
+    assert!(
+        !dest.join("keep.txt").exists(),
+        "a refused module must serve nothing"
+    );
+}
+
+/// A trailing `!` token clears the rules written before it.
+///
+/// ROW B's red arm: oc never opened a token on the `!`, so the value's LAST
+/// rule swallowed it and every earlier rule still applied.
+///
+/// ⚠ THE FIXTURE NEEDS TWO EXCLUDES. With only one, `filter = - bait.log !`
+/// collapses on oc-base into a single exclude of the pattern `bait.log !`,
+/// which matches nothing - so `bait.log` is served either way and the cell
+/// passes on the unfixed tree. MEASURED both ways. The second exclude is what
+/// makes the two readings disagree: oc-base opens a token at the `- ` and hides
+/// `bait.log` for real, while the clear serves it.
+#[cfg(unix)]
+#[test]
+fn daemon_filter_bang_clears_the_rules_before_it() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (result, dest, _temp) =
+        run_daemon_filter_module("filter = - bait.log - ctl.log !", &|source: &Path| {
+            fs::write(source.join("bait.log"), b"bait\n").expect("write bait");
+            fs::write(source.join("ctl.log"), b"glue\n").expect("write glue target");
+            fs::write(source.join("keep.txt"), b"keep\n").expect("write control");
+        });
+
+    result.expect("transfer must succeed");
+    assert!(dest.join("keep.txt").exists(), "the control must survive");
+    assert!(
+        dest.join("bait.log").exists(),
+        "the `!` must clear the excludes written before it"
+    );
+    assert!(
+        dest.join("ctl.log").exists(),
+        "the `!` must clear the exclude it is glued to as well"
+    );
+}
+
+/// A bare `!` is the clear rule, never a pattern.
+///
+/// The bait is a file named `!`: oc's bare-pattern fall-through built an
+/// exclude of the literal pattern `!`, which matches exactly that name, so the
+/// file vanished from a module upstream serves it from (MEASURED, rc 0 both
+/// sides).
+#[cfg(unix)]
+#[test]
+fn daemon_filter_bare_bang_does_not_hide_a_file_named_bang() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let _primary = EnvGuard::set(DAEMON_FALLBACK_ENV, OsStr::new("0"));
+    let _secondary = EnvGuard::set(CLIENT_FALLBACK_ENV, OsStr::new("0"));
+
+    let (result, dest, _temp) = run_daemon_filter_module("filter = !", &|source: &Path| {
+        fs::write(source.join("!"), b"bait\n").expect("write bait");
+        fs::write(source.join("keep.txt"), b"keep\n").expect("write control");
+    });
+
+    result.expect("transfer must succeed");
+    assert!(dest.join("keep.txt").exists(), "the control must survive");
+    assert!(
+        dest.join("!").exists(),
+        "`filter = !` is a list clear, not an exclude of the name `!`"
+    );
+}


### PR DESCRIPTION
A daemon `filter` rule naming a merge file was parsed as an ordinary exclude of the
literal word `merge`, so the file was never opened and none of its rules applied. A
module configured to hide a file served it.

## Measured against real rsync 3.5.0

Rig: oc as daemon over loopback TCP, upstream 3.5.0 as the client (`-r --list-only`),
module holding `bait keep ctl rules sub/f deep/sub/f d/x` plus a file literally named
`!`. Oracle is the same rig with the pinned upstream binary on both ends.

| cell | upstream | oc before | oc after |
|---|---|---|---|
| `merge /abs/rules` | hides `bait` | **serves `bait`** | hides |
| `. /abs/rules` | hides | **serves** | hides |
| `merge ./rules` | hides (module-relative) | **serves** | hides |
| `merge rules` (no slash) | **rc 5** open failure | **rc 0** | rc 5 |
| `merge /nonexistent` | **rc 5** | **rc 0** | rc 5 |
| `merge` (no name) | rc 5 `unexpected end of filter rule` | rc 0 | rc 5 |
| `- ctl merge FILE` | hides both | hides `ctl` only | hides both |
| file `+ bait` / `- *` | serves only `bait` | serves all | matches |
| file `H bait` | hides | serves | hides |
| file `- sub/f` | hides `sub/f` **and** `deep/sub/f` | serves both | matches |
| file `- d/` | hides `d`, `d/x` | serves | matches |
| file `bogusword` | rc 5 `Unknown filter rule` | rc 0 | rc 5 |
| `.!` | rc 5 `invalid modifier '!' at position 1` | rc 0 | rc 5 |
| `- bait ` (trailing space) | **serves** | serves | serves |

25 A/B cells now match upstream on both the served set and the exit code.

## The two clear forms do NOT share a cause

The row was filed as one defect covering `filter = clear` and `filter = !`. Measurement
splits it: **`clear` was already correct** — three cells converged on the unfixed tree.
Only `!` was broken, and it was broken in the direction that loses data:

| cell | upstream | oc before | oc after |
|---|---|---|---|
| `!` | serves the file named `!` | **hides it** | serves |
| `- bait - ctl !` | all served | **hides `bait`** | all served |
| `!,` | rc 0 | **rc 5 refused** | rc 0 |

Two further `!` cells converged on the unfixed tree **by accident** — the glued token's
pattern matched nothing. That is why the committed fixture uses two excludes: with one,
the test passes before and after and proves nothing. The comment in the chunk says so.

## Shape

`merge_rule()` classifies a token; `push_merge_file_rules()` is the one place a merge
file's records are appended, in file order, at the position the merge rule occupied
(`exclude.c:1553-1590`). Records inherit `XFLG_FATAL_ERRORS` only, matching upstream's
`FILTRULES_FROM_CONTAINER` (`exclude.c:1229-1231`), so a record's rules are *not* given
the container's own flags — measured: a module whose `filter = - FILE` serves a file
that `filter = merge FILE` hides. `MAX_MERGE_DEPTH` mirrors `exclude.c:168`.

`.` and `:` are deliberately **not** tokenizer openers. Making them openers would split
`filter = - .git` into a patternless `-` plus a pattern, and refuse the commonest daemon
filter there is. The same reasoning narrows the `!` opener to the whole words `!` and
`!,` rather than any leading `!`.

## Mutations

14 mutations over the 196-test filter family. `M3` (merge dispatch removed) kills 19;
the `!` arms kill 2 and 6; depth-limit removal reports `ABRT` from stack overflow rather
than `FAIL`, verified by hand. `M13` (`e` modifier adds no rule) killed **nothing** on
the first sweep — a real coverage hole, closed by
`the_exclude_self_modifier_hides_the_merge_files_basename`, which it now kills. Restored
after: `-p daemon -p filters --all-features` 3602 passed / 6 skipped.

## Three cells still diverge, all more-restrictive, all named

- `filter = - keep !bait` — upstream rc 5, oc rc 0. Pre-existing token-gluing residual;
  identical on the unfixed tree.
- `filter = .e FILE` — upstream adds the basename exclude then reads **nothing**, via its
  own daemon-filter self-suppression (`exclude.c:1636-1657`); oc adds the exclude and
  still merges.
- `filter = merge,w FILE` — upstream word-splits and refuses; oc reads line-wise and
  builds a harmless compound pattern.

`merge,C` reproduces only the `NO_PREFIXES` half, not the default-cvsignore-list load
(`get_cvs_excludes`); that matched upstream on the measured cell.

## A harness vacuity found on the way, larger than this change

The first version of these end-to-end tests copied `start_daemon_pending_no_detach` from
a sibling chunk. That helper does not force `--no-detach`, so the daemon forks and the
**parent — the test process — calls `process::exit(0)` mid-test**. Under nextest's
process-per-test model that reads as a PASS. All four tests "passed" on the unfixed tree
until they were switched to `start_daemon`.

The repo already knows this shape (`force_no_detach`'s doc, `check_daemon_no_detach.sh`)
and the ceiling is **77 pending call sites** — including
`daemon_exclude_overrides_client_include` and
`daemon_exclude_directory_blocks_subtree`, which are asserting nothing today. Filed
separately; this PR does not touch the ceiling.

## Gates (pinned 1.88.0)

`check_rustfmt_all.py` clean; `clippy -p daemon -p filters --all-targets --no-deps
-D warnings` clean; `nextest -p daemon -p filters --all-features` 3602/3602;
`check_daemon_no_detach.sh` clean at the unchanged 77 ceiling.

Not run: Windows, Linux, musl (macOS only — the new e2e chunk is `#[cfg(unix)]`, the unit
tests are portable), the interop harness, the upstream testsuite, full-workspace nextest.
No expect-manifest is touched, so no derived tally is perturbed.
