### PR TITLE
ci: stop an unrelated apt repo's index failure from failing the job

### DIFF
--- a/.github/workflows/_test-features.yml
+++ b/.github/workflows/_test-features.yml
@@ -256,7 +256,7 @@ jobs:
       - name: Install APT packages
         if: matrix.apt != ''
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y --no-install-recommends ${{ matrix.apt }}
 
       - name: Rust cache

--- a/.github/workflows/bench-daemon-coldstart.yml
+++ b/.github/workflows/bench-daemon-coldstart.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y rsync hyperfine jq
 
       - name: Build oc-rsync (release)

--- a/.github/workflows/bench-daemon-concurrency.yml
+++ b/.github/workflows/bench-daemon-concurrency.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y rsync hyperfine jq time
 
       - name: Build oc-rsync (release)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y build-essential autoconf automake libtool \
             libacl1-dev libattr1-dev zlib1g-dev libxxhash-dev libzstd-dev liblz4-dev \
             openssh-server libssl-dev

--- a/.github/workflows/build-rsync-2-6-9.yml
+++ b/.github/workflows/build-rsync-2-6-9.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Install build dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y build-essential autoconf
 
       - name: Build rsync 2.6.9 via helper script

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,14 +717,18 @@ jobs:
           # Cold miss only: resolve and download the package set once. There is
           # no retry - a failure here fails the job immediately and loudly, with
           # the apt diagnostics needed to tell a mirror outage from a package
-          # that has been renamed out from under us.
+          # that has been renamed out from under us. The index refresh goes
+          # through apt_update.sh, which forwards every failure except the one
+          # apt itself declares ignorable (a third-party repo's index that was
+          # skipped in favour of the cached copy); the download below is what
+          # decides whether the compiler is actually resolvable.
           if ! compgen -G "$debs/*.deb" >/dev/null; then
             # Empty apt's archive dir first so the copy below picks up only what
             # this install resolves, never leftovers from the image build - an
             # unrelated .deb swept into the cache would be dpkg -i'd on every
             # later hit.
             sudo apt-get clean
-            if ! sudo apt-get update; then
+            if ! bash tools/ci/apt_update.sh; then
               echo "apt-get update failed; mingw-w64 cannot be resolved" >&2
               apt-cache policy gcc-mingw-w64-x86-64 2>&1 | head -30 >&2 || true
               exit 1
@@ -887,7 +891,7 @@ jobs:
         run: rustup target add x86_64-unknown-linux-musl
 
       - name: Install musl toolchain
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        run: bash tools/ci/apt_update.sh && sudo apt-get install -y musl-tools
 
       - name: Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2

--- a/.github/workflows/mdf-8-filter-diff.yml
+++ b/.github/workflows/mdf-8-filter-diff.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install upstream rsync
         run: |
-          sudo apt-get update
+          bash tools/ci/apt_update.sh
           sudo apt-get install -y rsync
           /usr/bin/rsync --version | head -n 1
 

--- a/.github/workflows/release-cross.yml
+++ b/.github/workflows/release-cross.yml
@@ -183,7 +183,7 @@ jobs:
               } > /etc/apt/sources.list.d/ubuntu-ports-arm64.sources
             ' sh "$codename"
 
-            sudo apt-get update
+            bash tools/ci/apt_update.sh
             sudo apt-get -y install \
               pkg-config \
               libssl-dev \
@@ -200,7 +200,7 @@ jobs:
               zlib1g-dev:arm64 \
               libxxhash-dev:arm64
           else
-            sudo apt-get update
+            bash tools/ci/apt_update.sh
             sudo apt-get -y install \
               pkg-config \
               libssl-dev \

--- a/tools/ci/apt_update.sh
+++ b/tools/ci/apt_update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Refresh the APT indexes without letting an unrelated third-party repository
+# fail the job.
+#
+# WHY THIS EXISTS
+#
+# The GitHub runner image ships source lists for repositories this project has
+# no interest in - Google Chrome, Microsoft, and whatever a future image adds.
+# When one of them republishes its Release between the Release fetch and the
+# index fetch, `apt-get update` reports:
+#
+#     Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
+#       Hash Sum mismatch
+#     ...
+#     E: Failed to fetch https://dl.google.com/.../Packages.gz  Hash Sum mismatch
+#     E: Some index files failed to download. They have been ignored, or old ones used instead.
+#
+# and exits 100. Measured on run 34376473178 (2026-09-09), where it failed
+# `Linux musl (stable)` and `Linux musl (nightly)` at the "Install musl
+# toolchain" step - before a single line of this project was compiled - on a
+# pull request whose entire diff was doc comments.
+#
+# THE CONTRACT
+#
+# `apt-get update` is a best-effort index refresh; `apt-get install` is the
+# gate. That split is apt's own: the summary line above says the failed indexes
+# were IGNORED and the cached ones used, and the Ubuntu archive indexes this
+# project actually needs fetched successfully in the same run. If the package a
+# caller wants is genuinely unresolvable, its `apt-get install` says so by name
+# and fails there, which is a better diagnostic than exit 100 from a repository
+# nobody asked for.
+#
+# So: exit 0 when every error apt reported is a per-URL index fetch covered by
+# its own "they have been ignored" summary, and emit a warning naming the URLs
+# so the degradation is visible rather than silent. Exit non-zero - unchanged -
+# for anything else, including a lock conflict, a broken sources.list, or an
+# archive that is wholly unreachable.
+#
+# This is not a retry. A retry would paper over a genuine outage and cost a
+# minute doing it; this reclassifies one specific, self-declared-recoverable
+# failure and leaves every other one fatal.
+set -uo pipefail
+
+readonly IGNORED_SUMMARY='Some index files failed to download. They have been ignored, or old ones used instead.'
+
+output=$(sudo apt-get update 2>&1) && status=0 || status=$?
+printf '%s\n' "$output"
+
+if [ "$status" -eq 0 ]; then
+    exit 0
+fi
+
+# apt did not declare the failure recoverable, so it is not.
+if ! grep -qF "E: $IGNORED_SUMMARY" <<<"$output"; then
+    printf '::error::apt-get update failed (exit %s); apt did not report the failure as ignorable\n' "$status"
+    exit "$status"
+fi
+
+# The summary line covers index downloads only. Any other error - a lock, a
+# malformed source, a missing key - rides in on the same exit code and must
+# still be fatal, so it is matched out explicitly rather than assumed absent.
+unexplained=$(grep '^E: ' <<<"$output" | grep -vF "E: $IGNORED_SUMMARY" | grep -v '^E: Failed to fetch ')
+if [ -n "$unexplained" ]; then
+    printf '::error::apt-get update reported errors beyond the ignored index downloads:\n%s\n' "$unexplained"
+    exit "$status"
+fi
+
+urls=$(grep '^E: Failed to fetch ' <<<"$output" | awk '{ print $4 }' | tr '\n' ' ')
+count=$(grep -c '^E: Failed to fetch ' <<<"$output")
+printf '::warning::apt-get update ignored %s unreachable index file(s); the install step remains the gate: %s\n' \
+    "$count" "$urls"
+exit 0

--- a/tools/ci/ensure_apt_packages.sh
+++ b/tools/ci/ensure_apt_packages.sh
@@ -83,7 +83,9 @@ fi
 printf '::warning::APT cache restored without payload; installing %d missing package(s): %s\n' \
     "${#missing[@]}" "${missing[*]}"
 
-sudo apt-get update
+# Index refresh is best effort; the install below plus the dpkg re-check are the
+# gate. See apt_update.sh for which failures it forwards and which it swallows.
+bash "$(dirname "$0")/apt_update.sh"
 sudo apt-get install -y --no-install-recommends "${missing[@]}"
 
 # Re-ask dpkg. `apt-get install` can exit 0 having skipped a package it could

--- a/tools/tests/test_apt_update.py
+++ b/tools/tests/test_apt_update.py
@@ -1,0 +1,174 @@
+"""Unit tests for tools/ci/apt_update.sh.
+
+The script reclassifies exactly one `apt-get update` failure - index files that
+apt itself reports as ignored - as non-fatal, and leaves every other failure
+fatal. Both halves have to be tested, and the second half is the one that keeps
+the first half honest: a script that simply swallowed exit 100 would pass every
+test about the Chrome hash-sum case and quietly hide a lock conflict.
+
+CI cannot exercise either path on demand. Whether a third-party repository
+republishes its Release mid-fetch on a given run is not something the run
+controls, so a green workflow proves the script is wired, never that it
+classifies correctly. These tests are the only thing that does.
+
+`sudo` is stubbed on PATH with a canned transcript, so the tests install
+nothing, need no root, and run identically on a developer machine and a runner.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "tools" / "ci" / "apt_update.sh"
+
+CLEAN = """\
+Hit:1 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+Fetched 126 kB in 1s (126 kB/s)
+Reading package lists...
+"""
+
+# Transcript captured verbatim from job 102552809625 of run 34376473178
+# (2026-09-09), the failure this script exists for. The Ubuntu archive indexes
+# all fetched; Google's Chrome repository republished its Release mid-fetch.
+CHROME_HASH_MISMATCH = """\
+Get:23 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [334 kB]
+Get:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages [1405 B]
+Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
+  Hash Sum mismatch
+  Hashes of expected file:
+   - Filesize:1405 [weak]
+   - SHA256:233e56de019b57db89238fa7bcc3647718dbbea3a40c2dc1c633a8c8952aa9e9
+  Hashes of received file:
+   - SHA256:bc1428ab27c6d76ee9bb76de07f1ded0ddb4aaabd958fc72855634ef5894a4b3
+  Last modification reported: Wed, 09 Sep 2026 09:41:12 +0000
+  Release file created at: Wed, 09 Sep 2026 17:16:59 +0000
+Fetched 9436 kB in 1s (9511 kB/s)
+Reading package lists...
+E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
+   Hashes of expected file:
+    - Filesize:1405 [weak]
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+"""
+
+LOCK_CONFLICT = """\
+Reading package lists...
+E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4242
+E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
+"""
+
+# The decisive mixed case: a real error arriving alongside the ignorable
+# summary. Reclassifying on the summary alone would swallow the lock too.
+IGNORED_PLUS_LOCK = """\
+Reading package lists...
+E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
+E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 4242
+E: Some index files failed to download. They have been ignored, or old ones used instead.
+"""
+
+NO_DIAGNOSTIC = """\
+Reading package lists...
+"""
+
+
+class AptUpdateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tempdir.name)
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _stub_sudo(self, transcript: str, exit_code: int) -> None:
+        canned = self.tmp / "apt-output.txt"
+        canned.write_text(transcript)
+        stub = self.bin / "sudo"
+        stub.write_text(
+            "#!/bin/sh\n"
+            f'cat "{canned}"\n'
+            f"exit {exit_code}\n"
+        )
+        stub.chmod(0o755)
+
+    def _run(self) -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        return subprocess.run(
+            ["bash", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def test_clean_update_succeeds_silently(self) -> None:
+        self._stub_sudo(CLEAN, 0)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("::warning::", result.stdout)
+        self.assertNotIn("::error::", result.stdout)
+
+    def test_ignored_index_download_is_not_fatal_and_is_announced(self) -> None:
+        # The measured case. apt exits 100 having declared the failed indexes
+        # ignored; the caller's `apt-get install` is what decides whether the
+        # package it wants is resolvable.
+        self._stub_sudo(CHROME_HASH_MISMATCH, 100)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("::warning::", result.stdout)
+        self.assertIn("ignored 1 unreachable index file(s)", result.stdout)
+        self.assertIn("dl.google.com", result.stdout)
+        self.assertNotIn("::error::", result.stdout)
+
+    def test_lock_conflict_stays_fatal(self) -> None:
+        self._stub_sudo(LOCK_CONFLICT, 100)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 100)
+        self.assertIn("::error::", result.stdout)
+        self.assertIn("did not report the failure as ignorable", result.stdout)
+
+    def test_a_real_error_alongside_the_ignorable_summary_stays_fatal(self) -> None:
+        # Without this, the script would be a blanket swallow of exit 100
+        # wearing a hash-sum-shaped excuse.
+        self._stub_sudo(IGNORED_PLUS_LOCK, 100)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 100)
+        self.assertIn("::error::", result.stdout)
+        self.assertIn("beyond the ignored index downloads", result.stdout)
+        self.assertIn("Could not get lock", result.stdout)
+
+    def test_failure_without_any_diagnostic_stays_fatal(self) -> None:
+        self._stub_sudo(NO_DIAGNOSTIC, 100)
+
+        result = self._run()
+
+        self.assertEqual(result.returncode, 100)
+        self.assertIn("::error::", result.stdout)
+
+    def test_apt_output_is_always_echoed(self) -> None:
+        # The transcript is the diagnostic. Reclassifying the exit status must
+        # not also hide what apt said.
+        self._stub_sudo(CHROME_HASH_MISMATCH, 100)
+
+        result = self._run()
+
+        self.assertIn("Hash Sum mismatch", result.stdout)
+        self.assertIn("Fetched 9436 kB", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The failure

`apt-get update` exits 100 when **any** configured repository's index fails to download - including third-party repositories the GitHub runner image ships and this project never uses. On 2026-09-09 Google's Chrome repo republished its `Release` mid-fetch, and every job that refreshed the index in that window died:

```
Err:14 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Process completed with exit code 100.
```

## Blast radius, measured

**12 red jobs, four differently named setup steps, five workflows, four pull requests** whose diffs are unrelated to each other and to apt:

| failing step | workflow | PRs |
| --- | --- | --- |
| Install musl toolchain (stable, beta, nightly) | `ci.yml` | #7793 |
| Install APT packages | `_test-features.yml` | #7793, #7794 |
| Verify APT packages are installed | `_interop.yml` | #7794, #7796 |
| Install dependencies | `bench-daemon-*.yml` | #7795 |

Every one was **read, not inferred from its step name**. All 12 carry byte-identical Chrome transcripts - the same `Err:` line, the same Hash Sum mismatch, the same ignorable-summary line, the same exit 100 - which is what justifies folding them into one diagnosis rather than twelve.

Every one failed **before a line of this project was compiled** (`Build` and `Test` are `SKIPPED` in the step list), and the Ubuntu archive indexes each job actually needed had fetched successfully.

## The fix

`tools/ci/apt_update.sh` makes the split explicit: **the index refresh is best effort, `apt-get install` is the gate.**

It exits 0 only when every error apt reported is a per-URL index fetch covered by apt's own summary line - *"they have been ignored, or old ones used instead"* - and emits a `::warning::` naming the skipped URLs so the degradation stays visible. Every other failure keeps its exit status and stays fatal:

- a `dpkg` lock conflict
- a malformed `sources.list` / missing key
- a failure apt reported with no diagnostic at all
- **an ignorable summary arriving alongside a real error** - matched out explicitly rather than assumed absent

A package that genuinely cannot be resolved now fails at the install step, with apt naming the package - a better diagnostic than exit 100 from the refresh.

**This is not a retry.** A retry would paper over a genuine outage and cost a minute doing it. This reclassifies one specific, self-declared-recoverable failure and leaves every other one fatal.

## One owner

Every `apt-get update` in `.github/workflows/` and in `ensure_apt_packages.sh`'s repair path routes onto that script - **11 call sites, zero bare invocations left**, 54 workflow YAMLs parse:

`ci.yml` (3) · `release-cross.yml` (2) · `ensure_apt_packages.sh` (2) · `_test-features.yml` · `bench-daemon-coldstart.yml` · `bench-daemon-concurrency.yml` · `benchmark.yml` · `build-rsync-2-6-9.yml` · `mdf-8-filter-diff.yml`

Note on `release-cross.yml`: it adds the arm64 ports sources immediately before the refresh, so if *those* indexes fail the subsequent `install ...:arm64` fails by package name. That is the contract working as designed, and a strictly better diagnostic than the current exit 100.

The mingw-w64 comment block is corrected in the same commit rather than left describing behaviour that changed.

## Tests

`tools/tests/test_apt_update.py` - 6 hermetic cells, stubbing `sudo` on `PATH` with a canned transcript, picked up automatically by `tools/ci/run_tools_tests.sh`'s pattern discovery.

The **decisive** cell replays the real captured transcript from job 102552809625. The one that keeps it **honest** is a lock conflict arriving alongside the ignorable summary: a blanket swallow of exit 100 would pass the first and silently hide the second.
