### PR TITLE
docs(ssh): ssh-config-parse honours Host and Match blocks

### DIFF
--- a/crates/rsync_io/Cargo.toml
+++ b/crates/rsync_io/Cargo.toml
@@ -59,15 +59,25 @@ async-ssh = ["dep:tokio"]
 # ssh-config-parse:
 #   what:    Extends `SshCommand::has_ssh_compression` to consult
 #            `~/.ssh/config` and `/etc/ssh/ssh_config` for `Compression yes`
-#            at top level or under `Host *`, closing the SSC-3 gap where a
-#            user-configured default would silently double-compress when
-#            paired with rsync's `--compress`.
+#            at top level or under a matching `Host` or `Match` block,
+#            closing the SSC-3 gap where a user-configured default would
+#            silently double-compress when paired with rsync's `--compress`.
 #   why:     SSC-1 (argv warning) misses the case where the user sets
 #            `Compression yes` globally in ssh_config and never passes `-C`
 #            on the rsync command line.
-#   scope:   Top-level and `Host *` directives only. Per-host `Host foo`
-#            blocks and `Match` blocks are deferred because they need
-#            runtime context the warning site does not have.
+#   scope:   Top-level directives, `Host` blocks (SSC-5.b: glob and
+#            negation tokens matched against the connection target, so
+#            `Host foo` and `Host !bad *` both resolve), and `Match`
+#            blocks over the `host`, `originalhost`, `user`, `localuser`
+#            and `all` conditions (SSC-4.c). The warning site supplies
+#            that context from the connection target and user - see
+#            `SshCommand::has_ssh_compression` in `src/ssh/builder.rs`.
+#            `Match exec` is refused by design: evaluating it would run
+#            arbitrary commands from a passive lookup path, so the block
+#            is inert and a `Compression yes` inside one draws a warning
+#            naming the workaround. `canonical`, `final` and `tagged`
+#            likewise render their block inert, as oc neither canonicalises
+#            hostnames nor makes a final pass.
 #   safety:  Pure Rust, no extra dependencies, no unsafe code.
 #   opt out: `cargo build -p rsync_io --no-default-features` (then re-add
 #            any other features you need). Without this feature the


### PR DESCRIPTION
The `ssh-config-parse` feature comment said per-host `Host foo` blocks and `Match`
blocks were deferred "because they need runtime context the warning site does not
have". Both statements are false, and the stated reason is refuted by the code that
supplies exactly that context.

Verified before editing, not assumed:

| claim in the old comment | what the tree does |
| --- | --- |
| only `Host *` is honoured | `config_lookup/parser.rs:85-96` builds `Block::Host(parse_pattern_list(value))` and matches it with `pattern_list_matches(.., MatchKind::Host)` against the connection target — glob and negation tokens included |
| `Match` blocks deferred | `config_lookup/match_block.rs:152-205` evaluates `all`, `host`, `originalhost`, `user`, `localuser`; the parser caches the verdict as `Block::MatchEvaluated` |
| "needs runtime context the warning site does not have" | `ssh/builder.rs:326-345` builds the `MatchContext` from host and user before calling the lookup |

The new comment records the real scope **including the conditions that are
deliberately inert**, so it does not overclaim in the other direction:

- `Match exec` is refused by design — evaluating it would run arbitrary commands
  from a passive lookup path. The block stays inert and a `Compression yes` inside
  one draws a warning naming the workaround.
- `canonical`, `final` and `tagged` return false, since oc neither canonicalises
  hostnames nor makes a final pass.

## Scope

Comment-only, one file. No behavioural surface, so there is nothing to mutate and no
test is added — stated explicitly rather than papered over with a token assertion.

## Gates (pinned 1.88.0)

- `tools/ci/check_rustfmt_all.py` — 3430 files, clean
- `cargo clippy -p rsync_io --all-targets --no-deps -- -D warnings` — clean
- `cargo nextest run -p rsync_io --lib` — 884 passed, 0 skipped

## Related drift found and NOT fixed here

The same false "deferred" claim is mirrored in `docs/design/ssc-5-host-pattern-audit.md`,
`docs/design/ssc-4a-match-conditions.md:7`, and the module comment at
`ssh/embedded/ssh_config_differential.rs:54`. Those docs also cite `config_lookup.rs`
as a single file, but it is now a module directory
(`config_lookup/{mod,parser,match_block,pattern,paths}.rs`), so every
`config_lookup.rs:<line>` reference in them is dangling. That is a doc sweep of its
own and is tracked separately; this PR is scoped to the feature manifest comment.
