### PR TITLE
docs: record the three structural-constant closures

### DIFF
--- a/docs/design/structural-constant-measurement-gate.md
+++ b/docs/design/structural-constant-measurement-gate.md
@@ -130,38 +130,47 @@ their provenance, not an assertion that any value is wrong.
 The peer-facing row is first among equals. For everything else an arbitrary value
 costs throughput; there, it is what an untrusted peer can make the daemon accept.
 
-## Three that look mirrored and are not
+## Three that looked mirrored and were not
 
-Value equality is not provenance. Each of these matches upstream today for a
-reason that does not hold in general.
+Value equality is not provenance. Each of these matched upstream's value while
+resting on a rule that did not hold in general, and all three have since been
+closed. The entries stay, with their closures recorded, because the shape recurs
+and because each fix is the evidence that the reading was right.
 
-**The hash table mirrors a floor and drops the growth.** `TAG_TABLE_SIZE` is
-`1 << 16` in `crates/matching/src/index/mod.rs:57` and again in
-`optimized_search.rs:12`, documented as matching upstream's `TABLESIZE`.
-Upstream's constant is named `TRADITIONAL_TABLESIZE` (`match.c:45`) and is a
-floor, not a size: `build_hash_table` computes `tablesize = (s->count/8) * 10 +
-11` and raises it to the floor only if it comes out smaller (`match.c:86-88`),
-with the stated intent of holding hash load near 80 percent for big files.
-Upstream then runs different insert and probe paths depending on whether it grew
-(`match.c:98`, `match.c:215`). Above roughly 52k blocks upstream's table grows
-and oc's does not, so oc's chains lengthen as block count rises. That is a
-candidate cause for the measured delta-matching gap on large files, and it is
-also a warning: a port of the formula alone would be incomplete, because the
-two-path branch and the odd-number constraint travel with it.
+**The hash table mirrored a floor and dropped the growth.** `TAG_TABLE_SIZE` is
+`1 << 16` at `crates/matching/src/index/mod.rs:68`, documented as matching
+upstream's `TABLESIZE`. Upstream's constant is named `TRADITIONAL_TABLESIZE`
+(`match.c:45`) and is a floor, not a size: `build_hash_table` computes
+`tablesize = (s->count/8) * 10 + 11` and raises it to the floor only if it comes
+out smaller (`match.c:84-88`), with the stated intent of holding hash load near
+80 percent for big files. Upstream then runs different insert and probe paths
+depending on whether it grew (`match.c:98`, `match.c:215`). Above roughly 52k
+blocks upstream's table grew and oc's did not, so oc's chains lengthened as block
+count rose. Closed by #7790: `CompactLookup` grows on upstream's rule and carries
+both addressing modes, and `TAG_TABLE_SIZE` is documented as the tag-array size
+alone, explicitly not the growth-bearing structure. The warning in the original
+entry held - the two-path branch and the odd-number constraint did travel with
+the formula.
 
-**A digest bound is written where upstream derives one.** `MAX_XATTR_DIGEST_LEN`
-is the literal 16 in `crates/protocol/src/xattr/mod.rs:64`; upstream writes
-`#define MAX_XATTR_DIGEST_LEN MD5_DIGEST_LEN` (`xattrs.c:48`). The values agree
-because MD5 is 16 bytes. If the digest ever changes, upstream's bound follows and
-oc's does not, and the symptom would be a wire-length mismatch in a decoder
-rather than a compile error.
+**A digest bound was written where upstream derives one.** `MAX_XATTR_DIGEST_LEN`
+was the literal 16 in `crates/protocol/src/xattr/mod.rs`; upstream writes
+`#define MAX_XATTR_DIGEST_LEN MD5_DIGEST_LEN` (`xattrs.c:48`). The values agreed
+because MD5 is 16 bytes, so a digest change would have moved upstream's bound and
+not oc's, and the symptom would have been a wire-length mismatch in a decoder
+rather than a compile error. Closed by #7786: the bound is derived from the hasher
+that fills the buffer, with a const assertion pinning it to 16 so the derivation
+cannot drift into a wire-format change.
 
-**One bound is copied nine times.** `MAX_INPUT_SIZE` (1 MiB) is defined
+**One bound was copied at every backend.** `MAX_INPUT_SIZE` (1 MiB) was defined
 independently in each SIMD checksum backend under
 `crates/checksums/src/simd_batch/`. Each copy decides whether its backend bails
-to the scalar path. Nine copies means one edit can desynchronise batch
-eligibility across architectures, and parity tests that compare outputs cannot
-see it, because both paths produce correct output.
+to the scalar path, so one edit could desynchronise batch eligibility across
+architectures, and parity tests that compare outputs cannot see that, because
+both paths produce correct output. Closed by #7787: one definition at
+`simd_batch/mod.rs:46`, every backend importing it, and the bound itself tested
+for the first time. The count in the original entry was low - the sweep found
+twelve sites, eleven constants plus one bare literal that no grep for the name
+could reach.
 
 ## What a proposal has to carry
 

--- a/docs/design/zsync-inspired-matching.md
+++ b/docs/design/zsync-inspired-matching.md
@@ -261,6 +261,6 @@ for each technique is recorded in #2054 once benchmarks land.
   - `librcksum/internal.h`, `hash.c`, `rsum.c`, `state.c`, `rcksum.h`
 - Upstream rsync 3.4.1: `target/interop/upstream-src/rsync-3.4.1/`
   - `match.c`, `token.c`, `checksum.c`
-- oc-rsync match crate: `crates/match/src/{generator.rs, optimized_search.rs,
-  script.rs, ring_buffer.rs, index/{builder,mod}.rs}`
+- oc-rsync matching crate: `crates/matching/src/{generator.rs, script.rs,
+  ring_buffer.rs, index/{builder,mod}.rs}`
 - oc-rsync rolling Adler: `crates/checksums/src/rolling/checksum/{mod,x86,neon}.rs`


### PR DESCRIPTION
`docs/design/structural-constant-measurement-gate.md` shipped its "Three that look mirrored and are not" section in #7779. All three entries were fixed within a day, so the section now describes defects that no longer exist — and one of them cites a file that #7798 deletes.

## Each closure verified in the tree

| entry | claim as written | tree today |
| --- | --- | --- |
| hash table mirrors a floor, drops the growth | `TAG_TABLE_SIZE` at two sites; "oc's does not grow" | #7790. One site, `crates/matching/src/index/mod.rs:68`, whose doc states the growth role "belongs to `CompactLookup`"; that structure grows on upstream's `(count/8) * 10 + 11` (`match.c:84-88`) |
| digest bound written where upstream derives | literal `16` | #7786. `<Md5 as OutputSizeUser>::OutputSize::USIZE` (`xattr/mod.rs:76`) with `const _: () = assert!(MAX_XATTR_DIGEST_LEN == 16)` at `:81` |
| one bound copied nine times | nine independent `MAX_INPUT_SIZE` | #7787. One definition, `simd_batch/mod.rs:46`; every backend `use`s it |

The third entry's **count was wrong and is corrected upward**: the sweep found twelve sites, eleven constants plus one bare literal that no grep for the name could reach. Stating twelve rather than leaving nine is the point — the original number understated the problem it was describing.

## Why the section is kept, not deleted

The lesson is why the gate exists: value equality is not provenance. Each fix is the evidence that the reading was right, so the entries stay with their closures recorded and the original warnings marked where they held (the hash-table entry predicted that "the two-path branch and the odd-number constraint travel with" the formula — they did).

## Scope

Two files, prose only.

The `optimized_search.rs:12` mention is dropped rather than updated: that module has no consumers and its deletion is open as #7798, and the live `TAG_TABLE_SIZE` was never the growth-bearing constant, so omitting the dead copy is accurate whichever of the two PRs lands first. The zsync design note's file list loses the same filename and has its crate directory corrected (`crates/match/` -> `crates/matching/`).

## Gate status, stated rather than claimed

Both citation gates are **structurally blind to this change**, and that is a scope decision already written down, not a gap I am relying on:

- `cargo xtask citations` exempts the prefix at `xtask/src/commands/citations.rs:102` (`source.starts_with("docs/")`), documented at `:92-102` as a scope statement.
- `tools/ci/citation_drift_audit.py --ratchet` reports per-crate populations only; run locally against the pinned 3.5.0 source it exits `ratchet OK`, unperturbed by this diff.

So the upstream anchors here were checked **by hand against the pinned source**, not by a gate: `match.c:45` is `#define TRADITIONAL_TABLESIZE (1<<16)`, and `match.c:84-88` covers the comment plus `tablesize = (uint32)(s->count/8) * 10 + 11` and the floor-raise. That range replaces the entry's `match.c:86-88` so it matches what `index/mod.rs` cites for the same rule.

No behavioural surface, so there is nothing to mutate and no test is added.
