### PR TITLE
fix(ssh): a comma is not a Host pattern separator, and Host is case-sensitive

### DIFF
--- a/crates/rsync_io/src/ssh/config_lookup/match_block.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/match_block.rs
@@ -210,9 +210,11 @@ pub(super) fn match_line_applies(value: &str, ctx: &MatchContext<'_>, saw_exec: 
 fn evaluate_condition(condition: &MatchCondition, ctx: &MatchContext<'_>) -> bool {
     match condition {
         MatchCondition::All => true,
-        MatchCondition::Host(patterns) => pattern_list_matches(patterns, ctx.host, MatchKind::Host),
+        MatchCondition::Host(patterns) => {
+            pattern_list_matches(patterns, ctx.host, MatchKind::MatchHost)
+        }
         MatchCondition::OriginalHost(patterns) => {
-            pattern_list_matches(patterns, ctx.original_host, MatchKind::Host)
+            pattern_list_matches(patterns, ctx.original_host, MatchKind::MatchHost)
         }
         MatchCondition::User(patterns) => pattern_list_matches(patterns, ctx.user, MatchKind::User),
         MatchCondition::LocalUser(patterns) => {

--- a/crates/rsync_io/src/ssh/config_lookup/mod.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/mod.rs
@@ -67,12 +67,16 @@ use paths::candidate_paths;
 // consumes `ssh_config_enables_compression` and `MatchContext`.
 #[cfg(test)]
 use match_block::{MatchCondition, evaluate_match, match_line_applies};
+// `pub(super)` rather than module-private: the `ssh -G` differential
+// harness (`embedded::ssh_config_differential`) reads the compression
+// decision straight out of the parser so its `compression` row is pinned
+// against real ssh instead of against a unit test's own belief.
 #[cfg(test)]
-use parser::parse_enables_compression;
+pub(super) use parser::parse_enables_compression;
 #[cfg(test)]
 use paths::extract_dash_f_path;
 #[cfg(test)]
-use pattern::{Pattern, parse_pattern_list};
+use pattern::{Pattern, parse_host_pattern_list, parse_pattern_list};
 
 /// Returns `true` when `~/.ssh/config` or `/etc/ssh/ssh_config`
 /// configures `Compression yes` for `ctx` at top level or under a

--- a/crates/rsync_io/src/ssh/config_lookup/parser.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/parser.rs
@@ -100,7 +100,7 @@ pub(in crate::ssh) fn parse_enables_compression(text: &str, ctx: &MatchContext<'
                     Block::TopLevel if top_level.is_none() => top_level = parsed,
                     Block::Host(patterns)
                         if host_block.is_none()
-                            && pattern_list_matches(patterns, ctx.host, MatchKind::Host) =>
+                            && pattern_list_matches(patterns, ctx.host, MatchKind::HostBlock) =>
                     {
                         host_block = parsed;
                     }

--- a/crates/rsync_io/src/ssh/config_lookup/parser.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/parser.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use logging::debug_log;
 
 use super::match_block::{MatchContext, match_line_applies};
-use super::pattern::{MatchKind, Pattern, parse_pattern_list, pattern_list_matches};
+use super::pattern::{MatchKind, Pattern, parse_host_pattern_list, pattern_list_matches};
 
 /// Reads `path` and returns whether it enables compression for `ctx`.
 /// Parse and I/O errors are converted to `false` with a single
@@ -83,7 +83,7 @@ pub(in crate::ssh) fn parse_enables_compression(text: &str, ctx: &MatchContext<'
         let key_lc = key.to_ascii_lowercase();
         match key_lc.as_str() {
             "host" => {
-                block = Block::Host(parse_pattern_list(value));
+                block = Block::Host(parse_host_pattern_list(value));
             }
             "match" => {
                 let mut saw_exec = false;

--- a/crates/rsync_io/src/ssh/config_lookup/pattern.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/pattern.rs
@@ -1,10 +1,12 @@
 //! Host/user pattern matching shared by `Host` blocks and `Match`
 //! lines.
 //!
-//! Holds the [`Pattern`] token type, the tokeniser
-//! ([`parse_pattern_list`]), and the byte-level glob matcher with the
-//! case-folding policy selected by [`MatchKind`]. Mirrors OpenSSH's
-//! `match_pattern_list` semantics.
+//! Holds the [`Pattern`] token type, the two tokenisers
+//! ([`parse_host_pattern_list`] for `Host` lines,
+//! [`parse_pattern_list`] for `Match` criteria), and the byte-level glob
+//! matcher with the case-folding policy selected by [`MatchKind`].
+//! The separator set and the case-folding rule both differ per keyword,
+//! so neither is inferred from "it is a hostname".
 
 /// A single token from an ssh_config `Host` or `Match` pattern-list.
 ///
@@ -44,17 +46,41 @@ impl Pattern {
     }
 }
 
-/// Tokenises a raw pattern-list (the value half of a `Host` line or a
-/// `Match host`/`originalhost`/`user`/`localuser` condition) into
-/// [`Pattern`] entries.
+/// Tokenises a `Match host`/`originalhost`/`user`/`localuser` condition
+/// argument into [`Pattern`] entries.
 ///
-/// Tokens are split on whitespace or commas, matching OpenSSH's
-/// `match_pattern_list`. Empty tokens are dropped. Shared by
-/// `Host`-block resolution (SSC-5.b) and the `Match`-line evaluator
-/// (SSC-4.c) so both callers route through one tokeniser.
+/// Tokens are split on whitespace **or commas**: the `Match` criteria are
+/// pattern-lists, and `match_pattern_list` cuts each subpattern at a comma
+/// (openssh/match.c:143). Empty tokens are dropped.
+///
+/// ⚠ Not for `Host` lines - those are argv-tokenised and a comma is
+/// ordinary pattern text there. Use [`parse_host_pattern_list`].
 pub(in crate::ssh) fn parse_pattern_list(value: &str) -> Vec<Pattern> {
+    split_tokens(value, |c| c.is_whitespace() || c == ',')
+}
+
+/// Tokenises the value half of a `Host` line into [`Pattern`] entries.
+///
+/// Tokens are separated by spaces and TABs only, and a comma is ordinary
+/// pattern text. Upstream splits the line with `argv_split`
+/// (openssh/misc.c:2130-2185), whose only separators are `' '` and `'\t'`
+/// (openssh/misc.c:2141), then matches each token with `match_pattern` in
+/// the `argv_next` loop (openssh/readconf.c:1831-1858); the `oHost` arm
+/// never reaches `match_pattern_list`, so `Host a,b` does not match the
+/// alias `a`.
+///
+/// A separate entry point rather than a widened [`parse_pattern_list`]:
+/// the separator set differs *per keyword*, and the four `Match` criteria
+/// that share the tokeniser need the comma split that `Host` must not
+/// have.
+pub(in crate::ssh) fn parse_host_pattern_list(value: &str) -> Vec<Pattern> {
+    split_tokens(value, |c| c == ' ' || c == '\t')
+}
+
+/// Splits `value` on `is_separator`, dropping empty tokens.
+fn split_tokens(value: &str, is_separator: impl Fn(char) -> bool) -> Vec<Pattern> {
     value
-        .split(|c: char| c.is_whitespace() || c == ',')
+        .split(is_separator)
         .map(str::trim)
         .filter(|tok| !tok.is_empty())
         .map(Pattern::new)

--- a/crates/rsync_io/src/ssh/config_lookup/pattern.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/pattern.rs
@@ -87,11 +87,25 @@ fn split_tokens(value: &str, is_separator: impl Fn(char) -> bool) -> Vec<Pattern
         .collect()
 }
 
-/// Whether the input is a hostname or a username; controls case
-/// folding per SSC-4.a.
+/// Which keyword's pattern is being matched; controls case folding.
+///
+/// Split by keyword rather than by "hostname vs username": the two
+/// host-carrying keywords differ from each other, so folding cannot be
+/// inferred from the input being a hostname.
 #[derive(Copy, Clone)]
 pub(super) enum MatchKind {
-    Host,
+    /// A `Host` block pattern: compared byte-exactly. The `oHost` arm
+    /// calls `match_pattern` directly (openssh/readconf.c:1844), and
+    /// `match_pattern` folds nothing -
+    /// `if (*pattern != '?' && *pattern != *s) return 0;`
+    /// (openssh/match.c:105-106).
+    HostBlock,
+    /// A `Match host` / `Match originalhost` argument: compared
+    /// case-INSENSITIVELY. These route through `match_hostname`
+    /// (openssh/match.c:193-203), which lowercases the host and passes
+    /// `dolower=1` into `match_pattern_list`.
+    MatchHost,
+    /// A `Match user` / `Match localuser` argument.
     User,
 }
 
@@ -130,11 +144,13 @@ fn pattern_glob_matches(glob: &str, input: &str, kind: MatchKind) -> bool {
 }
 
 /// Returns `true` when comparisons for `kind` should be ASCII
-/// case-folded. Hostnames are always folded; usernames are folded only
-/// on Windows, where account names are inherently case-insensitive.
+/// case-folded. `Host` block patterns are never folded; `Match host`
+/// patterns always are; usernames are folded only on Windows, where
+/// account names are inherently case-insensitive.
 fn case_fold(kind: MatchKind) -> bool {
     match kind {
-        MatchKind::Host => true,
+        MatchKind::HostBlock => false,
+        MatchKind::MatchHost => true,
         MatchKind::User => cfg!(windows),
     }
 }

--- a/crates/rsync_io/src/ssh/config_lookup/tests.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/tests.rs
@@ -210,6 +210,32 @@ fn host_block_with_a_comma_matches_only_the_literal_alias() {
 }
 
 #[test]
+fn host_block_pattern_is_case_sensitive() {
+    // `oHost` calls `match_pattern` directly
+    // (openssh/readconf.c:1844) and `match_pattern` folds nothing -
+    // `if (*pattern != '?' && *pattern != *s) return 0;`
+    // (openssh/match.c:105-106). Measured on real `ssh -G`: alias `web1`
+    // against `Host WEB1` reports `compression no`.
+    let text = "Host WEB1\n  Compression yes\n";
+    assert!(!parse_enables_compression(text, &host_ctx("web1")));
+    assert!(parse_enables_compression(text, &host_ctx("WEB1")));
+}
+
+#[test]
+fn match_host_pattern_stays_case_insensitive() {
+    // The control for the `Host` case fix. `Match host` and
+    // `Match originalhost` go through `match_hostname`
+    // (openssh/match.c:193-203), which lowercases the host and passes
+    // `dolower=1`, so the fold is CORRECT here. If this reddens, the
+    // shared `case_fold` policy was flipped instead of the `Host` call
+    // site being given its own kind.
+    let text = "Match host WEB1\n  Compression yes\n";
+    assert!(parse_enables_compression(text, &host_ctx("web1")));
+    let original = "Match originalhost WEB1\n  Compression yes\n";
+    assert!(parse_enables_compression(original, &host_ctx("web1")));
+}
+
+#[test]
 fn match_host_still_comma_splits_its_pattern_list() {
     // The control for the `Host` tokeniser split. `Match host` DOES
     // comma-split - `match_pattern_list` cuts each subpattern at a comma

--- a/crates/rsync_io/src/ssh/config_lookup/tests.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/tests.rs
@@ -182,6 +182,47 @@ fn parse_pattern_list_empty_input_yields_no_tokens() {
 }
 
 #[test]
+fn parse_host_pattern_list_keeps_a_comma_inside_one_token() {
+    // A `Host` line is argv-tokenised: upstream splits it with
+    // `argv_split` (openssh/misc.c:2130-2185), whose only separators are
+    // `' '` and `'\t'` (openssh/misc.c:2141), then matches each token with
+    // `match_pattern` (openssh/readconf.c:1844). The comma-splitting
+    // `match_pattern_list` (openssh/match.c:143) is reachable only from
+    // the `Match` criteria, so a comma here is pattern text.
+    let parsed = parse_host_pattern_list("a,b\tc d");
+    assert_eq!(parsed.len(), 3);
+    assert_eq!(parsed[0].glob(), "a,b");
+    assert_eq!(parsed[1].glob(), "c");
+    assert_eq!(parsed[2].glob(), "d");
+}
+
+#[test]
+fn host_block_with_a_comma_matches_only_the_literal_alias() {
+    // Measured on real `ssh -G -F fixture a`: `compression no`, i.e. the
+    // block does not apply. The differential harness pins that half; this
+    // pins the mirror image, which the oracle cannot answer because
+    // `ssh -G a,b` refuses the alias with "hostname contains invalid
+    // characters" and exits nonzero.
+    let text = "Host a,b\n  Compression yes\n";
+    assert!(!parse_enables_compression(text, &host_ctx("a")));
+    assert!(!parse_enables_compression(text, &host_ctx("b")));
+    assert!(parse_enables_compression(text, &host_ctx("a,b")));
+}
+
+#[test]
+fn match_host_still_comma_splits_its_pattern_list() {
+    // The control for the `Host` tokeniser split. `Match host` DOES
+    // comma-split - `match_pattern_list` cuts each subpattern at a comma
+    // (openssh/match.c:143) - so the very token that must not match under
+    // `Host` must still match here. If this reddens, the shared `Match`
+    // tokeniser was narrowed instead of the `Host` caller being given its
+    // own.
+    let text = "Match host a,b\n  Compression yes\n";
+    assert!(parse_enables_compression(text, &host_ctx("a")));
+    assert!(parse_enables_compression(text, &host_ctx("b")));
+}
+
+#[test]
 fn extracts_split_dash_f() {
     let opts = vec![OsString::from("-F"), OsString::from("/tmp/custom")];
     assert_eq!(

--- a/crates/rsync_io/src/ssh/embedded/ssh_config.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config.rs
@@ -117,13 +117,21 @@ fn split_directive(line: &str) -> Option<(&str, &str)> {
 }
 
 /// Returns `true` when `host` matches any pattern in `patterns`, after
-/// expanding wildcards and applying negations. OpenSSH treats space- or
-/// comma-separated tokens as alternatives within a single `Host` line; a
-/// leading `!` on any token negates and causes the whole line to fail to
-/// match.
+/// expanding wildcards and applying negations. A leading `!` on any token
+/// negates and causes the whole line to fail to match.
+///
+/// Tokens are separated by spaces and TABs only. Upstream splits a `Host`
+/// line with `argv_split` (openssh/misc.c:2130-2185), whose only
+/// separators are `' '` and `'\t'` (openssh/misc.c:2141), then matches
+/// each token individually with `match_pattern` in the `argv_next` loop
+/// (openssh/readconf.c:1831-1858). The `oHost` arm never calls
+/// `match_pattern_list`, so a comma inside a token is ordinary pattern
+/// text, not a separator: `Host a,b` does not match the alias `a`.
+/// (`Match host` is the comma-splitting case, openssh/match.c:143 - a
+/// different keyword with a different rule.)
 fn host_matches_any_pattern(host: &str, patterns: &str) -> bool {
     let mut any_positive_match = false;
-    for raw in patterns.split(|c: char| c.is_whitespace() || c == ',') {
+    for raw in patterns.split([' ', '\t']) {
         let token = raw.trim();
         if token.is_empty() {
             continue;
@@ -320,6 +328,33 @@ mod tests {
         assert!(resolved.user.is_none());
         let resolved_ok = resolve_host_str(text, "ok.example.com");
         assert_eq!(resolved_ok.user.as_deref(), Some("u"));
+    }
+
+    /// A comma inside a `Host` token is pattern text, not a separator.
+    ///
+    /// Upstream tokenises the line with `argv_split`, whose separators are
+    /// `' '` and `'\t'` only (openssh/misc.c:2141), and matches each token
+    /// with `match_pattern` (openssh/readconf.c:1844). Measured on real
+    /// `ssh -G -F fixture a`: `port 22`, i.e. no match. The differential
+    /// harness pins that half against the oracle; this pins the mirror
+    /// image, which the oracle cannot answer because `ssh -G a,b` refuses
+    /// the alias as an invalid hostname.
+    #[test]
+    fn comma_in_a_host_pattern_is_literal_not_a_separator() {
+        let text = "Host a,b\n  Port 2222\n";
+        assert!(resolve_host_str(text, "a").port.is_none());
+        assert!(resolve_host_str(text, "b").port.is_none());
+        assert_eq!(resolve_host_str(text, "a,b").port, Some(2222));
+    }
+
+    /// A TAB separates `Host` tokens exactly as a space does
+    /// (openssh/misc.c:2141), so narrowing the separator set to space and
+    /// TAB must not have dropped the TAB.
+    #[test]
+    fn tab_separates_host_patterns() {
+        let text = "Host first\tsecond\n  Port 2222\n";
+        assert_eq!(resolve_host_str(text, "first").port, Some(2222));
+        assert_eq!(resolve_host_str(text, "second").port, Some(2222));
     }
 
     #[test]

--- a/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
@@ -52,8 +52,11 @@
 //! neither produces an upstream-shaped resolved config:
 //!
 //! - `ssh::config_lookup` has the `Host`/`Match` matching machinery but
-//!   its single entry point returns a `bool` for `Compression` alone. It
-//!   resolves no values.
+//!   resolves exactly one value: a `bool` for `Compression`. That one
+//!   value is wired into [`oc_resolution`] as the `compression` row (behind
+//!   the `ssh-config-parse` feature that owns the parser), so parser B's
+//!   `Host`-pattern behaviour is measured here rather than only by unit
+//!   tests asserting our own reading of the C.
 //! - `ssh::embedded::ssh_config` (this module's neighbour) is the
 //!   value-carrying resolver - [`ResolvedHost`], six directives - but it
 //!   understands `Host` only, with no `Match`, no `Include`, and no token
@@ -86,6 +89,8 @@ use std::path::Path;
 use std::process::Command;
 
 use super::ssh_config::resolve_host_str;
+#[cfg(feature = "ssh-config-parse")]
+use crate::ssh::config_lookup::{MatchContext, parse_enables_compression};
 
 /// Whether `ssh -G` prints a keyword's value with tokens already expanded.
 ///
@@ -276,6 +281,22 @@ fn oc_resolution(config_text: &str, alias: &str) -> BTreeMap<String, Option<Vec<
         "identityagent".to_owned(),
         resolved.identity_agent.clone().map(|a| vec![a]),
     );
+
+    // Parser B's one resolved value. Its `false` covers both "Compression
+    // no" and "no directive at all", and upstream's default is also `no`
+    // (openssh/readconf.c dumps `compression no`), so the boolean is
+    // comparable end to end. Without the feature the row is absent and
+    // upstream's `compression` line lands in `NotResolvedByOc`, which is
+    // the truth for that build rather than a hidden pass.
+    #[cfg(feature = "ssh-config-parse")]
+    {
+        let ctx = MatchContext::new(alias, alias, "", "");
+        let enabled = parse_enables_compression(config_text, &ctx);
+        map.insert(
+            "compression".to_owned(),
+            Some(vec![if enabled { "yes" } else { "no" }.to_owned()]),
+        );
+    }
 
     map
 }
@@ -524,6 +545,71 @@ mod tests {
                 "{keyword}: upstream {:?} vs oc {:?}",
                 cell.upstream,
                 cell.oc
+            );
+        }
+    }
+
+    /// A COMMA is not a `Host` separator, measured on both parsers at once.
+    ///
+    /// Upstream tokenises the `Host` line with `argv_split`
+    /// (openssh/misc.c:2130-2185), whose only separators are `' '` and
+    /// `'\t'` (openssh/misc.c:2141), then matches each token individually
+    /// with `match_pattern` in the `argv_next` loop
+    /// (openssh/readconf.c:1831-1858, the call at :1844). The `oHost` arm
+    /// never reaches `match_pattern_list`, the function that does cut at a
+    /// comma (openssh/match.c:143), so `a,b` is one pattern matching only
+    /// the literal string `a,b`.
+    ///
+    /// Measured before the fix on `OpenSSH_10.3p1`: upstream reports
+    /// `port 22` and `compression no` for alias `a`, while oc applied the
+    /// block - port 2222 from the value-carrying parser and compression
+    /// yes from the `config_lookup` parser. One fixture, both parsers: the
+    /// `port`/`user` rows are `embedded::ssh_config`, the `compression`
+    /// row is `config_lookup`.
+    ///
+    /// ⚠ The mirror image - alias `a,b`, which upstream DOES match - cannot
+    /// be measured here: `ssh -G a,b` refuses with "hostname contains
+    /// invalid characters" and exits nonzero, so the oracle has no verdict
+    /// to give. That half is pinned by unit tests beside each parser.
+    #[test]
+    fn a_comma_in_a_host_line_is_not_a_separator() {
+        const FIXTURE: &str = "Host a,b\n  Port 2222\n  User alice\n  Compression yes\n";
+
+        let diff = match run(FIXTURE, "a") {
+            Ok(d) => d,
+            Err(why) => {
+                report_skip("host comma separator", &why);
+                return;
+            }
+        };
+
+        // Upstream declined the block, so its port is the built-in
+        // default. The harness models no defaults, so oc's side must be
+        // unresolved - `OcUnset` is the assertion, and a pre-fix oc would
+        // land on `Mismatch` with 2222.
+        let port = diff.cell("port").expect("dumped");
+        assert_eq!(port.upstream, vec!["22"]);
+        assert_eq!(
+            port.verdict,
+            Verdict::OcUnset,
+            "oc applied a comma-separated Host block: {:?} on {}",
+            port.oc,
+            diff.oracle_version
+        );
+        // `user` is dumped as the local account when no directive matched,
+        // so the value is host-dependent; the verdict is not.
+        assert_eq!(diff.cell("user").expect("dumped").verdict, Verdict::OcUnset);
+
+        #[cfg(feature = "ssh-config-parse")]
+        {
+            let cell = diff.cell("compression").expect("dumped");
+            assert_eq!(cell.upstream, vec!["no".to_owned()]);
+            assert_eq!(
+                cell.verdict,
+                Verdict::Match,
+                "compression parser applied a comma-separated Host block: oc {:?} on {}",
+                cell.oc,
+                diff.oracle_version
             );
         }
     }

--- a/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
@@ -614,6 +614,58 @@ mod tests {
         }
     }
 
+    /// A `Host` BLOCK pattern is matched byte-exactly, in the compression
+    /// parser too.
+    ///
+    /// `oHost` calls `match_pattern` directly (openssh/readconf.c:1844) and
+    /// `match_pattern` folds nothing:
+    /// `if (*pattern != '?' && *pattern != *s) return 0;`
+    /// (openssh/match.c:105-106). `Match host` is the case-INSENSITIVE one,
+    /// because it routes through `match_hostname`
+    /// (openssh/match.c:193-203), which lowercases the host and passes
+    /// `dolower=1` - a different keyword with a different rule.
+    ///
+    /// Measured before the fix on `OpenSSH_10.3p1`: alias `web1` against
+    /// `Host WEB1` gives upstream `compression no`, oc `yes`. The
+    /// value-carrying parser already agreed with upstream here - see
+    /// `host_pattern_matching_is_case_sensitive_on_both_sides` - so this
+    /// row exists to cover the second parser.
+    #[cfg(feature = "ssh-config-parse")]
+    #[test]
+    fn host_block_pattern_case_is_significant_for_compression() {
+        const FIXTURE: &str = "Host WEB1\n  Compression yes\n  Port 2222\n";
+
+        let mismatched_case = match run(FIXTURE, "web1") {
+            Ok(d) => d,
+            Err(why) => {
+                report_skip("compression case-sensitivity", &why);
+                return;
+            }
+        };
+        let cell = mismatched_case.cell("compression").expect("dumped");
+        assert_eq!(cell.upstream, vec!["no".to_owned()]);
+        assert_eq!(
+            cell.verdict,
+            Verdict::Match,
+            "compression parser case-folded a Host pattern: oc {:?} on {}",
+            cell.oc,
+            mismatched_case.oracle_version
+        );
+
+        // Control: the exact-case alias must still fire. Without it, a
+        // parser that answered `no` unconditionally would pass above.
+        let exact_case = match run(FIXTURE, "WEB1") {
+            Ok(d) => d,
+            Err(why) => {
+                report_skip("compression case-sensitivity control", &why);
+                return;
+            }
+        };
+        let cell = exact_case.cell("compression").expect("dumped");
+        assert_eq!(cell.upstream, vec!["yes".to_owned()]);
+        assert_eq!(cell.verdict, Verdict::Match, "oc {:?}", cell.oc);
+    }
+
     /// SHARP EDGE 2, demonstrated live rather than asserted from the C.
     ///
     /// `IdentityFile` is dumped UNEXPANDED because openssh/ssh.c:2428 expands it


### PR DESCRIPTION
Two `Host`-matching divergences from OpenSSH, one commit each, each proven by mutation.
Measured against `OpenSSH_10.3p1` via the `ssh -G` differential harness (#7784).

## Oracle, measured before the fixes

| fixture | alias | real `ssh -G` | oc before |
| --- | --- | --- | --- |
| `Host a,b` + `Port 2222` / `User alice` / `Compression yes` | `a` | port 22, user = local, compression no | port 2222, user alice, compression yes |
| `Host WEB1` + `Compression yes` | `web1` | compression no | compression yes |
| same | `WEB1` | compression yes | compression yes |

## Fix 1 — a comma is not a `Host` separator

`Host` tokenizes through `argv_split`, whose separator set is **space and TAB only**
(`openssh/misc.c:2130-2185`, `:2141`); `readconf.c:1831-1858`/`:1844` then calls `match_pattern`
per token. The comma split belongs to `match_pattern_list` (`openssh/match.c:143`), which the
`oHost` path never reaches. So `Host a,b` is one pattern containing a literal comma.

Both parsers split on comma. Both fixed:

- **parser A** (`ssh/embedded/ssh_config.rs:124-142`) — `host_matches_any_pattern` splits on
  `[' ', '\t']` instead of `is_whitespace() || ','`.
- **parser B** (`ssh/config_lookup/`) — the shared tokenizer is **deliberately not narrowed**.
  `parse_pattern_list` (comma + whitespace) still serves the four `Match` criteria, which do
  comma-split; a new `parse_host_pattern_list` (space/TAB) serves `Host`. Both delegate to one
  `split_tokens(value, is_separator)`. The separator set is a property of the **keyword**, not of
  the value being a hostname — narrowing the shared helper would have broken `Match host=a,b`.

## Fix 2 — `Host` matching is case-sensitive

`oHost` calls `match_pattern` directly, which compares raw bytes
(`openssh/match.c:105-106`: `if (*pattern != '?' && *pattern != *s) return 0;`). `Match host`
is the one that folds, because `match_hostname` lowercases with `dolower=1`
(`openssh/match.c:193-203`). oc folded both.

`MatchKind` now distinguishes `HostBlock` (fold = false) from `MatchHost` (fold = true) — renamed
rather than added-alongside so the two keywords cannot be confused at a call site. `case_fold` is
the only place the policy lives; `Match host`/`originalhost` folding is unchanged.

## Mutation kill sets

| mutation | kills |
| --- | --- |
| revert both comma call sites (helper kept) | exactly 3: the differential cell + one unit test per parser |
| `HostBlock => true` (re-fold `Host`) | exactly 2: differential + unit |
| **inverse**: `MatchHost => false` ("fix the shared helper instead") | exactly 2, and they are the *other* two — `evaluate_match_host_case_insensitive`, `match_host_pattern_stays_case_insensitive` |

That last row is the load-bearing one: the two kinds are separately guarded **in both directions**,
so a future edit that folds `Host` or unfolds `Match host` reddens a named test either way. No
`Match`-criteria test moved on either forward mutation. All reverted, 1204/1204 green.

## Where the differential cannot reach

`ssh -G a,b` refuses outright (`hostname contains invalid characters`, nonzero exit), so the
"literal `a,b` *does* match a host actually named `a,b`" half has no oracle and is unit-tested.
Stated in the test's own doc comment rather than left implicit.

## Gates (pinned 1.88.0)

- `cargo nextest run -p rsync_io --all-features` — **1204 passed, 3 skipped**, with
  `OC_RSYNC_REQUIRE_SSH_G=1` set, so both differential cells genuinely invoked the oracle instead
  of skipping
- `cargo clippy -p rsync_io --all-targets --all-features --no-deps -- -D warnings` — clean; also
  clean for default features and `--no-default-features --features embedded-ssh`
- `tools/ci/check_rustfmt_all.py` — clean (3430 files; it caught one diff, fixed)
- rustdoc with `-D warnings -D rustdoc::broken_intra_doc_links` — clean
- Every OpenSSH citation in the diff carries the `openssh/` prefix, verified by grepping the diff:
  `openssh/match.c:{105,143,193}`, `openssh/misc.c:{2130,2141}`, `openssh/readconf.c:{1831,1844}`.
  The directory component is what makes `xtask citations` classify them `ForeignUpstream`; a bare
  `match.c:105` would have been silently validated against **rsync's** `match.c`.

## Commit split

`b52deb876` (comma) then `aa53d410a` (case). Each commit's code change is independently
revertable, with one coupling worth knowing: commit 1 adds the harness's `compression` row and
commit 2's differential test reads it, so reverting commit 1 alone would redden commit 2's cell
(it would fall back to `NotResolvedByOc`). The fix-1-only tree was verified green on its own
(1201/1201) before commit 2 was written.

## Out of scope, filed separately

`argv_split`'s quote/escape/`#` handling and its empty-token hard error. Upstream refuses
`Host a "" b` with rc 255 and `line 1: keyword host empty argument`
(`openssh/readconf.c:1832-1836`) where oc silently skips empties, and `Host "web 1" other` is one
token upstream but two in oc. That changes token boundaries for **every** directive, not just
`Host`, so it is its own row. Negation and the single-pass `Host` subject are untouched.
