### PR TITLE
feat(daemon): honour `dir-merge` in a module filter rule

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -353,8 +353,8 @@ struct MergeRule<'a> {
 /// gives it `FILTRULE_MERGE_FILE`. `parse_filter_str` reads such a file once, at
 /// parse time (exclude.c:1581-1590), which is what this function feeds.
 ///
-/// ⚠ THE PER-DIRECTORY SPELLINGS `:` / `dir-merge` ARE DELIBERATELY NOT HANDLED
-/// HERE, and they are NOT a no-op in upstream. `add_rule` registers every
+/// ⚠ THE PER-DIRECTORY SPELLINGS `:` / `dir-merge` ARE NOT EAGER, so they are
+/// deliberately not answered here. `add_rule` registers every
 /// `FILTRULE_PERDIR_MERGE` rule into the GLOBAL `mergelist_parents`
 /// (exclude.c:349-391) whatever list it was added to, so a rule in
 /// `daemon_filter_list` is registered too; `push_local_filters` then fills that
@@ -362,9 +362,9 @@ struct MergeRule<'a> {
 /// MEASURED against rsync 3.5.0 (module with `sub/.rsync-filter` holding
 /// `- bait.txt`): `filter = : .rsync-filter` HIDES `sub/bait.txt`, and so does
 /// `filter = dir-merge rules` with the merge file and the bait at the module
-/// root. Expressing that needs a `RuleType::DirMerge` wire rule rather than an
-/// eager read, so it is tracked as its own change; a token opening `:` or
-/// `dir-merge` keeps whatever the single-rule parser already did with it.
+/// root. That is a `RuleType::DirMerge` wire rule carried to the walk, not a
+/// parse-time read, so [`short_rule_prefix`] and [`KEYWORD_PREFIXES`] own those
+/// two spellings and [`build_prefixed_rule`] builds the rule.
 ///
 /// ⚠ `.` is NOT a token-boundary opener in [`split_filter_tokens`], and
 /// deliberately so - see [`opens_clear_rule`] for the same reasoning applied to
@@ -880,10 +880,12 @@ fn read_patterns_from_file(path: &Path) -> Result<Vec<(String, usize)>, io::Erro
 /// character. The list is shared by the tokenizer and, through
 /// [`is_rule_keyword`], uses one terminator rule rather than a second copy.
 ///
-/// `merge` is an opener here and is answered by [`merge_rule`], which
-/// [`push_token_rules`] consults before the single-rule parser. `dir-merge`
-/// opens a token too and still reaches the single-rule parser's bare-pattern
-/// arm - see [`merge_rule`] for why the per-directory spellings are held back.
+/// Both merge spellings are openers here, and each is answered on its own path.
+/// `merge` reaches [`merge_rule`], which [`push_token_rules`] consults before
+/// the single-rule parser, because upstream replaces such a token with the
+/// parsed contents of the file. `dir-merge` reaches [`KEYWORD_PREFIXES`], which
+/// maps it to [`SHORT_DIR_MERGE`]: a per-directory rule is carried on the wire,
+/// not read here.
 const RULE_KEYWORDS: &[&str] = &[
     "include",
     "exclude",
@@ -1039,7 +1041,7 @@ fn parse_daemon_filter_token(
             Some(after_comma) => (after_comma, 2),
             None => (rest, 1),
         };
-        match scan_modifiers(run, prefix.specifies_side, base, token) {
+        match scan_modifiers(run, prefix, base, token) {
             Ok((modifiers, used)) => {
                 return build_prefixed_rule(prefix, modifiers, run, used, token, xflags);
             }
@@ -1143,7 +1145,7 @@ fn parse_daemon_filter_token(
                 Some(after_comma) => (after_comma, keyword.len() + 1),
                 None => (rest, keyword.len()),
             };
-            let (modifiers, used) = scan_modifiers(run, prefix.specifies_side, base, token)?;
+            let (modifiers, used) = scan_modifiers(run, prefix, base, token)?;
             return build_prefixed_rule(prefix, modifiers, run, used, token, xflags);
         }
     }
@@ -1368,6 +1370,11 @@ struct RulePrefix {
     /// True for the SHORT characters that a bare pattern could also start
     /// with. See the failed-scan arm in [`parse_daemon_filter_token`].
     competes_with_bare_words: bool,
+    /// `FILTRULE_MERGE_FILE` (`:`, `dir-merge`), which is what opens the
+    /// merge-only half of the modifier alphabet - `-`, `+`, `e`, `n` and `w`
+    /// are `goto invalid` without it, and `!` is `goto invalid` WITH it
+    /// (`exclude.c:1381-1440`).
+    merge_file: bool,
 }
 
 /// The long-form keywords, in upstream's own mapping order.
@@ -1378,6 +1385,8 @@ const KEYWORD_PREFIXES: &[(&str, RulePrefix)] = &[
     ("show", SHORT_SHOW),
     ("protect", SHORT_PROTECT),
     ("risk", SHORT_RISK),
+    // upstream: `exclude.c:1310-1311` maps `dir-merge` to `:`.
+    ("dir-merge", SHORT_DIR_MERGE),
 ];
 
 const SHORT_EXCLUDE: RulePrefix = RulePrefix {
@@ -1385,6 +1394,7 @@ const SHORT_EXCLUDE: RulePrefix = RulePrefix {
     sender_side: false,
     specifies_side: false,
     competes_with_bare_words: false,
+    merge_file: false,
 };
 const SHORT_INCLUDE: RulePrefix = RulePrefix {
     is_include: true,
@@ -1408,15 +1418,32 @@ const SHORT_RISK: RulePrefix = RulePrefix {
     is_include: true,
     ..SHORT_PROTECT
 };
+/// `:` / `dir-merge` - `FILTRULE_PERDIR_MERGE | FILTRULE_MERGE_FILE`.
+///
+/// upstream: `exclude.c:1331-1338` - `case ':'` sets `FILTRULE_PERDIR_MERGE`
+/// plus `FILTRULE_FINISH_SETUP` and FALLS THROUGH to `case '.'`, which is what
+/// adds `FILTRULE_MERGE_FILE`. It names no side, so `specifies_side` stays
+/// false and the full `r`/`s`/`C` half of the alphabet remains open.
+///
+/// `competes_with_bare_words` is FALSE: a failed modifier scan REFUSES rather
+/// than falling back to a bare-word exclude. Upstream's scan sends any byte
+/// outside the alphabet to `invalid:` -> `"invalid modifier '%c' at position
+/// %d"` and `RERR_SYNTAX` (`exclude.c:1370-1379`), so `:` belongs to the
+/// `+`/`-` class, not to the `P R S H` class that competes with bare words.
+const SHORT_DIR_MERGE: RulePrefix = RulePrefix {
+    merge_file: true,
+    ..SHORT_EXCLUDE
+};
 
 /// Matches the one-character rule prefixes upstream's `default:` arm accepts.
 ///
 /// upstream: `exclude.c:1325-1329` makes any single character a rule
 /// character, and the second switch (`exclude.c:1331-1364`) gives
-/// `+ - S H R P` their meanings. `.`, `:` and `!` are the merge and clear
-/// characters; oc handles `!` on its own arm and does not implement the merge
-/// characters at all, so they are deliberately absent here - adding them would
-/// be the merge change, not this one.
+/// `+ - S H R P :` their meanings. `!` is the clear character and oc handles it
+/// on its own arm. `.` - the EAGER `merge` character - is absent because it is
+/// answered EARLIER: [`push_token_rules`] consults [`merge_rule`] first, which
+/// reads the named file at parse time, so a `.` token never reaches this
+/// function.
 ///
 /// ⚠ `competes_with_bare_words` is what keeps the four UPPERCASE characters
 /// from swallowing the bare-word fall-through; only a token whose modifier run
@@ -1430,6 +1457,8 @@ fn short_rule_prefix(token: &str) -> Option<(RulePrefix, char)> {
         'H' => SHORT_HIDE,
         'R' => SHORT_RISK,
         'P' => SHORT_PROTECT,
+        // upstream: exclude.c:1331-1338.
+        ':' => SHORT_DIR_MERGE,
         _ => return None,
     };
     Some((prefix, ch))
@@ -1469,7 +1498,7 @@ fn opens_short_rule(s: &str) -> bool {
     // A `,` terminates the prefix outright (`rule_strcmp`, exclude.c:1224-1225), so
     // the token IS a rule token even when its modifier run is one upstream
     // refuses - the same split the parser's failed-scan arm makes.
-    rest.starts_with(',') || scan_modifiers(rest, prefix.specifies_side, 1, s).is_ok()
+    rest.starts_with(',') || scan_modifiers(rest, prefix, 1, s).is_ok()
 }
 
 /// The flags upstream's modifier scan can raise on a daemon `filter` rule.
@@ -1482,6 +1511,31 @@ struct RuleModifiers {
     /// `!`, `x` or `C`: upstream ACCEPTS these and gives them meanings this
     /// daemon path cannot express. See [`scan_modifiers`].
     inexpressible: bool,
+    /// `r` - `FILTRULE_RECEIVER_SIDE` (`exclude.c:1424-1427`).
+    ///
+    /// Kept rather than ignored: a `:r` dir-merge is receiver-side, which
+    /// `DirMergeConfig::with_receiver_only` expresses. On a non-merge rule the
+    /// daemon list matches side-blind, so the bit stays unread there.
+    receiver_side: bool,
+    /// `p` - `FILTRULE_PERISHABLE` (`exclude.c:1421-1423`).
+    perishable: bool,
+    /// `-` or `+` - `FILTRULE_NO_PREFIXES`; merge rules only
+    /// (`exclude.c:1381-1391`).
+    no_prefixes: bool,
+    /// The `+` variant of [`Self::no_prefixes`], which also sets
+    /// `FILTRULE_INCLUDE` on each record.
+    no_prefixes_include: bool,
+    /// `n` - `FILTRULE_NO_INHERIT`; merge rules only (`exclude.c:1415-1418`).
+    no_inherit: bool,
+    /// `e` - `FILTRULE_EXCLUDE_SELF`; merge rules only
+    /// (`exclude.c:1411-1414`).
+    exclude_self: bool,
+    /// `w` - `FILTRULE_WORD_SPLIT`; merge rules only (`exclude.c:1433-1436`).
+    word_split: bool,
+    /// `C` - `FILTRULE_CVS_IGNORE` on a MERGE rule, where it is expressible as
+    /// `DirMergeConfig`'s CVS mode. On a non-merge rule the same character sets
+    /// [`Self::inexpressible`] instead; see [`scan_modifiers`].
+    cvs_ignore: bool,
 }
 
 /// Runs upstream's modifier scan over `run` and reports what it raised.
@@ -1522,12 +1576,22 @@ struct RuleModifiers {
 /// residual is left open rather than half-closed, because expressing `!` needs
 /// the receiver-side plumbing this change does not touch, and a half-expressed
 /// `!` would INVERT the served set on a push.
+///
+/// A MERGE prefix (`:`, `dir-merge`) opens the merge-only half of the alphabet
+/// and closes one character. upstream gates each arm on `FILTRULE_MERGE_FILE`:
+/// `-`/`+` (`exclude.c:1381-1391`), `e` (`:1411-1414`), `n` (`:1415-1418`) and
+/// `w` (`:1433-1436`) are `goto invalid` WITHOUT it, and `!` is `goto invalid`
+/// WITH it - "negation really goes with the pattern, so it isn't useful as a
+/// merge-file default" (`exclude.c:1404-1410`). `C` stops being inexpressible
+/// there too, because `DirMergeConfig` has a CVS mode for it.
 fn scan_modifiers(
     run: &str,
-    specifies_side: bool,
+    prefix: RulePrefix,
     base: usize,
     token: &str,
 ) -> Result<(RuleModifiers, usize), MalformedRule> {
+    let specifies_side = prefix.specifies_side;
+    let merge = prefix.merge_file;
     let mut modifiers = RuleModifiers::default();
     for (offset, ch) in run.char_indices() {
         // upstream stops at `' '` or `'_'`, and `FILTRULE_WORD_SPLIT` - which
@@ -1538,15 +1602,44 @@ fn scan_modifiers(
         }
         match ch {
             '/' => modifiers.abs_path = true,
-            // `p` is FILTRULE_PERISHABLE, which steers --delete only and never
-            // the name match this list performs.
-            'p' => {}
+            // `p` is FILTRULE_PERISHABLE. On a non-merge rule it steers
+            // --delete only and never the name match this list performs; a
+            // merge rule passes it down to every record it reads.
+            'p' => modifiers.perishable = true,
+            // `!` is NEGATE on a plain rule and INVALID on a merge rule.
+            '!' if merge => {
+                return Err(MalformedRule::InvalidModifier {
+                    modifier: ch,
+                    position: base + offset,
+                    token: token.to_owned(),
+                });
+            }
+            // `x` is FILTRULE_XATTR. It is NOT in `FILTRULES_FROM_CONTAINER`
+            // (exclude.c:1229-1231), so a merge rule does not pass it down to
+            // the records it reads, and upstream frees the merge rule itself.
+            // The eager `merge` arm therefore accepts it and expresses nothing
+            // (MEASURED: `filter = .x FILE` hides what the file names); a
+            // per-directory merge takes the SAME reading, rather than dropping
+            // the whole rule as `inexpressible` and honouring no merge at all.
+            'x' if merge => {}
             '!' | 'x' => modifiers.inexpressible = true,
+            'C' if merge => modifiers.cvs_ignore = true,
             'C' if !specifies_side => modifiers.inexpressible = true,
-            // `r`/`s` are the SIDE modifiers. `r` (receiver) is kept, matching
-            // side-blind like `protect`; `s` (sender) is dropped at add time.
+            // The merge-only arms. Each is `goto invalid` without
+            // FILTRULE_MERGE_FILE, so they must stay behind the guard.
+            '-' if merge => modifiers.no_prefixes = true,
+            '+' if merge => {
+                modifiers.no_prefixes = true;
+                modifiers.no_prefixes_include = true;
+            }
+            'n' if merge => modifiers.no_inherit = true,
+            'e' if merge => modifiers.exclude_self = true,
+            'w' if merge => modifiers.word_split = true,
+            // `r`/`s` are the SIDE modifiers. `s` (sender) is dropped at add
+            // time. `r` (receiver) is recorded, but only a merge rule reads it:
+            // a kept non-merge daemon rule matches side-blind, like `protect`.
             // Both are invalid once the prefix already named a side.
-            'r' if !specifies_side => {}
+            'r' if !specifies_side => modifiers.receiver_side = true,
             's' if !specifies_side => modifiers.sender_side = true,
             _ => {
                 return Err(MalformedRule::InvalidModifier {
@@ -1620,6 +1713,31 @@ fn build_prefixed_rule(
         xflags == RuleXflags::Daemon && (prefix.sender_side || modifiers.sender_side);
     if side_dropped || modifiers.inexpressible {
         return Ok(None);
+    }
+
+    // A MERGE prefix names a FILE, not a pattern, so it must not go through
+    // `build_pattern_rule`: that helper's anchoring and XFLG_DIR2WILD3 rewrites
+    // are for match patterns and would turn `: sub/.rsync-filter` into an
+    // anchored rule and `: rules/` into `rules/***`. upstream skips both for a
+    // merge rule - `add_rule`'s ABS_PATH-from-slash branch tests
+    // `!(rule->rflags & (FILTRULE_ABS_PATH | FILTRULE_MERGE_FILE))`
+    // (exclude.c:297-300), so an embedded slash in a merge FILENAME sets
+    // nothing, and only the explicit `/` MODIFIER does.
+    if prefix.merge_file {
+        return Ok(Some(FilterRuleWireFormat {
+            rule_type: protocol::filters::RuleType::DirMerge,
+            pattern: pattern.into(),
+            anchored: modifiers.abs_path,
+            no_inherit: modifiers.no_inherit,
+            cvs_exclude: modifiers.cvs_ignore,
+            word_split: modifiers.word_split,
+            exclude_from_merge: modifiers.exclude_self,
+            receiver_side: modifiers.receiver_side,
+            perishable: modifiers.perishable,
+            no_prefixes: modifiers.no_prefixes,
+            no_prefixes_include: modifiers.no_prefixes_include,
+            ..FilterRuleWireFormat::default()
+        }));
     }
 
     let mut rule = build_pattern_rule(pattern, prefix.is_include, xflags);

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3305,6 +3305,231 @@ mod module_access_tests {
         assert!(rule.pattern.is_empty());
     }
 
+    /// Both spellings of a per-directory merge produce a `DirMerge` rule whose
+    /// pattern is the merge FILENAME, verbatim.
+    ///
+    /// upstream: `exclude.c:1331-1338` - `case ':'` sets FILTRULE_PERDIR_MERGE
+    /// and falls through to `case '.'` for FILTRULE_MERGE_FILE;
+    /// `exclude.c:1310-1311` maps the `dir-merge` keyword onto `:`.
+    ///
+    /// ⚠ `rule_type` is the load-bearing assertion, not the pattern text. A
+    /// parser that produced an EXCLUDE whose pattern happened to be
+    /// `.rsync-filter` would satisfy every served-file expectation of a module
+    /// that has no file by that name, so asserting only the pattern cannot tell
+    /// a real per-directory merge from a mangled exclude.
+    #[test]
+    fn a_dir_merge_token_produces_a_dir_merge_rule() {
+        for token in [": .rsync-filter", "dir-merge .rsync-filter"] {
+            let rule = accepted_rule(token);
+            assert_eq!(
+                rule.rule_type,
+                protocol::filters::RuleType::DirMerge,
+                "{token} must be a per-directory merge, not an include/exclude"
+            );
+            assert_eq!(rule.pattern, ".rsync-filter", "{token}");
+            // A merge FILENAME is not a match pattern: upstream's
+            // ABS_PATH-from-slash branch skips FILTRULE_MERGE_FILE rules
+            // (exclude.c:297-300), so only the `/` MODIFIER anchors one.
+            assert!(!rule.anchored, "{token}");
+            assert!(!rule.directory_only, "{token}");
+        }
+    }
+
+    /// The merge FILENAME escapes `build_pattern_rule`'s pattern rewrites.
+    ///
+    /// upstream: `add_rule`'s ABS_PATH-from-slash branch tests
+    /// `!(rule->rflags & (FILTRULE_ABS_PATH | FILTRULE_MERGE_FILE))`
+    /// (exclude.c:297-300) and XFLG_DIR2WILD3 applies only to a directory-only
+    /// EXCLUDE (exclude.c:212-213), so neither rewrite can reach a merge rule.
+    /// Routing a merge token through that helper would turn
+    /// `: sub/.rsync-filter` into an anchored rule and `: rules/` into
+    /// `rules/***`, and `setup_merge_file` would then look for a file that does
+    /// not exist.
+    #[test]
+    fn a_dir_merge_filename_is_not_rewritten_as_a_pattern() {
+        let nested = accepted_rule(": sub/.rsync-filter");
+        assert_eq!(nested.pattern, "sub/.rsync-filter");
+        assert!(
+            !nested.anchored,
+            "an embedded slash in a merge filename sets nothing"
+        );
+
+        let trailing = accepted_rule(": rules/");
+        assert_eq!(
+            trailing.pattern, "rules/",
+            "DIR2WILD3 must not append `***` to a merge filename"
+        );
+        assert!(!trailing.directory_only);
+    }
+
+    /// Every modifier upstream's grammar accepts on a `:` rule, and where each
+    /// one lands on the wire rule.
+    ///
+    /// upstream: the merge-gated arms of the modifier switch - `-`/`+`
+    /// (exclude.c:1381-1391), `/` (:1392-1394), `e` (:1411-1414), `n`
+    /// (:1415-1418), `p` (:1421-1423), `r` (:1424-1427), `w` (:1433-1436), `C`
+    /// (:1395-1403).
+    #[test]
+    fn dir_merge_modifiers_map_onto_the_wire_rule() {
+        /// Reads back the one flag the token under test is expected to set.
+        type ModifierSet = fn(&FilterRuleWireFormat) -> bool;
+
+        let cases: &[(&str, ModifierSet)] = &[
+            (":n .filt", |r| r.no_inherit),
+            (":e .filt", |r| r.exclude_from_merge),
+            (":w .filt", |r| r.word_split),
+            (":p .filt", |r| r.perishable),
+            (":r .filt", |r| r.receiver_side),
+            (":C .filt", |r| r.cvs_exclude),
+            (":/ .filt", |r| r.anchored),
+            (":- .filt", |r| r.no_prefixes && !r.no_prefixes_include),
+            (":+ .filt", |r| r.no_prefixes && r.no_prefixes_include),
+        ];
+        for (token, holds) in cases {
+            let rule = accepted_rule(token);
+            assert_eq!(
+                rule.rule_type,
+                protocol::filters::RuleType::DirMerge,
+                "{token}"
+            );
+            assert_eq!(rule.pattern, ".filt", "{token}");
+            assert!(holds(&rule), "{token} did not set its modifier flag");
+        }
+    }
+
+    /// `:s` is dropped at ADD time, not carried as a sender-side rule.
+    ///
+    /// upstream: `add_rule` drops a rule whose side flags equal
+    /// `am_sender ? FILTRULE_RECEIVER_SIDE : FILTRULE_SENDER_SIDE`
+    /// (exclude.c:279-285). Every daemon module directive passes
+    /// XFLG_ABS_IF_SLASH (clientserver.c:933-952) and parses before
+    /// `parse_arguments` runs, so `am_sender` is still its static 0 whatever
+    /// role the transfer later takes - the same drop `hide`/`show` and the `s`
+    /// modifier already take on a non-merge rule.
+    ///
+    /// SOURCE-DERIVED for the `:s` spelling specifically: the 12-cell daemon
+    /// harness was not re-run for it. The mechanism is the one already measured
+    /// for `exclude,s` and `hide`, which share this code path.
+    #[test]
+    fn a_sender_side_dir_merge_is_dropped_at_add_time() {
+        assert!(is_skipped(":s .rsync-filter"));
+        assert!(is_skipped("dir-merge,s .rsync-filter"));
+    }
+
+    /// A `:` whose modifier run is invalid REFUSES; it does not fall through to
+    /// a bare-word exclude.
+    ///
+    /// upstream: the modifier loop sends any unrecognised byte to `invalid:`,
+    /// which reports `"invalid modifier '%c' at position %d"` and exits
+    /// RERR_SYNTAX (exclude.c:1370-1379). `:` therefore joins the `+`/`-` class
+    /// rather than the `P R S H` class that competes with bare words - there is
+    /// no plausible bare pattern beginning with `:`.
+    ///
+    /// `!` is the one character the merge half CLOSES: it is NEGATE on a plain
+    /// rule but `goto invalid` on a merge rule, because "negation really goes
+    /// with the pattern, so it isn't useful as a merge-file default"
+    /// (exclude.c:1404-1410).
+    #[test]
+    fn an_invalid_dir_merge_modifier_is_refused_not_served() {
+        for (token, msg) in [
+            (
+                ":g .filt",
+                "invalid modifier 'g' at position 1 in filter rule: :g .filt",
+            ),
+            (
+                ":! .filt",
+                "invalid modifier '!' at position 1 in filter rule: :! .filt",
+            ),
+        ] {
+            let err =
+                parse_daemon_filter_token(token, RuleXflags::Daemon).expect_err("must refuse");
+            assert_eq!(err.to_string(), msg, "{token}");
+        }
+        // A patternless merge rule is the same refusal every other prefix gets
+        // (exclude.c:1474-1476).
+        assert!(parse_daemon_filter_token(":", RuleXflags::Daemon).is_err());
+        assert!(parse_daemon_filter_token("dir-merge", RuleXflags::Daemon).is_err());
+    }
+
+    /// The merge-only modifiers stay REFUSED on a non-merge rule.
+    ///
+    /// upstream: `-`/`+`, `e`, `n` and `w` all `goto invalid` unless
+    /// FILTRULE_MERGE_FILE is set (exclude.c:1381-1391, :1411-1418, :1433-1436).
+    /// Opening them for `:` must not open them for `-`/`exclude`, or the daemon
+    /// would serve a module upstream refuses.
+    #[test]
+    fn merge_only_modifiers_are_still_invalid_on_a_plain_rule() {
+        for token in ["-,e keep", "-,n keep", "-,w keep", "exclude,e keep"] {
+            assert!(
+                parse_daemon_filter_token(token, RuleXflags::Daemon).is_err(),
+                "{token} must stay refused on a non-merge rule"
+            );
+        }
+    }
+
+    /// Adding `:` does NOT change how a leading-`.` token is read.
+    ///
+    /// `.` - upstream's EAGER `merge` character - is deliberately still absent
+    /// from `short_rule_prefix`, so `filter = .git` keeps reaching the bare-word
+    /// fall-through and stays a literal exclude. This cell exists to pin that
+    /// the `:` arm did not disturb it.
+    ///
+    /// ⚠ THIS PINS A KNOWN DIVERGENCE, NOT FIDELITY. MEASURED against rsync
+    /// 3.5.0: `filter = .git` is rc 5 UPSTREAM, because `.` is a rule character
+    /// there and `g` is then an invalid modifier (exclude.c:1370-1379); oc
+    /// serves the module with `.git` excluded literally (rc 0). Closing that
+    /// needs the eager `merge` reader, which is tracked separately - so the
+    /// assertion below records today's behaviour deliberately and must be
+    /// FLIPPED, not deleted, when that arm lands.
+    ///
+    /// Note the neighbouring spelling is NOT affected: `filter = - .git` is one
+    /// rule whose pattern is `.git` and is rc 0 on both, because the `.` is
+    /// pattern text there rather than a leading rule character.
+    #[test]
+    fn a_leading_dot_token_is_still_a_literal_exclude() {
+        let rule = accepted_rule(".git");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(rule.pattern, ".git");
+
+        let prefixed = accepted_rule("- .git");
+        assert_eq!(prefixed.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(prefixed.pattern, ".git");
+    }
+
+    /// Recognising `:` as a rule PREFIX must not make it a token BOUNDARY.
+    ///
+    /// The two are separate mechanisms and only the first changed here:
+    /// [`short_rule_prefix`] decides what a token that ALREADY begins a rule
+    /// means, while [`RULE_KEYWORDS`] / `split_filter_tokens` decide where a new
+    /// token starts. Upstream keeps them separate the same way - `parse_rule_tok`
+    /// dispatches on the first character of a rule it has already been handed
+    /// (exclude.c:1325-1338), and the word-split loop is what hands rules over.
+    ///
+    /// If `:` became an opener, `filter = - :foo` would split into a patternless
+    /// `-` plus a `:foo` rule and the `-` would be refused
+    /// (`exclude.c:1474-1476`), turning a config upstream serves into an error.
+    /// The `.` spelling is the same hazard and the reason `.` is not an opener
+    /// either.
+    ///
+    /// MEASURED against rsync 3.5.0, module holding `.git`, `:foo`, `keep.txt`:
+    ///
+    /// ```text
+    /// filter = - .git     rc 0, serves `:foo` + `keep.txt`
+    /// filter = - :foo     rc 0, serves `.git` + `keep.txt`
+    /// ```
+    ///
+    /// oc matches on both, before AND after the `:` prefix arm - the pattern
+    /// text is untouched.
+    #[test]
+    fn a_colon_in_pattern_text_is_not_a_token_boundary() {
+        let rule = accepted_rule("- :foo");
+        assert_eq!(rule.rule_type, protocol::filters::RuleType::Exclude);
+        assert_eq!(
+            rule.pattern, ":foo",
+            "`:` after a prefix is PATTERN text, not a second rule"
+        );
+    }
+
     #[test]
     fn a_clear_with_a_comma_joined_trailer_is_refused() {
         // upstream: `clear` maps to `!`, the modifier scan is SKIPPED
@@ -3777,41 +4002,6 @@ mod module_access_tests {
                 "modifier {modifier} must not change the merged rule"
             );
         }
-    }
-
-    #[test]
-    fn the_per_dir_spellings_are_not_read_eagerly() {
-        // SCOPE BOUNDARY, and NOT a claim that this is upstream-faithful.
-        //
-        // ⚠ AN EARLIER VERSION OF THIS CELL ASSERTED THE OPPOSITE - that `:`
-        // and `dir-merge` add no rule because upstream's daemon list "never
-        // descends per directory". That is REFUTED. `add_rule` registers every
-        // FILTRULE_PERDIR_MERGE rule into the GLOBAL `mergelist_parents`
-        // (exclude.c:349-391) whatever list it went into, so a rule in
-        // `daemon_filter_list` is registered too; `push_local_filters` then
-        // fills that rule's own `u.mergelist` per directory and `check_filter`
-        // recurses into it. MEASURED against rsync 3.5.0, module holding
-        // `sub/.rsync-filter` = `- bait.txt`: `filter = : .rsync-filter` HIDES
-        // `sub/bait.txt`, and `filter = dir-merge rules` hides it with the merge
-        // file and the bait at the module root too. oc serves it in every one of
-        // those cells - a live divergence, tracked as its own change because it
-        // needs a `RuleType::DirMerge` wire rule rather than an eager read.
-        //
-        // The cell survives so [`merge_rule`] cannot quietly grow a `:` arm that
-        // reads the file EAGERLY: that would answer a per-directory rule with a
-        // root-only one and look like the feature while not being it.
-        let dir = tempfile::tempdir().expect("temp dir");
-        merge_file(dir.path(), "rules", "- bait\n");
-        assert_eq!(
-            filter_patterns(dir.path(), ": ./rules"),
-            vec![": ./rules".to_string()],
-            "`:` must not be read eagerly"
-        );
-        assert_eq!(
-            filter_patterns(dir.path(), "dir-merge ./rules"),
-            vec!["dir-merge ./rules".to_string()],
-            "`dir-merge` must not be read eagerly"
-        );
     }
 
     #[test]

--- a/crates/filters/tests/daemon_session_dir_merge_confinement.rs
+++ b/crates/filters/tests/daemon_session_dir_merge_confinement.rs
@@ -1,0 +1,194 @@
+//! A daemon session's module root bounds the per-directory merge read.
+//!
+//! # Why this cell exists
+//!
+//! Each half of this composition is already pinned on its own - `fast_io`'s
+//! `confine_root_merge_alias.rs` pins the resolver against a lexically-invisible
+//! escape, and its `operator_open_module_confinement.rs` pins a real daemon
+//! session - but nothing pinned the two TOGETHER through the public filter API.
+//! The join is what a daemon `filter = : NAME` newly depends on, and it runs
+//! through three separate decisions:
+//!
+//! 1. `install_daemon_session` takes the confinement root from
+//!    `ModuleState.root`. It is NOT the CLI `--confine-root` slot, which stays
+//!    `None` on this arm - reading that field and concluding the daemon is
+//!    unconfined is the available misreading.
+//! 2. `FilterChain::enter_directory` opens the merge file through
+//!    `merge_open::read_to_string`, which on unix is
+//!    `fast_io::operator_read_to_string_confined` - the ownership walk AND
+//!    `abspath_outside_confinement`.
+//! 3. A refused merge file is SKIPPED, not fatal, so the observable is that the
+//!    escaping file's rules never took effect - not an error return.
+//!
+//! This is the cell that would catch a future change to the daemon arm of
+//! `Activation::root()`: were it to stop taking the module root, the escaping
+//! merge file would be read and `bait.txt` would start being denied.
+//!
+//! # The companion control is load-bearing
+//!
+//! A resolver that refused EVERY merge file would satisfy the escape assertion
+//! by doing nothing at all. [`an_in_tree_merge_file_is_still_read`] keeps an
+//! ordinary in-module `.rsync-filter` green through the same session, so the
+//! pair distinguishes "refused the escape" from "refused everything".
+//!
+//! # Upstream Reference
+//!
+//! - `rsync-3.5.0/exclude.c:1668-1684` `parse_filter_file()` - wraps the
+//!   merge-file open in `operator_path_resolve = 1`, scoped by
+//!   `if (!daemon_config_filter_file)`: a PER-DIRECTORY merge is confined, while
+//!   the daemon's own `filter` / `include from` / `exclude from` parameters are
+//!   deliberately EXEMPT. The two directions are opposite on purpose.
+//! - `rsync-3.5.0/syscall.c:308-310` - a daemon seeds `abspath` from
+//!   `module_dir`, which is what `ModuleState.root` carries here.
+//! - `rsync-3.5.0/exclude.c:1682` - `parse_filter_file()` runs without
+//!   `XFLG_FATAL_ERRORS`, so an unopenable merge file is skipped.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
+use fast_io::confinement::{ModuleInsecureLinks, ModuleState};
+use filters::{DirMergeConfig, FilterChain};
+use tempfile::TempDir;
+
+/// The confinement root is process-global, mirroring upstream's `module_dir`,
+/// so the cells must not interleave.
+static SESSION: Mutex<()> = Mutex::new(());
+
+/// Serves `module` as a non-chrooted daemon module with confinement engaged.
+fn serve_module(module: &Path) -> MutexGuard<'static, ()> {
+    let guard = SESSION
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    fast_io::confinement::install_daemon_session(ModuleState {
+        root: Some(module.to_path_buf()),
+        chrooted: false,
+        selected: true,
+        insecure_links: ModuleInsecureLinks::from_module_config(false),
+    });
+    guard
+}
+
+/// A module holding `sub/`, plus an out-of-module file of filter rules.
+struct Fixture {
+    _tmp: TempDir,
+    module: PathBuf,
+    sub: PathBuf,
+    outside_rules: PathBuf,
+}
+
+fn fixture() -> Fixture {
+    let tmp = TempDir::new().expect("tempdir");
+    // The module is a level BELOW the tempdir root, so `outside_rules` is a
+    // genuine sibling outside the confinement root rather than an ancestor.
+    let module = tmp.path().join("module");
+    let sub = module.join("sub");
+    fs::create_dir_all(&sub).expect("create module tree");
+    let outside_rules = tmp.path().join("outside-rules");
+    fs::write(&outside_rules, b"- bait.txt\n").expect("write outside rules");
+    Fixture {
+        _tmp: tmp,
+        module,
+        sub,
+        outside_rules,
+    }
+}
+
+/// A chain carrying exactly one per-directory merge config, as a daemon
+/// `filter = : .rsync-filter` produces.
+fn dir_merge_chain() -> FilterChain {
+    let mut chain = FilterChain::empty();
+    chain.add_merge_config(DirMergeConfig::new(".rsync-filter"));
+    assert!(
+        chain.has_per_dir_merge(),
+        "the fixture must actually register a per-directory merge"
+    );
+    chain
+}
+
+/// THE PIN. `sub/.rsync-filter` is a symlink out of the module. The ownership
+/// walk follows it - it is owned by our own euid, which upstream treats as
+/// trusted - so the refusal has to come from the module root. If it does not,
+/// the out-of-module file becomes filter-rule text and `bait.txt` is denied.
+#[test]
+fn a_merge_file_symlinked_out_of_the_module_is_not_read() {
+    let fixture = fixture();
+    symlink(&fixture.outside_rules, fixture.sub.join(".rsync-filter"))
+        .expect("plant the escaping merge file");
+
+    let _session = serve_module(&fixture.module);
+    let mut chain = dir_merge_chain();
+    // A refused merge file is skipped rather than fatal (exclude.c:1682), so
+    // this must not error - the divergence shows up in the match below.
+    let guard = chain
+        .enter_directory(&fixture.sub)
+        .expect("a refused merge file is skipped, not fatal");
+
+    assert!(
+        chain.allows(Path::new("bait.txt"), false),
+        "the escaping merge file's rules must never take effect; reading it \
+         would let a peer-named path outside the module become filter rules"
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// THE INSTRUMENT CHECK. The identical symlink, read under a session whose root
+/// is widened to the tempdir so the target is INSIDE it, must be READ.
+///
+/// Without this, the escape cell could be satisfied by a resolver that simply
+/// never follows a symlinked merge file, or by one that fails the open for any
+/// unrelated reason - both of which would keep `bait.txt` allowed while proving
+/// nothing about the confinement ROOT. Because the only difference between this
+/// cell and the escape cell is `ModuleState.root`, a pass here plus a pass there
+/// localises the refusal to the root check.
+#[test]
+fn the_same_symlink_is_read_when_the_root_is_widened_to_contain_it() {
+    let fixture = fixture();
+    symlink(&fixture.outside_rules, fixture.sub.join(".rsync-filter"))
+        .expect("plant the escaping merge file");
+
+    // Root at the tempdir, one level ABOVE the module, so `outside-rules` is
+    // inside the confinement root.
+    let widened = fixture
+        .module
+        .parent()
+        .expect("module has a parent")
+        .to_path_buf();
+    let _session = serve_module(&widened);
+    let mut chain = dir_merge_chain();
+    let guard = chain.enter_directory(&fixture.sub).expect("enter sub");
+
+    assert!(
+        !chain.allows(Path::new("bait.txt"), false),
+        "the symlinked merge file IS followed and read when its target lies \
+         inside the confinement root - so the escape cell's refusal is the \
+         root check, not a blanket refusal to follow symlinks"
+    );
+
+    chain.leave_directory(guard);
+}
+
+/// THE COMPANION. The same session, the same chain, an ordinary in-module merge
+/// file - which must still be read, or the cell above proves nothing.
+#[test]
+fn an_in_tree_merge_file_is_still_read() {
+    let fixture = fixture();
+    fs::write(fixture.sub.join(".rsync-filter"), b"- bait.txt\n").expect("write in-tree rules");
+
+    let _session = serve_module(&fixture.module);
+    let mut chain = dir_merge_chain();
+    let guard = chain.enter_directory(&fixture.sub).expect("enter sub");
+    assert_eq!(chain.scope_depth(), 1, "the merge file must have been read");
+
+    assert!(
+        !chain.allows(Path::new("bait.txt"), false),
+        "an in-module merge file must still be read; an over-refusing resolver \
+         would satisfy the escape cell while breaking every ordinary module"
+    );
+
+    chain.leave_directory(guard);
+}

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -149,6 +149,28 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
                     }
                     return Some(rule);
                 }
+                // ⚠ A KNOWN, MEASURED DIVERGENCE, not a settled choice. This is
+                // a flat `FilterSet`, so it has nowhere to put a per-directory
+                // merge and drops it. Upstream consults ONE `daemon_filter_list`
+                // whose PERDIR_MERGE entries `check_filter` recurses into
+                // (exclude.c:1043-1056), and its mergelist is filled by the
+                // delete pass's `change_local_filter_dir`
+                // (generator.c:1924-1929) - so upstream's per-file receive check
+                // at generator.c:1662-1676 sees the merge file's rules.
+                //
+                // MEASURED, module `filter = : .rsync-filter` with
+                // `sub/.rsync-filter` holding `- bait.txt`, real 3.5.0 client:
+                //   push WITH    --delete: upstream rc 23 `ERROR: daemon refused
+                //                          to receive file "sub/bait.txt"`;
+                //                          oc rc 0, file written
+                //   push WITHOUT --delete: BOTH rc 0, file written - upstream
+                //                          never loads the merge file, so this
+                //                          arm must NOT start refusing outright
+                // Closing the first row needs a per-directory daemon chain here
+                // plus an `enter_directory` driver on the candidates pass
+                // (`receiver/transfer/candidates.rs`); it is tracked separately.
+                // The SENDER half is complete - `generator/filters.rs` builds
+                // the merge configs and the walk drives them.
                 RuleType::DirMerge | RuleType::Merge => return None,
             };
 

--- a/crates/transfer/tests/daemon_dir_merge_filter.rs
+++ b/crates/transfer/tests/daemon_dir_merge_filter.rs
@@ -1,0 +1,232 @@
+//! A daemon module's `filter = : NAME` must be read per directory.
+//!
+//! # What this pins
+//!
+//! `mergelist_parents` is a GLOBAL registry: `add_rule` files every
+//! `FILTRULE_PERDIR_MERGE` rule into it (`exclude.c:349-391`) whatever list the
+//! rule itself went into, so a rule that came from a module's `filter`
+//! directive - and therefore lives in `daemon_filter_list`
+//! (`clientserver.c:934`) - is registered alongside the transfer's own. The
+//! sender walk then calls `change_local_filter_dir` -> `push_local_filters`
+//! per directory (`flist.c:2265-2331`), which populates that rule's
+//! `u.mergelist`, and `check_filter` recurses into `ent->u.mergelist` for every
+//! PERDIR_MERGE entry it walks. The daemon list therefore DOES descend per
+//! directory.
+//!
+//! ⚠ The load-bearing assertion is that `sub/bait.txt` is HIDDEN. Nothing names
+//! `bait.txt` in the daemon config: the only place that name appears is inside
+//! `sub/.rsync-filter`. So the file can only disappear if the daemon actually
+//! opened and read that file while walking `sub/`. A parser that produced an
+//! ordinary exclude - whether of `.rsync-filter` or of the whole literal token
+//! `: .rsync-filter` - cannot hide it, which is what makes this cell able to
+//! tell a real per-directory merge from a mangled exclude rather than merely
+//! observing that some rule was created.
+//!
+//! `sub/keep.txt` is the in-tree companion control: an over-refusing merge
+//! reader that hid everything under `sub/` would satisfy the bait assertion on
+//! its own, so both halves are asserted together.
+//!
+//! MEASURED against a real rsync 3.5.0 daemon (loopback TCP, `lsof`
+//! port-ownership assert per cell), which is the behaviour asserted here:
+//!
+//! ```text
+//! filter = : .rsync-filter          pull -> root.txt, sub/.rsync-filter, sub/keep.txt
+//! filter = dir-merge .rsync-filter  pull -> identical
+//! (no filter directive)             pull -> the same plus sub/bait.txt
+//! ```
+//!
+//! # Upstream References
+//!
+//! - `exclude.c:1331-1338` - `case ':'` sets `FILTRULE_PERDIR_MERGE` and falls
+//!   through to `case '.'` for `FILTRULE_MERGE_FILE`
+//! - `exclude.c:1310-1311` - the `dir-merge` keyword maps onto `:`
+//! - `exclude.c:349-391` - `add_rule` registers the rule in `mergelist_parents`
+//! - `exclude.c:858-1000` - `push_local_filters` / `change_local_filter_dir`
+//! - `clientserver.c:934` - `filter =` parses into `daemon_filter_list`
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::sync::mpsc::{Receiver, channel};
+use std::thread;
+
+use tempfile::{TempDir, tempdir};
+
+/// A running daemon with both pipes drained on their own threads.
+struct Daemon {
+    child: Child,
+    port: u16,
+    _stderr_rx: Receiver<String>,
+    _stdout_rx: Receiver<String>,
+}
+
+impl Drop for Daemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn drain<R: Read + Send + 'static>(pipe: Option<R>) -> Receiver<String> {
+    let (tx, rx) = channel();
+    thread::spawn(move || {
+        let mut buf = String::new();
+        if let Some(mut pipe) = pipe {
+            let _ = pipe.read_to_string(&mut buf);
+        }
+        let _ = tx.send(buf);
+    });
+    rx
+}
+
+fn spawn_daemon(bin: &Path, config_path: &Path) -> io::Result<Daemon> {
+    let (mut child, port) = test_support::spawn_daemon_on_free_port(|port| {
+        Command::new(bin)
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg("--port")
+            .arg(port.to_string())
+            .arg("--config")
+            .arg(config_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+    })?;
+    let _stdout_rx = drain::<ChildStdout>(child.stdout.take());
+    let _stderr_rx = drain::<ChildStderr>(child.stderr.take());
+    Ok(Daemon {
+        child,
+        port,
+        _stderr_rx,
+        _stdout_rx,
+    })
+}
+
+/// A module tree whose ONLY mention of `bait.txt` is inside `sub/.rsync-filter`.
+struct Scratch {
+    _tmp: TempDir,
+    config: PathBuf,
+    dest: PathBuf,
+}
+
+/// `directive` is written verbatim into the module, or omitted entirely when
+/// `None` - the no-filter control.
+fn scratch(directive: Option<&str>) -> io::Result<Scratch> {
+    let tmp = tempdir()?;
+    let root = tmp.path().to_path_buf();
+    let module = root.join("module");
+    let sub = module.join("sub");
+    fs::create_dir_all(&sub)?;
+    fs::write(module.join("root.txt"), b"root\n")?;
+    fs::write(sub.join(".rsync-filter"), b"- bait.txt\n")?;
+    fs::write(sub.join("bait.txt"), b"bait\n")?;
+    fs::write(sub.join("keep.txt"), b"keep\n")?;
+
+    let filter_line = match directive {
+        Some(rule) => format!("    filter = {rule}\n"),
+        None => String::new(),
+    };
+    let config = root.join("rsyncd.conf");
+    fs::write(
+        &config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [m]\n\
+             \x20   path = {module}\n\
+             \x20   read only = false\n\
+             \x20   list = true\n\
+             {filter_line}",
+            pid = root.join("rsyncd.pid").display(),
+            log = root.join("rsyncd.log").display(),
+            module = module.display(),
+        ),
+    )?;
+    Ok(Scratch {
+        _tmp: tmp,
+        config,
+        dest: root.join("dest"),
+    })
+}
+
+/// Pulls the whole module and returns the relative paths that arrived, sorted.
+fn pull_served_names(bin: &Path, scratch: &Scratch) -> io::Result<Vec<String>> {
+    let daemon = spawn_daemon(bin, &scratch.config)?;
+    let src = format!("rsync://127.0.0.1:{}/m/", daemon.port);
+    let dest = format!("{}/", scratch.dest.display());
+    let output = Command::new(bin)
+        .args(["-r", &src, &dest])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "pull must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut names = Vec::new();
+    let mut stack = vec![scratch.dest.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let path = entry?.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else {
+                let rel = path
+                    .strip_prefix(&scratch.dest)
+                    .expect("walked path is under dest");
+                names.push(rel.to_string_lossy().into_owned());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+/// The control: with no `filter` directive the bait is served, so the fixture
+/// can never pass by having planted an unreadable or absent bait file.
+#[test]
+fn without_a_filter_directive_the_bait_is_served() {
+    let bin = test_support::oc_rsync_bin();
+    let scratch = scratch(None).expect("scratch");
+    let names = pull_served_names(&bin, &scratch).expect("pull");
+    assert!(
+        names.contains(&"sub/bait.txt".to_string()),
+        "control must serve the bait, got {names:?}"
+    );
+    assert!(names.contains(&"sub/keep.txt".to_string()), "{names:?}");
+}
+
+/// Both spellings of the directive hide the bait and keep the control file.
+#[test]
+fn a_daemon_dir_merge_hides_a_name_only_the_merge_file_names() {
+    let bin = test_support::oc_rsync_bin();
+    for directive in [": .rsync-filter", "dir-merge .rsync-filter"] {
+        let scratch = scratch(Some(directive)).expect("scratch");
+        let names = pull_served_names(&bin, &scratch).expect("pull");
+        assert!(
+            !names.contains(&"sub/bait.txt".to_string()),
+            "`filter = {directive}` must read sub/.rsync-filter and hide the \
+             bait; served {names:?}"
+        );
+        assert!(
+            names.contains(&"sub/keep.txt".to_string()),
+            "`filter = {directive}` must not over-refuse the sibling control; \
+             served {names:?}"
+        );
+        assert!(
+            names.contains(&"root.txt".to_string()),
+            "`filter = {directive}` must not over-refuse the module root; \
+             served {names:?}"
+        );
+    }
+}


### PR DESCRIPTION
A module's `filter = : NAME` / `filter = dir-merge NAME` parsed as a bare literal
exclude. The per-directory merge machinery is already built and already driven on
the sender walk; it was simply never handed a rule.

## Oracle, measured against a real rsync 3.5.0 daemon and client over loopback TCP

Module `filter = : .rsync-filter`, `sub/.rsync-filter` holding `- bait.txt`. Every
cell asserts port ownership with `lsof` before it runs, after a port collision with
a peer agent's daemon produced a false upstream reading on an earlier task.

| cell | upstream 3.5.0 | oc base | oc fix |
| --- | --- | --- | --- |
| pull | hides `sub/bait.txt`, serves `sub/keep.txt` | serves both | matches upstream |
| push, no `--delete` | rc 0, file written | rc 0, file written | unchanged |
| push `--delete` | rc 23 `daemon refused to receive file` | rc 0, file written | rc 0 — RESIDUAL |

The middle row is why the fix must not simply start refusing: upstream reaches
`change_local_filter_dir` only from the `delete_during` branch
(`generator.c:1924-1929`), so a plain push never loads the merge file at all. That
row is a control, and it has to stay green.

The third row is a **residual, not a claim**. The receiver's daemon check compiles
to a flat `FilterSet` with nowhere to put a per-directory merge, so it drops the
rule. It is unchanged from before this commit and now documented at the site
(`receiver/pipeline_setup.rs`) with the measurement above; closing it needs a
per-directory chain there plus an `enter_directory` driver on the candidates pass.

## The change

Three parser sites, plus the modifier alphabet:

- `short_rule_prefix` gains `':'` — upstream `exclude.c:1331-1338`, where `case ':'`
  sets `FILTRULE_PERDIR_MERGE` and falls through to `case '.'` for
  `FILTRULE_MERGE_FILE`.
- `KEYWORD_PREFIXES` gains `dir-merge` (`exclude.c:1310-1311`).
- `build_prefixed_rule` emits a `RuleType::DirMerge` rule. Without this the first
  two ship a rule that is still an exclude with a mangled pattern.

A merge rule names a FILE, so it bypasses `build_pattern_rule`: upstream skips the
ABS_PATH-from-slash rewrite for `FILTRULE_MERGE_FILE` (`exclude.c:297-300`), and
DIR2WILD3 applies only to a directory-only exclude. So `: sub/.rsync-filter` must
not become anchored and `: rules/` must not become `rules/***`.

`scan_modifiers` now takes the whole `RulePrefix` so it can gate the merge-only half
of the alphabet the way upstream does: `-`, `+`, `e`, `n`, `w` are `goto invalid`
without `FILTRULE_MERGE_FILE` and `!` is `goto invalid` with it
(`exclude.c:1381-1440`). `C` becomes expressible, since `DirMergeConfig` has a CVS
mode. `x` is accepted and expressed nowhere, matching what the eager `merge` arm
already does — `FILTRULE_XATTR` is not in `FILTRULES_FROM_CONTAINER`
(`exclude.c:1229-1231`), so a merge rule never passes it to its records; the two
merge paths now agree rather than one dropping the whole rule.

`:` REFUSES an invalid modifier instead of falling back to a bare-word exclude,
joining the `+`/`-` class rather than the `P R S H` class: there is no plausible bare
pattern starting with `:`, and upstream exits RERR_SYNTAX (`exclude.c:1370-1379`).
Recognising `:` as a rule PREFIX does not make it a token BOUNDARY — `filter = - :foo`
and `filter = - .git` stay one rule each, matching upstream.

## A deleted test, deliberately

`the_per_dir_spellings_are_not_read_eagerly` is **deleted, not updated**. It was a
tripwire against `merge_rule` growing an EAGER `:` arm (which would answer a
per-directory rule with a root-only read and look like the feature while not being
it), and it asserted the very divergence this change closes. Because it fails on a
value comparison rather than a compile error, "update the expectation" is the
tempting move and would have pinned the defect as correct.

Named replacement coverage:

- `a_dir_merge_token_produces_a_dir_merge_rule` — structural, both spellings.
- `a_daemon_dir_merge_hides_a_name_only_the_merge_file_names` — the e2e
  per-directory behaviour, against a live oc daemon.

## Rebase record

This is the same change as the pre-`xflags` commit, replayed on the current base.
The `helpers.rs` conflict was **two halves, not two opinions**: master's `RuleXflags`
threading (daemon vs merge-file parse mode) against this commit's `RulePrefix`
threading (merge-only modifier gating). Both are kept — `scan_modifiers(run, prefix,
..)` and `build_prefixed_rule(.., xflags)` compose. Master had also grown the eager
`merge` arm since, so two doc blocks that said the per-directory spellings are
unhandled, and one that said the eager `.` character is absent, were false on the
new base and are corrected in the same commit rather than left to drift.

## Gates, pinned 1.88.0

- `tools/ci/check_rustfmt_all.py` — clean, 3435 files (the whole-tree checker, since
  `cargo fmt --all` cannot see `include!`-ed files)
- `cargo clippy -p daemon -p filters -p transfer --all-targets -- -D warnings` — clean
- `cargo nextest run -p daemon -p filters -p transfer --lib` — 5002/5002
- `crates/transfer/tests/daemon_dir_merge_filter.rs` — 2/2 against a live daemon
- `crates/filters/tests/daemon_session_dir_merge_confinement.rs` — 3/3

Not run, and stated rather than implied: full-workspace nextest, `--all-features`,
macOS/Windows/musl cells, the 3.5.0 testsuite legs, interop. Touches no
expect-manifest, so no derived tally can skew.

## Confinement

The per-directory merge read goes through the confined operator walk, so a module
whose merge file is a symlink escaping the root cannot be read. That is asserted by
a real `install_daemon_session(ModuleState { root })` cell plus an instrument check
that the identical symlink IS read once the root is widened — without which the
refusal could be coming from anywhere.

## Residuals filed separately

- receiver flat `FilterSet` drops `DirMerge`, so push `--delete` does not refuse
- `wire_rule_to_dir_merge_config` ignores `wire_rule.anchored`, so `:/ NAME` loses its
  anchor on the network path
