### PR TITLE
fix(daemon): honour a module `dir-merge` on the receive path

### DIFF
--- a/crates/filters/src/chain/mod.rs
+++ b/crates/filters/src/chain/mod.rs
@@ -748,6 +748,40 @@ impl FilterChain {
         self.current_depth = self.current_depth.saturating_sub(1);
     }
 
+    /// Loads the per-directory merge scopes for `root`/`relative` onto a chain
+    /// that carries no scopes yet, entering `root` and then every component of
+    /// `relative` in turn.
+    ///
+    /// This is the random-access form of the walk's
+    /// [`enter_directory`](Self::enter_directory) /
+    /// [`leave_directory`](Self::leave_directory) stack: a caller that reaches
+    /// directories in no particular order takes a fresh clone of its rule chain
+    /// and rebuilds the ancestor scopes for the one directory it is about to
+    /// judge. `relative` is the directory's path below `root`; an empty path or
+    /// `.` loads `root` alone.
+    ///
+    /// A merge file that does not exist, cannot be read, or is refused is
+    /// skipped, exactly as [`enter_directory`](Self::enter_directory) skips it.
+    ///
+    /// # Upstream Reference
+    ///
+    /// Mirrors `exclude.c:change_local_filter_dir()`, which pops the merge
+    /// state above the requested depth and calls `push_local_filters()` for the
+    /// new directory. Upstream can keep a stack because its callers descend in
+    /// sorted order; rebuilding from `root` reaches the same state for any
+    /// directory without that ordering assumption.
+    pub fn reload_for_directory(&mut self, root: &Path, relative: &Path) {
+        let _ = self.enter_directory(root);
+        if relative.as_os_str().is_empty() || relative == Path::new(".") {
+            return;
+        }
+        let mut cursor = root.to_path_buf();
+        for component in relative.iter() {
+            cursor.push(component);
+            let _ = self.enter_directory(&cursor);
+        }
+    }
+
     /// Returns `true` if the chain has no rules at all (global, per-directory
     /// scopes, or per-directory merge configs).
     ///

--- a/crates/transfer/src/receiver/context.rs
+++ b/crates/transfer/src/receiver/context.rs
@@ -27,8 +27,8 @@ use crate::transfer_state::TransferPipeline;
 use super::basis::BasisFileConfig;
 use super::file_list::DirFlist;
 use super::{
-    NDX_CONVERT_CALLS, NDX_CONVERT_CMPS, ParallelThresholds, compile_daemon_filter_set,
-    partition_point_depth,
+    DaemonFilterGate, NDX_CONVERT_CALLS, NDX_CONVERT_CMPS, ParallelThresholds,
+    compile_daemon_filter_set, compile_daemon_merge_configs, partition_point_depth,
 };
 
 /// Context for the receiver role during a transfer.
@@ -124,6 +124,20 @@ pub struct ReceiverContext {
     /// - `flist.c:266-284` - `path_is_daemon_excluded()` checks each path
     ///   component against the daemon filter list
     pub(in crate::receiver) daemon_filter_set: Option<FilterSet>,
+    /// The module's `dir-merge` directives, which [`Self::daemon_filter_set`]
+    /// cannot express.
+    ///
+    /// Held apart because they are read per directory rather than matched
+    /// directly: [`Self::daemon_filter_gate`] hands them to a
+    /// [`DaemonFilterGate`] for the passes that judge incoming names.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `exclude.c:349-391` - `add_rule()` registers a `FILTRULE_PERDIR_MERGE`
+    ///   rule in the global `mergelist_parents` whatever list it belongs to
+    /// - `exclude.c:858-925` - `push_local_filters()` fills that mergelist from
+    ///   the directory being processed
+    pub(in crate::receiver) daemon_merge_configs: Vec<filters::DirMergeConfig>,
     /// Client-only view of the wire filter rules for the file-list re-check.
     ///
     /// `Some` only on a server-receiver whose `filter_chain` had daemon rules
@@ -515,6 +529,7 @@ impl ReceiverContext {
         // upstream: clientserver.c:876-895 - daemon_filter_list is built from
         // module filter/exclude/include directives and used by all roles.
         let daemon_filter_set = compile_daemon_filter_set(&config.daemon_filter_rules);
+        let daemon_merge_configs = compile_daemon_merge_configs(&config.daemon_filter_rules);
 
         Self {
             protocol: handshake.protocol,
@@ -531,6 +546,7 @@ impl ReceiverContext {
             uid_list: IdList::new(),
             gid_list: IdList::new(),
             daemon_filter_set,
+            daemon_merge_configs,
             recheck_client_filter: None,
             filter_chain: FilterChain::empty(),
             deletion_filter_chain: FilterChain::empty(),
@@ -1169,6 +1185,35 @@ impl ReceiverContext {
     /// before accepting transfer data.
     pub fn daemon_filter_set(&self) -> Option<&FilterSet> {
         self.daemon_filter_set.as_ref()
+    }
+
+    /// Builds the module's filter list for one pass over incoming names,
+    /// rooted at `dest_dir`.
+    ///
+    /// Returns `None` when the module declares no rules the pass could apply.
+    ///
+    /// The `dir-merge` directives join only when `--delete` is in effect. That
+    /// is not a shortcut: on the receiving side upstream reads a per-directory
+    /// merge file exclusively from the delete pass - `delete_in_dir()` calls
+    /// `change_local_filter_dir()` for every content directory
+    /// (`generator.c:314`) and the `delete_during` branch calls it for the rest
+    /// (`generator.c:1924-1929`; `generator.c:2799-2801` under incremental
+    /// recursion). Without `--delete` none of them runs, the mergelist stays
+    /// empty, and `check_filter` finds nothing to recurse into, so the module's
+    /// per-directory rules do not apply to the incoming names. MEASURED
+    /// against a real rsync 3.5.0 daemon; see `receiver/daemon_filter.rs`.
+    ///
+    /// The module's plain rules always apply, with or without `--delete`.
+    pub(in crate::receiver) fn daemon_filter_gate(
+        &self,
+        dest_dir: &std::path::Path,
+    ) -> Option<DaemonFilterGate> {
+        let merge_configs: &[filters::DirMergeConfig] = if self.config.flags.delete {
+            &self.daemon_merge_configs
+        } else {
+            &[]
+        };
+        DaemonFilterGate::new(self.daemon_filter_set.as_ref(), merge_configs, dest_dir)
     }
 
     /// Reclaims heap data from the oldest unreclaimed INC_RECURSE segment.

--- a/crates/transfer/src/receiver/daemon_filter.rs
+++ b/crates/transfer/src/receiver/daemon_filter.rs
@@ -1,0 +1,277 @@
+//! The receiving side's view of a daemon module's filter list.
+//!
+//! Upstream keeps exactly one `daemon_filter_list` and consults it, per
+//! incoming name, at `generator.c:1662-1676`. Its `FILTRULE_PERDIR_MERGE`
+//! entries are not flat rules: `check_filter` recurses into
+//! `ent->u.mergelist` (`exclude.c:1194-1198`), and that mergelist holds
+//! whatever `push_local_filters` last read out of the directory currently
+//! being processed (`exclude.c:858-925`). So the same rule list answers
+//! differently in each directory, and this module is where the receiver holds
+//! that per-directory state.
+//!
+//! # When the merge files are read
+//!
+//! On the receiving side the only thing that ever calls
+//! `change_local_filter_dir` is the delete pass: `delete_in_dir` calls it for
+//! every content directory (`generator.c:314`), and the `delete_during` branch
+//! calls it directly for the directories `delete_in_dir` skips
+//! (`generator.c:1924-1929`, and `generator.c:2799-2801` under incremental
+//! recursion). A transfer without `--delete` reaches none of them, so its
+//! mergelist stays empty and a per-directory merge rule is inert - MEASURED
+//! against a real rsync 3.5.0 daemon, a push into a module declaring
+//! `filter = : .rsync-filter` writes the name `sub/.rsync-filter` excludes
+//! unless `--delete` is also passed. [`DaemonFilterGate`] therefore takes the
+//! merge configurations only when the delete pass is active; the module's
+//! plain rules always apply.
+
+use std::path::{Path, PathBuf};
+
+use filters::{DirMergeConfig, FilterChain, FilterSet};
+
+/// A module's filter list, evaluated in the directory each name lives in.
+///
+/// Built per receive pass by
+/// [`ReceiverContext::daemon_filter_gate`](crate::receiver::ReceiverContext::daemon_filter_gate)
+/// and consulted through [`allows`](Self::allows) /
+/// [`refuses_ancestor`](Self::refuses_ancestor). Probing takes `&mut self`
+/// because a name in a new directory reloads that directory's merge files, the
+/// way `change_local_filter_dir` reloads upstream's mergelists.
+pub(in crate::receiver) struct DaemonFilterGate {
+    /// The module's rules with no directory loaded: the base every
+    /// per-directory reload starts from.
+    prototype: FilterChain,
+    /// Destination root the merge file names are resolved against. This is the
+    /// module root for a daemon receiver, matching upstream's post-`chdir`
+    /// `curr_dir` in `set_filter_dir()` (`exclude.c:756-776`).
+    dest_dir: PathBuf,
+    /// Whether any per-directory merge directive is active. False collapses
+    /// every probe onto `prototype`, so a module with only plain rules costs
+    /// no reloads.
+    per_dir: bool,
+    /// The directory whose merge files `chain` currently holds, relative to
+    /// [`Self::dest_dir`] and `/`-separated, plus that loaded chain.
+    loaded: Option<(String, FilterChain)>,
+}
+
+impl DaemonFilterGate {
+    /// Builds the gate for one receive pass, or `None` when the module
+    /// contributes no rules at all.
+    ///
+    /// `merge_configs` is what the caller decided is live for this pass - empty
+    /// when the delete pass is not running, per this module's header.
+    pub(in crate::receiver) fn new(
+        globals: Option<&FilterSet>,
+        merge_configs: &[DirMergeConfig],
+        dest_dir: &Path,
+    ) -> Option<Self> {
+        if globals.is_none() && merge_configs.is_empty() {
+            return None;
+        }
+        let mut prototype = FilterChain::new(globals.cloned().unwrap_or_default());
+        for config in merge_configs {
+            prototype.add_merge_config(config.clone());
+        }
+        // upstream: exclude.c:200-228 - a leading-`/` rule read from a per-dir
+        // merge file is re-anchored to that file's directory relative to the
+        // module root, which is what the transfer root records here.
+        prototype.set_transfer_root(dest_dir.to_path_buf());
+        Some(Self {
+            prototype,
+            dest_dir: dest_dir.to_path_buf(),
+            per_dir: !merge_configs.is_empty(),
+            loaded: None,
+        })
+    }
+
+    /// Reports whether the module's filter list admits `name`.
+    ///
+    /// `name` is a wire-format path relative to the destination root, always
+    /// `/`-separated. The rules consulted are the module's own plus the merge
+    /// files of the directory holding `name` and its ancestors - never
+    /// `name`'s own merge file when it is itself a directory, matching
+    /// upstream, where `recv_generator` refuses a directory before the
+    /// `delete_during` branch below it pushes that directory's filters
+    /// (`generator.c:1662` precedes `generator.c:1924-1929`).
+    pub(in crate::receiver) fn allows(&mut self, name: &str, is_dir: bool) -> bool {
+        let directory = name.rsplit_once('/').map_or("", |(parent, _)| parent);
+        self.chain_for(directory).allows(Path::new(name), is_dir)
+    }
+
+    /// Reports whether any ancestor directory of `name` is refused, in which
+    /// case the entry must be dropped without a diagnostic.
+    ///
+    /// Upstream refuses the *directory* once, sets `skip_dir` to it, and every
+    /// later entry below that directory returns from `recv_generator()` before
+    /// the `daemon_filter_list` check is reached - so the contents are dropped
+    /// in silence, with no second "daemon refused" line. Recomputing the
+    /// ancestor verdict here reproduces that outcome without threading
+    /// generator state across oc's separate directory and candidate passes.
+    ///
+    /// # Upstream Reference
+    ///
+    /// - `generator.c:1258-1266` - `if (skip_dir) { if (is_below(file, skip_dir)) ... return; }`
+    /// - `generator.c:1284-1285` / `generator.c:1491-1495` - a refused directory
+    ///   jumps to `skipping_dir_contents`, which assigns `skip_dir = file`
+    pub(in crate::receiver) fn refuses_ancestor(&mut self, name: &str) -> bool {
+        let mut cursor = name;
+        while let Some(separator) = cursor.rfind('/') {
+            cursor = &cursor[..separator];
+            if cursor.is_empty() {
+                break;
+            }
+            if !self.allows(cursor, true) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Returns the rule chain as it stands inside `directory`, reloading that
+    /// directory's merge files when the previous probe was in another one.
+    ///
+    /// upstream: `exclude.c:974-1000 change_local_filter_dir()` pops the merge
+    /// state above the new depth and pushes the new directory's. oc's candidate
+    /// and directory passes do not descend in a single ordered walk, so the
+    /// state is rebuilt from the destination root instead of popped down to a
+    /// depth; the loaded rules are the same either way.
+    fn chain_for(&mut self, directory: &str) -> &FilterChain {
+        if !self.per_dir {
+            return &self.prototype;
+        }
+        if self
+            .loaded
+            .as_ref()
+            .is_none_or(|(loaded, _)| loaded != directory)
+        {
+            let mut chain = self.prototype.clone();
+            chain.reload_for_directory(&self.dest_dir, Path::new(directory));
+            self.loaded = Some((directory.to_owned(), chain));
+        }
+        &self
+            .loaded
+            .as_ref()
+            .expect("the directory was just loaded")
+            .1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use filters::{DirMergeConfig, FilterRule, FilterSet};
+    use tempfile::TempDir;
+
+    use super::DaemonFilterGate;
+
+    /// A destination whose ONLY mention of `bait.txt` is inside
+    /// `sub/.rsync-filter`, so nothing but a real read of that file can refuse
+    /// the name.
+    fn dest_with_merge_file() -> TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let sub = tmp.path().join("sub");
+        fs::create_dir_all(&sub).expect("create sub");
+        fs::write(sub.join(".rsync-filter"), b"- bait.txt\n").expect("write merge file");
+        tmp
+    }
+
+    fn merge_configs() -> Vec<DirMergeConfig> {
+        vec![DirMergeConfig::new(".rsync-filter")]
+    }
+
+    /// The discriminating cell.
+    ///
+    /// Ground truth, MEASURED against a real rsync 3.5.0 daemon on loopback TCP
+    /// with `read only = no` and a module declaring `filter = : .rsync-filter`,
+    /// pushing `sub/bait.txt` and `sub/keep.txt` with `--delete`: the daemon
+    /// answers `ERROR: daemon refused to receive file "sub/bait.txt"` and exits
+    /// 23, while `sub/keep.txt` lands.
+    ///
+    /// ⚠ The load-bearing half is the pair. A gate that refused everything
+    /// under `sub/` would satisfy the bait assertion on its own, so the sibling
+    /// control is asserted with it.
+    #[test]
+    fn a_dir_merge_refuses_the_name_only_the_merge_file_names() {
+        let dest = dest_with_merge_file();
+        let mut gate = DaemonFilterGate::new(None, &merge_configs(), dest.path())
+            .expect("a merge directive alone builds a gate");
+
+        assert!(
+            !gate.allows("sub/bait.txt", false),
+            "sub/.rsync-filter excludes bait.txt, so the receiver must refuse it"
+        );
+        assert!(
+            gate.allows("sub/keep.txt", false),
+            "the sibling control must not be swept up"
+        );
+    }
+
+    /// The merge file governs its own directory, not the whole tree.
+    ///
+    /// Upstream reads `sub/.rsync-filter` while processing `sub`, so a
+    /// same-named file at the destination root is judged by the root's rules -
+    /// of which there are none here. Without this the first test would also
+    /// pass on a gate that simply applied every merge file everywhere.
+    #[test]
+    fn a_merge_file_does_not_reach_outside_its_directory() {
+        let dest = dest_with_merge_file();
+        let mut gate = DaemonFilterGate::new(None, &merge_configs(), dest.path())
+            .expect("a merge directive alone builds a gate");
+
+        assert!(
+            gate.allows("bait.txt", false),
+            "a root-level name is not governed by sub/.rsync-filter"
+        );
+        assert!(
+            !gate.allows("sub/bait.txt", false),
+            "the same name inside sub/ still is"
+        );
+    }
+
+    /// Directory changes both ways, so the loaded-directory cache cannot pass
+    /// by loading once and never reloading, nor by never caching a miss.
+    #[test]
+    fn the_verdict_follows_the_directory_back_and_forth() {
+        let dest = dest_with_merge_file();
+        let mut gate = DaemonFilterGate::new(None, &merge_configs(), dest.path())
+            .expect("a merge directive alone builds a gate");
+
+        assert!(!gate.allows("sub/bait.txt", false));
+        assert!(gate.allows("bait.txt", false));
+        assert!(!gate.allows("sub/bait.txt", false));
+        assert!(gate.allows("bait.txt", false));
+    }
+
+    /// With no merge directive live - which is what the gate is handed when
+    /// `--delete` is absent - the module's plain rules still apply and the
+    /// merge file on disk is not consulted.
+    ///
+    /// MEASURED: pushing into the same module WITHOUT `--delete`, real rsync
+    /// 3.5.0 writes `sub/bait.txt` and exits 0, because nothing on the
+    /// receiving side calls `change_local_filter_dir` outside the delete pass.
+    #[test]
+    fn without_merge_configs_the_merge_file_is_not_read() {
+        let dest = dest_with_merge_file();
+        let globals =
+            FilterSet::from_rules(vec![FilterRule::exclude("plain.txt")]).expect("compiles");
+        let mut gate = DaemonFilterGate::new(Some(&globals), &[], dest.path())
+            .expect("plain rules alone build a gate");
+
+        assert!(
+            gate.allows("sub/bait.txt", false),
+            "the merge file must stay unread when no merge directive is live"
+        );
+        assert!(
+            !gate.allows("plain.txt", false),
+            "the module's plain rules apply with or without the delete pass"
+        );
+    }
+
+    /// A module that declares nothing has no gate, so the passes skip the probe
+    /// entirely.
+    #[test]
+    fn an_empty_module_builds_no_gate() {
+        let dest = dest_with_merge_file();
+        assert!(DaemonFilterGate::new(None, &[], dest.path()).is_none());
+    }
+}

--- a/crates/transfer/src/receiver/directory/creation.rs
+++ b/crates/transfer/src/receiver/directory/creation.rs
@@ -243,23 +243,23 @@ impl ReceiverContext {
         // (generator.c:1281-1283) before the `skipping_dir_contents` jump. A
         // server receiver forwards that frame to the pushing client instead of
         // writing it to the daemon's own stderr.
-        let daemon_filters = self.daemon_filter_set();
+        let mut daemon_filters = self.daemon_filter_gate(dest_dir);
         let dir_entries: Vec<(usize, PathBuf, PathBuf)> = self
             .file_list
             .iter()
             .enumerate()
             .filter(|(_, e)| e.is_dir())
             .filter(|(_, e)| {
-                if let Some(filters) = daemon_filters {
+                if let Some(filters) = daemon_filters.as_mut() {
                     let name = e.name();
                     if name != "." && !name.is_empty() {
                         // upstream: generator.c:1258-1266 - a directory below an
                         // already-refused one is dropped in silence; only the
                         // outermost refusal is reported.
-                        if crate::receiver::daemon_filter_refuses_ancestor(filters, name) {
+                        if filters.refuses_ancestor(name) {
                             return false;
                         }
-                        if !filters.allows(Path::new(name), true) {
+                        if !filters.allows(name, true) {
                             let _ = self.emit_error_xfer_line(
                                 writer,
                                 &format!("ERROR: daemon refused to receive directory \"{name}\"\n"),

--- a/crates/transfer/src/receiver/directory/deletion.rs
+++ b/crates/transfer/src/receiver/directory/deletion.rs
@@ -926,19 +926,12 @@ impl ReceiverContext {
                     // so dir-merge self-exclusion and merge-driven excludes are
                     // active while deciding deletions. Only entered when the
                     // deletion chain has per-dir merge configs; otherwise the
-                    // flat global chain is consulted directly. enter_directory
-                    // takes `&mut self`, so each worker reloads onto its own
-                    // clone of the merge chain.
+                    // flat global chain is consulted directly.
+                    // `reload_for_directory` takes `&mut self`, so each worker
+                    // reloads onto its own clone of the merge chain.
                     let local_chain = if needs_perdir_merge {
                         let mut chain = (*merge_chain).clone();
-                        let _ = chain.enter_directory(&dest_dir_owned);
-                        if dir_relative.as_os_str() != "." {
-                            let mut cur = dest_dir_owned.clone();
-                            for comp in dir_relative.iter() {
-                                cur.push(comp);
-                                let _ = chain.enter_directory(&cur);
-                            }
-                        }
+                        chain.reload_for_directory(&dest_dir_owned, &dir_relative);
                         Some(chain)
                     } else {
                         None
@@ -1328,14 +1321,7 @@ impl ReceiverContext {
             let local_chain = if needs_perdir_merge {
                 let mut chain = deletion_chain.clone();
                 chain.set_transfer_root(dest_dir.to_path_buf());
-                let _ = chain.enter_directory(dest_dir);
-                if dir_relative.as_os_str() != "." {
-                    let mut cur = dest_dir.to_path_buf();
-                    for comp in dir_relative.iter() {
-                        cur.push(comp);
-                        let _ = chain.enter_directory(&cur);
-                    }
-                }
+                chain.reload_for_directory(dest_dir, dir_relative);
                 Some(chain)
             } else {
                 None

--- a/crates/transfer/src/receiver/mod.rs
+++ b/crates/transfer/src/receiver/mod.rs
@@ -31,6 +31,7 @@
 
 mod basis;
 mod context;
+mod daemon_filter;
 mod dest_root;
 mod directory;
 mod file_list;
@@ -56,12 +57,13 @@ pub use self::basis::{
     find_basis_file_with_config, set_checksum_threads_policy,
 };
 pub use self::context::ReceiverContext;
+pub(in crate::receiver) use self::daemon_filter::DaemonFilterGate;
 pub(in crate::receiver) use self::dest_root::dest_arg_has_trailing_slash;
 pub use self::dest_root::ensure_dest_root_exists;
 pub use self::file_list::IncrementalFileListReceiver;
 pub(in crate::receiver) use self::pipeline_setup::{
     PipelineSetup, apply_acls_from_receiver_cache, compile_daemon_filter_set,
-    daemon_filter_refuses_ancestor,
+    compile_daemon_merge_configs,
 };
 pub use self::stats::{ListOnlyEntry, SenderStats, TransferStats};
 pub use self::wire::{

--- a/crates/transfer/src/receiver/pipeline_setup.rs
+++ b/crates/transfer/src/receiver/pipeline_setup.rs
@@ -149,28 +149,18 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
                     }
                     return Some(rule);
                 }
-                // ⚠ A KNOWN, MEASURED DIVERGENCE, not a settled choice. This is
-                // a flat `FilterSet`, so it has nowhere to put a per-directory
-                // merge and drops it. Upstream consults ONE `daemon_filter_list`
-                // whose PERDIR_MERGE entries `check_filter` recurses into
-                // (exclude.c:1043-1056), and its mergelist is filled by the
-                // delete pass's `change_local_filter_dir`
-                // (generator.c:1924-1929) - so upstream's per-file receive check
-                // at generator.c:1662-1676 sees the merge file's rules.
+                // A per-directory merge is not a flat rule and has no place in
+                // this set: upstream keeps it as a `FILTRULE_PERDIR_MERGE`
+                // entry that `check_filter` recurses into
+                // (exclude.c:1194-1198), holding whatever the current
+                // directory's merge file last supplied. That state lives in
+                // `DaemonFilterGate`, which takes these rules through
+                // [`compile_daemon_merge_configs`].
                 //
-                // MEASURED, module `filter = : .rsync-filter` with
-                // `sub/.rsync-filter` holding `- bait.txt`, real 3.5.0 client:
-                //   push WITH    --delete: upstream rc 23 `ERROR: daemon refused
-                //                          to receive file "sub/bait.txt"`;
-                //                          oc rc 0, file written
-                //   push WITHOUT --delete: BOTH rc 0, file written - upstream
-                //                          never loads the merge file, so this
-                //                          arm must NOT start refusing outright
-                // Closing the first row needs a per-directory daemon chain here
-                // plus an `enter_directory` driver on the candidates pass
-                // (`receiver/transfer/candidates.rs`); it is tracked separately.
-                // The SENDER half is complete - `generator/filters.rs` builds
-                // the merge configs and the walk drives them.
+                // A `merge` rule is eager: the daemon reads the named file at
+                // parse time (exclude.c:1581-1590), so its contents reach this
+                // function as ordinary rules and the directive itself carries
+                // nothing further.
                 RuleType::DirMerge | RuleType::Merge => return None,
             };
 
@@ -195,45 +185,74 @@ pub(in crate::receiver) fn compile_daemon_filter_set(
     FilterSet::from_rules(filter_rules).ok()
 }
 
-/// Reports whether any ancestor directory of `name` is refused by the daemon
-/// filter list, in which case the entry must be dropped without a diagnostic.
+/// Compiles the per-directory merge directives out of a module's filter rules.
 ///
-/// Upstream refuses the *directory* once, sets `skip_dir` to it, and every
-/// later entry below that directory returns from `recv_generator()` before the
-/// `daemon_filter_list` check is reached - so the contents are dropped in
-/// silence, with no second "daemon refused" line. Recomputing the ancestor
-/// verdict here reproduces that outcome without threading generator state
-/// across oc's separate directory and candidate passes.
-///
-/// `name` is a wire-format relative path, always `/`-separated.
+/// The companion to [`compile_daemon_filter_set`]: that function owns the flat
+/// rules, this one owns the `dir-merge` directives they cannot express. Both
+/// read the same wire list, and
+/// [`DaemonFilterGate`](crate::receiver::DaemonFilterGate) evaluates them
+/// together.
 ///
 /// # Upstream Reference
 ///
-/// - `generator.c:1258-1266` - `if (skip_dir) { if (is_below(file, skip_dir)) ... return; }`
-/// - `generator.c:1284-1285` / `generator.c:1491-1495` - a refused directory
-///   jumps to `skipping_dir_contents`, which assigns `skip_dir = file`
-pub(in crate::receiver) fn daemon_filter_refuses_ancestor(filters: &FilterSet, name: &str) -> bool {
-    let mut cursor = name;
-    while let Some(sep) = cursor.rfind('/') {
-        cursor = &cursor[..sep];
-        if cursor.is_empty() {
-            break;
-        }
-        if !filters.allows(std::path::Path::new(cursor), true) {
-            return true;
-        }
-    }
-    false
+/// `exclude.c:349-391 add_rule()` registers every `FILTRULE_PERDIR_MERGE` rule
+/// in the global `mergelist_parents`, whichever list it was added to - so a
+/// rule from a module's `filter` directive, which lands in
+/// `daemon_filter_list` (`clientserver.c:934`), is registered alongside the
+/// transfer's own and `push_local_filters` fills it per directory.
+pub(in crate::receiver) fn compile_daemon_merge_configs(
+    rules: &[FilterRuleWireFormat],
+) -> Vec<filters::DirMergeConfig> {
+    use protocol::filters::RuleType;
+
+    rules
+        .iter()
+        .filter(|rule| rule.rule_type == RuleType::DirMerge)
+        .map(crate::receiver::transfer::dir_merge_config_from_wire)
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::compile_daemon_filter_set;
+    use super::{compile_daemon_filter_set, compile_daemon_merge_configs};
     use protocol::filters::{FilterRuleWireFormat, RuleType};
     use std::path::Path;
 
     fn exclude(pattern: &str) -> FilterRuleWireFormat {
         FilterRuleWireFormat::exclude(pattern)
+    }
+
+    /// A module's `filter = : NAME` reaches the receiver as a `DirMerge` wire
+    /// rule, and the two compilers split it correctly: the flat set has nothing
+    /// to say about it, and the merge compiler names the file to read per
+    /// directory.
+    ///
+    /// ⚠ Both halves are asserted. A compiler that turned the directive into an
+    /// exclude of `.rsync-filter` would leave the flat set non-empty, and one
+    /// that dropped it entirely would leave the merge list empty - the pair
+    /// tells those apart.
+    #[test]
+    fn a_dir_merge_directive_compiles_to_a_merge_config_and_no_flat_rule() {
+        let rules = vec![FilterRuleWireFormat {
+            rule_type: RuleType::DirMerge,
+            pattern: ".rsync-filter".into(),
+            ..FilterRuleWireFormat::default()
+        }];
+
+        assert!(
+            compile_daemon_filter_set(&rules).is_none(),
+            "a per-directory merge is not a flat rule"
+        );
+        let configs = compile_daemon_merge_configs(&rules);
+        assert_eq!(configs.len(), 1, "the directive must survive as a config");
+        assert_eq!(configs[0].filename(), ".rsync-filter");
+    }
+
+    /// A plain rule contributes nothing to the merge list, so the two
+    /// compilers cannot both be reading the whole wire list indiscriminately.
+    #[test]
+    fn a_plain_rule_contributes_no_merge_config() {
+        assert!(compile_daemon_merge_configs(&[exclude("foo")]).is_empty());
     }
 
     /// An unsided `clear`, as a module's `filter = clear` directive produces.

--- a/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
+++ b/crates/transfer/src/receiver/tests/errors_and_timeouts/daemon_filter_tests.rs
@@ -143,8 +143,6 @@ fn daemon_filter_rules_prepended_to_receiver_deletion_chain() {
 fn refused_directory_swallows_its_contents_without_a_second_report() {
     use protocol::filters::{FilterRuleWireFormat, RuleType};
 
-    use crate::receiver::daemon_filter_refuses_ancestor;
-
     let handshake = test_handshake();
     let mut config = test_config();
     config.daemon_filter_rules = vec![FilterRuleWireFormat {
@@ -153,26 +151,30 @@ fn refused_directory_swallows_its_contents_without_a_second_report() {
         ..FilterRuleWireFormat::default()
     }];
     let ctx = ReceiverContext::new_for_test(&handshake, config);
-    let filters = ctx.daemon_filter_set().unwrap();
+    // The module declares no `dir-merge`, so the gate never touches the
+    // destination and the path it is rooted at is immaterial.
+    let mut filters = ctx
+        .daemon_filter_gate(std::path::Path::new("/nonexistent"))
+        .expect("the module declares a rule");
 
     assert!(
-        daemon_filter_refuses_ancestor(filters, "dir.secret/inner.txt"),
+        filters.refuses_ancestor("dir.secret/inner.txt"),
         "a file under a refused directory is dropped silently, not reported again"
     );
     assert!(
-        daemon_filter_refuses_ancestor(filters, "dir.secret/deep/inner.txt"),
+        filters.refuses_ancestor("dir.secret/deep/inner.txt"),
         "the skip applies at every depth below the refused directory"
     );
     assert!(
-        !daemon_filter_refuses_ancestor(filters, "sub/nested.secret"),
+        !filters.refuses_ancestor("sub/nested.secret"),
         "the entry's own name is the outer refusal's business, not the ancestor probe's"
     );
     assert!(
-        !daemon_filter_refuses_ancestor(filters, "top.secret"),
+        !filters.refuses_ancestor("top.secret"),
         "a top-level entry has no ancestor to inherit a refusal from"
     );
     assert!(
-        !daemon_filter_refuses_ancestor(filters, "sub/fine.txt"),
+        !filters.refuses_ancestor("sub/fine.txt"),
         "an allowed tree must not be swallowed"
     );
 }

--- a/crates/transfer/src/receiver/transfer.rs
+++ b/crates/transfer/src/receiver/transfer.rs
@@ -24,7 +24,7 @@ mod pipelined_incremental;
 mod setup;
 mod sync;
 
-pub(in crate::receiver) use setup::parse_wire_filters_for_receiver;
+pub(in crate::receiver) use setup::{dir_merge_config_from_wire, parse_wire_filters_for_receiver};
 
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};

--- a/crates/transfer/src/receiver/transfer/candidates.rs
+++ b/crates/transfer/src/receiver/transfer/candidates.rs
@@ -217,11 +217,10 @@ impl ReceiverContext {
         // Phase A: Filter candidates (cheap, in-memory checks only).
         // Pre-extract config values to avoid repeated field access in the
         // filter closures at 100K scale.
-        let daemon_filters = self.daemon_filter_set();
+        let mut daemon_filters = self.daemon_filter_gate(dest_dir);
         let min_size = self.config.file_selection.min_file_size;
         let max_size = self.config.file_selection.max_file_size;
         let has_size_bounds = min_size.is_some() || max_size.is_some();
-        let has_daemon_filters = daemon_filters.is_some();
         let has_failed_dirs = failed_dirs.is_some();
         let verbose_client = self.config.flags.verbose && self.config.connection.client_mode;
 
@@ -240,19 +239,17 @@ impl ReceiverContext {
                 // than writing to the daemon's own stderr. Dropping the file
                 // without that frame would let a push of module-excluded files
                 // exit 0 with no diagnostic at all.
-                if has_daemon_filters {
-                    let filters =
-                        daemon_filters.expect("daemon_filters is Some when has_daemon_filters");
+                if let Some(filters) = daemon_filters.as_mut() {
                     let name = e.name();
                     if name != "." {
                         // upstream: generator.c:1258-1266 - the `skip_dir` check
                         // runs before the filter check, so a file below an
                         // already-refused directory is dropped in silence.
-                        if crate::receiver::daemon_filter_refuses_ancestor(filters, name) {
+                        if filters.refuses_ancestor(name) {
                             stats.files_skipped += 1;
                             return false;
                         }
-                        if !filters.allows(Path::new(name), false) {
+                        if !filters.allows(name, false) {
                             let _ = self.emit_error_xfer_line(
                                 writer,
                                 &format!("ERROR: daemon refused to receive file \"{name}\"\n"),

--- a/crates/transfer/src/receiver/transfer/setup.rs
+++ b/crates/transfer/src/receiver/transfer/setup.rs
@@ -9,7 +9,9 @@
 mod context;
 mod wire_filters;
 
-pub(in crate::receiver) use wire_filters::parse_wire_filters_for_receiver;
+pub(in crate::receiver) use wire_filters::{
+    dir_merge_config_from_wire, parse_wire_filters_for_receiver,
+};
 
 #[cfg(unix)]
 mod sandbox;

--- a/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
+++ b/crates/transfer/src/receiver/transfer/setup/wire_filters.rs
@@ -64,39 +64,7 @@ pub(in crate::receiver) fn parse_wire_filters_for_receiver(
                 continue;
             }
             RuleType::DirMerge => {
-                // upstream: exclude.c:setup_merge_file() derives the
-                // per-directory merge FILENAME from the basename after the last
-                // '/' in the rule pattern (`ex->pattern = strdup(y+1)` where
-                // `y = strrchr(x, '/')`). A client's `-F` reaches the receiver as
-                // `: /.rsync-filter` (exclude.c:1608), so the wire pattern is
-                // `/.rsync-filter`. Using it verbatim as the merge filename makes
-                // `directory.join("/.rsync-filter")` resolve to the filesystem
-                // root (Rust's `Path::join` discards the base on an absolute
-                // component), so the per-directory merge file is never found and
-                // its protect rules are absent when the --delete pass decides
-                // candidates - deleting dir-merge-protected destination entries.
-                // Split off the basename to mirror setup_merge_file(); oc's own
-                // encoder emits the anchor as a `/` modifier with a bare pattern,
-                // so this is a no-op for the oc<->oc wire and only normalises the
-                // `/`-in-body form a real upstream client sends.
-                let filename = lossy.rsplit('/').next().unwrap_or(lossy.as_ref());
-                let mut config = DirMergeConfig::new(filename);
-                if wire_rule.no_inherit {
-                    config = config.with_inherit(false);
-                }
-                if wire_rule.exclude_from_merge {
-                    config = config.with_exclude_self(true);
-                }
-                if wire_rule.sender_side {
-                    config = config.with_sender_only(true);
-                }
-                if wire_rule.receiver_side {
-                    config = config.with_receiver_only(true);
-                }
-                if wire_rule.perishable {
-                    config = config.with_perishable(true);
-                }
-                merge_configs.push(config);
+                merge_configs.push(dir_merge_config_from_wire(wire_rule));
                 continue;
             }
             RuleType::Merge => continue,
@@ -125,6 +93,53 @@ pub(in crate::receiver) fn parse_wire_filters_for_receiver(
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("filter error: {e}")))?;
 
     Ok((filter_set, merge_configs))
+}
+
+/// Decodes one `DirMerge` wire rule into the receiver's per-directory merge
+/// configuration.
+///
+/// The receiver reaches per-directory merges from two directions - the rules a
+/// client transmits and the rules a daemon module's `filter` directive
+/// contributes - and both must decode the same way, so this is the single
+/// decoder for both.
+///
+/// # Upstream Reference
+///
+/// `exclude.c:setup_merge_file()` derives the per-directory merge FILENAME from
+/// the basename after the last '/' in the rule pattern (`ex->pattern =
+/// strdup(y+1)` where `y = strrchr(x, '/')`). A client's `-F` reaches the
+/// receiver as `: /.rsync-filter` (exclude.c:1608), so the wire pattern is
+/// `/.rsync-filter`. Using it verbatim as the merge filename makes
+/// `directory.join("/.rsync-filter")` resolve to the filesystem root (Rust's
+/// `Path::join` discards the base on an absolute component), so the
+/// per-directory merge file is never found and its protect rules are absent
+/// when the --delete pass decides candidates - deleting dir-merge-protected
+/// destination entries. Splitting off the basename mirrors
+/// `setup_merge_file()`; oc's own encoder emits the anchor as a `/` modifier
+/// with a bare pattern, so this is a no-op for the oc<->oc wire and only
+/// normalises the `/`-in-body form a real upstream client sends.
+pub(in crate::receiver) fn dir_merge_config_from_wire(
+    wire_rule: &FilterRuleWireFormat,
+) -> DirMergeConfig {
+    let lossy = wire_rule.pattern.to_string_lossy();
+    let filename = lossy.rsplit('/').next().unwrap_or(lossy.as_ref());
+    let mut config = DirMergeConfig::new(filename);
+    if wire_rule.no_inherit {
+        config = config.with_inherit(false);
+    }
+    if wire_rule.exclude_from_merge {
+        config = config.with_exclude_self(true);
+    }
+    if wire_rule.sender_side {
+        config = config.with_sender_only(true);
+    }
+    if wire_rule.receiver_side {
+        config = config.with_receiver_only(true);
+    }
+    if wire_rule.perishable {
+        config = config.with_perishable(true);
+    }
+    config
 }
 
 #[cfg(test)]

--- a/crates/transfer/tests/daemon_dir_merge_filter.rs
+++ b/crates/transfer/tests/daemon_dir_merge_filter.rs
@@ -230,3 +230,190 @@ fn a_daemon_dir_merge_hides_a_name_only_the_merge_file_names() {
         );
     }
 }
+
+/// A push fixture: the module is the DESTINATION and already carries
+/// `sub/.rsync-filter`, while the source carries the bait it names.
+///
+/// The source carries an identical copy of `sub/.rsync-filter` so that
+/// `--delete` has nothing to remove there - the merge file the daemon must read
+/// is the destination's, and a fixture that deleted it out from under the check
+/// would prove nothing.
+struct PushScratch {
+    _tmp: TempDir,
+    config: PathBuf,
+    module: PathBuf,
+    source: PathBuf,
+}
+
+fn push_scratch(directive: Option<&str>) -> io::Result<PushScratch> {
+    let tmp = tempdir()?;
+    let root = tmp.path().to_path_buf();
+
+    let module = root.join("module");
+    fs::create_dir_all(module.join("sub"))?;
+    fs::write(module.join("root.txt"), b"root\n")?;
+    fs::write(module.join("sub/.rsync-filter"), b"- bait.txt\n")?;
+
+    let source = root.join("source");
+    fs::create_dir_all(source.join("sub"))?;
+    fs::write(source.join("root.txt"), b"root\n")?;
+    fs::write(source.join("sub/.rsync-filter"), b"- bait.txt\n")?;
+    fs::write(source.join("sub/bait.txt"), b"bait\n")?;
+    fs::write(source.join("sub/keep.txt"), b"keep\n")?;
+
+    let filter_line = match directive {
+        Some(rule) => format!("    filter = {rule}\n"),
+        None => String::new(),
+    };
+    let config = root.join("rsyncd.conf");
+    fs::write(
+        &config,
+        format!(
+            "pid file = {pid}\n\
+             log file = {log}\n\
+             use chroot = false\n\
+             \n\
+             [m]\n\
+             \x20   path = {module}\n\
+             \x20   read only = false\n\
+             \x20   list = true\n\
+             {filter_line}",
+            pid = root.join("rsyncd.pid").display(),
+            log = root.join("rsyncd.log").display(),
+            module = module.display(),
+        ),
+    )?;
+    Ok(PushScratch {
+        _tmp: tmp,
+        config,
+        module,
+        source,
+    })
+}
+
+/// Pushes the source into the module and returns `(exit code, stderr)`.
+fn push_into_module(
+    bin: &Path,
+    scratch: &PushScratch,
+    delete: bool,
+) -> io::Result<(Option<i32>, String)> {
+    let daemon = spawn_daemon(bin, &scratch.config)?;
+    let src = format!("{}/", scratch.source.display());
+    let dest = format!("rsync://127.0.0.1:{}/m/", daemon.port);
+    let mut command = Command::new(bin);
+    command.arg("-r");
+    if delete {
+        command.arg("--delete");
+    }
+    let output = command
+        .args([&src, &dest])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    Ok((
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    ))
+}
+
+fn landed(scratch: &PushScratch, relative: &str) -> bool {
+    scratch.module.join(relative).exists()
+}
+
+/// A push under `--delete` must be refused for the name the destination's own
+/// `sub/.rsync-filter` excludes.
+///
+/// # Why `--delete` is part of the cell
+///
+/// On the receiving side the ONLY caller of `change_local_filter_dir` is the
+/// delete pass (`generator.c:314` from `delete_in_dir`, `generator.c:1924-1929`
+/// and `generator.c:2799-2801` for the directories it skips), so that is the
+/// only way the module's per-directory mergelist is ever filled. The refusal
+/// itself is `generator.c:1662-1676`, which reports
+/// `ERROR: daemon refused to receive %s "%s"` at `FERROR_XFER` - a frame the
+/// server forwards to the pushing client - and `log.c:338` turns that into
+/// `got_xfer_error`, which `cleanup.c:217-218` lifts to exit 23.
+///
+/// MEASURED against a real rsync 3.5.0 daemon and client over loopback TCP,
+/// with per-cell `lsof` port-ownership asserts, module `filter = : .rsync-filter`
+/// and `sub/.rsync-filter` holding `- bait.txt`:
+///
+/// ```text
+/// push --delete   rc 23, `ERROR: daemon refused to receive file "sub/bait.txt"`,
+///                 sub/bait.txt absent, sub/keep.txt written
+/// push (plain)    rc 0, sub/bait.txt written
+/// ```
+///
+/// ⚠ `sub/keep.txt` is the in-tree control: a receiver that refused everything
+/// under `sub/` would satisfy the bait assertion alone.
+#[test]
+fn a_daemon_dir_merge_refuses_a_pushed_name_under_delete() {
+    let bin = test_support::oc_rsync_bin();
+    for directive in [": .rsync-filter", "dir-merge .rsync-filter"] {
+        let scratch = push_scratch(Some(directive)).expect("scratch");
+        let (code, stderr) = push_into_module(&bin, &scratch, true).expect("push");
+
+        assert_eq!(
+            code,
+            Some(23),
+            "`filter = {directive}` must refuse the excluded name and exit 23; \
+             stderr: {stderr}"
+        );
+        assert!(
+            stderr.contains("daemon refused to receive file \"sub/bait.txt\""),
+            "`filter = {directive}` must name the refused file; stderr: {stderr}"
+        );
+        assert!(
+            !landed(&scratch, "sub/bait.txt"),
+            "`filter = {directive}` must not write the refused name"
+        );
+        assert!(
+            landed(&scratch, "sub/keep.txt"),
+            "`filter = {directive}` must not over-refuse the sibling control"
+        );
+    }
+}
+
+/// The same push WITHOUT `--delete` is silent and writes the bait.
+///
+/// This is not a leniency oc chose: upstream reaches
+/// `change_local_filter_dir` only from the delete pass, so a plain push never
+/// opens the merge file and the name it excludes is accepted. MEASURED against
+/// rsync 3.5.0 (rc 0, `sub/bait.txt` written).
+///
+/// It is also the guard that keeps the fix above from being "refuse anything a
+/// dir-merge directive is present for": that shape would fail here.
+#[test]
+fn a_push_without_delete_never_reads_the_merge_file() {
+    let bin = test_support::oc_rsync_bin();
+    let scratch = push_scratch(Some(": .rsync-filter")).expect("scratch");
+    let (code, stderr) = push_into_module(&bin, &scratch, false).expect("push");
+
+    assert_eq!(code, Some(0), "a plain push must succeed; stderr: {stderr}");
+    assert!(stderr.is_empty(), "a plain push must be silent: {stderr}");
+    assert!(
+        landed(&scratch, "sub/bait.txt"),
+        "without --delete the merge file is never read, so the name is accepted"
+    );
+}
+
+/// The control: with no `filter` directive the same `--delete` push writes the
+/// bait, so the refusal above can only come from the directive - not from the
+/// delete pass, the fixture, or an unwritable destination.
+#[test]
+fn without_a_filter_directive_a_delete_push_writes_the_bait() {
+    let bin = test_support::oc_rsync_bin();
+    let scratch = push_scratch(None).expect("scratch");
+    let (code, stderr) = push_into_module(&bin, &scratch, true).expect("push");
+
+    assert_eq!(code, Some(0), "the control push must succeed: {stderr}");
+    assert!(
+        landed(&scratch, "sub/bait.txt"),
+        "the control must write the bait"
+    );
+    assert!(
+        landed(&scratch, "sub/keep.txt"),
+        "the control must write the sibling too"
+    );
+}


### PR DESCRIPTION
`#7804` made a module's `filter = : NAME` honoured on the daemon **sender**
walk. This is the receiving half, which that PR documented as its own residual:
the receiver's daemon check compiled to a flat `FilterSet` with nowhere to put a
per-directory merge, so it dropped the rule and accepted a file upstream
refuses.

## Measured, real rsync 3.5.0 daemon and client over loopback TCP

Module `filter = : .rsync-filter`; destination `sub/.rsync-filter` holds
`- bait.txt`; the source pushes `sub/bait.txt` plus a `sub/keep.txt` control.
Port ownership asserted with `lsof` before every cell.

| cell | upstream 3.5.0 | oc base (`afea16f83`) | oc fix |
| --- | --- | --- | --- |
| pull | hides `sub/bait.txt`, serves `sub/keep.txt` | same | same |
| push, no `--delete` | rc 0, bait written | rc 0, bait written | rc 0, bait written |
| push `--delete` | rc 23, `ERROR: daemon refused to receive file "sub/bait.txt"`, bait absent, keep written | **rc 0, bait written** | rc 23, identical text, bait absent, keep written |

oc-daemon against oc-client reproduces the same three rows, so the in-repo e2e
does not depend on an upstream binary being present.

⚠ **A measurement trap worth pinning, because it first refuted the table.** The
initial upstream run showed the dir-merge inert in *both* directions. The
fixture lived under `/tmp`, which on macOS is a symlink to `/private/tmp`, and
upstream's confined merge-file open (`parse_filter_file` →
`open_no_attacker_symlinks` with `operator_path_resolve = 1`,
`exclude.c:1676-1686`) refuses it and logs `parse_filter_file(...) [not found]`.
Re-run from a non-symlinked path, `#7804`'s numbers reproduce exactly. Anyone
re-measuring in this area must avoid `/tmp` — it silently manufactures a
"the feature does not exist upstream" reading.

## The upstream rule

- `add_rule` registers every `FILTRULE_PERDIR_MERGE` rule into the global
  `mergelist_parents` regardless of which list it went into
  (`exclude.c:349-391`), so a module rule in `daemon_filter_list`
  (`clientserver.c:934`) participates; `check_filter` recurses into
  `ent->u.mergelist` (`exclude.c:1194-1198`).
- Refusal path: `generator.c:1662-1676` → `FERROR_XFER` → `got_xfer_error`
  (`log.c:338`) → exit 23 (`cleanup.c:217-218`).
- **Merge files are read only under `--delete`.** The only receiver-side callers
  of `change_local_filter_dir` are `delete_in_dir` (`generator.c:314`) and the
  `delete_during` branches (`generator.c:1924-1929`, `:2799-2801`), and
  `compat.c:683-688` makes plain `--delete` mean `delete_during` at protocol
  ≥ 30. That is why the middle row must stay green, and it is asserted as a
  control rather than left implicit.

## Design

`DaemonFilterGate` owns the per-directory state. The module's plain rules keep
coming from `compile_daemon_filter_set`; its `dir-merge` directives come from a
new `compile_daemon_merge_configs`; both are evaluated through one
`FilterChain`. No second decoder — `dir_merge_config_from_wire` was lifted out
of `parse_wire_filters_for_receiver` rather than reimplemented.

`FilterChain::reload_for_directory` is the random-access form of upstream's
`change_local_filter_dir` (upstream can keep a stack because its callers descend
in sorted order). It **replaced two hand-rolled copies of that same loop already
in the receiver's delete pass**, so merge loading now has one owner instead of
three.

`wire_rule_to_dir_merge_config` is deliberately untouched — a parallel change
(`#7805`) owns its `anchored` handling.

## Mutations

| mutation | lib tests killed | e2e killed |
| --- | --- | --- |
| M1 drop the merge configs (restores pre-fix behaviour) | 1 — `a_dir_merge_directive_compiles_to_a_merge_config_and_no_flat_rule` | 1 — `a_daemon_dir_merge_refuses_a_pushed_name_under_delete` |
| M2 remove the `--delete` gate | **0** | 1 — `a_push_without_delete_never_reads_the_merge_file` |
| M3 never reload after the first directory | 2 — `a_merge_file_does_not_reach_outside_its_directory`, `the_verdict_follows_the_directory_back_and_forth` | 1 |
| M4 load the root's merges only, skip components | 3 — the two above plus `a_dir_merge_refuses_the_name_only_the_merge_file_names` | 1 |

**M2 kills no unit test, and that is reported as measured rather than papered
over:** the `--delete` gate lives in `ReceiverContext::daemon_filter_gate`, which
the gate's own unit tests bypass by construction, so only the e2e can reach it.
All mutations reverted, green re-confirmed.

Non-vacuity: the 5 e2e cells run 1.30–1.45 s each (real daemon spawns), not the
~0.03 s that would mean they self-skipped.

## Gates, pinned 1.88.0

- `tools/ci/check_rustfmt_all.py` — 3434 files, clean
- `cargo clippy -p filters -p transfer --all-targets --no-deps -- -D warnings` — clean
- `cargo nextest run -p transfer --lib` — 2544 passed
- `cargo nextest run -p filters` (lib + 37 test binaries) — 1551 passed
- `daemon_dir_merge_filter` + 6 delete/filter integration targets — 22 passed
- 5 workspace dir-merge integration binaries — 18 passed

Not run, stated rather than implied: full-workspace nextest, Windows/macOS-CI/musl
matrices, interop, the upstream testsuite legs, `llvm-cov`, benchmarks. `core`
and `cli` suites were not run; `deletion.rs` changed there only by extraction,
verified line-for-line equivalent.

## Residuals found, filed not fixed

1. **`parse_wire_filters_for_receiver`'s `Clear` arm is still the `#7795`
   defect.** It calls `FilterRule::clear().with_sides(sender_side, receiver_side)`
   unconditionally, and `apply_clear_rule` no-ops when neither side is set, so an
   *unsided* `!` from a client is silently dropped. `#7795` fixed exactly this in
   `generator/filters.rs` and `pipeline_setup.rs` but left this third converter,
   which feeds the receiver's `filter_chain`/`deletion_filter_chain`. The daemon
   check was deliberately not routed through it for that reason.
2. **No oc counterpart to upstream's second receive check** at
   `receiver.c:887-895`, which aborts `RERR_PROTOCOL` when a daemon-excluded name
   reaches `recv_files`. oc refuses at the generator stage only. Not reached by
   this cell.
3. **A deliberate non-mirror, stated at the site rather than silently.** Under
   `--delete-before`, upstream's `do_delete_pass` walks the whole tree and leaves
   `change_local_filter_dir` parked at the *last* directory, so the per-file loop
   that follows consults stale merge state. oc's gate always tracks the current
   entry's directory. Protocol ≥ 30 always selects `delete_during`, so the live
   path agrees; correctness was chosen over reproducing the artifact.
