### PR TITLE
fix(engine): confine the backup parent chain and copy/symlink tiers

### DIFF
--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 
 use crate::local_copy::LocalCopyError;
 use crate::local_copy::context::BackupStrategy;
+#[cfg(not(unix))]
 use crate::local_copy::create_symlink;
 #[cfg(unix)]
 use crate::local_copy::map_metadata_error;
@@ -170,17 +171,39 @@ pub(crate) fn create_backup_parents(
             .map_err(|error| LocalCopyError::io("create backup directory", parent, error));
     };
 
-    // Delegate the `--backup-dir` subtree to the shared helper, using a plain
-    // recursive create for each element (the local path has no receiver
-    // sandbox to anchor against).
+    // Delegate the `--backup-dir` subtree to the shared helper. The local path
+    // has no receiver sandbox to anchor against, so each element is created
+    // through the ownership walk bound to the session's confinement root -
+    // upstream's `do_mkdir_at()` under `make_backup()`'s `operator_path_resolve`
+    // (backup.c:128, backup.c:437-449). `ACCESSPERMS` is upstream's mode and
+    // 0o777 is what `create_dir_all` passed before, so the umask still decides
+    // the bits.
     create_backup_dir_parents(
         destination_root,
         backup_dir,
         parent,
         metadata_options,
-        |path| fs::create_dir_all(path),
+        create_backup_dir_confined,
     )
     .map_err(|error| LocalCopyError::io("create backup directory", parent, error))
+}
+
+/// Creates one element of a local `--backup-dir` chain through the ownership
+/// walk, bound to the session's confinement root.
+///
+/// upstream: `backup.c:128` `do_mkdir_at(backup_dir_buf, ACCESSPERMS)` and
+/// `backup.c:206` `make_path()`, both inside the `operator_path_resolve = 1`
+/// window `make_backup()` raises around the whole backup (backup.c:437-449).
+#[cfg(unix)]
+fn create_backup_dir_confined(path: &Path) -> io::Result<()> {
+    fast_io::operator_create_dir_all_confined(path, 0o777)
+}
+
+/// Non-Unix has no ownership walk to run; degrade to a plain recursive create,
+/// as the other operator-path helpers on this file do.
+#[cfg(not(unix))]
+fn create_backup_dir_confined(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)
 }
 
 /// Creates the `--backup-dir` parent tree for a backup path, inheriting each
@@ -239,14 +262,14 @@ where
     let mut current = backup_root.clone();
     for component in rel.components() {
         current.push(component.as_os_str());
-        match fs::symlink_metadata(&current) {
+        match backup_dir_element_metadata(&current) {
             Ok(meta) if meta.is_dir() => continue,
             // upstream: backup.c:48-53 - a non-directory (including a symlink) in
             // the way is removed so it can be recreated as a directory. A
             // non-directory is never a recursive tree, so a plain unlink mirrors
-            // `delete_item` for this case (backup.c:50); `remove_file` drops a
+            // `delete_item` for this case (backup.c:50); the unlink drops a
             // symlink without following it, matching the `lstat`-based check.
-            Ok(_) => fs::remove_file(&current)?,
+            Ok(_) => remove_backup_dir_obstruction(&current)?,
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) => return Err(error),
         }
@@ -257,6 +280,47 @@ where
     }
 
     Ok(())
+}
+
+/// Stats one element of a `--backup-dir` chain without following it, through
+/// the ownership walk bound to the session's confinement root.
+///
+/// upstream: `backup.c:69` `validate_backup_dir()` calls `do_lstat_at()`, whose
+/// `operator_path_resolve` arm (`syscall.c:2208`, inside the shared
+/// `do_xstat_at()`) resolves the parent with `owner_walk_parent()` and
+/// `fstatat`s the leaf through it. The decision this stat feeds is "delete
+/// whatever is here", so resolving it by path is what lets a flipped component
+/// aim that deletion outside the tree.
+#[cfg(unix)]
+fn backup_dir_element_metadata(path: &Path) -> io::Result<fs::Metadata> {
+    fast_io::operator_symlink_metadata_confined(path)
+}
+
+/// Non-Unix has no ownership walk to run; degrade to a plain `lstat`.
+#[cfg(not(unix))]
+fn backup_dir_element_metadata(path: &Path) -> io::Result<fs::Metadata> {
+    fs::symlink_metadata(path)
+}
+
+/// Removes a non-directory obstruction from a `--backup-dir` chain through the
+/// ownership walk bound to the session's confinement root.
+///
+/// The confined stat above does not cover this: the component can be flipped
+/// between the two, which is upstream's `backup-dir-symlink-race` shape, so the
+/// unlink resolves its own parent chain.
+///
+/// upstream: `backup.c:75-79` `validate_backup_dir()` -
+/// `delete_item(..., DEL_FOR_BACKUP | DEL_RECURSE)`, reaching `do_unlink_at()`
+/// (`syscall.c:673`) inside `make_backup()`'s `operator_path_resolve` window.
+#[cfg(unix)]
+fn remove_backup_dir_obstruction(path: &Path) -> io::Result<()> {
+    fast_io::operator_remove_file_confined(path)
+}
+
+/// Non-Unix has no ownership walk to run; degrade to a plain unlink.
+#[cfg(not(unix))]
+fn remove_backup_dir_obstruction(path: &Path) -> io::Result<()> {
+    fs::remove_file(path)
 }
 
 /// Copies a freshly-created backup subdirectory's attributes from the
@@ -324,14 +388,23 @@ pub(crate) fn copy_entry_to_backup(
     fake_super: bool,
 ) -> Result<Option<BackupStrategy>, LocalCopyError> {
     if file_type.is_file() {
-        fs::copy(source, backup_path)
+        // upstream: backup.c:401 `copy_file(fname, buf, -1, file->mode)`, whose
+        // destination open is `do_open_at()` via `unlink_and_reopen()`
+        // (util1.c:366) and therefore takes the confined ownership walk inside
+        // `make_backup()`'s `operator_path_resolve` window. `fs::copy` resolves
+        // `backup_path` by path instead, so a symlink at the leaf - or at a
+        // component flipped since the parent chain was validated - redirects
+        // the pre-image out of the tree. Shared with the `--inplace` tier: it
+        // is the same upstream `copy_file()` call with the same destination
+        // policy.
+        copy_pre_image_to_backup(source, backup_path)
             .map_err(|error| LocalCopyError::io("create backup", backup_path, error))?;
         return Ok(Some(BackupStrategy::Copy));
     }
     if file_type.is_symlink() {
         let target = fs::read_link(source)
             .map_err(|error| LocalCopyError::io("read symbolic link", source, error))?;
-        create_symlink(&target, source, backup_path)
+        create_backup_symlink(&target, source, backup_path)
             .map_err(|error| LocalCopyError::io("create symbolic link", backup_path, error))?;
         return Ok(Some(BackupStrategy::Symlink));
     }
@@ -358,6 +431,29 @@ pub(crate) fn copy_entry_to_backup(
         );
         Ok(None)
     }
+}
+
+/// Recreates the pre-image symlink in the backup area with its parent chain
+/// resolved by the ownership walk, bound to the session's confinement root.
+///
+/// Deliberately not folded into `create_symlink`: that one also materialises
+/// the transfer's own symlinks, which are receiver paths and take the confined
+/// beneath-walk rather than the ownership one.
+///
+/// upstream: `backup.c:377` `do_symlink_at(sl, buf)` inside `make_backup()`'s
+/// `operator_path_resolve = 1` window (backup.c:437-449); `syscall.c:780`
+/// `do_symlink_at()` resolves the parent with `owner_walk_parent()` and creates
+/// the leaf with `symlinkat`.
+#[cfg(unix)]
+fn create_backup_symlink(target: &Path, _source: &Path, backup_path: &Path) -> io::Result<()> {
+    fast_io::operator_symlink_confined(target, backup_path)
+}
+
+/// Non-Unix has no ownership walk to run; degrade to the platform symlink
+/// creation the transfer path uses.
+#[cfg(not(unix))]
+fn create_backup_symlink(target: &Path, source: &Path, backup_path: &Path) -> io::Result<()> {
+    create_symlink(target, source, backup_path)
 }
 
 /// Re-materialises a device, FIFO, or socket node at `backup_path` from the

--- a/crates/engine/src/local_copy/executor/mod.rs
+++ b/crates/engine/src/local_copy/executor/mod.rs
@@ -50,7 +50,10 @@ pub(crate) use reference::{
     find_copy_dest_symlink, find_reference_action, reference_attrs_unchanged,
 };
 pub(crate) use sources::copy_sources;
-pub(crate) use special::{
-    copy_device, copy_fifo, copy_symlink, create_symlink, symlink_target_is_safe,
-};
+pub(crate) use special::{copy_device, copy_fifo, copy_symlink, symlink_target_is_safe};
+// The backup ladder's SYMLINK tier takes the confined operator-path spelling on
+// Unix (`fast_io::operator_symlink_confined`), so this re-export serves only the
+// non-Unix fallback in `file::backup` and the Windows symlink cells.
+#[cfg(not(unix))]
+pub(crate) use special::create_symlink;
 pub(crate) use util::{follow_symlink_metadata, non_empty_path};

--- a/crates/engine/src/local_copy/executor/special/mod.rs
+++ b/crates/engine/src/local_copy/executor/special/mod.rs
@@ -17,7 +17,12 @@ mod symlink;
 
 pub(crate) use device::copy_device;
 pub(crate) use fifo::copy_fifo;
-pub(crate) use symlink::{copy_symlink, create_symlink, symlink_target_is_safe};
+pub(crate) use symlink::{copy_symlink, symlink_target_is_safe};
+// Outside this module `create_symlink` serves only the non-Unix backup
+// fallback: on Unix the backup ladder's SYMLINK tier takes the confined
+// operator-path spelling (`fast_io::operator_symlink_confined`) instead.
+#[cfg(not(unix))]
+pub(crate) use symlink::create_symlink;
 
 /// Attempts a `--link-dest` basis hard link, reporting whether it succeeded.
 ///

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -3527,3 +3527,364 @@ fn inplace_backup_dir_leaving_an_unconfined_session_does_receive_the_pre_image()
         "and the in-place rewrite completed on the original inode"
     );
 }
+
+// The two backup-ladder sites the cells above do NOT reach: the `--backup-dir`
+// PARENT CHAIN that `create_backup_parents` builds before any tier runs, and
+// the COPY / SYMLINK tiers that run only once both the hard-link and the rename
+// tier have reported `EXDEV`.
+//
+// Upstream confines both. `make_backup()` raises `operator_path_resolve` around
+// the whole of `make_backup_inner` (backup.c:437-449), which covers
+// `get_backup_name()` -> `copy_valid_path()`'s `do_lstat_at()` /
+// `delete_item()` / `do_mkdir_at()` (backup.c:69-128) and, further down, the
+// `do_symlink_at(sl, buf)` at backup.c:377 and the `copy_file(fname, buf, -1,
+// mode)` at backup.c:401 whose destination open is `do_open_at()`
+// (util1.c:366 `unlink_and_reopen`). Each of those wrappers takes the ownership
+// walk while the flag is set, and `owner_walk_parent()` judges the resolved
+// leaf against the confinement root (syscall.c:581-596).
+//
+// As with the cells above, the escape shape is a symlink the test itself owns,
+// so these pin the CONFINEMENT-ROOT half of the walk, never the ownership half:
+// a single-uid test can never make ownership refuse.
+
+/// WITNESS (confinement-root half). `create_backup_parents` runs BEFORE any
+/// tier, so it is the first thing an out-of-root `--backup-dir` reaches - and
+/// creating the backup subtree is already an escape, whatever the ladder does
+/// afterwards.
+///
+/// The ladder cells above assert only that no `file.txt~` appears outside the
+/// root, which a path-based `create_dir_all` satisfies while still having
+/// created `outside/source/` as a side effect. This asserts the DIRECTORY, so
+/// the parent chain's own resolver is what is measured rather than the tiers
+/// below it.
+///
+/// Non-vacuity is carried by
+/// [`backup_dir_leaving_an_unconfined_session_does_receive_the_pre_image`],
+/// which runs this exact fixture with no confinement root and finds the backup
+/// at `outside/source/file.txt~` - so the subtree the assertion below forbids is
+/// demonstrably creatable when nothing forbids it.
+///
+/// upstream: `backup.c:128` `do_mkdir_at(backup_dir_buf, ACCESSPERMS)` and
+/// `backup.c:69` `do_lstat_at()`, both inside `make_backup()`'s
+/// `operator_path_resolve = 1` window (backup.c:437-449).
+#[cfg(unix)]
+#[test]
+fn backup_dir_parents_cannot_be_created_outside_the_confinement_root() {
+    let fx = backup_confinement_fixture();
+    fx.plant_backup_dir_link(&fx.outside);
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let result = plan.execute_with_options(LocalCopyExecution::Apply, options);
+
+    assert!(
+        result.is_err(),
+        "a --backup-dir whose parent chain can only be built outside the \
+         confinement root must fail closed"
+    );
+    assert!(
+        !fx.outside.join("source").exists(),
+        "the backup subtree was created at {} - create_backup_parents resolved \
+         an operator-named path out of the confinement root",
+        fx.outside.join("source").display()
+    );
+}
+
+#[cfg(unix)]
+impl BackupConfinementFixture {
+    /// A REAL `--backup-dir` inside the confinement root, so the parent chain
+    /// validates cleanly and the tiers below it are the only thing left to
+    /// refuse.
+    fn real_backup_dir(&self) -> PathBuf {
+        self.dest.join("bak")
+    }
+}
+
+/// Builds the post-validation component swap the COPY and SYMLINK tier cells
+/// share: the `bak/source` directory `create_backup_parents` just accepted is
+/// replaced by a symlink pointing out of the confinement root.
+///
+/// This is upstream's `backup-dir-symlink-race` in deterministic form, and it
+/// is the ONLY shape that reaches those tiers once the parent chain is itself
+/// confined - any escape the chain can see is refused there first. It is also
+/// exactly why upstream confines the tiers rather than trusting
+/// `copy_valid_path()`'s earlier verdict.
+#[cfg(unix)]
+fn flip_validated_parent_outside(backup_dir: PathBuf, outside: PathBuf) -> impl Fn() + Send {
+    move || {
+        let validated = backup_dir.join("source");
+        fs::remove_dir(&validated).expect("the parent chain must have created it");
+        std::os::unix::fs::symlink(&outside, &validated).expect("flip it to a symlink");
+    }
+}
+
+/// Forces both the hard-link and the rename tier to report `EXDEV` so the
+/// copy-tree fallback is what places the backup, running `action` under both
+/// overrides.
+///
+/// `before_rename` runs once the link tier has already failed, which is the
+/// window a component swap has to land in to reach the tiers unvalidated.
+#[cfg(unix)]
+fn with_cross_device_backup_tiers<R>(
+    before_rename: impl Fn() + Send + 'static,
+    action: impl FnOnce() -> R,
+) -> R {
+    with_hard_link_override(
+        |_, _| Err(io::Error::from_raw_os_error(super::CROSS_DEVICE_ERROR_CODE)),
+        || {
+            with_backup_rename_override(
+                move |_, _| {
+                    before_rename();
+                    Some(Err(io::Error::from_raw_os_error(
+                        super::CROSS_DEVICE_ERROR_CODE,
+                    )))
+                },
+                action,
+            )
+        },
+    )
+}
+
+/// WITNESS (confinement-root half) for the COPY tier, which is a THIRD call
+/// site: it runs only when neither the hard-link nor the rename tier can place
+/// the backup, so the cells above never reach it. A refusal here has to stop an
+/// OPEN FOR WRITING from resolving out of the root, and `std::fs::copy` has
+/// exactly the path-following behaviour that would let it.
+///
+/// upstream: `backup.c:401` `copy_file(fname, buf, -1, file->mode)`, whose
+/// destination goes through `unlink_and_reopen()` -> `do_open_at()`
+/// (util1.c:366, syscall.c:1513) inside `make_backup()`'s
+/// `operator_path_resolve = 1` window.
+#[cfg(unix)]
+#[test]
+fn cross_device_copy_tier_cannot_receive_the_pre_image_outside_the_confinement_root() {
+    let fx = backup_confinement_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let result = with_cross_device_backup_tiers(
+        flip_validated_parent_outside(fx.real_backup_dir(), fx.outside.clone()),
+        || plan.execute_with_options(LocalCopyExecution::Apply, options),
+    );
+
+    assert!(
+        result.is_err(),
+        "a copy-tier backup that can only land outside the confinement root \
+         must fail closed"
+    );
+    let escaped = fx.outside.join("file.txt~");
+    assert!(
+        !escaped.exists(),
+        "the pre-transfer bytes reached {} - the copy tier opened an \
+         operator-named path out of the confinement root",
+        escaped.display()
+    );
+}
+
+/// NON-VACUITY COMPANION for
+/// [`cross_device_copy_tier_cannot_receive_the_pre_image_outside_the_confinement_root`]:
+/// the same fixture and the same post-validation flip with no confinement root
+/// installed - the plain local client, upstream's NULL `confine_root` - really
+/// does write the pre-image outside the tree.
+///
+/// Without it the witness would pass just as well on a fixture that never
+/// reaches the copy tier at all: an override that fired too early, a
+/// destination that was never out of date, a flip that broke the transfer
+/// before the backup.
+#[cfg(unix)]
+#[test]
+fn cross_device_copy_tier_in_an_unconfined_session_does_receive_the_pre_image() {
+    let fx = backup_confinement_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(None);
+    with_cross_device_backup_tiers(
+        flip_validated_parent_outside(fx.real_backup_dir(), fx.outside.clone()),
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("with nothing to be outside of, the copy tier must succeed")
+        },
+    );
+
+    assert_eq!(
+        fs::read(fx.outside.join("file.txt~")).expect("the copy tier must place a backup at all"),
+        b"original",
+        "unconfined, the copy tier follows the flipped component and writes the \
+         pre-image outside the tree - so the confined cell's placement assertion \
+         is discriminating, not vacuous"
+    );
+    assert_eq!(
+        fs::read(fx.existing()).expect("read dest"),
+        b"updated",
+        "and the transfer completed, so the fixture exercises the whole ladder"
+    );
+}
+
+/// NEGATIVE CONTROL for the COPY tier. With no flip, a confined session must
+/// still place the cross-device backup inside the root.
+///
+/// Without this, "refuse every copy-tier backup" would satisfy the witness
+/// above while breaking every legitimate `--backup-dir` on another filesystem -
+/// the one case the copy tier exists for.
+#[cfg(unix)]
+#[test]
+fn cross_device_copy_tier_inside_the_confinement_root_still_places_the_backup() {
+    let fx = backup_confinement_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    with_cross_device_backup_tiers(
+        || {},
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("an in-root copy-tier backup must still be placed")
+        },
+    );
+
+    assert_eq!(
+        fs::read(fx.real_backup_dir().join("source/file.txt~")).expect("the backup exists"),
+        b"original",
+        "a copy-tier backup landing inside the root must be placed, not refused"
+    );
+    assert_eq!(fs::read(fx.existing()).expect("read dest"), b"updated");
+}
+
+/// A confinement fixture whose pre-transfer destination entry is a SYMLINK, so
+/// the copy-tree fallback takes its SYMLINK branch rather than its COPY branch.
+#[cfg(unix)]
+fn backup_confinement_symlink_fixture() -> BackupConfinementFixture {
+    let fx = backup_confinement_fixture();
+    std::os::unix::fs::symlink("new_target", fx.source.join("link")).expect("source symlink");
+    let existing = fx.dest.join("source/link");
+    std::os::unix::fs::symlink("old_target", &existing).expect("dest symlink");
+    let stale = FileTime::from_unix_time(1_500_000_000, 0);
+    filetime::set_symlink_file_times(&existing, stale, stale).expect("backdate the dest symlink");
+    fx
+}
+
+/// WITNESS (confinement-root half) for the SYMLINK tier, a FOURTH call site: a
+/// symlink pre-image cannot be copied, so the fallback recreates the link in
+/// the backup area with `symlink(2)`.
+///
+/// `symlink(2)` never follows its own leaf - an occupied name is `EEXIST` - so
+/// unlike the COPY tier the entire exposure is the PARENT chain, and the only
+/// way to reach it past a confined `create_backup_parents` is the
+/// post-validation flip. That is precisely the race upstream confines
+/// `do_symlink_at()` for.
+///
+/// upstream: `backup.c:377` `do_symlink_at(sl, buf)` inside `make_backup()`'s
+/// `operator_path_resolve = 1` window (backup.c:437-449); `syscall.c:780`
+/// resolves the parent with `owner_walk_parent()`.
+#[cfg(unix)]
+#[test]
+fn cross_device_symlink_tier_cannot_recreate_the_link_outside_the_confinement_root() {
+    let fx = backup_confinement_symlink_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .links(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let result = with_cross_device_backup_tiers(
+        flip_validated_parent_outside(fx.real_backup_dir(), fx.outside.clone()),
+        || plan.execute_with_options(LocalCopyExecution::Apply, options),
+    );
+
+    assert!(
+        result.is_err(),
+        "a symlink-tier backup that can only land outside the confinement root \
+         must fail closed"
+    );
+    let escaped = fx.outside.join("link~");
+    assert!(
+        fs::symlink_metadata(&escaped).is_err(),
+        "the pre-image link was recreated at {} - the symlink tier resolved an \
+         operator-named path out of the confinement root",
+        escaped.display()
+    );
+}
+
+/// NON-VACUITY COMPANION for
+/// [`cross_device_symlink_tier_cannot_recreate_the_link_outside_the_confinement_root`]:
+/// the same fixture and flip with no confinement root really does recreate the
+/// link outside the tree.
+#[cfg(unix)]
+#[test]
+fn cross_device_symlink_tier_in_an_unconfined_session_does_recreate_the_link() {
+    let fx = backup_confinement_symlink_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .links(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(None);
+    with_cross_device_backup_tiers(
+        flip_validated_parent_outside(fx.real_backup_dir(), fx.outside.clone()),
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("with nothing to be outside of, the symlink tier must succeed")
+        },
+    );
+
+    assert_eq!(
+        fs::read_link(fx.outside.join("link~")).expect("the symlink tier must place a backup"),
+        PathBuf::from("old_target"),
+        "unconfined, the symlink tier follows the flipped component and \
+         recreates the pre-image link outside the tree"
+    );
+}
+
+/// NEGATIVE CONTROL for the SYMLINK tier. With no flip, a confined session must
+/// still recreate the cross-device symlink backup inside the root.
+#[cfg(unix)]
+#[test]
+fn cross_device_symlink_tier_inside_the_confinement_root_still_places_the_backup() {
+    let fx = backup_confinement_symlink_fixture();
+    fs::create_dir(fx.real_backup_dir()).expect("create the in-root backup dir");
+
+    let plan = LocalCopyPlan::from_operands(&fx.operands()).expect("plan");
+    let options = LocalCopyOptions::default()
+        .backup(true)
+        .links(true)
+        .with_backup_directory(Some(PathBuf::from("bak")));
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    with_cross_device_backup_tiers(
+        || {},
+        || {
+            plan.execute_with_options(LocalCopyExecution::Apply, options)
+                .expect("an in-root symlink-tier backup must still be placed")
+        },
+    );
+
+    assert_eq!(
+        fs::read_link(fx.real_backup_dir().join("source/link~")).expect("the backup exists"),
+        PathBuf::from("old_target"),
+        "a symlink-tier backup landing inside the root must be placed, not refused"
+    );
+}

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -421,11 +421,12 @@ pub use linux_capabilities::openat2_supported;
 pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
-    operator_create_dir_all, operator_link, operator_link_confined, operator_mkdir,
-    operator_open_append, operator_open_create_new, operator_open_dir, operator_open_read,
-    operator_open_read_confined, operator_open_recv, operator_open_rw_create,
-    operator_open_write_create, operator_open_write_create_confined, operator_read_to_string,
-    operator_read_to_string_confined, operator_rename, operator_rename_confined,
+    operator_create_dir_all, operator_create_dir_all_confined, operator_link,
+    operator_link_confined, operator_mkdir, operator_open_append, operator_open_create_new,
+    operator_open_dir, operator_open_read, operator_open_read_confined, operator_open_recv,
+    operator_open_rw_create, operator_open_write_create, operator_open_write_create_confined,
+    operator_read_to_string, operator_read_to_string_confined, operator_remove_file_confined,
+    operator_rename, operator_rename_confined, operator_symlink_confined,
     operator_symlink_metadata, operator_symlink_metadata_confined, owner_trusted_parent,
     owner_trusted_parent_kind, symlink_owner_is_trusted,
 };

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -643,7 +643,23 @@ pub fn owner_trusted_parent_kind(
 /// Surfaces any walk error (including the refusal of a foreign-owned symlink)
 /// and any `mkdirat` error other than `EEXIST`.
 pub fn operator_mkdir(path: &Path, mode: u32) -> io::Result<()> {
-    let (parent, leaf) = owner_trusted_parent(path)?;
+    operator_mkdir_kind(path, mode, crate::confinement::PathKind::Ancillary)
+}
+
+/// The body behind [`operator_mkdir`] and the per-component step of
+/// [`operator_create_dir_all_kind`], with the confinement decision handed in
+/// rather than duplicated.
+///
+/// There is no public single-component `_confined` spelling: every operator
+/// path oc creates a directory at under a confinement root is a `--backup-dir`
+/// chain, and upstream builds those with `make_path()`, which is the recursive
+/// form.
+fn operator_mkdir_kind(
+    path: &Path,
+    mode: u32,
+    kind: crate::confinement::PathKind,
+) -> io::Result<()> {
+    let (parent, leaf) = owner_trusted_parent_kind(path, kind)?;
     match rustix::fs::mkdirat(
         &parent,
         leaf.as_os_str(),
@@ -676,15 +692,61 @@ pub fn operator_mkdir(path: &Path, mode: u32) -> io::Result<()> {
 /// on; every other failure is reported as-is so a refused component stays
 /// refused rather than being retried unconfined.
 pub fn operator_create_dir_all(path: &Path, mode: u32) -> io::Result<()> {
+    operator_create_dir_all_kind(path, mode, crate::confinement::PathKind::Ancillary)
+}
+
+/// [`operator_create_dir_all`] additionally bound to the session's confinement
+/// root, judging every component and not only the deepest.
+///
+/// The `--backup-dir` parent chain. Upstream builds it with the same
+/// `do_mkdir_at()` as the partial dir, but under `make_backup()`'s
+/// `operator_path_resolve`, where `owner_walk_parent()` also judges the
+/// resolved leaf against the confinement root. That second half is what this
+/// spelling adds, and it is load-bearing for a backup: a non-chrooted daemon
+/// owns everything it creates, so a directory symlink standing where the
+/// operator named `--backup-dir` is TRUSTED-owned by construction and the
+/// ownership half follows it by design. Without the root check the daemon
+/// creates the backup subtree - and, tiers later, deposits an in-module file's
+/// pre-transfer bytes - outside the module it serves.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:437-449` `make_backup()` - `operator_path_resolve =
+///   1` around the WHOLE backup, `copy_valid_path()`'s directory creation
+///   included.
+/// - `rsync-3.5.0/backup.c:128` `copy_valid_path()` - `do_mkdir_at(backup_dir_buf,
+///   ACCESSPERMS)` per new element, and `backup.c:206` `make_path()` for the
+///   backup root, which is `do_mkdir_at()` again (`util1.c:238`).
+/// - `rsync-3.5.0/util1.c:207` `make_path()` - the per-component
+///   `do_mkdir_at()` loop this mirrors.
+/// - `rsync-3.5.0/syscall.c:2082-2094` `do_mkdir_at()` under
+///   `operator_path_resolve` - `owner_walk_parent()`, then `mkdirat`.
+/// - `rsync-3.5.0/syscall.c:581-596` - the resolved-leaf confinement judgement
+///   inside `owner_walk_parent()`.
+///
+/// # Errors
+///
+/// As [`operator_create_dir_all`], plus the `ELOOP` reported when a resolved
+/// component lands outside the confinement root.
+pub fn operator_create_dir_all_confined(path: &Path, mode: u32) -> io::Result<()> {
+    operator_create_dir_all_kind(path, mode, crate::confinement::PathKind::Confined)
+}
+
+/// The shared body of the two `operator_create_dir_all*` spellings.
+fn operator_create_dir_all_kind(
+    path: &Path,
+    mode: u32,
+    kind: crate::confinement::PathKind,
+) -> io::Result<()> {
     if path.as_os_str().is_empty() {
         return Ok(());
     }
-    match operator_mkdir(path, mode) {
+    match operator_mkdir_kind(path, mode, kind) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
             let parent = path.parent().ok_or(error)?;
-            operator_create_dir_all(parent, mode)?;
-            operator_mkdir(path, mode)
+            operator_create_dir_all_kind(parent, mode, kind)?;
+            operator_mkdir_kind(path, mode, kind)
         }
         Err(error) => Err(error),
     }
@@ -812,6 +874,74 @@ pub fn operator_link_confined(old_path: &Path, new_path: &Path) -> io::Result<()
     let (old_dirfd, old_leaf) = owner_trusted_parent_kind(old_path, kind)?;
     let (new_dirfd, new_leaf) = owner_trusted_parent_kind(new_path, kind)?;
     crate::linkat(old_dirfd.as_fd(), &old_leaf, new_dirfd.as_fd(), &new_leaf)
+}
+
+/// Create a symlink at an operator-supplied path through the ownership walk,
+/// bound to the session's confinement root.
+///
+/// The SYMLINK tier of the backup ladder: when the pre-image is itself a
+/// symlink and neither the hard-link nor the rename tier can place it (a
+/// `--backup-dir` on another mount), the ladder recreates the link in the
+/// backup area instead. `symlinkat(2)` never follows its own leaf - an
+/// occupied name is `EEXIST` - so the exposure here is entirely in the PARENT
+/// chain, which is exactly what the walk resolves and what a flipped component
+/// redirects.
+///
+/// There is no `Ancillary` twin: every operator path oc creates a symlink at is
+/// a backup path, and upstream's only `do_symlink_at()` call under
+/// `operator_path_resolve` is the backup one.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:377` `make_backup_inner()` - `do_symlink_at(sl, buf)`
+///   for the copy-tier symlink branch, inside `make_backup()`'s
+///   `operator_path_resolve = 1` window (`backup.c:437-449`).
+/// - `rsync-3.5.0/syscall.c:780-791` `do_symlink_at()` under
+///   `operator_path_resolve` - `owner_walk_parent()`, then the shared
+///   `symlinkat` leaf create.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved leaf lands outside the confinement root.
+/// - Otherwise the `symlinkat(2)` errno, notably `EEXIST` for an occupied name.
+pub fn operator_symlink_confined(target: &Path, path: &Path) -> io::Result<()> {
+    let (parent, leaf) = owner_trusted_parent_kind(path, crate::confinement::PathKind::Confined)?;
+    crate::symlinkat(target, parent.as_fd(), &leaf)
+}
+
+/// Unlink an operator-supplied path through the ownership walk, bound to the
+/// session's confinement root.
+///
+/// The obstruction clear in the `--backup-dir` parent chain: an element that
+/// exists but is not a directory is removed so the directory can be created in
+/// its place. That removal is the most dangerous step in the chain - it is an
+/// unlink whose target the attacker chose - and the confined `lstat` that
+/// decided it does not protect the unlink itself, because the component can be
+/// flipped in between. Both go through the walk for that reason, exactly as
+/// upstream routes `validate_backup_dir()`'s `do_lstat_at()` and the
+/// `delete_item()` that follows it.
+///
+/// `unlinkat(2)` never follows a terminal symlink, so this removes the link
+/// itself and never its target - matching the `lstat`-based decision that
+/// selected it.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:65-80` `validate_backup_dir()` - `do_lstat_at()`,
+///   then `delete_item(..., DEL_FOR_BACKUP | DEL_RECURSE)` for a non-directory.
+/// - `rsync-3.5.0/syscall.c:673-684` `do_unlink_at()` under
+///   `operator_path_resolve` - `owner_walk_parent()`, then `unlinkat`.
+/// - `rsync-3.5.0/backup.c:437-449` `make_backup()` - the window both sit in.
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved leaf lands outside the confinement root.
+/// - Otherwise the `unlinkat(2)` errno.
+pub fn operator_remove_file_confined(path: &Path) -> io::Result<()> {
+    let (parent, leaf) = owner_trusted_parent_kind(path, crate::confinement::PathKind::Confined)?;
+    crate::unlinkat(parent.as_fd(), &leaf, crate::UnlinkFlags::File)
 }
 
 /// Open `path` with every component resolved by the ownership walk.

--- a/crates/fast_io/tests/operator_open_module_confinement.rs
+++ b/crates/fast_io/tests/operator_open_module_confinement.rs
@@ -447,3 +447,153 @@ fn an_ancillary_rename_may_still_leave_the_module() {
         "PRE-IMAGE-IN-MODULE"
     );
 }
+
+/// Plants the `--backup-dir` escape shape - a trusted-owned directory symlink
+/// inside the module pointing out of it - and hands back both ends.
+fn plant_out_of_module_backup_dir(fixture: &Fixture) -> (PathBuf, PathBuf) {
+    let outside_dir = fixture.secret.parent().expect("outside dir").to_path_buf();
+    let backup_dir = fixture.module.join("backup/out");
+    symlink(&outside_dir, &backup_dir).expect("plant the out-of-module dir symlink");
+    (backup_dir, outside_dir)
+}
+
+/// THE MKDIR-SIDE PIN. The `--backup-dir` PARENT CHAIN is built before any
+/// backup tier runs, so it is the first thing an out-of-module backup area
+/// reaches - and creating the subtree is already an escape, whatever the tiers
+/// decide afterwards.
+///
+/// upstream: `rsync-3.5.0/backup.c:128` `do_mkdir_at(backup_dir_buf,
+/// ACCESSPERMS)` inside `make_backup()`'s `operator_path_resolve = 1` window
+/// (backup.c:437-449); `syscall.c:2082` `do_mkdir_at()` walks the parent with
+/// `owner_walk_parent()` while it is set.
+#[test]
+fn a_confined_mkdir_through_a_symlinked_dir_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let (backup_dir, outside_dir) = plant_out_of_module_backup_dir(&fixture);
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_create_dir_all_confined(&backup_dir.join("sub/deep"), 0o777)
+        .expect_err("a confined mkdir must not build a subtree outside the module");
+
+    assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    assert!(
+        !outside_dir.join("sub").exists(),
+        "no part of the backup subtree may have been created outside the module"
+    );
+}
+
+/// NON-VACUITY companion for the mkdir pin: the ANCILLARY spelling on the same
+/// fixture really does build the subtree outside the module, so the refusal
+/// above is the confinement firing rather than a walk that fails for every
+/// input.
+#[test]
+fn an_ancillary_mkdir_may_still_leave_the_module() {
+    let fixture = fixture();
+    let (backup_dir, outside_dir) = plant_out_of_module_backup_dir(&fixture);
+
+    let _session = serve_module(&fixture.module);
+    fast_io::operator_create_dir_all(&backup_dir.join("sub/deep"), 0o777)
+        .expect("an ancillary mkdir is not bound to the module root");
+
+    assert!(
+        outside_dir.join("sub/deep").is_dir(),
+        "the fixture must be able to create the subtree at all"
+    );
+}
+
+/// NEGATIVE CONTROL for the mkdir side: an in-module subtree is still created.
+/// Without this, "refuse every confined mkdir" would satisfy the pin above
+/// while breaking every legitimate `--backup-dir`.
+#[test]
+fn a_confined_mkdir_inside_the_module_still_creates_the_subtree() {
+    let fixture = fixture();
+
+    let _session = serve_module(&fixture.module);
+    fast_io::operator_create_dir_all_confined(&fixture.module.join("bak/a/b"), 0o777)
+        .expect("an in-module subtree must still be created");
+
+    assert!(fixture.module.join("bak/a/b").is_dir());
+}
+
+/// THE SYMLINK-SIDE PIN, the backup ladder's SYMLINK tier. `symlinkat` never
+/// follows its own leaf - an occupied name is `EEXIST` - so the whole exposure
+/// is the PARENT chain, which is what the walk resolves.
+///
+/// upstream: `rsync-3.5.0/backup.c:377` `do_symlink_at(sl, buf)` inside
+/// `make_backup()`'s `operator_path_resolve = 1` window; `syscall.c:780`
+/// `do_symlink_at()` walks the parent while it is set.
+#[test]
+fn a_confined_symlink_through_a_symlinked_dir_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let (backup_dir, outside_dir) = plant_out_of_module_backup_dir(&fixture);
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_symlink_confined(
+        Path::new("pre-image-target"),
+        &backup_dir.join("link~"),
+    )
+    .expect_err("a confined symlink must not be created outside the module");
+
+    assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    assert!(
+        fs::symlink_metadata(outside_dir.join("link~")).is_err(),
+        "no link may have been created outside the module"
+    );
+}
+
+/// NEGATIVE CONTROL for the symlink side: an in-module backup link is still
+/// created, with its target recorded verbatim as `symlinkat(2)` does.
+#[test]
+fn a_confined_symlink_inside_the_module_is_still_created() {
+    let fixture = fixture();
+
+    let _session = serve_module(&fixture.module);
+    let link = fixture.module.join("backup/sub/link~");
+    fast_io::operator_symlink_confined(Path::new("old_target"), &link)
+        .expect("an in-module backup link must still be created");
+
+    assert_eq!(
+        fs::read_link(&link).expect("read the recreated link"),
+        Path::new("old_target")
+    );
+}
+
+/// THE UNLINK-SIDE PIN. Clearing a non-directory obstruction from the
+/// `--backup-dir` chain is an unlink whose target the attacker chose, and the
+/// confined `lstat` that decided it does not protect the unlink itself: the
+/// component can be flipped in between. Both take the walk for that reason.
+///
+/// upstream: `rsync-3.5.0/backup.c:65-80` `validate_backup_dir()` -
+/// `do_lstat_at()`, then `delete_item(..., DEL_FOR_BACKUP | DEL_RECURSE)`;
+/// `syscall.c:673` `do_unlink_at()` under `operator_path_resolve`.
+#[test]
+fn a_confined_unlink_through_a_symlinked_dir_leaving_the_module_is_refused() {
+    let fixture = fixture();
+    let (backup_dir, _outside_dir) = plant_out_of_module_backup_dir(&fixture);
+
+    let _session = serve_module(&fixture.module);
+    let error = fast_io::operator_remove_file_confined(&backup_dir.join("secret"))
+        .expect_err("a confined unlink must not reach outside the module");
+
+    assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+    assert_eq!(
+        fs::read_to_string(&fixture.secret).expect("the outside file survives"),
+        "SECRET-MARKER",
+        "a refused unlink must not have deleted the out-of-module file"
+    );
+}
+
+/// NEGATIVE CONTROL for the unlink side: an in-module obstruction is still
+/// cleared, which is what lets the chain recreate the element as a directory.
+#[test]
+fn a_confined_unlink_inside_the_module_still_clears_the_obstruction() {
+    let fixture = fixture();
+    let obstruction = fixture.module.join("backup/sub/obstruction");
+    fs::write(&obstruction, "NOT-A-DIRECTORY").expect("plant the obstruction");
+
+    let _session = serve_module(&fixture.module);
+    fast_io::operator_remove_file_confined(&obstruction)
+        .expect("an in-module obstruction must still be cleared");
+
+    assert!(fs::symlink_metadata(&obstruction).is_err());
+}


### PR DESCRIPTION
Five syscalls inside `make_backup()`'s window resolved their paths with libc
where upstream resolves them through the confined ownership walk. `#7802` pinned
the link tier, the rename tier and the `--inplace` copy; everything here is
outside those cells.

## Premise verified, not assumed — measured unconfined at base

| site | base syscall | upstream wrapper | verdict |
| --- | --- | --- | --- |
| `create_backup_parents` mkdir | `fs::create_dir_all` | `do_mkdir_at` (backup.c:128, :206 `make_path`) → syscall.c:2082 | upstream CONFINES, oc did not |
| chain element lstat | `fs::symlink_metadata` | `do_lstat_at` (backup.c:69 `validate_backup_dir`) → syscall.c:2208 | upstream CONFINES |
| chain obstruction unlink | `fs::remove_file` | `delete_item` → `do_unlink_at` (backup.c:75-79) → syscall.c:673 | upstream CONFINES |
| COPY tier | `fs::copy` | `copy_file` (backup.c:401) → `unlink_and_reopen` → `do_open_at` (util1.c:366, syscall.c:1513) | upstream CONFINES |
| SYMLINK tier | `std::os::unix::fs::symlink` | `do_symlink_at` (backup.c:377) → syscall.c:780 | upstream CONFINES |

All five sit inside `make_backup()`'s `operator_path_resolve = 1` window
(backup.c:437-449), and `owner_walk_parent()` applies the resolved-leaf root
check unconditionally (syscall.c:581-596) — so upstream's single flag is both
halves, which is exactly oc's `_confined` suffix. **No case here of oc being
deliberately stronger than upstream**, so nothing was weakened to match.

## RED arm — witnesses, not merely guards

All three engine witnesses FAIL at base:

- **parent chain**: `outside/source/` really is created. `#7802`'s cells asserted
  only that no `file.txt~` landed there, so this escape was invisible to them.
- **COPY tier**: `outside/file.txt~` receives the pre-image bytes.
- **SYMLINK tier**: `outside/link~` is recreated.

The tier cells reach their tier through the existing `EXDEV` overrides and flip
the just-validated component to an out-of-root symlink **from inside the rename
override** — upstream's own `backup-dir-symlink-race` made deterministic, and the
only shape that still reaches those tiers once the chain itself is confined. Each
witness carries a non-vacuity companion (same fixture, no root → the escape
happens) and a negative control (in-root cross-device backup still placed). Six
`fast_io` cells pin the new primitives directly with in-module controls.

**Honest scope:** the planted symlinks are single-uid, so these exercise the
**confinement-root** half of the walk and never the ownership half. Stated in the
code, not just here.

## Mutations (engine lib 5543 + fast_io 861)

| mutant | kills |
| --- | --- |
| COPY tier → `fs::copy` | 1 |
| SYMLINK tier → `std` symlink | 1 |
| `operator_create_dir_all_confined` → Ancillary | 1 |
| `operator_symlink_confined` → Ancillary | 2 |
| `operator_remove_file_confined` → Ancillary | 1 |
| chain mkdir alone | **0** — masked by the confined lstat refusing first |
| chain lstat alone | **0** — masked by the confined mkdir refusing first |
| both chain guards together | 1 (parent-chain witness) |
| chain unlink alone | **0** — the confined lstat refuses before it is reached |

The three non-kills are reported as measured rather than papered over: mkdir and
lstat are **alternative guards on one escape**, so neither alone is observable,
and the unlink is defence-in-depth on the lstat→unlink window that upstream also
carries (its own `delete_item` call is confined independently).

One mutation earned its keep by killing nothing: M6 exposed that the first
`operator_mkdir_confined` had **no caller** — the recursive spelling bypassed it.
Removed rather than left as dead public API, with its doc moved onto
`operator_create_dir_all_confined`.

## Gates, pinned 1.88.0

- `tools/ci/check_rustfmt_all.py` — 3433 files clean
- `cargo clippy --workspace --all-targets --all-features --no-deps -D warnings` — clean
- `cargo nextest -p engine -p fast_io -p transfer --all-features` — 8946 passed, 27 skipped
- root-level integration targets (`append_implies_inplace`, `commit_backup_failure_is_fatal`,
  `delay_updates_backup_failure`, `directory_obstacle_removal`, `integration_delete_backup`,
  `local_write_devices_device_destination`, `local_directory_obstacle_removal`,
  `server_backup_temp_dir`, `integration_basic`, `integration_daemon`, `integration_links`,
  `integration_filters`) — 145 passed

⚠ The transfer daemon cells need `cargo build --bin oc-rsync` first or they all
fail with "binary missing" — the freshness guard from `#7385` working as designed.

Not run, stated rather than implied: full-workspace nextest, interop, UTS,
Linux/Windows/musl matrices.

## Residuals, filed not fixed

1. **DEVICE tier is still unconfined** — `create_device_node_with_fake_super` /
   `create_fifo_with_fake_super` are path-based `mknod` where upstream uses
   `do_mknod_at` (backup.c:360, syscall.c:1270) under the same flag. It lives in
   the `metadata` crate plus the fake-super xattr path, outside this row's stated
   scope. Its own row.
2. **Task 1236 interaction:** the COPY tier now calls `copy_pre_image_to_backup`,
   the same function the `--inplace` tier uses. Upstream reaches both through one
   `copy_file()`, so 1236's pre-image-ACL work has one place to land instead of
   two — but it will touch this function.
3. `create_backup_parents`' no-`--backup-dir` arm keeps `fs::create_dir_all`
   deliberately: upstream runs no `copy_valid_path` at all there (backup.c:216)
   and a suffix cannot introduce a directory, so it creates nothing.
4. `create_backup_dir_parents` is shared with the network receiver, so the
   confined lstat/unlink now apply there too — correct, same upstream window, and
   its daemon backup-dir confinement cells stay green. The receiver keeps its own
   sandbox-anchored mkdir closure.
