### PR TITLE
fix(engine): confine the backup ladder's device tier through the walk

### DIFF
--- a/crates/engine/src/local_copy/executor/file/backup.rs
+++ b/crates/engine/src/local_copy/executor/file/backup.rs
@@ -14,8 +14,6 @@ use crate::local_copy::LocalCopyError;
 use crate::local_copy::context::BackupStrategy;
 #[cfg(not(unix))]
 use crate::local_copy::create_symlink;
-#[cfg(unix)]
-use crate::local_copy::map_metadata_error;
 
 /// Duplicates a destination's pre-transfer bytes into the operator-named
 /// backup path, resolving that path with the ownership walk and confining the
@@ -464,8 +462,18 @@ fn create_backup_symlink(target: &Path, source: &Path, backup_path: &Path) -> io
 /// emits `make_backup: DEVICE` for both devices and specials), or `None` when
 /// the preserve gates decline it (upstream `make_backup` returns 3 without
 /// placing a backup). Under `--fake-super` the node is virtualised as a `0600`
-/// placeholder carrying the `%stat` xattr, matching `syscall.c:do_mknod()`'s
+/// placeholder carrying the `%stat` xattr, matching `syscall.c:do_mknod_at()`'s
 /// `am_root < 0` branch.
+///
+/// `backup_path` is operator-named - it is `--backup-dir` plus the transfer's
+/// relative path - so the node is created through the ownership walk bound to
+/// the session's confinement root rather than by a path-based `mknod(2)`. A
+/// trusted-owned directory symlink standing where the operator named the backup
+/// area is followed by the ownership half by design (a non-chrooted daemon owns
+/// everything it creates), so without the root check this tier would
+/// re-materialise the destination's pre-transfer node - and, through the
+/// metadata reapply the caller performs afterwards, its mode, owner and times -
+/// outside the module being served.
 /// upstream: backup.c:278 - `(am_root && preserve_devices && IS_DEVICE(mode))
 /// || (preserve_specials && IS_SPECIAL(mode))` gates `do_mknod_at`. am_root is
 /// non-zero for real root, --super, and --fake-super (options.c:90).
@@ -477,7 +485,7 @@ fn copy_special_to_backup(
     specials_enabled: bool,
     fake_super: bool,
 ) -> Result<Option<BackupStrategy>, LocalCopyError> {
-    use std::os::unix::fs::FileTypeExt;
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
 
     let source_meta = fs::symlink_metadata(source)
         .map_err(|error| LocalCopyError::io("stat backup source", source, error))?;
@@ -495,13 +503,17 @@ fn copy_special_to_backup(
         return Ok(None);
     }
 
-    if is_device {
-        ::metadata::create_device_node_with_fake_super(backup_path, &source_meta, fake_super)
-            .map_err(map_metadata_error)?;
-    } else {
-        ::metadata::create_fifo_with_fake_super(backup_path, &source_meta, fake_super)
-            .map_err(map_metadata_error)?;
-    }
+    // upstream: backup.c:360 `do_mknod_at(buf, file->mode, sx.st.st_rdev)` -
+    // one call for devices and specials alike, handed the source node's FULL
+    // mode (file-type bits included) and its rdev word, which `mknodat` ignores
+    // for a FIFO or socket.
+    fast_io::operator_mknod_confined(
+        backup_path,
+        source_meta.mode(),
+        source_meta.rdev(),
+        fake_super,
+    )
+    .map_err(|error| LocalCopyError::io("create backup", backup_path, error))?;
     Ok(Some(BackupStrategy::Device))
 }
 

--- a/crates/engine/src/local_copy/tests/backups.rs
+++ b/crates/engine/src/local_copy/tests/backups.rs
@@ -3888,3 +3888,230 @@ fn cross_device_symlink_tier_inside_the_confinement_root_still_places_the_backup
         "a symlink-tier backup landing inside the root must be placed, not refused"
     );
 }
+
+/// A special-file pre-image inside a confinement root, plus an out-of-root
+/// directory a trusted `--backup-dir` symlink aims at.
+///
+/// The DEVICE tier is only reachable through the copy-tree fallback - the link
+/// and rename tiers have to fail with `EXDEV` first (backup.c:316-325 ->
+/// backup.c:358-365) - which a single-filesystem fixture cannot arrange, so
+/// these cells call the tier's entry point directly, as the other
+/// `copy_entry_to_backup` cells do.
+#[cfg(unix)]
+struct DeviceTierFixture {
+    _temp: tempfile::TempDir,
+    confine_root: PathBuf,
+    source: PathBuf,
+    outside: PathBuf,
+    backup_path: PathBuf,
+}
+
+/// Builds a FIFO pre-image inside the root and points the backup area at a
+/// directory through a trusted-owned symlink, outside the root when
+/// `target_outside` is set.
+///
+/// A FIFO rather than a device node on purpose: `mknod(2)` for a character or
+/// block device needs privileges the test suite does not have, while
+/// `--specials` routes a FIFO down the SAME `copy_special_to_backup` call
+/// (backup.c:358 gates devices and specials in one condition and hands both to
+/// the same `do_mknod_at`). The tier is therefore exercised unprivileged.
+#[cfg(unix)]
+fn device_tier_fixture(target_outside: bool) -> DeviceTierFixture {
+    let temp = test_support::create_tempdir();
+    let base = temp.path().to_path_buf();
+    let confine_root = base.join("tree");
+    let dest = confine_root.join("dest");
+    let outside = base.join("outside");
+    let inside = dest.join("realbak");
+
+    fs::create_dir_all(&dest).expect("create dest");
+    fs::create_dir_all(&outside).expect("create the out-of-root directory");
+    fs::create_dir_all(&inside).expect("create the in-root backup dir");
+
+    let source = dest.join("pipe");
+    mkfifo_for_tests(&source, 0o644).expect("mkfifo");
+
+    let link_target = if target_outside { &outside } else { &inside };
+    std::os::unix::fs::symlink(link_target, dest.join("bak")).expect("plant the dir symlink");
+
+    DeviceTierFixture {
+        _temp: temp,
+        confine_root,
+        source,
+        outside,
+        backup_path: dest.join("bak/pipe~"),
+    }
+}
+
+/// WITNESS (confinement-root half). The DEVICE tier must not re-materialise a
+/// special-file pre-image through a `--backup-dir` that resolves out of the
+/// confinement root.
+///
+/// This is the residual tier of the backup ladder: the link, rename, copy and
+/// symlink tiers each resolve their operator path through the ownership walk,
+/// and a node created by a path-based `mknod(2)` here would put a working FIFO -
+/// and, through the metadata reapply that follows, the pre-image's mode, owner
+/// and times - outside the module a daemon serves.
+///
+/// upstream: `backup.c:358-365` `make_backup_inner()` hands the DEVICE branch to
+/// `do_mknod_at()`, inside the `operator_path_resolve = 1` window
+/// `make_backup()` raises around the whole backup (backup.c:437-449);
+/// `syscall.c:1268-1305` `do_mknod_at()` under that flag resolves the parent
+/// with `owner_walk_parent()` and creates the leaf with `mknodat`.
+#[cfg(unix)]
+#[test]
+fn device_backup_leaving_the_confinement_root_is_refused() {
+    let fx = device_tier_fixture(true);
+    let file_type = fs::symlink_metadata(&fx.source)
+        .expect("stat the pre-image")
+        .file_type();
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let result = copy_entry_to_backup(&fx.source, &fx.backup_path, file_type, true, true, false);
+
+    assert!(
+        result.is_err(),
+        "a special-file backup that can only land outside the confinement root \
+         must fail closed, not be materialised there"
+    );
+    let escaped = fx.outside.join("pipe~");
+    assert!(
+        !escaped.exists(),
+        "the DEVICE tier created a node at {} - it resolved an operator-named \
+         path out of the confinement root",
+        escaped.display()
+    );
+}
+
+/// NON-VACUITY COMPANION for
+/// [`device_backup_leaving_the_confinement_root_is_refused`]: the same fixture
+/// with no confinement root installed - the plain local client, upstream's NULL
+/// `confine_root` - follows the trusted symlink and really does create the node
+/// outside the tree.
+///
+/// Without this the witness would pass just as well on a fixture where no
+/// special-file backup could ever be made: `--specials` off, a source that is
+/// not a special file, a backup path whose parent does not exist. This asserts
+/// the escape HAPPENS when the root is absent, which is what makes the witness
+/// a discrimination.
+#[cfg(unix)]
+#[test]
+fn device_backup_leaving_an_unconfined_session_is_created_outside() {
+    use crate::local_copy::context::BackupStrategy;
+    use std::os::unix::fs::FileTypeExt;
+
+    let fx = device_tier_fixture(true);
+    let file_type = fs::symlink_metadata(&fx.source)
+        .expect("stat the pre-image")
+        .file_type();
+
+    let _session = install_backup_confinement(None);
+    let strategy = copy_entry_to_backup(&fx.source, &fx.backup_path, file_type, true, true, false)
+        .expect("with nothing to be outside of, the special-file backup must succeed");
+
+    assert_eq!(strategy, Some(BackupStrategy::Device));
+    let escaped = fx.outside.join("pipe~");
+    assert!(
+        fs::symlink_metadata(&escaped)
+            .expect("the fixture must be able to place a special-file backup at all")
+            .file_type()
+            .is_fifo(),
+        "unconfined, the DEVICE tier follows the trusted symlink and creates the \
+         node outside the tree - so the confined cell's assertion discriminates"
+    );
+}
+
+/// NEGATIVE CONTROL. A trusted directory symlink at the `--backup-dir` whose
+/// target stays INSIDE the confinement root is still followed, so the ordinary
+/// operator layout keeps working for special files too.
+///
+/// Without it, "refuse every special-file backup through a symlinked parent" -
+/// or a confinement root so mis-anchored that nothing resolves inside it -
+/// would satisfy the witness above while breaking a legitimate `--backup-dir`.
+#[cfg(unix)]
+#[test]
+fn device_backup_staying_inside_the_confinement_root_is_created() {
+    use crate::local_copy::context::BackupStrategy;
+    use std::os::unix::fs::FileTypeExt;
+
+    let fx = device_tier_fixture(false);
+    let file_type = fs::symlink_metadata(&fx.source)
+        .expect("stat the pre-image")
+        .file_type();
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let strategy = copy_entry_to_backup(&fx.source, &fx.backup_path, file_type, true, true, false)
+        .expect("an in-root landing site must still be backed up through");
+
+    assert_eq!(strategy, Some(BackupStrategy::Device));
+    assert!(
+        fs::symlink_metadata(&fx.backup_path)
+            .expect("the backup node exists")
+            .file_type()
+            .is_fifo(),
+        "a trusted symlink resolving inside the root must be followed, not refused"
+    );
+}
+
+/// WITNESS for the `--fake-super` arm, which is a DIFFERENT syscall: the node is
+/// virtualised as an inert `0600` regular placeholder rather than created with
+/// `mknod(2)`, so confining only the node-creating arm would leave the
+/// placeholder open to exactly the same redirection.
+///
+/// upstream: `syscall.c:1276-1285` `do_mknod_at()` - the `am_root < 0` arm under
+/// `operator_path_resolve` creates the placeholder with `openat()` against the
+/// walked parent "so the confinement guarantee is unchanged".
+#[cfg(unix)]
+#[test]
+fn fake_super_device_backup_leaving_the_confinement_root_is_refused() {
+    let fx = device_tier_fixture(true);
+    let file_type = fs::symlink_metadata(&fx.source)
+        .expect("stat the pre-image")
+        .file_type();
+
+    let _session = install_backup_confinement(Some(&fx.confine_root));
+    let result = copy_entry_to_backup(&fx.source, &fx.backup_path, file_type, true, true, true);
+
+    assert!(
+        result.is_err(),
+        "a --fake-super placeholder that can only land outside the confinement \
+         root must fail closed"
+    );
+    let escaped = fx.outside.join("pipe~");
+    assert!(
+        !escaped.exists(),
+        "the --fake-super arm created a placeholder at {} - it resolved an \
+         operator-named path out of the confinement root",
+        escaped.display()
+    );
+}
+
+/// NON-VACUITY COMPANION for
+/// [`fake_super_device_backup_leaving_the_confinement_root_is_refused`]: with no
+/// root installed the placeholder really is written outside the tree, so the
+/// witness's `is_err()` means "refused" and not "this arm never writes anything".
+#[cfg(unix)]
+#[test]
+fn fake_super_device_backup_leaving_an_unconfined_session_is_created_outside() {
+    use crate::local_copy::context::BackupStrategy;
+
+    let fx = device_tier_fixture(true);
+    let file_type = fs::symlink_metadata(&fx.source)
+        .expect("stat the pre-image")
+        .file_type();
+
+    let _session = install_backup_confinement(None);
+    let strategy = copy_entry_to_backup(&fx.source, &fx.backup_path, file_type, true, true, true)
+        .expect("with nothing to be outside of, the placeholder must be written");
+
+    assert_eq!(strategy, Some(BackupStrategy::Device));
+    let escaped = fx.outside.join("pipe~");
+    assert!(
+        fs::symlink_metadata(&escaped)
+            .expect("the fixture must be able to place a placeholder at all")
+            .file_type()
+            .is_file(),
+        "unconfined, the --fake-super arm follows the trusted symlink and writes \
+         the placeholder outside the tree"
+    );
+}

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/create.rs
@@ -1,4 +1,5 @@
-//! create-class SEC-1.h cutover: `mkdirat`, `symlinkat`, `linkat`.
+//! create-class SEC-1.h cutover: `mkdirat`, `symlinkat`, `linkat`,
+//! `mknodat`, `mkfifoat`.
 //!
 //! Each primitive anchors the new entry on a parent dirfd so a TOCTOU
 //! swap on a mid-path component cannot redirect the create to an
@@ -156,6 +157,96 @@ pub fn linkat(
             0,
         )
     };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `mknodat(dirfd, name, mode, dev)`.
+///
+/// `mode` carries the file-type bits (`S_IFCHR`, `S_IFBLK`, `S_IFIFO`,
+/// `S_IFSOCK`, `S_IFREG`) alongside the permission bits, exactly as
+/// upstream's `do_mknod_at()` passes `file->mode` through. The leaf is
+/// resolved relative to `dirfd` and `mknodat(2)` never follows a symlink
+/// standing at it, so neither a mid-path swap nor a leaf plant can
+/// redirect the new node.
+///
+/// This calls the platform C library's `mknodat` symbol rather than
+/// issuing the raw syscall, matching the path-based `mknod()` this
+/// module's callers came from: `fakeroot`/`fakeroot-ng` fake `CAP_MKNOD`
+/// by `LD_PRELOAD`-interposing that symbol, and a raw syscall is never
+/// intercepted. Upstream calls libc `mknodat()` for the same reason.
+///
+/// `name` must not contain an interior NUL byte; callers that pull names
+/// from `Path::file_name` cannot trigger this.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim. Notable cases:
+/// - `EEXIST` when `name` already exists beneath `dirfd`.
+/// - `EPERM` when the caller lacks `CAP_MKNOD` for a device node.
+/// - `EINVAL`/`EOPNOTSUPP` when the filesystem cannot materialise this
+///   node type (sockets outside Linux; see [`mkfifoat`] for the FIFO
+///   retry upstream performs on that failure).
+/// - `EINVAL` when `name` contains an interior NUL byte (translated from
+///   [`std::ffi::NulError`]).
+// upstream: syscall.c:1285-1287 do_mknod_at() - mknodat() on the walked parent
+pub fn mknodat(dirfd: BorrowedFd<'_>, name: &OsStr, mode: u32, dev: u64) -> io::Result<()> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY:
+    // - `dirfd.as_raw_fd()` returns the raw fd of a `BorrowedFd<'_>`
+    //   whose lifetime is bound to the borrow and outlives the syscall.
+    // - `c_name.as_ptr()` is a valid NUL-terminated C string borrowed
+    //   for the duration of the call; the kernel does not retain the
+    //   pointer past return.
+    // - `mode` and `dev` are plain integers the kernel interprets; an
+    //   unsupported combination is rejected with an errno, never UB.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::mknodat(
+            dirfd.as_raw_fd(),
+            c_name.as_ptr(),
+            mode as libc::mode_t,
+            dev as libc::dev_t,
+        )
+    };
+
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Issue `mkfifoat(dirfd, name, mode)`.
+///
+/// The type-specific retry for the one node kind `mknodat(2)` cannot
+/// always make: the BSDs, macOS and Solaris reject `S_IFIFO` there. The
+/// capability is filesystem-dependent, so upstream decides it per call
+/// rather than probing at build time, and the retry stays on the SAME
+/// held dirfd so the confinement guarantee is unchanged.
+///
+/// `name` must not contain an interior NUL byte.
+///
+/// # Errors
+///
+/// Surfaces the underlying syscall error verbatim, plus `EINVAL` when
+/// `name` contains an interior NUL byte.
+// upstream: syscall.c:1288-1300 do_mknod_at() - the mkfifoat() retry
+pub fn mkfifoat(dirfd: BorrowedFd<'_>, name: &OsStr, mode: u32) -> io::Result<()> {
+    let c_name =
+        CString::new(name.as_bytes()).map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+
+    // SAFETY: same argument shape as `mknodat` above - a borrowed fd that
+    // outlives the call, a NUL-terminated name the kernel does not retain,
+    // and a mode the kernel validates itself.
+    #[allow(unsafe_code)]
+    let rc = unsafe { libc::mkfifoat(dirfd.as_raw_fd(), c_name.as_ptr(), mode as libc::mode_t) };
 
     if rc == 0 {
         Ok(())

--- a/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
+++ b/crates/fast_io/src/dir_sandbox/at_syscalls/mod.rs
@@ -45,8 +45,8 @@ mod tests;
 
 pub use create::{
     CloneAttempt, confined_clone_file, confined_create_new, confined_link_anonymous, linkat,
-    linkat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, symlinkat,
-    symlinkat_via_sandbox_or_fallback,
+    linkat_via_sandbox_or_fallback, mkdirat, mkdirat_via_sandbox_or_fallback, mkfifoat, mknodat,
+    symlinkat, symlinkat_via_sandbox_or_fallback,
 };
 pub use lstat::{LstatOutcome, lstat_via_sandbox_or_fallback};
 pub use metadata::{AtMetadata, fstatat_follow, fstatat_nofollow};

--- a/crates/fast_io/src/lib.rs
+++ b/crates/fast_io/src/lib.rs
@@ -422,13 +422,13 @@ pub use nofollow_open::open_basis_nofollow;
 #[cfg(unix)]
 pub use owner_walk::{
     operator_create_dir_all, operator_create_dir_all_confined, operator_link,
-    operator_link_confined, operator_mkdir, operator_open_append, operator_open_create_new,
-    operator_open_dir, operator_open_read, operator_open_read_confined, operator_open_recv,
-    operator_open_rw_create, operator_open_write_create, operator_open_write_create_confined,
-    operator_read_to_string, operator_read_to_string_confined, operator_remove_file_confined,
-    operator_rename, operator_rename_confined, operator_symlink_confined,
-    operator_symlink_metadata, operator_symlink_metadata_confined, owner_trusted_parent,
-    owner_trusted_parent_kind, symlink_owner_is_trusted,
+    operator_link_confined, operator_mkdir, operator_mknod_confined, operator_open_append,
+    operator_open_create_new, operator_open_dir, operator_open_read, operator_open_read_confined,
+    operator_open_recv, operator_open_rw_create, operator_open_write_create,
+    operator_open_write_create_confined, operator_read_to_string, operator_read_to_string_confined,
+    operator_remove_file_confined, operator_rename, operator_rename_confined,
+    operator_symlink_confined, operator_symlink_metadata, operator_symlink_metadata_confined,
+    owner_trusted_parent, owner_trusted_parent_kind, symlink_owner_is_trusted,
 };
 pub use refs_detect::{clear_refs_cache, is_refs_filesystem};
 #[cfg(unix)]

--- a/crates/fast_io/src/owner_walk.rs
+++ b/crates/fast_io/src/owner_walk.rs
@@ -944,6 +944,106 @@ pub fn operator_remove_file_confined(path: &Path) -> io::Result<()> {
     crate::unlinkat(parent.as_fd(), &leaf, crate::UnlinkFlags::File)
 }
 
+/// Re-materialise a device, FIFO or socket node at an operator-supplied path
+/// through the ownership walk, bound to the session's confinement root.
+///
+/// The DEVICE tier of the backup ladder, and the last one that still resolved
+/// its operator path with a path-based syscall. `mode` carries the file-type
+/// bits alongside the permission bits, exactly as upstream passes `file->mode`
+/// through; `dev` is the source node's `rdev` word, ignored for a FIFO or
+/// socket. `fake_super` selects upstream's `am_root < 0` representation - an
+/// inert `0600` regular placeholder whose privileged metadata is carried in a
+/// `%stat` xattr - which is created against the SAME verified parent so the
+/// confinement guarantee does not depend on which representation is in use.
+///
+/// Three arms, mirroring upstream:
+///
+/// - Opted out (`--insecure-links`, or a module with `insecure links = yes`):
+///   the walk itself short-circuits to the legacy symlink-following resolution,
+///   which is upstream's `return do_mknod(...)`.
+/// - The walk succeeds: the node is created with `mknodat` on the held dirfd,
+///   with the `mkfifoat` retry for the platforms whose `mknodat` cannot make a
+///   FIFO, and an `EOPNOTSUPP` refusal for a socket, which has no
+///   dirfd-relative `bind(2)`. That refusal is deliberate - re-resolving the
+///   parent by path to bind a socket would launder the confinement.
+/// - The walk fails: the error is returned. There is no fall-back to the
+///   path-based `mknod`, because a refusal that retries unconfined is not a
+///   refusal.
+///
+/// # Upstream Reference
+///
+/// - `rsync-3.5.0/backup.c:358-365` `make_backup_inner()` - the DEVICE branch
+///   calls `do_mknod_at(buf, file->mode, sx.st.st_rdev)`.
+/// - `rsync-3.5.0/backup.c:437-449` `make_backup()` - `operator_path_resolve =
+///   1` around the WHOLE backup, so the DEVICE branch runs inside it.
+/// - `rsync-3.5.0/syscall.c:1270-1305` `do_mknod_at()` - the
+///   `operator_path_resolve` arm this mirrors, including the opt-out
+///   short-circuit (1271-1272), the `dfd < 0` bail (1274-1275), the fake-super
+///   placeholder (1276-1284) and the FIFO/socket retry (1288-1300).
+///
+/// # Errors
+///
+/// - `ELOOP` when a component is an untrusted-owner symlink, or when the
+///   resolved leaf lands outside the confinement root.
+/// - `EOPNOTSUPP` for a socket the platform cannot create beneath a dirfd.
+/// - Otherwise the `mknodat(2)`/`mkfifoat(2)`/`openat(2)` errno verbatim.
+pub fn operator_mknod_confined(
+    path: &Path,
+    mode: u32,
+    dev: u64,
+    fake_super: bool,
+) -> io::Result<()> {
+    let (parent, leaf) = owner_trusted_parent_kind(path, crate::confinement::PathKind::Confined)?;
+    if fake_super {
+        return operator_fake_super_placeholder(parent.as_fd(), &leaf);
+    }
+
+    let Err(error) = at_syscalls::mknodat(parent.as_fd(), leaf.as_os_str(), mode, dev) else {
+        return Ok(());
+    };
+
+    // Computed in `mode_t` space so the comparison needs no cast to a concrete
+    // width: `S_IFMT` and friends are `u16` on Apple targets and `u32` on Linux.
+    let node_type = (mode as libc::mode_t) & libc::S_IFMT;
+    if node_type == libc::S_IFIFO {
+        at_syscalls::mkfifoat(parent.as_fd(), leaf.as_os_str(), mode)
+    } else if node_type == libc::S_IFSOCK {
+        Err(io::Error::from_raw_os_error(libc::EOPNOTSUPP))
+    } else {
+        Err(error)
+    }
+}
+
+/// Write the `--fake-super` placeholder for [`operator_mknod_confined`] against
+/// the parent the walk verified.
+///
+/// The leaf is unlinked first and then created `O_EXCL`, which is the shape
+/// this placeholder has always had (`metadata::special`'s
+/// `create_fake_super_placeholder`) and is what upstream's own socket arm does
+/// before `bind(2)` (`syscall.c:1213`). Upstream's operator arm spells it
+/// `O_CREAT | O_TRUNC` instead; on a leaf that is already a FIFO that open
+/// blocks until a reader appears, so the unlink-first form is kept. Both
+/// refuse to follow a symlink standing at the leaf - `unlinkat(2)` never does,
+/// and the create carries `O_NOFOLLOW`.
+///
+/// upstream: `rsync-3.5.0/syscall.c:1276-1284` `do_mknod_at()` - the
+/// `am_root < 0` arm, "created relative to the verified parent so the
+/// confinement guarantee is unchanged".
+fn operator_fake_super_placeholder(parent: BorrowedFd<'_>, leaf: &OsStr) -> io::Result<()> {
+    match at_syscalls::unlinkat(parent, leaf, at_syscalls::UnlinkFlags::File) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    at_syscalls::openat(
+        parent,
+        leaf,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW,
+        0o600,
+    )
+    .map(drop)
+}
+
 /// Open `path` with every component resolved by the ownership walk.
 ///
 /// One policy applies end to end, leaf included: follow a symlink owned by uid


### PR DESCRIPTION
## The gap is live, not stale

PR #7808 confines the backup parent chain and the COPY/SYMLINK tiers and leaves
`copy_special_to_backup` untouched. The DEVICE tier is the genuine residual: it resolved its
operator-supplied `--backup-dir` path with a path-based `mknod`.

Measured on the **unmodified base**: the two new witness cells FAILED and the two non-vacuity
companions PASSED — i.e. the FIFO node and the `--fake-super` placeholder really were created at
`<outside-root>/pipe~` through a trusted-owned `--backup-dir` symlink.

```
FAIL device_backup_leaving_the_confinement_root_is_refused
FAIL fake_super_device_backup_leaving_the_confinement_root_is_refused
(3 companions/control passed)
```

## The three-arm contract

`fast_io::operator_mknod_confined(path, mode, dev, fake_super)` in `owner_walk.rs`, mirroring
`syscall.c:1270-1305` (`do_mknod_at`), with `backup.c:358-365` as the call site and
`backup.c:437-449` establishing that `operator_path_resolve = 1` covers the whole backup:

1. **Gate OFF** (`--insecure-links` / `insecure links = yes`) — the shared walk short-circuits to
   legacy symlink-following resolution, which is upstream's `return do_mknod(...)`.
2. **Walk SUCCEEDS** — `mknodat` on the held dirfd; `mkfifoat` retry where `mknodat` cannot make a
   FIFO; `EOPNOTSUPP` for a socket, since there is no dirfd-relative `bind(2)` and re-resolving
   the parent by path to bind one would launder the confinement. Under `--fake-super` the `0600`
   placeholder is written against the **same** verified parent, so the guarantee does not depend
   on which representation is in use.
3. **Walk FAILS** — the error is returned. No path-based fallback: a refusal that retries
   unconfined is not a refusal.

New `at_syscalls::mknodat` / `mkfifoat` are on the **libc symbols**, preserving the fakeroot
`LD_PRELOAD` interposition that `metadata::special` documents for `mknod`.

## Witness scope, stated honestly

This is a **witness for the confinement-root half only**, and the tests say so in-code. A
single-uid test owns every symlink it plants, so the *ownership* half can never be made to refuse
there; what fires is the resolved-leaf-outside-root check — the half that actually defends this
shape. `mknod(2)` for a real device needs privileges, so the fixture uses a **FIFO**, which
`backup.c:358` routes down the identical `do_mknod_at` call. No live device-node exploit was run.

## Mutation kill list

Both mutations killed **exactly** the two witnesses, 4785/4787 otherwise green; the 3
companion/control cells survive both, by design.

- restore the path-based `metadata::create_{device_node,fifo}_with_fake_super` → 2 FAIL
- `PathKind::Confined` → `Ancillary` (isolates the root half from the walk itself) → same 2 FAIL

## Gates (pinned toolchain 1.88.0)

- `cargo nextest run -p engine --lib`: 4787 passed, 23 skipped
- `cargo nextest run -p fast_io`: 854 passed
- `cargo clippy -p engine -p fast_io --all-targets -D warnings`: clean
- `tools/ci/check_rustfmt_all.py`: 3433 files clean; `cargo fmt --all --check` clean
- `citation_drift_audit.py`: engine and fast_io blocking populations both 0% drift, no baseline touched
- `tools/ci/check_module_reachability.py`: clean

## Behaviour changes and call-outs

- **macOS socket backups** in this tier now refuse with `EOPNOTSUPP` instead of the old `bind(2)`
  fallback. That is exactly upstream's confined arm (`syscall.c:1298-1299`), but it is a
  behaviour change on Apple targets.
- **Fake-super placeholder flags deviate** from upstream's `O_CREAT|O_TRUNC|O_NOFOLLOW`:
  unlink-then-`O_EXCL|O_NOFOLLOW`. This preserves oc's existing
  `create_fake_super_placeholder` semantics and avoids upstream's *blocking* open on a leaf that
  is already a FIFO. Both refuse to follow a symlink at the leaf. Documented in-code.
- **Mode now carries the full `st_mode`** (setuid/sgid/sticky included) rather than `& 0o777`,
  matching upstream's `file->mode`.
- ⚠ **Sequencing**: a merge conflict with #7808 is certain in `crates/fast_io/src/lib.rs` (same
  export block) and likely adjacent in `backup.rs`. Whichever lands second needs a rebase.
- Windows engine build not compiled here (`zstd-sys` needs an MSVC C toolchain absent on this
  host). Mitigations: `fast_io` cross-checks clean for that target, `owner_walk`/`dir_sandbox` are
  `#[cfg(unix)]`, every engine edit sits inside the existing `#[cfg(unix)] fn
  copy_special_to_backup`, and the `#[cfg(not(unix))]` arm of `copy_entry_to_backup` is unchanged.
- Not run on Linux (the `mknodat`-makes-sockets path) and not run as root.
