### PR TITLE
fix(daemon): gate a merge-file open on the daemon list and honour `w`

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/helpers.rs
+++ b/crates/daemon/src/daemon/sections/module_access/helpers.rs
@@ -345,6 +345,11 @@ struct MergeRule<'a> {
     /// `e` - `FILTRULE_EXCLUDE_SELF`: an exclude of the merge file's basename
     /// is added BEFORE the file is read (exclude.c:1553-1568).
     exclude_self: bool,
+    /// `w` - `FILTRULE_WORD_SPLIT`: the file's records are its
+    /// whitespace-delimited WORDS, and a leading `;`/`#` is no longer a comment
+    /// (exclude.c:1772-1773 breaks the record at any space, and the
+    /// `word_split ||` disjunct at exclude.c:1806 skips the comment test).
+    word_split: bool,
 }
 
 /// Classifies a token as an EAGER merge rule - `merge` / `.` - or `None`.
@@ -409,6 +414,7 @@ fn merge_rule<'a>(
         no_prefixes: modifiers.no_prefixes,
         include: modifiers.include,
         exclude_self: modifiers.exclude_self,
+        word_split: modifiers.word_split,
     }))
 }
 
@@ -418,6 +424,7 @@ struct MergeModifiers {
     no_prefixes: bool,
     include: bool,
     exclude_self: bool,
+    word_split: bool,
 }
 
 /// Runs upstream's modifier scan over a merge rule's run.
@@ -447,9 +454,10 @@ struct MergeModifiers {
 ///   module-relative name. MEASURED: `filter = ./ FILE` and `filter = . FILE`
 ///   over a merge file holding `- sub/f` hide the same set - `sub/f` AND
 ///   `deep/sub/f`.
-/// - `w` (`FILTRULE_WORD_SPLIT`) and `e` (`FILTRULE_EXCLUDE_SELF`) are
-///   accepted and NOT reproduced; each has its own measured divergence
-///   recorded at its site in [`push_merge_file_rules`].
+///
+/// `w` (`FILTRULE_WORD_SPLIT`) and `e` (`FILTRULE_EXCLUDE_SELF`) are the two
+/// modifiers that are NOT inert: each changes what [`push_merge_file_rules`]
+/// does with the named file, and both are reproduced there.
 fn scan_merge_modifiers(
     run: &str,
     base: usize,
@@ -483,8 +491,12 @@ fn scan_merge_modifiers(
             // exclude.c:1596-1598); that is NOT reproduced here.
             'C' => modifiers.no_prefixes = true,
             'e' => modifiers.exclude_self = true,
+            // upstream: exclude.c:1433-1437. `w` raises FILTRULE_WORD_SPLIT on
+            // the merge rule, which `parse_filter_file` reads to decide how the
+            // file's records are cut (exclude.c:1606, :1772-1773, :1806).
+            'w' => modifiers.word_split = true,
             // Accepted and inert - see this function's doc block.
-            '/' | 'n' | 'p' | 'w' | 'x' | 'r' | 's' => {}
+            '/' | 'n' | 'p' | 'x' | 'r' | 's' => {}
             _ => {
                 return Err(MalformedRule::InvalidModifier {
                     modifier: ch,
@@ -520,16 +532,9 @@ fn push_merge_file_rules(
 ) -> Result<(), io::Error> {
     if merge.exclude_self {
         // upstream: exclude.c:1557-1567 adds an exclude of the merge file's
-        // BASENAME before the file is read.
-        //
-        // ⚠ MEASURED DIVERGENCE. Upstream's own `parse_filter_file` then tests
-        // the merge file against `daemon_filter_list` (exclude.c:1636-1657) and,
-        // finding it hidden by the rule just added, treats it as non-existent -
-        // so `filter = .e FILE` upstream adds the basename exclude and reads
-        // NOTHING (rc 0, `bait` served). oc adds the exclude and still reads the
-        // file, which hides strictly MORE than upstream. Reproducing the
-        // self-suppression needs the daemon list's own matcher at parse time,
-        // which this path does not have.
+        // BASENAME before the file is read. The rule lands in the SAME list the
+        // gate below consults, which is why `.e` reads nothing - see
+        // [`merge_file_hidden_by_daemon_rules`].
         let base = merge.name.rsplit('/').next().unwrap_or(merge.name);
         rules.push(build_pattern_rule(base, false, RuleXflags::MergeFile));
     }
@@ -548,6 +553,28 @@ fn push_merge_file_rules(
     }
 
     let path = merge_file_path(merge.name, root);
+
+    // upstream: exclude.c:1639-1664. Before the open, `parse_filter_file` tests
+    // the merge file's own name against `daemon_filter_list` and, when a rule
+    // already in that list hides it, returns as if the file did not exist -
+    // WITHOUT opening it and WITHOUT tripping `XFLG_FATAL_ERRORS`, "so it
+    // neither errors out nor leaks a fatal-vs-silent oracle".
+    //
+    // The gate is what makes `filter = .e FILE` read NOTHING: the self-exclude
+    // pushed above is itself the rule that hides the file. MEASURED against
+    // rsync 3.5.0, a module holding `bait` + `keep` and a `MERGEF` file holding
+    // `- bait`:
+    //
+    // * `filter = .e MERGEF` -> rc 0, `MERGEF` hidden, `bait` STILL SERVED.
+    // * `filter = .e NOSUCHFILE` -> rc 0, everything served - the absent file is
+    //   never opened, so the fatal-open arm is unreachable. (`filter = merge
+    //   NOSUCHFILE`, with no self-exclude, is rc 5 on both.)
+    // * `filter = - keep . MERGEF` -> the merge file is NOT hidden by `- keep`,
+    //   so it IS read and `bait` is excluded.
+    if merge_file_hidden_by_daemon_rules(rules, &path, root) {
+        return Ok(());
+    }
+
     let content = read_filter_file_contents(&path).map_err(|err| {
         io::Error::new(
             err.kind(),
@@ -555,19 +582,23 @@ fn push_merge_file_rules(
         )
     })?;
 
-    for record in filters::filter_file_records(&content) {
-        // `true`: a plain merge is line-parsed, so a leading `;`/`#` is a
-        // comment (`exclude.c:1806`, `word_split ||`).
-        //
-        // ⚠ MEASURED DIVERGENCE for the `w` modifier: upstream word-splits such
-        // a file AND stops recognising comments. oc reads a `merge,w` file
-        // line-by-line, so a file holding `- bait - ctl` becomes ONE rule whose
-        // pattern is `bait - ctl` and every file is served, where upstream
-        // refuses the module (`unexpected end of filter rule`, rc 5, because the
-        // word-split leaves a patternless `-`).
-        if !filters::filter_file_line_is_rule(record, true) {
-            continue;
-        }
+    // upstream: exclude.c:1756-1809 cuts the file into records, and
+    // `word_split` (raised by the `w` modifier) changes BOTH halves of that
+    // loop: a record ends at any `isspace` (:1772-1773) instead of at a
+    // newline, and the `word_split ||` disjunct at :1806 stops treating a
+    // leading `;`/`#` as a comment. MEASURED against rsync 3.5.0 on a file
+    // holding `- bait - other`: `filter = merge,w FILE` is rc 5 (`unexpected
+    // end of filter rule`, because the split leaves a patternless `-`) while
+    // `filter = merge FILE` serves everything (the whole line is one pattern).
+    let records: Vec<&str> = if merge.word_split {
+        content.split_ascii_whitespace().collect()
+    } else {
+        filters::filter_file_records(&content)
+            .filter(|record| filters::filter_file_line_is_rule(record, true))
+            .collect()
+    };
+
+    for record in records {
         if merge.no_prefixes {
             rules.push(build_pattern_rule(
                 record,
@@ -580,6 +611,62 @@ fn push_merge_file_rules(
     }
 
     Ok(())
+}
+
+/// Answers upstream's pre-open `check_filter(&daemon_filter_list, ...)` gate.
+///
+/// upstream: `exclude.c:1639-1664`. The name tested is the RESOLVED merge-file
+/// path with the module root stripped when it is absolute (`dir = line +
+/// (*line == '/' ? module_dirlen : 0)`), because the daemon list matches
+/// module-relative names.
+///
+/// Returns `false` when no rules have accumulated yet - upstream guards the
+/// whole block on `if (daemon_filter_list.head)`, so the FIRST merge rule in a
+/// module's configuration is never gated.
+fn merge_file_hidden_by_daemon_rules(
+    rules: &[FilterRuleWireFormat],
+    path: &Path,
+    root: &Path,
+) -> bool {
+    if rules.is_empty() {
+        return false;
+    }
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    let name = relative.strip_prefix("/").unwrap_or(relative);
+    if name.as_os_str().is_empty() {
+        return false;
+    }
+    match daemon_filter_set(rules) {
+        Some(set) => !set.allows(name, false),
+        None => false,
+    }
+}
+
+/// Compiles the rules accumulated so far into the matcher the gate consults.
+///
+/// The wire rules are the daemon list in `FilterRuleWireFormat` form; a `Clear`
+/// among them pops what came before it, exactly as it does for every other
+/// consumer of this list.
+fn daemon_filter_set(rules: &[FilterRuleWireFormat]) -> Option<filters::FilterSet> {
+    use filters::FilterRule;
+    use protocol::filters::RuleType;
+
+    let compiled: Vec<FilterRule> = rules
+        .iter()
+        .filter_map(|wire_rule| {
+            let pat = wire_rule.pattern.to_string_lossy();
+            Some(match wire_rule.rule_type {
+                RuleType::Include => FilterRule::include(pat),
+                RuleType::Exclude => FilterRule::exclude(pat),
+                RuleType::Clear => FilterRule::clear(),
+                // Only include/exclude decide whether a NAME is hidden here:
+                // upstream calls `check_filter` with `name_flags == 0`, and the
+                // sided and per-directory kinds are answered elsewhere.
+                _ => return None,
+            })
+        })
+        .collect();
+    filters::FilterSet::from_rules(compiled).ok()
 }
 
 /// Resolves a merge-file name the way `parse_merge_name()` does.

--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3916,21 +3916,93 @@ mod module_access_tests {
     #[test]
     fn the_exclude_self_modifier_hides_the_merge_files_basename() {
         // upstream: exclude.c:1557-1567 - `e` adds an exclude of the merge
-        // file's BASENAME before the file is read.
+        // file's BASENAME before the file is read, and that rule lands in the
+        // SAME list `parse_filter_file`'s pre-open gate consults
+        // (exclude.c:1639-1664). The file is therefore hidden from the very
+        // parse that was about to read it, and `filter = .e FILE` adds the
+        // basename exclude and reads NOTHING.
         //
-        // ⚠ PINNED AS A DIVERGENCE, not asserted as correct. Upstream's
-        // `parse_filter_file` then finds the merge file hidden by the rule it
-        // just added and treats it as non-existent (exclude.c:1636-1657), so
-        // `filter = .e FILE` upstream reads NOTHING: MEASURED rc 0 with `bait`
-        // SERVED. oc adds the basename exclude and still merges, hiding
-        // strictly more. This cell exists so the arm that adds the exclude is
-        // not silently dead, and so the day the self-suppression lands the cell
-        // reddens and names the decision.
+        // MEASURED against a real rsync 3.5.0 daemon (module holding `bait` +
+        // `keep`, merge file holding `- bait`): rc 0 with `bait` SERVED and only
+        // the merge file itself hidden.
         let dir = tempfile::tempdir().expect("temp dir");
         let path = merge_file(dir.path(), "rules", "- bait\n");
         assert_eq!(
             filter_patterns(dir.path(), &format!(".e {path}")),
-            vec!["rules".to_string(), "bait".to_string()]
+            vec!["rules".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_merge_file_the_daemon_rules_do_not_hide_is_still_read() {
+        // NON-VACUITY COMPANION to the cell above: the gate must fire on the
+        // NAME, not on "a merge rule was reached". Rules already in the list
+        // that do NOT match the merge file leave it readable.
+        //
+        // MEASURED: `filter = - keep merge MERGEF` over a merge file holding
+        // `- bait` hides BOTH `keep` and `bait` on rsync 3.5.0.
+        //
+        // ⚠ The `.` spelling of the same value is NOT interchangeable here:
+        // `split_filter_tokens` does not open a token on a bare `.`, so
+        // `- keep . FILE` becomes ONE exclude of the literal pattern
+        // `keep . FILE`. That is a separate, still-open divergence in the
+        // TOKENISER, measured against rsync 3.5.0 and deliberately untouched by
+        // this gate - which is why this cell uses the keyword spelling.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("- keep merge {path}")),
+            vec!["keep".to_string(), "bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn the_first_merge_rule_in_a_module_is_never_gated() {
+        // upstream guards the whole block on `if (daemon_filter_list.head)`
+        // (exclude.c:1639), so a merge that is the module's FIRST filter rule
+        // has no list to be hidden by and is always opened. Without this row a
+        // gate that fired unconditionally would still pass the `.e` cell.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge {path}")),
+            vec!["bait".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_self_excluded_merge_file_that_does_not_exist_is_not_a_refusal() {
+        // The gate returns BEFORE the open, so `XFLG_FATAL_ERRORS` is never
+        // reached and an absent file cannot refuse the module
+        // (exclude.c:1639-1664 returns as if the file did not exist).
+        //
+        // MEASURED against rsync 3.5.0: `filter = .e NOSUCHFILE` is rc 0 with
+        // every file served, while `filter = merge NOSUCHFILE` is rc 5.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing = dir.path().join("nosuchfile");
+        let missing = missing.to_str().expect("utf-8 path");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".e {missing}")),
+            vec!["nosuchfile".to_string()]
+        );
+        // NON-VACUITY: without `e` there is no self-exclude, nothing hides the
+        // name, the open happens and it is fatal.
+        filter_rules(dir.path(), &format!("merge {missing}")).expect_err("must refuse");
+    }
+
+    #[test]
+    fn a_rule_after_a_self_excluded_merge_still_lands() {
+        // The gate skips the FILE, not the rest of the directive: upstream
+        // returns from `parse_filter_file` and `parse_filter_str` carries on
+        // with the next token.
+        //
+        // MEASURED: `filter = .e MERGEF - other` on rsync 3.5.0 hides the merge
+        // file and `other`, and serves `bait`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".e {path} - other")),
+            vec!["rules".to_string(), "other".to_string()]
         );
     }
 
@@ -3948,9 +4020,13 @@ mod module_access_tests {
         // spelled path yields no basename at all.
         let dir = tempfile::tempdir().expect("temp dir");
         let path = merge_file(dir.path(), r"a\b", "- bait\n");
+        // The self-exclude is the WHOLE `a\b`, and the pre-open gate then hides
+        // the file by that name - so, as with any `e` merge, nothing is read.
+        // Split on the host separator instead and the basename would be `b`,
+        // which matches neither the file nor this assertion.
         assert_eq!(
             filter_patterns(dir.path(), &format!(".e {path}")),
-            vec![r"a\b".to_string(), "bait".to_string()]
+            vec![r"a\b".to_string()]
         );
     }
 
@@ -3987,6 +4063,84 @@ mod module_access_tests {
                 .starts_with("invalid modifier '!' at position 1"),
             "unexpected refusal: {err}"
         );
+    }
+
+    #[test]
+    fn the_w_modifier_word_splits_the_merge_files_records() {
+        // upstream: `w` raises `FILTRULE_WORD_SPLIT` (exclude.c:1433-1437), and
+        // `parse_filter_file` reads that flag off the merge rule
+        // (exclude.c:1606) to change BOTH halves of its record loop: a record
+        // ends at any `isspace` (exclude.c:1772-1773) instead of at a newline,
+        // and the `word_split ||` disjunct (exclude.c:1806) stops treating a
+        // leading `;`/`#` as a comment.
+        //
+        // `_` is upstream's in-word separator (exclude.c:1218-1227), so
+        // `-_bait` is a complete rule inside one whitespace-delimited word.
+        // Every word must be one: a merge file has no bare-word fall-through,
+        // so a lone `ctl` word is `Unknown filter rule` - which is why BOTH
+        // words here carry their own prefix.
+        // MEASURED against rsync 3.5.0: `filter = merge,w FILE` over a file
+        // holding `-_bait -_ctl` hides `bait` and `ctl`.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "-_bait -_ctl\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge,w {path}")),
+            vec!["bait".to_string(), "ctl".to_string()]
+        );
+        // The `.` spelling carries the same modifier run.
+        assert_eq!(
+            filter_patterns(dir.path(), &format!(".,w {path}")),
+            vec!["bait".to_string(), "ctl".to_string()]
+        );
+    }
+
+    #[test]
+    fn without_w_a_merge_files_line_is_one_record() {
+        // NON-VACUITY COMPANION: the split must come from the `w` MODIFIER, not
+        // from how oc reads merge files generally. The same file read without
+        // `w` is one rule whose pattern is the whole line.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "-_bait -_ctl\n");
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge {path}")),
+            vec!["bait -_ctl".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_w_merge_files_word_must_be_a_whole_rule() {
+        // A word-split file whose action prefix is separated from its pattern
+        // by a SPACE leaves a patternless `-`, which upstream refuses
+        // (exclude.c:1474-1476 `unexpected end of filter rule`).
+        //
+        // MEASURED: `filter = merge,w FILE` over a file holding `- bait` is
+        // rc 5 on rsync 3.5.0, while the same file read WITHOUT `w` is rc 0.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "- bait - other\n");
+        let err = filter_rules(dir.path(), &format!("merge,w {path}")).expect_err("must refuse");
+        assert!(
+            err.to_string().contains("unexpected end of filter rule"),
+            "unexpected refusal: {err}"
+        );
+        assert_eq!(
+            filter_patterns(dir.path(), &format!("merge {path}")),
+            vec!["bait - other".to_string()]
+        );
+    }
+
+    #[test]
+    fn a_w_merge_file_has_no_comments() {
+        // upstream: exclude.c:1806 - the comment test is `word_split || (*line
+        // != ';' && *line != '#')`, so under `w` a leading `#` is rule text,
+        // and a bare word in a merge file is `Unknown filter rule`
+        // (exclude.c:1363). The SAME file therefore reads as a comment without
+        // `w` and refuses the module with it, which is what makes this cell a
+        // discriminator for the comment half rather than for the split half.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = merge_file(dir.path(), "rules", "#note\n");
+        assert!(filter_patterns(dir.path(), &format!("merge {path}")).is_empty());
+        let err = filter_rules(dir.path(), &format!("merge,w {path}")).expect_err("must refuse");
+        assert_eq!(err.to_string(), "Unknown filter rule: #note");
     }
 
     #[test]


### PR DESCRIPTION
Two `filter` directive divergences in the daemon's merge-rule handling, measured against a real rsync 3.5.0 daemon with the 3.5.0 binary as the constant client on both arms.

## `filter = .e FILE` read the file

Upstream's `parse_filter_file` tests the merge file's own name against `daemon_filter_list` **before** opening it (`exclude.c:1639-1664`) and returns as if the file did not exist when a rule already in that list hides it — which is exactly what the `e` self-exclude pushed one statement earlier does (`exclude.c:1557-1567`). Upstream adds the basename exclude and reads **nothing**; oc added the exclude *and* merged the file, hiding strictly more than the operator asked for.

The same gate explains a second cell: `filter = .e NOSUCHFILE` is rc 0 upstream and was rc 5 in oc, because the fatal-open arm is unreachable once the name is hidden.

## `filter = merge,w FILE` ignored the `w`

The modifier raises `FILTRULE_WORD_SPLIT` (`exclude.c:1433-1437`), which `parse_filter_file` reads off the merge rule (`exclude.c:1606`) to change **both** halves of its record loop: a record ends at any `isspace` (`:1772-1773`) rather than at a newline, and the `word_split ||` disjunct (`:1806`) stops treating a leading `;`/`#` as a comment. oc accepted `w` as an inert modifier and read the file line-by-line.

## Measured

17 cells, upstream vs oc-base vs oc-fix, comparing exit code + sorted served-set. **Base matched upstream on 10, the fix on 15. Five cells converge; none regressed.**

| cell | `filter =` | upstream | oc base | oc fix |
|---|---|---|---|---|
| C7-dot-e | `.e MERGEF` | rc 0, MERGEF hidden, **bait served** | rc 0, MERGEF+bait hidden | matches |
| C7b-dot-e-absent | `.e NOSUCHFILE` | rc 0, all served | rc 5 (module refused) | matches |
| C7d-dot-e-then-other | `.e MERGEF - other` | MERGEF+other hidden, bait served | bait also hidden | matches |
| C8-merge-comma-w | `merge,w WSPLITF` | rc 5 | rc 0, all served | matches |
| C8b-dot-comma-w | `.,w WSPLITF` | rc 5 | rc 0, all served | matches |

Scoring is mechanical — a scorer splits each arm's transcript on injected cell markers, strips the timestamp envelope, and diffs per cell; no cell was read by eye. Each cell asserts `lsof` listener-pid ownership so a concurrent daemon on the same port cannot answer. The oc column was re-baselined at current master (with #7795/#7750/#7757/#7804 in) before any conclusion — all three filed cells still diverge; none was stale.

## Mutations

- **Disable the gate** — fails exactly the four `e` cells. Both non-vacuity companions survive (`a_merge_file_the_daemon_rules_do_not_hide_is_still_read`, `the_first_merge_rule_in_a_module_is_never_gated`), which is what shows the gate fires on the **name** and not merely on "a merge was reached".
- **Disable word_split** — fails exactly the three `w` cells; `without_w_a_merge_files_line_is_one_record` survives.

Both reverted. Four planned fixtures were wrong against measured reality and were **restated, not re-engineered**: `- keep . MERGEF` yields one literal rule in oc (that is a residual below), so the companion uses the `merge` spelling; `-_bait ctl` refuses on the bare word, so the `w` cell is `-_bait -_ctl`; `#note bait` refuses under `w`, so the comment discriminator is `#note` alone.

## Not addressed here

Two cells still diverge and are deliberately out of scope:

- `filter = - keep !bait` — upstream rc 5, oc rc 0 serving everything.
- `filter = - keep . MERGEF` — the `.` spelling after another token is not treated as a merge boundary; oc builds one literal rule and hides nothing.

Both have one cause: `split_filter_tokens` is a heuristic boundary scanner where upstream's `parse_rule_tok` is a sequential positional walk. Converting it is substantially larger than this change and lands on the pin corpus from the earlier daemon-filter work, so it wants its own task and its own oracle rather than a bolt-on.

Two of the divergences fixed here (`C7b`, `C7d`) were found by this change's own control cells, not by the filed report.

## Residual noted during review

`daemon_filter_set` returns `None` if `FilterSet::from_rules` fails, and the gate then reports "not hidden" — the permissive direction. The rules have already been accepted by the daemon parser at that point, so this is near-unreachable; recorded rather than guarded.

## Gates (pinned 1.88.0)

`check_rustfmt_all.py` 3433 files clean; `clippy -p daemon -p filters --all-targets -D warnings` clean; `nextest -p daemon -p filters --lib` 2473/2473; `citation_drift_audit.py` exit 0.

Not run, and not claimed: full-workspace nextest, root `tests/integration_*.rs`, `--all-features`, macOS/Windows/musl cells, the 3.5.0 testsuite legs, interop.
