### PR TITLE
fix(ssh): tokenise ssh_config lines the way argv_split does

### DIFF
--- a/crates/rsync_io/src/ssh/argv_split.rs
+++ b/crates/rsync_io/src/ssh/argv_split.rs
@@ -1,0 +1,321 @@
+//! The one ssh_config tokeniser: a faithful port of OpenSSH's `argv_split`.
+//!
+//! Upstream splits the value half of *every* config line with a single
+//! call - `argv_split(str, &oac, &oav, 1)` at openssh/readconf.c:1196 -
+//! and each keyword arm then consumes tokens from that one vector via
+//! `argv_next`. So quoting, backslash escapes and comment termination are
+//! properties of the *line*, not of any individual directive, and a
+//! second tokeniser anywhere in the parser is a divergence by
+//! construction. Both of oc's ssh_config readers call [`argv_split`]
+//! here; nothing else in `crate::ssh` may split a config value.
+//!
+//! # The rules, each from the C
+//!
+//! * Separators are `' '` and `'\t'` only (openssh/misc.c:2141, :2165).
+//!   Not `\n`, not `\r`, and never a comma - a comma is ordinary token
+//!   text, which is why `Host a,b` does not match the alias `a`.
+//! * A `#` ends the line, but **only at a token boundary**
+//!   (openssh/misc.c:2143-2144): the test sits in the outer loop, after
+//!   leading whitespace has been skipped and before a token is opened.
+//!   A `#` reached from inside the inner copy loop falls through to the
+//!   final `else` and is emitted literally, so `HostName x#y` resolves to
+//!   `x#y` and `IdentityFile /k#1` keeps its `#1`.
+//! * A quote character (`"` or `'`) is a *state toggle*, not a delimiter
+//!   (openssh/misc.c:2167-2170). It is consumed rather than emitted, it
+//!   may open mid-token (`a"b c"d` is the single token `ab cd`), and
+//!   inside one quote kind the other kind is ordinary text.
+//! * A backslash escapes exactly four things: `'`, `"`, `\`, and - only
+//!   while unquoted - a space (openssh/misc.c:2154-2158). Anything else
+//!   is an *unrecognised* escape and upstream emits the backslash itself
+//!   and re-processes the following character normally
+//!   (openssh/misc.c:2161-2164), so `x\ny` stays `x\ny` and a trailing
+//!   `\` survives as `\`. Note the `quote == 0` guard on the space arm:
+//!   inside quotes `\ ` is *not* an escape, and both characters are kept.
+//! * A quote left open when the string ends is `SSH_ERR_INVALID_FORMAT`
+//!   (openssh/misc.c:2174-2179), which readconf reports as
+//!   `"%s line %d: invalid quotes"` and turns into a bad-option count
+//!   that aborts the whole load (openssh/readconf.c:1196-1199, :2667).
+//!
+//! # What this function does *not* decide
+//!
+//! An **empty token is produced, not rejected**: `Host a "" b` yields
+//! three tokens, the middle one empty. The refusal is per keyword, in
+//! the `oHost` arm's `if (*arg == '\0')` guard
+//! (openssh/readconf.c:1832-1836) and its siblings, so it belongs to the
+//! caller. Keeping it out of the tokeniser is upstream's own split, and
+//! it matters: `Match` criteria and several list options do *not* carry
+//! that guard.
+
+/// Why [`argv_split`] refused a line.
+///
+/// One variant because upstream's `argv_split` has exactly one failure
+/// return, `SSH_ERR_INVALID_FORMAT` from the ran-out-of-string-looking-
+/// for-a-close-quote branch (openssh/misc.c:2174-2179). Adding a second
+/// variant would mean oc had invented a refusal upstream does not have.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(in crate::ssh) enum ArgvSplitError {
+    /// A `"` or `'` was opened and the line ended before it closed.
+    UnterminatedQuote,
+}
+
+impl ArgvSplitError {
+    /// The reason text upstream prints for this failure, verbatim.
+    ///
+    /// upstream: openssh/readconf.c:1197
+    /// `error("%s line %d: invalid quotes", filename, linenum)`.
+    pub(in crate::ssh) fn reason(self) -> &'static str {
+        match self {
+            Self::UnterminatedQuote => "invalid quotes",
+        }
+    }
+}
+
+/// Splits one ssh_config value into tokens exactly as upstream's
+/// `argv_split` does (openssh/misc.c:2130-2196).
+///
+/// `terminate_on_comment` mirrors upstream's fourth parameter; readconf
+/// always passes `1` (openssh/readconf.c:1196). It is a parameter rather
+/// than a constant so the two behaviours stay distinguishable in tests
+/// and so a caller that needs upstream's `0` mode cannot get it by
+/// accident.
+///
+/// Returns the tokens in order, including any empty ones - see the
+/// module docs for why the empty-token refusal is the caller's.
+///
+/// # Errors
+///
+/// [`ArgvSplitError::UnterminatedQuote`] when a quote is still open at
+/// end of input.
+pub(in crate::ssh) fn argv_split(
+    value: &str,
+    terminate_on_comment: bool,
+) -> Result<Vec<String>, ArgvSplitError> {
+    // Indexed rather than iterated because the C reads `s[i + 1]` to
+    // classify an escape and then advances past it; a peeking iterator
+    // would have to reproduce that lookahead less legibly. Every
+    // character the algorithm branches on is ASCII, so a `char` vector
+    // and upstream's byte indexing agree on every decision.
+    let chars: Vec<char> = value.chars().collect();
+    let mut argv: Vec<String> = Vec::new();
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        // Skip leading whitespace (openssh/misc.c:2140-2142).
+        if chars[i] == ' ' || chars[i] == '\t' {
+            i += 1;
+            continue;
+        }
+        // Comment start - but only here, at a token boundary
+        // (openssh/misc.c:2143-2144).
+        if terminate_on_comment && chars[i] == '#' {
+            break;
+        }
+
+        // Start of a token (openssh/misc.c:2145-2150). The token is
+        // created unconditionally, which is how an empty one survives.
+        let mut quote: Option<char> = None;
+        let mut arg = String::new();
+
+        // Copy the token in, removing escapes (openssh/misc.c:2152-2173).
+        while i < chars.len() {
+            let c = chars[i];
+            if c == '\\' {
+                let next = chars.get(i + 1).copied();
+                let escapes = matches!(next, Some('\'') | Some('"') | Some('\\'))
+                    || (quote.is_none() && next == Some(' '));
+                if escapes {
+                    i += 1; // skip the '\'
+                    arg.push(chars[i]);
+                } else {
+                    // Unrecognised escape: upstream emits the backslash
+                    // and leaves the next character to the following
+                    // iteration (openssh/misc.c:2161-2164).
+                    arg.push('\\');
+                }
+            } else if quote.is_none() && (c == ' ' || c == '\t') {
+                break; // done
+            } else if quote.is_none() && (c == '"' || c == '\'') {
+                quote = Some(c); // quote start
+            } else if quote == Some(c) {
+                quote = None; // quote end
+            } else {
+                arg.push(c);
+            }
+            i += 1;
+        }
+
+        argv.push(arg);
+
+        if i >= chars.len() {
+            // Ran off the end of the string (openssh/misc.c:2174-2181).
+            if quote.is_some() {
+                return Err(ArgvSplitError::UnterminatedQuote);
+            }
+            break;
+        }
+        // The outer loop's own `i++`, which steps past the separator the
+        // inner loop stopped on (openssh/misc.c:2139).
+        i += 1;
+    }
+
+    Ok(argv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split(value: &str) -> Vec<String> {
+        argv_split(value, true).expect("value tokenises")
+    }
+
+    /// Separators are space and TAB, and nothing else
+    /// (openssh/misc.c:2141, :2165).
+    #[test]
+    fn space_and_tab_separate_and_a_comma_does_not() {
+        assert_eq!(split("a b"), ["a", "b"]);
+        assert_eq!(split("a\tb"), ["a", "b"]);
+        assert_eq!(split("  a \t  b  "), ["a", "b"]);
+        assert_eq!(split("a,b"), ["a,b"]);
+    }
+
+    /// An empty value produces no tokens at all: upstream's outer `for`
+    /// never executes, leaving `argc == 0` (openssh/misc.c:2139).
+    #[test]
+    fn an_empty_value_produces_no_tokens() {
+        assert_eq!(split(""), Vec::<String>::new());
+        assert_eq!(split("   "), Vec::<String>::new());
+    }
+
+    /// Quotes group a separator into one token and are themselves
+    /// consumed (openssh/misc.c:2167-2170).
+    #[test]
+    fn quotes_group_a_separator_and_are_not_emitted() {
+        assert_eq!(split(r#""web 1" other"#), ["web 1", "other"]);
+        assert_eq!(split("'web 1' other"), ["web 1", "other"]);
+    }
+
+    /// A quote is a state toggle, so it may open and close *inside* a
+    /// token: upstream builds `ab cd` from `a"b c"d`.
+    #[test]
+    fn a_quote_may_open_and_close_mid_token() {
+        assert_eq!(split(r#"a"b c"d"#), ["ab cd"]);
+        assert_eq!(split(r#""a"b"#), ["ab"]);
+    }
+
+    /// Inside one quote kind the other kind is ordinary text: the
+    /// `quote != 0 && s[i] == quote` arm only fires for the *same*
+    /// character that opened the quote (openssh/misc.c:2169).
+    #[test]
+    fn the_other_quote_kind_is_literal_inside_a_quote() {
+        assert_eq!(split(r#""a'b""#), ["a'b"]);
+        assert_eq!(split(r#"'a"b'"#), [r#"a"b"#]);
+    }
+
+    /// The empty token is PRODUCED. The refusal lives in the keyword
+    /// arms (openssh/readconf.c:1832-1836), not here, so a tokeniser
+    /// that dropped it would make that refusal unreachable.
+    #[test]
+    fn an_empty_quoted_token_is_produced_not_dropped() {
+        assert_eq!(split(r#"a "" b"#), ["a", "", "b"]);
+        assert_eq!(split(r#""" a"#), ["", "a"]);
+        assert_eq!(split(r#"a """#), ["a", ""]);
+        assert_eq!(split("a '' b"), ["a", "", "b"]);
+    }
+
+    /// `#` terminates the line only at a token boundary, and is literal
+    /// anywhere inside a token (openssh/misc.c:2143-2144 vs :2171-2172).
+    #[test]
+    fn hash_ends_the_line_only_at_a_token_boundary() {
+        assert_eq!(split("a #b"), ["a"]);
+        assert_eq!(split("a\t#b c"), ["a"]);
+        assert_eq!(split("#b"), Vec::<String>::new());
+        assert_eq!(split("a#b"), ["a#b"]);
+        assert_eq!(split("x#y z"), ["x#y", "z"]);
+    }
+
+    /// A quoted `#` is inside a token by the time it is read, so it is
+    /// literal for the same reason `a#b` is.
+    #[test]
+    fn hash_inside_quotes_is_literal() {
+        assert_eq!(split(r#""a#b""#), ["a#b"]);
+        assert_eq!(split(r#""a #b""#), ["a #b"]);
+    }
+
+    /// With `terminate_on_comment` off, `#` is never a comment - the
+    /// non-vacuity companion proving the parameter is consulted rather
+    /// than ignored.
+    #[test]
+    fn comment_termination_is_the_parameters_to_decide() {
+        assert_eq!(argv_split("a #b", false).expect("tokenises"), ["a", "#b"]);
+    }
+
+    /// The four recognised escapes (openssh/misc.c:2155-2160): the
+    /// backslash is dropped and the next character emitted verbatim.
+    #[test]
+    fn the_four_recognised_escapes_drop_the_backslash() {
+        assert_eq!(split(r#"a\ b"#), ["a b"]);
+        assert_eq!(split(r#"a\"b"#), [r#"a"b"#]);
+        assert_eq!(split(r"a\'b"), ["a'b"]);
+        assert_eq!(split(r"a\\b"), [r"a\b"]);
+    }
+
+    /// An unrecognised escape keeps BOTH characters: upstream emits the
+    /// backslash and does not skip the next byte
+    /// (openssh/misc.c:2161-2164).
+    #[test]
+    fn an_unrecognised_escape_keeps_the_backslash() {
+        assert_eq!(split(r"x\ny"), [r"x\ny"]);
+        assert_eq!(split(r"x\#y"), [r"x\#y"]);
+        assert_eq!(split(r"x\ty"), [r"x\ty"]);
+    }
+
+    /// A trailing backslash has no next character, so it is an
+    /// unrecognised escape and survives as itself.
+    #[test]
+    fn a_trailing_backslash_survives() {
+        assert_eq!(split(r"xy\"), [r"xy\"]);
+        assert_eq!(split(r"a\ b\"), [r"a b\"]);
+    }
+
+    /// The space escape is guarded on `quote == 0`
+    /// (openssh/misc.c:2158), so inside quotes `\ ` is unrecognised and
+    /// both characters are kept - the space needed no escaping there.
+    #[test]
+    fn the_space_escape_does_not_apply_inside_quotes() {
+        assert_eq!(split(r#""x\ y""#), [r"x\ y"]);
+        assert_eq!(split(r"x\ y"), ["x y"]);
+    }
+
+    /// An unclosed quote is upstream's one failure return
+    /// (openssh/misc.c:2174-2179).
+    #[test]
+    fn an_unterminated_quote_is_refused() {
+        assert_eq!(
+            argv_split(r#""a b"#, true),
+            Err(ArgvSplitError::UnterminatedQuote)
+        );
+        assert_eq!(
+            argv_split("a 'b", true),
+            Err(ArgvSplitError::UnterminatedQuote)
+        );
+        assert_eq!(ArgvSplitError::UnterminatedQuote.reason(), "invalid quotes");
+    }
+
+    /// A quote closed before the end is not a failure - the control for
+    /// the cell above, without which a tokeniser that refused every
+    /// quote would also satisfy it.
+    #[test]
+    fn a_closed_quote_is_not_a_failure() {
+        assert_eq!(split(r#""a b""#), ["a b"]);
+    }
+
+    /// Non-ASCII text passes through untouched: every character the
+    /// algorithm branches on is ASCII, so a multi-byte code point can
+    /// only reach the final `else`.
+    #[test]
+    fn non_ascii_token_text_is_preserved() {
+        assert_eq!(split("héllo wörld"), ["héllo", "wörld"]);
+        assert_eq!(split(r#""héllo wörld""#), ["héllo wörld"]);
+    }
+}

--- a/crates/rsync_io/src/ssh/argv_split.rs
+++ b/crates/rsync_io/src/ssh/argv_split.rs
@@ -52,22 +52,19 @@
 /// return, `SSH_ERR_INVALID_FORMAT` from the ran-out-of-string-looking-
 /// for-a-close-quote branch (openssh/misc.c:2174-2179). Adding a second
 /// variant would mean oc had invented a refusal upstream does not have.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+/// The `Display` text is the reason upstream prints, verbatim, so the
+/// only consumer that needs it reads it off the error rather than from a
+/// second accessor. An inherent method would be dead code in any build
+/// that compiles out the keyword arms (`embedded-ssh` off), which is what
+/// the fuzz workspace does; a trait impl is not.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
 pub(in crate::ssh) enum ArgvSplitError {
     /// A `"` or `'` was opened and the line ended before it closed.
-    UnterminatedQuote,
-}
-
-impl ArgvSplitError {
-    /// The reason text upstream prints for this failure, verbatim.
     ///
     /// upstream: openssh/readconf.c:1197
     /// `error("%s line %d: invalid quotes", filename, linenum)`.
-    pub(in crate::ssh) fn reason(self) -> &'static str {
-        match self {
-            Self::UnterminatedQuote => "invalid quotes",
-        }
-    }
+    #[error("invalid quotes")]
+    UnterminatedQuote,
 }
 
 /// Splits one ssh_config value into tokens exactly as upstream's
@@ -299,7 +296,10 @@ mod tests {
             argv_split("a 'b", true),
             Err(ArgvSplitError::UnterminatedQuote)
         );
-        assert_eq!(ArgvSplitError::UnterminatedQuote.reason(), "invalid quotes");
+        assert_eq!(
+            ArgvSplitError::UnterminatedQuote.to_string(),
+            "invalid quotes"
+        );
     }
 
     /// A quote closed before the end is not a failure - the control for

--- a/crates/rsync_io/src/ssh/config_lookup/match_block.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/match_block.rs
@@ -145,13 +145,28 @@ pub(in crate::ssh) fn evaluate_match(
 /// repeated calls accumulate the signal across multiple `Match exec`
 /// blocks.
 ///
-/// Recognises keys case-insensitively; arguments are split on whitespace
-/// or commas via [`parse_pattern_list`] for the keys that take a
-/// pattern-list. Unknown tokens cause the line to be treated as inert
-/// (conservative: a typo cannot accidentally flip the warning).
-pub(super) fn match_line_applies(value: &str, ctx: &MatchContext<'_>, saw_exec: &mut bool) -> bool {
+/// Recognises keys case-insensitively. Unknown tokens cause the line to
+/// be treated as inert (conservative: a typo cannot accidentally flip the
+/// warning).
+///
+/// Takes `argv_split` tokens rather than the raw value: upstream's
+/// `match_cfg_line` is handed the very `(ac, av)` the line was split into
+/// once at openssh/readconf.c:1196 and walks it with `argv_next`
+/// (openssh/readconf.c:1870), so a `Match` header sees exactly the same
+/// quote, escape and `#` handling as every other keyword. Splitting again
+/// here would be a third tokeniser free to disagree with that one.
+///
+/// The pattern-list argument of a criterion is then split a second time,
+/// on whitespace *and commas*, by [`parse_pattern_list`] - that is
+/// upstream's shape too, since `match_pattern_list`
+/// (openssh/match.c) is applied to one already-extracted argv token.
+pub(super) fn match_line_applies(
+    argv: &[String],
+    ctx: &MatchContext<'_>,
+    saw_exec: &mut bool,
+) -> bool {
     let mut conditions = Vec::new();
-    let mut tokens = value.split_ascii_whitespace();
+    let mut tokens = argv.iter();
     while let Some(keyword) = tokens.next() {
         let keyword_lc = keyword.to_ascii_lowercase();
         match keyword_lc.as_str() {

--- a/crates/rsync_io/src/ssh/config_lookup/mod.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/mod.rs
@@ -76,7 +76,7 @@ pub(super) use parser::parse_enables_compression;
 #[cfg(test)]
 use paths::extract_dash_f_path;
 #[cfg(test)]
-use pattern::{Pattern, parse_host_pattern_list, parse_pattern_list};
+use pattern::{Pattern, host_patterns_from_tokens, parse_pattern_list};
 
 /// Returns `true` when `~/.ssh/config` or `/etc/ssh/ssh_config`
 /// configures `Compression yes` for `ctx` at top level or under a

--- a/crates/rsync_io/src/ssh/config_lookup/parser.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/parser.rs
@@ -2,16 +2,22 @@
 //!
 //! Reads a config file, walks its lines tracking the active [`Block`],
 //! and applies OpenSSH's first-match-wins rule per scope. Holds the
-//! line-level helpers ([`strip_comment`], [`split_directive`],
-//! [`parse_yes_no`]) and the public [`parse_enables_compression`]
-//! entry consumed by tests and the lookup driver.
+//! line-level helpers ([`split_directive`], [`parse_yes_no`]) and the
+//! public [`parse_enables_compression`] entry consumed by tests and the
+//! lookup driver.
+//!
+//! Values are tokenised by the shared [`argv_split`] owner, the same one
+//! the connection-configuring reader uses, so the two cannot disagree
+//! about where a token ends.
 
 use std::path::Path;
 
 use logging::debug_log;
 
+use crate::ssh::argv_split::argv_split;
+
 use super::match_block::{MatchContext, match_line_applies};
-use super::pattern::{MatchKind, Pattern, parse_host_pattern_list, pattern_list_matches};
+use super::pattern::{MatchKind, Pattern, host_patterns_from_tokens, pattern_list_matches};
 
 /// Reads `path` and returns whether it enables compression for `ctx`.
 /// Parse and I/O errors are converted to `false` with a single
@@ -68,8 +74,13 @@ pub(in crate::ssh) fn parse_enables_compression(text: &str, ctx: &MatchContext<'
     let mut exec_block_has_compression = false;
 
     for raw_line in text.lines() {
-        let line = strip_comment(raw_line).trim();
-        if line.is_empty() {
+        let line = raw_line.trim();
+        // The ONLY place a leading `#` is a comment marker: upstream tests
+        // the first non-blank character of the line and skips
+        // (openssh/readconf.c:1181). Anywhere else a `#` is handled by
+        // `argv_split`'s token-boundary rule below, not by cutting the
+        // string here - `HostName x#y` is a hostname containing a `#`.
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
         let Some((key, value)) = split_directive(line) else {
@@ -80,14 +91,27 @@ pub(in crate::ssh) fn parse_enables_compression(text: &str, ctx: &MatchContext<'
             );
             continue;
         };
+        // A value real `ssh` cannot tokenise aborts its whole config load
+        // (openssh/readconf.c:1196-1199 -> :2667), so there is no
+        // connection left to warn about. Abandoning the scan reports "no
+        // compression", which is this reader's documented degraded answer
+        // - it must not fail, and it must not guess.
+        let Ok(tokens) = argv_split(value, true) else {
+            debug_log!(
+                Io,
+                1,
+                "ssh_config compression detection: abandoning scan, ssh would refuse this file"
+            );
+            return false;
+        };
         let key_lc = key.to_ascii_lowercase();
         match key_lc.as_str() {
             "host" => {
-                block = Block::Host(parse_host_pattern_list(value));
+                block = Block::Host(host_patterns_from_tokens(&tokens));
             }
             "match" => {
                 let mut saw_exec = false;
-                let applies = match_line_applies(value, ctx, &mut saw_exec);
+                let applies = match_line_applies(&tokens, ctx, &mut saw_exec);
                 block = if saw_exec {
                     Block::MatchExecSkipped
                 } else {
@@ -95,7 +119,7 @@ pub(in crate::ssh) fn parse_enables_compression(text: &str, ctx: &MatchContext<'
                 };
             }
             "compression" => {
-                let parsed = parse_yes_no(value);
+                let parsed = tokens.first().and_then(|arg| parse_yes_no(arg));
                 match &block {
                     Block::TopLevel if top_level.is_none() => top_level = parsed,
                     Block::Host(patterns)
@@ -169,11 +193,6 @@ enum Block {
     /// Directives inside this block are not honoured but are inspected
     /// for `Compression yes` to emit a targeted user warning.
     MatchExecSkipped,
-}
-
-/// Strips a trailing `#...` comment from a config line.
-fn strip_comment(line: &str) -> &str {
-    line.find('#').map_or(line, |idx| &line[..idx])
 }
 
 /// Splits `Key Value` (or `Key=Value`) on the first whitespace or `=`

--- a/crates/rsync_io/src/ssh/config_lookup/pattern.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/pattern.rs
@@ -59,22 +59,34 @@ pub(in crate::ssh) fn parse_pattern_list(value: &str) -> Vec<Pattern> {
     split_tokens(value, |c| c.is_whitespace() || c == ',')
 }
 
-/// Tokenises the value half of a `Host` line into [`Pattern`] entries.
+/// Builds the `Host` pattern list from already-split `argv_split` tokens.
 ///
-/// Tokens are separated by spaces and TABs only, and a comma is ordinary
-/// pattern text. Upstream splits the line with `argv_split`
-/// (openssh/misc.c:2130-2185), whose only separators are `' '` and `'\t'`
-/// (openssh/misc.c:2141), then matches each token with `match_pattern` in
-/// the `argv_next` loop (openssh/readconf.c:1831-1858); the `oHost` arm
-/// never reaches `match_pattern_list`, so `Host a,b` does not match the
-/// alias `a`.
+/// Takes tokens rather than the raw value because upstream tokenises the
+/// line exactly once, at openssh/readconf.c:1196, and the `oHost` arm then
+/// consumes that same vector through `argv_next`
+/// (openssh/readconf.c:1831-1858). Re-splitting the value here would be a
+/// second tokeniser that could disagree with the first about quotes,
+/// escapes and `#`.
 ///
-/// A separate entry point rather than a widened [`parse_pattern_list`]:
-/// the separator set differs *per keyword*, and the four `Match` criteria
-/// that share the tokeniser need the comma split that `Host` must not
-/// have.
-pub(in crate::ssh) fn parse_host_pattern_list(value: &str) -> Vec<Pattern> {
-    split_tokens(value, |c| c == ' ' || c == '\t')
+/// Each token becomes one pattern verbatim: the `oHost` arm matches with
+/// `match_pattern` directly (openssh/readconf.c:1844) and never reaches
+/// `match_pattern_list`, so a comma is ordinary pattern text and
+/// `Host a,b` does not match the alias `a`. That is why this is a
+/// separate entry point rather than a widened [`parse_pattern_list`] -
+/// the four `Match` criteria that share the tokeniser need the comma
+/// split that `Host` must not have.
+///
+/// An empty token is kept rather than dropped. Upstream REFUSES the line
+/// outright (openssh/readconf.c:1832-1836), but that refusal is ordered
+/// *inside* the match loop, after a negated token that already matched has
+/// broken out - so `Host !a ""` is accepted for the alias `a` and refused
+/// for any other (measured against `ssh -G`). This reader cannot express
+/// that ordering because it builds the whole list before matching, and its
+/// documented contract is never to fail. An empty pattern matches only the
+/// empty host, so keeping it is inert here; the refusal lives in the
+/// reader that configures the connection (`embedded::ssh_config`).
+pub(in crate::ssh) fn host_patterns_from_tokens(tokens: &[String]) -> Vec<Pattern> {
+    tokens.iter().map(|token| Pattern::new(token)).collect()
 }
 
 /// Splits `value` on `is_separator`, dropping empty tokens.

--- a/crates/rsync_io/src/ssh/config_lookup/tests.rs
+++ b/crates/rsync_io/src/ssh/config_lookup/tests.rs
@@ -182,6 +182,48 @@ fn parse_pattern_list_empty_input_yields_no_tokens() {
 }
 
 #[test]
+fn a_hash_inside_a_host_token_is_pattern_text() {
+    // `argv_split` ends the line on a `#` only at a TOKEN BOUNDARY
+    // (openssh/misc.c:2143-2144), so `Host x#y` is a three-character pattern.
+    // This reader used to cut every line at the first `#`, which turned the
+    // pattern into `x` and lost the block for the real alias.
+    assert!(parse_enables_compression(
+        "Host x#y\n  Compression yes\n",
+        &ctx("x#y", "", "")
+    ));
+
+    // Non-vacuity: a `#` that STARTS a token DOES end the line, so the same
+    // spelling with the `#` separated yields the single pattern `x` - which
+    // the alias `x#y` does not match. Without this the first assertion would
+    // also pass for a reader that never terminated on `#` at all.
+    assert!(!parse_enables_compression(
+        "Host x # y\n  Compression yes\n",
+        &ctx("x#y", "", "")
+    ));
+    assert!(parse_enables_compression(
+        "Host x # y\n  Compression yes\n",
+        &ctx("x", "", "")
+    ));
+}
+
+#[test]
+fn a_value_keeps_a_hash_that_sits_inside_its_token() {
+    // Same rule on the value half: `yes#no` is one token, not `yes`, so it
+    // is not a recognised boolean and the bit must stay unset.
+    assert!(!parse_enables_compression(
+        "Host a\n  Compression yes#no\n",
+        &ctx("a", "", "")
+    ));
+
+    // Non-vacuity companion: the same line with the `#` at a token boundary
+    // IS `yes`, and the bit is set.
+    assert!(parse_enables_compression(
+        "Host a\n  Compression yes #no\n",
+        &ctx("a", "", "")
+    ));
+}
+
+#[test]
 fn parse_host_pattern_list_keeps_a_comma_inside_one_token() {
     // A `Host` line is argv-tokenised: upstream splits it with
     // `argv_split` (openssh/misc.c:2130-2185), whose only separators are
@@ -189,7 +231,7 @@ fn parse_host_pattern_list_keeps_a_comma_inside_one_token() {
     // `match_pattern` (openssh/readconf.c:1844). The comma-splitting
     // `match_pattern_list` (openssh/match.c:143) is reachable only from
     // the `Match` criteria, so a comma here is pattern text.
-    let parsed = parse_host_pattern_list("a,b\tc d");
+    let parsed = host_patterns_from_tokens(&match_tokens("a,b\tc d"));
     assert_eq!(parsed.len(), 3);
     assert_eq!(parsed[0].glob(), "a,b");
     assert_eq!(parsed[1].glob(), "c");
@@ -676,6 +718,12 @@ fn match_localuser_miss_keeps_compression_off() {
 }
 
 // MED-2: `Match exec` warning flag tests. These exercise the
+// Tokenises a `Match` header value the way the production caller does,
+// so the tests exercise the same `argv_split` boundaries as the parser.
+fn match_tokens(value: &str) -> Vec<String> {
+    crate::ssh::argv_split::argv_split(value, true).expect("fixture tokenises")
+}
+
 // `saw_exec` output parameter on `match_line_applies` to verify
 // the one-shot warning fires exactly when expected.
 
@@ -684,7 +732,11 @@ fn match_exec_sets_saw_exec_flag() {
     // When the parser encounters `Match exec`, the saw_exec flag
     // must be set to true so the caller can emit a warning.
     let mut saw_exec = false;
-    let result = match_line_applies("exec /bin/true", &ctx("web1", "", ""), &mut saw_exec);
+    let result = match_line_applies(
+        &match_tokens("exec /bin/true"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(!result, "Match exec must not match");
     assert!(saw_exec, "saw_exec flag must be set");
 }
@@ -693,14 +745,18 @@ fn match_exec_sets_saw_exec_flag() {
 fn match_without_exec_does_not_set_flag() {
     // Normal Match conditions must not set the saw_exec flag.
     let mut saw_exec = false;
-    match_line_applies("host web1", &ctx("web1", "", ""), &mut saw_exec);
+    match_line_applies(
+        &match_tokens("host web1"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(!saw_exec, "saw_exec should not be set for non-exec Match");
 }
 
 #[test]
 fn match_all_does_not_set_flag() {
     let mut saw_exec = false;
-    match_line_applies("all", &ctx("", "", ""), &mut saw_exec);
+    match_line_applies(&match_tokens("all"), &ctx("", "", ""), &mut saw_exec);
     assert!(!saw_exec, "saw_exec should not be set for Match all");
 }
 
@@ -710,9 +766,17 @@ fn match_exec_flag_set_once_across_multiple_exec_blocks() {
     // first encounter matters for the one-shot warning. Verify the
     // flag stays true after a second exec block.
     let mut saw_exec = false;
-    match_line_applies("exec /bin/true", &ctx("web1", "", ""), &mut saw_exec);
+    match_line_applies(
+        &match_tokens("exec /bin/true"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(saw_exec);
-    match_line_applies("exec /bin/false", &ctx("web1", "", ""), &mut saw_exec);
+    match_line_applies(
+        &match_tokens("exec /bin/false"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(saw_exec, "flag should remain true after second exec");
 }
 
@@ -721,9 +785,17 @@ fn match_exec_flag_not_reset_by_non_exec_match() {
     // Once saw_exec is set by a Match exec block, a subsequent
     // non-exec Match must not clear it.
     let mut saw_exec = false;
-    match_line_applies("exec /usr/bin/test", &ctx("web1", "", ""), &mut saw_exec);
+    match_line_applies(
+        &match_tokens("exec /usr/bin/test"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(saw_exec);
-    match_line_applies("host web1", &ctx("web1", "", ""), &mut saw_exec);
+    match_line_applies(
+        &match_tokens("host web1"),
+        &ctx("web1", "", ""),
+        &mut saw_exec,
+    );
     assert!(saw_exec, "non-exec Match must not clear saw_exec flag");
 }
 

--- a/crates/rsync_io/src/ssh/embedded/config.rs
+++ b/crates/rsync_io/src/ssh/embedded/config.rs
@@ -257,23 +257,38 @@ impl SshConfig {
     /// patterns match against the same string OpenSSH would see.
     ///
     /// Values already explicitly set on the config win over the file:
-    /// only fields left at their URL/default state are overwritten. The
-    /// method never fails - a missing, unreadable, or malformed config
-    /// file is silently treated as empty.
-    pub fn apply_ssh_config(&mut self, host_alias: &str) -> &mut Self {
+    /// only fields left at their URL/default state are overwritten. A
+    /// missing or unreadable config file is treated as empty.
+    ///
+    /// # Errors
+    ///
+    /// [`SshError::SshConfig`] when the file contains a line real `ssh`
+    /// would refuse. Upstream aborts the whole load on a bad line
+    /// (openssh/readconf.c:2667) rather than continuing with a partial
+    /// config, so silently resolving to different connection parameters
+    /// than `ssh` would have used is not an option here either.
+    pub fn apply_ssh_config(&mut self, host_alias: &str) -> Result<&mut Self, SshError> {
         if let Some(path) = default_ssh_config_path() {
-            self.apply_ssh_config_from(&path, host_alias);
+            self.apply_ssh_config_from(&path, host_alias)?;
         }
-        self
+        Ok(self)
     }
 
     /// Variant of [`Self::apply_ssh_config`] that reads from a caller-supplied
     /// path. Exposed for testing and for callers that ship a non-default
     /// config location.
-    pub fn apply_ssh_config_from(&mut self, path: &Path, host_alias: &str) -> &mut Self {
-        let resolved = resolve_ssh_config_host(path, host_alias);
+    ///
+    /// # Errors
+    ///
+    /// Same as [`Self::apply_ssh_config`].
+    pub fn apply_ssh_config_from(
+        &mut self,
+        path: &Path,
+        host_alias: &str,
+    ) -> Result<&mut Self, SshError> {
+        let resolved = resolve_ssh_config_host(path, host_alias)?;
         self.merge_resolved_host(&resolved);
-        self
+        Ok(self)
     }
 
     fn merge_resolved_host(&mut self, resolved: &ResolvedHost) {
@@ -415,7 +430,7 @@ impl SshConfig {
         // Honor user's ~/.ssh/config Host blocks for the typed alias.
         // URL-supplied fields win over file directives (handled by
         // merge_resolved_host's "only if default" checks below).
-        config.apply_ssh_config(host);
+        config.apply_ssh_config(host)?;
 
         Ok((config, remote_path))
     }
@@ -923,7 +938,8 @@ mod tests {
         std::fs::write(&path, "Host example\n  IdentityAgent /run/custom.sock\n")
             .expect("write config");
         let mut cfg = SshConfig::default();
-        cfg.apply_ssh_config_from(&path, "example");
+        cfg.apply_ssh_config_from(&path, "example")
+            .expect("config accepted");
         assert_eq!(cfg.identity_agent.as_deref(), Some("/run/custom.sock"));
     }
 
@@ -942,7 +958,8 @@ mod tests {
         .expect("write config");
 
         let mut cfg = SshConfig::default();
-        cfg.apply_ssh_config_from(&path, "example");
+        cfg.apply_ssh_config_from(&path, "example")
+            .expect("config accepted");
 
         assert!(cfg.identities_only);
         assert_eq!(cfg.identity_files, vec![PathBuf::from("/keys/deploy")]);
@@ -960,7 +977,8 @@ mod tests {
         std::fs::write(&path, "Host example\n  IdentitiesOnly yes\n").expect("write config");
 
         let mut cfg = SshConfig::default();
-        cfg.apply_ssh_config_from(&path, "example");
+        cfg.apply_ssh_config_from(&path, "example")
+            .expect("config accepted");
 
         assert!(cfg.identities_only);
         // Non-vacuity: with no home directory both sides would be empty and
@@ -982,7 +1000,8 @@ mod tests {
         std::fs::write(&path, "Host example\n  IdentityFile /keys/deploy\n").expect("write config");
 
         let mut cfg = SshConfig::default();
-        cfg.apply_ssh_config_from(&path, "example");
+        cfg.apply_ssh_config_from(&path, "example")
+            .expect("config accepted");
 
         assert_eq!(cfg.identity_files, vec![PathBuf::from("/keys/deploy")]);
     }
@@ -1001,7 +1020,8 @@ mod tests {
             .expect("write config");
         let mut cfg = SshConfig::default();
         cfg.identity_agent(Some("/run/explicit.sock".to_owned()));
-        cfg.apply_ssh_config_from(&path, "example");
+        cfg.apply_ssh_config_from(&path, "example")
+            .expect("config accepted");
         assert_eq!(cfg.identity_agent.as_deref(), Some("/run/explicit.sock"));
     }
 }

--- a/crates/rsync_io/src/ssh/embedded/error.rs
+++ b/crates/rsync_io/src/ssh/embedded/error.rs
@@ -91,6 +91,31 @@ pub enum SshError {
         reason: String,
     },
 
+    /// An `ssh_config` line was refused while resolving the host alias.
+    ///
+    /// Upstream counts every refused line and then aborts the whole load
+    /// rather than continuing with a partial config
+    /// (openssh/readconf.c:2667 `fatal("%s: terminating, %d bad
+    /// configuration options")`), so the connection never starts. oc
+    /// mirrors that: `SshConfig::apply_ssh_config_from` propagates
+    /// instead of silently treating the file as empty, because a config
+    /// real `ssh` would refuse must not silently resolve to different
+    /// connection parameters here.
+    ///
+    /// The rendered text reproduces upstream's `%s line %d: <reason>`
+    /// shape so an operator comparing the two diagnostics sees the same
+    /// words.
+    #[error("{path} line {line}: {reason}")]
+    SshConfig {
+        /// The config file the refused line came from.
+        path: String,
+        /// 1-based physical line number, as upstream counts them
+        /// (openssh/readconf.c:2654 `linenum++` per `getline`).
+        line: usize,
+        /// Upstream's reason text for this refusal.
+        reason: String,
+    },
+
     /// DNS resolution produced no addresses matching the IP version preference.
     #[error("no {preference} addresses found for {host}")]
     DnsResolution {

--- a/crates/rsync_io/src/ssh/embedded/ssh_config.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config.rs
@@ -149,7 +149,8 @@ fn resolve_host_in(text: &str, host_alias: &str, path: &str) -> Result<ResolvedH
 
         // One tokenisation per line, exactly as upstream does it
         // (openssh/readconf.c:1196).
-        let tokens = argv_split(value, true).map_err(|err| refuse(path, linenum, err.reason()))?;
+        let tokens =
+            argv_split(value, true).map_err(|err| refuse(path, linenum, err.to_string()))?;
 
         if key_lc == "host" {
             in_matching_block =

--- a/crates/rsync_io/src/ssh/embedded/ssh_config.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config.rs
@@ -7,14 +7,50 @@
 //! matches any sequence, `?` matches any single character, `!pattern`
 //! negates a match for that block.
 //!
-//! The parser is intentionally permissive: a malformed file produces an
-//! empty result rather than an error, so a broken config never blocks a
-//! transfer. The caller (`SshConfig::apply_ssh_config`) merges the
-//! resolved directives into the existing config, with the rule that any
-//! value already set on the URL wins over the config file.
+//! # Tokenisation
+//!
+//! Every line's value half is split by [`argv_split`], the shared port of
+//! upstream's `argv_split` - the same call readconf makes once per line at
+//! openssh/readconf.c:1196. That is where quoting, backslash escapes and
+//! `#`-comment termination are decided; this module only consumes the
+//! resulting tokens. In particular a `#` is a comment **only at a token
+//! boundary**, so `HostName x#y` resolves to `x#y`.
+//!
+//! # Failure mode
+//!
+//! A missing or unreadable file is still an empty result, but a file that
+//! real `ssh` would REFUSE is now an error rather than silently-empty.
+//! Upstream counts bad lines and then aborts the load outright
+//! (openssh/readconf.c:2667), so the connection never happens; resolving
+//! to different connection parameters than `ssh` would have used is the
+//! worse outcome. Three refusals are mirrored, each with upstream's own
+//! wording:
+//!
+//! * `invalid quotes` - a quote left open (openssh/readconf.c:1196-1199).
+//! * `keyword host empty argument` - an empty `Host` token
+//!   (openssh/readconf.c:1832-1836).
+//! * `Missing argument.` / `missing argument.` - a directive whose value
+//!   tokenised to nothing, e.g. `Port #comment`. The capitalisation is
+//!   upstream's own and splits by arm: string options say `Missing`
+//!   (openssh/readconf.c:1364), flag options say `missing`
+//!   (openssh/readconf.c:1240). Measured against real `ssh -G`, both.
+//!
+//! The caller (`SshConfig::apply_ssh_config`) merges the resolved
+//! directives into the existing config, with the rule that any value
+//! already set on the URL wins over the config file.
 
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use super::error::SshError;
+use crate::ssh::argv_split::argv_split;
+
+/// Placeholder file name used when a caller supplies config text with no
+/// path of its own. Upstream always has a real filename to name in a
+/// refusal (openssh/readconf.c:1197 `"%s line %d: ..."`), so the
+/// text-only entry point substitutes this rather than printing nothing.
+#[cfg(test)]
+const INLINE_CONFIG_NAME: &str = "<ssh_config>";
 
 /// Resolved directives for a single host alias, merged in declaration order
 /// across every matching `Host` block. Only the directives the embedded
@@ -31,27 +67,78 @@ pub(super) struct ResolvedHost {
 
 /// Parses `path` and returns the directives that apply to `host_alias`.
 ///
-/// Returns `ResolvedHost::default()` when the file cannot be read or
-/// contains no matching block. OpenSSH's first-match-wins precedence is
-/// honoured: once a directive is set inside the first matching block, a
-/// later block cannot overwrite it. Wildcards in `Host` patterns are
-/// expanded with [`pattern_matches`].
-pub(super) fn resolve_host(path: &Path, host_alias: &str) -> ResolvedHost {
+/// Returns `Ok(ResolvedHost::default())` when the file cannot be read -
+/// upstream treats an absent config the same way
+/// (openssh/readconf.c:2632-2633 `if ((f = fopen(...)) == NULL) return 0`).
+/// OpenSSH's first-match-wins precedence is honoured: once a directive is
+/// set inside the first matching block, a later block cannot overwrite it.
+/// Wildcards in `Host` patterns are expanded with [`pattern_matches`].
+///
+/// # Errors
+///
+/// [`SshError::SshConfig`] when a line is one upstream would refuse; see
+/// the module docs for the three cases.
+pub(super) fn resolve_host(path: &Path, host_alias: &str) -> Result<ResolvedHost, SshError> {
     let Ok(text) = fs::read_to_string(path) else {
-        return ResolvedHost::default();
+        return Ok(ResolvedHost::default());
     };
-    resolve_host_str(&text, host_alias)
+    resolve_host_in(&text, host_alias, &path.display().to_string())
 }
 
 /// Variant of [`resolve_host`] that takes the config text directly.
-/// Exposed for unit tests so they do not have to touch the filesystem.
-pub(super) fn resolve_host_str(text: &str, host_alias: &str) -> ResolvedHost {
+/// Exposed for unit tests and for the `ssh -G` differential harness so
+/// neither has to touch the filesystem. Refusals name
+/// [`INLINE_CONFIG_NAME`] instead of a real path.
+///
+/// # Errors
+///
+/// Same as [`resolve_host`].
+#[cfg(test)]
+pub(super) fn resolve_host_str(text: &str, host_alias: &str) -> Result<ResolvedHost, SshError> {
+    resolve_host_in(text, host_alias, INLINE_CONFIG_NAME)
+}
+
+/// Builds the refusal upstream would print for `path` line `line`.
+fn refuse(path: &str, line: usize, reason: impl Into<String>) -> SshError {
+    SshError::SshConfig {
+        path: path.to_owned(),
+        line,
+        reason: reason.into(),
+    }
+}
+
+/// The missing-argument wording for `keyword`.
+///
+/// Upstream splits by arm and the capitalisation differs: the string
+/// options route through `parse_string` and print `Missing argument.`
+/// (openssh/readconf.c:1364) while the yes/no flags route through
+/// `parse_flag` and print `missing argument.` (openssh/readconf.c:1240).
+/// Measured against real `ssh -G` for every keyword below rather than
+/// inferred from the arm names.
+fn missing_argument(keyword: &str) -> &'static str {
+    match keyword {
+        "identitiesonly" => "missing argument.",
+        _ => "Missing argument.",
+    }
+}
+
+fn resolve_host_in(text: &str, host_alias: &str, path: &str) -> Result<ResolvedHost, SshError> {
     let mut resolved = ResolvedHost::default();
     let mut in_matching_block = false;
 
-    for raw_line in text.lines() {
-        let line = strip_comment(raw_line).trim();
-        if line.is_empty() {
+    for (index, raw_line) in text.lines().enumerate() {
+        // Upstream counts physical lines from 1 (openssh/readconf.c:2651-2654).
+        let linenum = index + 1;
+        // Trailing whitespace strip + leading whitespace skip
+        // (openssh/readconf.c:1168-1172, :1178-1180). `\r` is in
+        // upstream's WHITESPACE set (openssh/misc.c:464), so a CRLF file
+        // needs no special case.
+        let line = raw_line.trim();
+        // A line whose keyword begins with `#` is a comment
+        // (openssh/readconf.c:1181). This is the ONLY place a leading `#`
+        // may be tested: mid-token a `#` is literal, and `argv_split`
+        // owns that decision.
+        if line.is_empty() || line.starts_with('#') {
             continue;
         }
 
@@ -60,53 +147,75 @@ pub(super) fn resolve_host_str(text: &str, host_alias: &str) -> ResolvedHost {
         };
         let key_lc = key.to_ascii_lowercase();
 
+        // One tokenisation per line, exactly as upstream does it
+        // (openssh/readconf.c:1196).
+        let tokens = argv_split(value, true).map_err(|err| refuse(path, linenum, err.reason()))?;
+
         if key_lc == "host" {
-            in_matching_block = host_matches_any_pattern(host_alias, value);
+            in_matching_block =
+                host_matches_any_pattern(host_alias, &tokens).map_err(|EmptyHostToken| {
+                    refuse(path, linenum, format!("keyword {key_lc} empty argument"))
+                })?;
             continue;
         }
         if !in_matching_block {
             continue;
         }
 
+        // Every directive below is single-valued, so it consumes exactly
+        // one token - upstream's `arg = argv_next(&ac, &av)`. A `NULL`
+        // there is fatal, which is how `Port #comment` is refused.
+        let arg = match key_lc.as_str() {
+            "hostname" | "user" | "port" | "identityfile" | "identitiesonly" | "identityagent" => {
+                match tokens.first() {
+                    Some(arg) => arg.as_str(),
+                    None => return Err(refuse(path, linenum, missing_argument(&key_lc))),
+                }
+            }
+            // Not a directive this parser acts on. Upstream would still
+            // classify it, but oc's unknown-keyword policy is task 237j's
+            // row, not this one.
+            _ => continue,
+        };
+
         match key_lc.as_str() {
-            "hostname" => set_if_unset(&mut resolved.hostname, value.to_owned()),
-            "user" => set_if_unset(&mut resolved.user, value.to_owned()),
+            "hostname" => set_if_unset(&mut resolved.hostname, arg.to_owned()),
+            "user" => set_if_unset(&mut resolved.user, arg.to_owned()),
             "port" => {
                 if resolved.port.is_none()
-                    && let Ok(parsed) = value.parse::<u16>()
+                    && let Ok(parsed) = arg.parse::<u16>()
                 {
                     resolved.port = Some(parsed);
                 }
             }
             "identityfile" => {
-                let expanded = expand_tilde(value);
+                let expanded = expand_tilde(arg);
                 if !resolved.identity_files.contains(&expanded) {
                     resolved.identity_files.push(expanded);
                 }
             }
             "identitiesonly" => {
                 if resolved.identities_only.is_none() {
-                    resolved.identities_only = parse_yes_no(value);
+                    resolved.identities_only = parse_yes_no(arg);
                 }
             }
             "identityagent" => {
-                set_if_unset(&mut resolved.identity_agent, expand_tilde_str(value));
+                set_if_unset(&mut resolved.identity_agent, expand_tilde_str(arg));
             }
-            _ => {}
+            _ => unreachable!("the match above already narrowed the keyword set"),
         }
     }
 
-    resolved
-}
-
-/// Strips a trailing `#...` comment from a config line.
-fn strip_comment(line: &str) -> &str {
-    line.find('#').map_or(line, |idx| &line[..idx])
+    Ok(resolved)
 }
 
 /// Splits a `Key Value` directive on the first run of whitespace or
 /// optional `=` separator. Returns `None` for lines that contain only the
 /// key with no value.
+///
+/// The keyword half is upstream's `strdelim` (openssh/readconf.c:1176,
+/// openssh/misc.c:469-507), a *different* splitter from `argv_split`; it
+/// is the value half that this module then tokenises.
 fn split_directive(line: &str) -> Option<(&str, &str)> {
     let (key, rest) = line.split_once(|c: char| c.is_whitespace() || c == '=')?;
     let value = rest.trim_start_matches(|c: char| c.is_whitespace() || c == '=');
@@ -116,37 +225,50 @@ fn split_directive(line: &str) -> Option<(&str, &str)> {
     Some((key, value))
 }
 
-/// Returns `true` when `host` matches any pattern in `patterns`, after
+/// A `Host` line carried a token that tokenised to the empty string.
+///
+/// A unit-like error rather than `()` so the call site reads as a named
+/// condition and clippy's `result_unit_err` has nothing to complain about.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+struct EmptyHostToken;
+
+/// Returns `true` when `host` matches any token in `tokens`, after
 /// expanding wildcards and applying negations. A leading `!` on any token
 /// negates and causes the whole line to fail to match.
 ///
-/// Tokens are separated by spaces and TABs only. Upstream splits a `Host`
-/// line with `argv_split` (openssh/misc.c:2130-2185), whose only
-/// separators are `' '` and `'\t'` (openssh/misc.c:2141), then matches
-/// each token individually with `match_pattern` in the `argv_next` loop
-/// (openssh/readconf.c:1831-1858). The `oHost` arm never calls
-/// `match_pattern_list`, so a comma inside a token is ordinary pattern
-/// text, not a separator: `Host a,b` does not match the alias `a`.
-/// (`Match host` is the comma-splitting case, openssh/match.c:143 - a
-/// different keyword with a different rule.)
-fn host_matches_any_pattern(host: &str, patterns: &str) -> bool {
+/// Mirrors the `oHost` arm's own loop (openssh/readconf.c:1829-1858) step
+/// for step, and the ORDER matters:
+///
+/// 1. `*activep = 0` before the loop (:1829) - a `Host` line with no
+///    tokens at all leaves the block inactive.
+/// 2. the empty-token guard (:1832-1836) runs FIRST, before negation is
+///    stripped, so `Host a "" b` is refused even though `a` would match.
+/// 3. a NEGATED match consumes the rest of the line and breaks
+///    (:1845-1852), so a later empty token after it is never reached.
+/// 4. a POSITIVE match does NOT break (:1854-1856): scanning continues so
+///    a later negation can still kill the block.
+///
+/// # Errors
+///
+/// [`EmptyHostToken`] when a token is empty; the caller renders
+/// upstream's `keyword host empty argument`.
+fn host_matches_any_pattern(host: &str, tokens: &[String]) -> Result<bool, EmptyHostToken> {
     let mut any_positive_match = false;
-    for raw in patterns.split([' ', '\t']) {
-        let token = raw.trim();
+    for token in tokens {
         if token.is_empty() {
-            continue;
+            return Err(EmptyHostToken);
         }
         let (negate, pat) = token
             .strip_prefix('!')
-            .map_or((false, token), |stripped| (true, stripped));
+            .map_or((false, token.as_str()), |stripped| (true, stripped));
         if pattern_matches(host, pat) {
             if negate {
-                return false;
+                return Ok(false);
             }
             any_positive_match = true;
         }
     }
-    any_positive_match
+    Ok(any_positive_match)
 }
 
 /// Glob-matches `host` against `pattern`, where `*` matches any sequence
@@ -268,9 +390,25 @@ fn parse_yes_no(value: &str) -> Option<bool> {
 mod tests {
     use super::*;
 
+    /// Resolve, asserting the config was accepted. Most cells below are
+    /// about which value wins, not about refusal.
+    fn resolve(text: &str, alias: &str) -> ResolvedHost {
+        resolve_host_str(text, alias).expect("config accepted")
+    }
+
+    /// The `path line N: reason` text of a refusal, for the cells that
+    /// assert on upstream's wording.
+    fn refusal(text: &str, alias: &str) -> String {
+        match resolve_host_str(text, alias) {
+            Ok(resolved) => panic!("expected a refusal, resolved {resolved:?}"),
+            Err(err) => err.to_string(),
+        }
+    }
+
     #[test]
     fn missing_file_returns_default() {
-        let resolved = resolve_host(Path::new("/nonexistent/ssh/config"), "anything");
+        let resolved =
+            resolve_host(Path::new("/nonexistent/ssh/config"), "anything").expect("absent is Ok");
         assert!(resolved.hostname.is_none());
         assert!(resolved.user.is_none());
         assert!(resolved.port.is_none());
@@ -280,7 +418,7 @@ mod tests {
     #[test]
     fn simple_host_block_applies() {
         let text = "Host example\n  HostName 1.2.3.4\n  User deploy\n  Port 2222\n";
-        let resolved = resolve_host_str(text, "example");
+        let resolved = resolve(text, "example");
         assert_eq!(resolved.hostname.as_deref(), Some("1.2.3.4"));
         assert_eq!(resolved.user.as_deref(), Some("deploy"));
         assert_eq!(resolved.port, Some(2222));
@@ -289,45 +427,41 @@ mod tests {
     #[test]
     fn non_matching_block_is_ignored() {
         let text = "Host other\n  HostName ignored\n";
-        let resolved = resolve_host_str(text, "example");
-        assert!(resolved.hostname.is_none());
+        assert!(resolve(text, "example").hostname.is_none());
     }
 
     #[test]
     fn wildcard_star_matches() {
         let text = "Host *.example.com\n  User wild\n";
-        let resolved = resolve_host_str(text, "alpha.example.com");
-        assert_eq!(resolved.user.as_deref(), Some("wild"));
+        assert_eq!(
+            resolve(text, "alpha.example.com").user.as_deref(),
+            Some("wild")
+        );
     }
 
     #[test]
     fn first_match_wins() {
         let text = "Host example\n  User first\nHost *\n  User second\n";
-        let resolved = resolve_host_str(text, "example");
-        assert_eq!(resolved.user.as_deref(), Some("first"));
+        assert_eq!(resolve(text, "example").user.as_deref(), Some("first"));
     }
 
     #[test]
     fn comments_and_blank_lines_skipped() {
         let text = "# top comment\n\nHost example  # inline\n  User u # trail\n";
-        let resolved = resolve_host_str(text, "example");
-        assert_eq!(resolved.user.as_deref(), Some("u"));
+        assert_eq!(resolve(text, "example").user.as_deref(), Some("u"));
     }
 
     #[test]
     fn equals_separator_supported() {
         let text = "Host example\n  Port=4242\n";
-        let resolved = resolve_host_str(text, "example");
-        assert_eq!(resolved.port, Some(4242));
+        assert_eq!(resolve(text, "example").port, Some(4242));
     }
 
     #[test]
     fn negation_disables_block() {
         let text = "Host *.example.com !banned.example.com\n  User u\n";
-        let resolved = resolve_host_str(text, "banned.example.com");
-        assert!(resolved.user.is_none());
-        let resolved_ok = resolve_host_str(text, "ok.example.com");
-        assert_eq!(resolved_ok.user.as_deref(), Some("u"));
+        assert!(resolve(text, "banned.example.com").user.is_none());
+        assert_eq!(resolve(text, "ok.example.com").user.as_deref(), Some("u"));
     }
 
     /// A comma inside a `Host` token is pattern text, not a separator.
@@ -342,9 +476,9 @@ mod tests {
     #[test]
     fn comma_in_a_host_pattern_is_literal_not_a_separator() {
         let text = "Host a,b\n  Port 2222\n";
-        assert!(resolve_host_str(text, "a").port.is_none());
-        assert!(resolve_host_str(text, "b").port.is_none());
-        assert_eq!(resolve_host_str(text, "a,b").port, Some(2222));
+        assert!(resolve(text, "a").port.is_none());
+        assert!(resolve(text, "b").port.is_none());
+        assert_eq!(resolve(text, "a,b").port, Some(2222));
     }
 
     /// A TAB separates `Host` tokens exactly as a space does
@@ -353,23 +487,21 @@ mod tests {
     #[test]
     fn tab_separates_host_patterns() {
         let text = "Host first\tsecond\n  Port 2222\n";
-        assert_eq!(resolve_host_str(text, "first").port, Some(2222));
-        assert_eq!(resolve_host_str(text, "second").port, Some(2222));
+        assert_eq!(resolve(text, "first").port, Some(2222));
+        assert_eq!(resolve(text, "second").port, Some(2222));
     }
 
     #[test]
     fn identities_only_yes_is_recognised() {
         let text = "Host example\n  IdentitiesOnly yes\n";
-        let resolved = resolve_host_str(text, "example");
-        assert_eq!(resolved.identities_only, Some(true));
+        assert_eq!(resolve(text, "example").identities_only, Some(true));
     }
 
     #[test]
     fn identity_files_collected_in_order() {
         let text = "Host example\n  IdentityFile /a\n  IdentityFile /b\n";
-        let resolved = resolve_host_str(text, "example");
         assert_eq!(
-            resolved.identity_files,
+            resolve(text, "example").identity_files,
             vec![PathBuf::from("/a"), PathBuf::from("/b")]
         );
     }
@@ -377,8 +509,253 @@ mod tests {
     #[test]
     fn invalid_port_is_ignored() {
         let text = "Host example\n  Port notanumber\n";
-        let resolved = resolve_host_str(text, "example");
-        assert!(resolved.port.is_none());
+        assert!(resolve(text, "example").port.is_none());
+    }
+
+    // -- argv_split boundary behaviour, as seen through the directives --
+    //
+    // The tokeniser itself is unit-tested in `crate::ssh::argv_split`;
+    // these cells prove the parser CONSUMES those tokens rather than
+    // re-deriving its own. Each was measured against real `ssh -G`
+    // (OpenSSH_10.3p1) before being written down.
+
+    /// A `#` inside a token is pattern text, so the alias that matches is
+    /// `a#b` and not `a`. Before the tokeniser landed, a whole-line
+    /// comment strip cut the value to `a` and inverted both rows.
+    /// Oracle: `Host a#b` + alias `a#b` gives `port 2222`; alias `a` gives
+    /// `port 22`.
+    #[test]
+    fn a_hash_inside_a_host_token_is_pattern_text() {
+        let text = "Host a#b\n  Port 2222\n";
+        assert_eq!(resolve(text, "a#b").port, Some(2222));
+        assert!(resolve(text, "a").port.is_none());
+    }
+
+    /// The non-vacuity companion: at a token boundary the `#` really does
+    /// end the line, so the trailing token is not a pattern.
+    /// Oracle: `Host a #b` + alias `a` gives `port 2222`.
+    #[test]
+    fn a_hash_at_a_token_boundary_still_ends_the_host_line() {
+        let text = "Host a #b\n  Port 2222\n";
+        assert_eq!(resolve(text, "a").port, Some(2222));
+        assert!(resolve(text, "b").port.is_none());
+    }
+
+    /// Quotes are consumed, not matched: `Host "a"` matches the alias `a`.
+    /// Oracle: `port 2222`. Without the tokeniser oc compared the alias
+    /// against the literal `"a"` and declined.
+    #[test]
+    fn quotes_around_a_host_token_are_stripped() {
+        assert_eq!(resolve("Host \"a\"\n  Port 2222\n", "a").port, Some(2222));
+        assert_eq!(resolve("Host 'a'\n  Port 2222\n", "a").port, Some(2222));
+    }
+
+    /// A quoted wildcard is still a wildcard once the quotes are gone.
+    /// Oracle: `Host "*"` + alias `x` gives `port 2222`.
+    #[test]
+    fn a_quoted_wildcard_still_globs() {
+        assert_eq!(resolve("Host \"*\"\n  Port 2222\n", "x").port, Some(2222));
+    }
+
+    /// A quote may open and close mid-token, splicing the halves.
+    /// Oracle: `Host "a"b` + alias `ab` gives `port 2222`.
+    #[test]
+    fn a_mid_token_quote_splices_the_host_pattern() {
+        assert_eq!(resolve("Host \"a\"b\n  Port 2222\n", "ab").port, Some(2222));
+    }
+
+    /// Quotes group a space into ONE pattern, so `Host "web 1" other`
+    /// carries two tokens and `web` matches neither.
+    /// Oracle: alias `web` gives `port 22`; alias `other` gives 2222.
+    /// (`ssh -G 'web 1'` refuses the alias itself, so the grouped token is
+    /// asserted here rather than differentially - the same oracle boundary
+    /// task 1204 recorded for `a,b`.)
+    #[test]
+    fn quotes_group_a_space_into_one_host_pattern() {
+        let text = "Host \"web 1\" other\n  Port 2222\n";
+        assert!(resolve(text, "web").port.is_none());
+        assert!(resolve(text, "1").port.is_none());
+        assert_eq!(resolve(text, "other").port, Some(2222));
+        assert_eq!(resolve(text, "web 1").port, Some(2222));
+    }
+
+    /// An escaped quote is ordinary text, so the token keeps the `"`.
+    /// Oracle: `Host \"a` + alias `a` gives `port 22`.
+    #[test]
+    fn an_escaped_quote_stays_in_the_host_pattern() {
+        let text = "Host \\\"a\n  Port 2222\n";
+        assert!(resolve(text, "a").port.is_none());
+        assert_eq!(resolve(text, "\"a").port, Some(2222));
+    }
+
+    /// A directive VALUE keeps its `#` too - this is the row that reaches
+    /// every keyword, not just `Host`.
+    /// Oracle: `HostName x#y` dumps `hostname x#y`; `IdentityFile /k#1`
+    /// dumps `identityfile /k#1`.
+    #[test]
+    fn a_hash_inside_a_directive_value_is_literal() {
+        let text = "Host a\n  HostName x#y\n  IdentityFile /k#1\n";
+        let resolved = resolve(text, "a");
+        assert_eq!(resolved.hostname.as_deref(), Some("x#y"));
+        assert_eq!(identity_file_strings(&resolved), vec!["/k#1".to_owned()]);
+    }
+
+    /// A quoted directive value keeps its embedded space and loses the
+    /// quotes. Oracle: `HostName "x y"` dumps `hostname x y`.
+    #[test]
+    fn a_quoted_directive_value_keeps_its_space_and_loses_the_quotes() {
+        let text = "Host a\n  HostName \"x y\"\n";
+        assert_eq!(resolve(text, "a").hostname.as_deref(), Some("x y"));
+    }
+
+    /// An unrecognised escape keeps BOTH characters
+    /// (openssh/misc.c:2161-2164). Oracle: `HostName x\ny` dumps
+    /// `hostname x\ny`, and `HostName "x\ y"` dumps `hostname x\ y`
+    /// because the space escape is quote-gated.
+    #[test]
+    fn an_unrecognised_escape_survives_into_the_value() {
+        assert_eq!(
+            resolve("Host a\n  HostName x\\ny\n", "a")
+                .hostname
+                .as_deref(),
+            Some("x\\ny")
+        );
+        assert_eq!(
+            resolve("Host a\n  HostName \"x\\ y\"\n", "a")
+                .hostname
+                .as_deref(),
+            Some("x\\ y")
+        );
+    }
+
+    // -- the refusals ---------------------------------------------------
+
+    /// The empty-token hard error, upstream's own wording.
+    /// Oracle: `ssh -G` exits 255 with
+    /// `<file> line 1: keyword host empty argument`
+    /// (openssh/readconf.c:1832-1836), measured for the middle, first and
+    /// last positions and for both quote characters.
+    #[test]
+    fn an_empty_host_token_is_refused_in_every_position() {
+        for text in [
+            "Host a \"\" b\n  Port 2222\n",
+            "Host \"\" a\n  Port 2222\n",
+            "Host a \"\"\n  Port 2222\n",
+            "Host a '' b\n  Port 2222\n",
+        ] {
+            assert_eq!(
+                refusal(text, "a"),
+                "<ssh_config> line 1: keyword host empty argument",
+                "fixture {text:?}"
+            );
+        }
+    }
+
+    /// The non-vacuity companion: the same shapes WITHOUT an empty token
+    /// resolve. Without this, a parser that refused every quoted `Host`
+    /// line would satisfy the cell above.
+    #[test]
+    fn a_host_line_with_no_empty_token_is_accepted() {
+        assert_eq!(
+            resolve("Host a \"b\" c\n  Port 2222\n", "a").port,
+            Some(2222)
+        );
+        assert_eq!(
+            resolve("Host a \"b\" c\n  Port 2222\n", "b").port,
+            Some(2222)
+        );
+    }
+
+    /// A NEGATED match consumes the rest of the line, so an empty token
+    /// after it is never reached (openssh/readconf.c:1845-1852). This is
+    /// the ordering cell: a guard hoisted ahead of the loop would refuse
+    /// here and diverge.
+    #[test]
+    fn an_empty_token_after_a_negated_match_is_not_reached() {
+        let text = "Host !a \"\"\n  Port 2222\n";
+        assert!(resolve(text, "a").port.is_none());
+        // For an alias the negation does NOT match, the loop runs on and
+        // the empty token IS refused.
+        assert_eq!(
+            refusal(text, "z"),
+            "<ssh_config> line 1: keyword host empty argument"
+        );
+    }
+
+    /// An unterminated quote refuses the line, with upstream's wording.
+    /// Oracle: `ssh -G` exits 255 with `<file> line 1: invalid quotes`
+    /// (openssh/readconf.c:1196-1199).
+    #[test]
+    fn an_unterminated_quote_is_refused() {
+        assert_eq!(
+            refusal("Host \"a b\n  Port 2222\n", "a"),
+            "<ssh_config> line 1: invalid quotes"
+        );
+        // A quote on a VALUE line refuses too, and carries that line's
+        // number - proving the refusal is per-line, not Host-specific.
+        assert_eq!(
+            refusal("Host a\n  HostName \"x\n", "a"),
+            "<ssh_config> line 2: invalid quotes"
+        );
+    }
+
+    /// A directive whose value tokenises to nothing is the
+    /// `argv_next` returned NULL arm. Oracle-measured per keyword: the
+    /// string options capitalise it (openssh/readconf.c:1364) and the
+    /// yes/no flags do not (openssh/readconf.c:1240).
+    #[test]
+    fn a_value_that_is_only_a_comment_is_refused() {
+        for (keyword, reason) in [
+            ("HostName", "Missing argument."),
+            ("User", "Missing argument."),
+            ("Port", "Missing argument."),
+            ("IdentityFile", "Missing argument."),
+            ("IdentityAgent", "Missing argument."),
+            ("IdentitiesOnly", "missing argument."),
+        ] {
+            let text = format!("Host a\n  {keyword} #x\n");
+            assert_eq!(
+                refusal(&text, "a"),
+                format!("<ssh_config> line 2: {reason}"),
+                "keyword {keyword}"
+            );
+        }
+    }
+
+    /// The non-vacuity companion for the cell above: the same directives
+    /// with a real value are accepted, and a comment AFTER the value is
+    /// not a missing argument.
+    #[test]
+    fn a_value_followed_by_a_comment_is_not_missing() {
+        let text = "Host a\n  HostName real #note\n  Port 2222 #note\n";
+        let resolved = resolve(text, "a");
+        assert_eq!(resolved.hostname.as_deref(), Some("real"));
+        assert_eq!(resolved.port, Some(2222));
+    }
+
+    /// A `Host` line whose value is only a comment leaves the block
+    /// INACTIVE rather than refusing - upstream clears `*activep` before
+    /// the loop and the loop then runs zero times
+    /// (openssh/readconf.c:1829-1831). Oracle: `port 22`, exit 0.
+    #[test]
+    fn a_host_line_that_is_only_a_comment_deactivates_without_refusing() {
+        let text = "Host a\n  Port 2222\nHost #x\n  Port 3333\n";
+        assert_eq!(resolve(text, "a").port, Some(2222));
+        assert!(resolve("Host #x\n  Port 3333\n", "a").port.is_none());
+    }
+
+    /// A refusal from a real file names that file, not the inline
+    /// placeholder - the path really is threaded through.
+    #[test]
+    fn a_refusal_names_the_file_it_came_from() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ssh_config");
+        std::fs::write(&path, "Host a \"\" b\n").expect("write fixture");
+        let err = resolve_host(&path, "a").expect_err("refused");
+        assert_eq!(
+            err.to_string(),
+            format!("{} line 1: keyword host empty argument", path.display())
+        );
     }
 
     /// Renders the resolved identity files as strings. `PathBuf` equality
@@ -401,7 +778,7 @@ mod tests {
     fn tilde_slash_run_keeps_home_prefix() {
         let home = home_dir().expect("HOME or USERPROFILE must be set");
         let text = "Host example\n  IdentityFile ~//probe\n";
-        let resolved = resolve_host_str(text, "example");
+        let resolved = resolve(text, "example");
         let expected = format!(
             "{}{}probe",
             home.to_string_lossy(),
@@ -414,7 +791,7 @@ mod tests {
     fn identity_file_tilde_expands_through_the_directive() {
         let home = home_dir().expect("HOME or USERPROFILE must be set");
         let text = "Host example\n  IdentityFile ~/.ssh/id_probe\n";
-        let resolved = resolve_host_str(text, "example");
+        let resolved = resolve(text, "example");
         let sep = std::path::MAIN_SEPARATOR;
         let expected = format!("{}{sep}.ssh{sep}id_probe", home.to_string_lossy());
         assert_eq!(identity_file_strings(&resolved), vec![expected]);
@@ -424,7 +801,7 @@ mod tests {
     fn identity_agent_tilde_expands_through_the_directive() {
         let home = home_dir().expect("HOME or USERPROFILE must be set");
         let text = "Host example\n  IdentityAgent ~/agent.sock\n";
-        let resolved = resolve_host_str(text, "example");
+        let resolved = resolve(text, "example");
         let expected = format!(
             "{}{}agent.sock",
             home.to_string_lossy(),

--- a/crates/rsync_io/src/ssh/embedded/ssh_config.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config.rs
@@ -579,6 +579,20 @@ mod tests {
         assert_eq!(resolve(text, "web 1").port, Some(2222));
     }
 
+    /// Non-vacuity companion for the row above: strip the quotes and the same
+    /// line is THREE patterns, so `web` matches on its own. Without this the
+    /// quoted assertions would also hold for a tokeniser that dropped the
+    /// whole line.
+    /// Oracle: `Host web 1 other` + alias `web` gives `port 2222`, where the
+    /// quoted spelling gives `port 22`.
+    #[test]
+    fn a_bare_space_still_separates_two_host_patterns() {
+        let text = "Host web 1 other\n  Port 2222\n";
+        assert_eq!(resolve(text, "web").port, Some(2222));
+        assert_eq!(resolve(text, "1").port, Some(2222));
+        assert_eq!(resolve(text, "other").port, Some(2222));
+    }
+
     /// An escaped quote is ordinary text, so the token keeps the `"`.
     /// Oracle: `Host \"a` + alias `a` gives `port 22`.
     #[test]

--- a/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
+++ b/crates/rsync_io/src/ssh/embedded/ssh_config_differential.rs
@@ -237,8 +237,38 @@ fn upstream_dump(
 /// `None` means "oc has a resolver but this fixture left it unset".
 /// A keyword absent from the returned map means oc has no resolver at all.
 fn oc_resolution(config_text: &str, alias: &str) -> BTreeMap<String, Option<Vec<String>>> {
-    let resolved = resolve_host_str(config_text, alias);
     let mut map: BTreeMap<String, Option<Vec<String>>> = BTreeMap::new();
+
+    // Parser B's one resolved value. Inserted BEFORE the parser-A rows so
+    // it still contributes when parser A refuses the file - the two
+    // readers have deliberately different failure policies (see
+    // `config_lookup`'s module docs) and the harness must show both.
+    //
+    // Its `false` covers both "Compression no" and "no directive at all",
+    // and upstream's default is also `no` (openssh/readconf.c dumps
+    // `compression no`), so the boolean is comparable end to end. Without
+    // the feature the row is absent and upstream's `compression` line
+    // lands in `NotResolvedByOc`, which is the truth for that build
+    // rather than a hidden pass.
+    #[cfg(feature = "ssh-config-parse")]
+    {
+        let ctx = MatchContext::new(alias, alias, "", "");
+        let enabled = parse_enables_compression(config_text, &ctx);
+        map.insert(
+            "compression".to_owned(),
+            Some(vec![if enabled { "yes" } else { "no" }.to_owned()]),
+        );
+    }
+
+    // A config parser A REFUSES leaves every one of its rows ABSENT, so
+    // upstream's dumped values land in `NotResolvedByOc` instead of
+    // panicking the harness. The refusal itself is asserted through
+    // [`upstream_refusal`], which is the only instrument that can see it:
+    // `ssh -G` reports these rules as a nonzero exit plus stderr text,
+    // never as a dumped option.
+    let Ok(resolved) = resolve_host_str(config_text, alias) else {
+        return map;
+    };
 
     map.insert(
         "hostname".to_owned(),
@@ -282,23 +312,44 @@ fn oc_resolution(config_text: &str, alias: &str) -> BTreeMap<String, Option<Vec<
         resolved.identity_agent.clone().map(|a| vec![a]),
     );
 
-    // Parser B's one resolved value. Its `false` covers both "Compression
-    // no" and "no directive at all", and upstream's default is also `no`
-    // (openssh/readconf.c dumps `compression no`), so the boolean is
-    // comparable end to end. Without the feature the row is absent and
-    // upstream's `compression` line lands in `NotResolvedByOc`, which is
-    // the truth for that build rather than a hidden pass.
-    #[cfg(feature = "ssh-config-parse")]
-    {
-        let ctx = MatchContext::new(alias, alias, "", "");
-        let enabled = parse_enables_compression(config_text, &ctx);
-        map.insert(
-            "compression".to_owned(),
-            Some(vec![if enabled { "yes" } else { "no" }.to_owned()]),
-        );
-    }
-
     map
+}
+
+/// Whether `ssh -G` REFUSED this fixture, and with what diagnostic.
+///
+/// `Ok(None)` means the oracle accepted it; `Ok(Some(text))` carries the
+/// first stderr line of a refusal.
+///
+/// This exists because [`differential`] can only compare a SUCCESSFUL
+/// dump, and two of upstream's tokeniser rules are observable *only* as a
+/// refusal: the empty-token guard (openssh/readconf.c:1832-1836) and the
+/// unterminated-quote guard (openssh/readconf.c:1196-1199) both abort the
+/// load and print to stderr rather than dumping a different option value.
+/// A harness that could only read accepted dumps would be structurally
+/// blind to exactly that half.
+///
+/// # Errors
+///
+/// [`Skipped::NoSshBinary`] when no `ssh` is on PATH.
+pub(super) fn upstream_refusal(config: &Path, alias: &str) -> Result<Option<String>, Skipped> {
+    let out = Command::new("ssh")
+        .arg("-G")
+        .arg("-F")
+        .arg(config)
+        .arg(alias)
+        .output()
+        .map_err(|_| Skipped::NoSshBinary)?;
+    if out.status.success() {
+        return Ok(None);
+    }
+    Ok(Some(
+        String::from_utf8_lossy(&out.stderr)
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_owned(),
+    ))
 }
 
 /// The per-keyword comparison rules, for the keywords oc can answer.
@@ -786,5 +837,226 @@ mod tests {
             FIXTURES.len()
         );
         assert_eq!(produced + skipped, FIXTURES.len(), "a fixture went missing");
+    }
+
+    /// Materialise a fixture and ask `ssh -G` whether it REFUSES the file.
+    fn refusal(text: &str, alias: &str) -> Result<Option<String>, Skipped> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("ssh_config");
+        let mut f = std::fs::File::create(&path).expect("create fixture");
+        f.write_all(text.as_bytes()).expect("write fixture");
+        drop(f);
+        upstream_refusal(&path, alias)
+    }
+
+    /// oc's own verdict on the same text, as the reason line or `None`.
+    fn oc_refusal(text: &str, alias: &str) -> Option<String> {
+        resolve_host_str(text, alias)
+            .err()
+            .map(|err| err.to_string())
+    }
+
+    /// An empty `Host` token is a HARD ERROR on both sides.
+    ///
+    /// `argv_split` PRODUCES the empty token (a quote pair is a state
+    /// toggle that consumes its delimiters, openssh/misc.c:2168-2172), and
+    /// the `oHost` arm is what refuses it - openssh/readconf.c:1832-1836
+    /// `fatal("%s line %d: keyword %s empty argument", ...)`. Splitting the
+    /// rule that way is deliberate: the `Match` criteria consume the same
+    /// tokeniser and have no such guard.
+    ///
+    /// The companion below is not decoration - it pins the ORDER, which is
+    /// the part a plausible-looking implementation gets wrong.
+    #[test]
+    fn an_empty_host_token_is_refused_by_both() {
+        const FIXTURE: &str = "Host a \"\"\n  Port 2222\n";
+
+        let upstream = match refusal(FIXTURE, "a") {
+            Ok(v) => v,
+            Err(why) => {
+                report_skip("empty-host-token refusal", &why);
+                return;
+            }
+        };
+        let upstream = upstream.expect("ssh -G must refuse an empty Host token");
+        assert!(
+            upstream.contains("keyword host empty argument"),
+            "oracle refused with unexpected text: {upstream}"
+        );
+
+        let oc = oc_refusal(FIXTURE, "a").expect("oc must refuse it too");
+        assert!(
+            oc.contains("keyword host empty argument"),
+            "oc refused with unexpected text: {oc}"
+        );
+    }
+
+    /// ORDER CELL: a negated token that MATCHES breaks out of the loop
+    /// before the empty token is ever examined, so the same line is
+    /// ACCEPTED for that alias and refused for every other.
+    ///
+    /// Measured against real `ssh -G` before this test was written:
+    /// `Host !a ""` gives `port 22` for alias `a` (block inactive, no
+    /// refusal) and exits 255 for alias `z`. openssh/readconf.c:1839-1855 -
+    /// the negation `break` at :1849 precedes nothing, but the empty check
+    /// at :1832 sits INSIDE the same per-token loop, so a break skips it.
+    ///
+    /// Without this cell an implementation that validated every token up
+    /// front would look correct: it passes the refusal test above and
+    /// diverges only here.
+    #[test]
+    fn a_negated_match_breaks_before_the_empty_token_is_seen() {
+        const FIXTURE: &str = "Host !a \"\"\n  Port 2222\n";
+
+        let matched = match refusal(FIXTURE, "a") {
+            Ok(v) => v,
+            Err(why) => {
+                report_skip("negated-match ordering", &why);
+                return;
+            }
+        };
+        assert_eq!(
+            matched, None,
+            "the oracle must ACCEPT the line whose negated token already matched"
+        );
+        assert_eq!(
+            oc_refusal(FIXTURE, "a"),
+            None,
+            "oc must accept it too - the empty-token guard is inside the match loop"
+        );
+
+        // Non-vacuity: the SAME line refuses for an alias the negation
+        // does not match, so the acceptance above is the ordering and not
+        // a missing guard.
+        let unmatched = refusal(FIXTURE, "z")
+            .expect("oracle available")
+            .expect("ssh -G must refuse when the walk reaches the empty token");
+        assert!(
+            unmatched.contains("keyword host empty argument"),
+            "oracle refused with unexpected text: {unmatched}"
+        );
+        assert!(
+            oc_refusal(FIXTURE, "z")
+                .expect("oc must refuse it too")
+                .contains("keyword host empty argument"),
+        );
+    }
+
+    /// An unterminated quote is a HARD ERROR on both sides.
+    ///
+    /// `argv_split` returns NULL when it runs off the end of the line with
+    /// a quote still open (openssh/misc.c:2174-2181), and the caller turns
+    /// that into `fatal("%s line %d: invalid quotes", ...)`
+    /// (openssh/readconf.c:1196-1199). It is a property of the TOKENISER,
+    /// so it fires on any keyword - the companion uses a value line, not a
+    /// `Host` line, to show the guard is not the `oHost` arm's.
+    #[test]
+    fn an_unterminated_quote_is_refused_by_both() {
+        const FIXTURE: &str = "Host a\n  HostName \"unclosed\n";
+
+        let upstream = match refusal(FIXTURE, "a") {
+            Ok(v) => v,
+            Err(why) => {
+                report_skip("unterminated-quote refusal", &why);
+                return;
+            }
+        };
+        let upstream = upstream.expect("ssh -G must refuse an unterminated quote");
+        assert!(
+            upstream.contains("invalid quotes"),
+            "oracle refused with unexpected text: {upstream}"
+        );
+        assert!(
+            oc_refusal(FIXTURE, "a")
+                .expect("oc must refuse it too")
+                .contains("invalid quotes"),
+        );
+
+        // Non-vacuity: CLOSING the quote makes the same line load.
+        const CLOSED: &str = "Host a\n  HostName \"closed\"\n";
+        assert_eq!(
+            refusal(CLOSED, "a").expect("oracle available"),
+            None,
+            "the oracle must accept the closed-quote control"
+        );
+        assert_eq!(oc_refusal(CLOSED, "a"), None, "oc must accept it too");
+    }
+
+    /// A `#` inside a token is ORDINARY TEXT, not a comment marker.
+    ///
+    /// `argv_split` only ends the line on a `#` that starts a token
+    /// (openssh/misc.c:2143-2144, tested at the top of the outer loop
+    /// after whitespace is skipped). oc's readers used to cut the line at
+    /// the first `#` anywhere, which truncated this hostname.
+    #[test]
+    fn a_hash_mid_token_is_hostname_text_on_both_sides() {
+        const FIXTURE: &str = "Host t\n  HostName x#y\n";
+
+        let diff = match run(FIXTURE, "t") {
+            Ok(d) => d,
+            Err(why) => {
+                report_skip("mid-token hash", &why);
+                return;
+            }
+        };
+        let hostname = diff.cell("hostname").expect("upstream dumps hostname");
+        assert_eq!(
+            hostname.verdict,
+            Verdict::Match,
+            "upstream {:?} vs oc {:?} on {}",
+            hostname.upstream,
+            hostname.oc,
+            diff.oracle_version
+        );
+        assert_eq!(hostname.upstream, vec!["x#y".to_owned()]);
+
+        // Non-vacuity: a `#` that STARTS a token still ends the line, so
+        // the value is the one token before it and the default survives
+        // for the rest.
+        const COMMENTED: &str = "Host t\n  HostName real # x#y\n";
+        let diff = run(COMMENTED, "t").expect("oracle available");
+        let hostname = diff.cell("hostname").expect("upstream dumps hostname");
+        assert_eq!(hostname.upstream, vec!["real".to_owned()]);
+        assert_eq!(hostname.verdict, Verdict::Match);
+    }
+
+    /// Quotes GROUP and are CONSUMED, so a quoted `Host` pattern matches
+    /// the bare alias.
+    ///
+    /// openssh/misc.c:2163-2166 toggles the quote state without copying the
+    /// delimiter, so `Host "a"` yields the one-character pattern `a`, and
+    /// the `oHost` arm matches it against the alias with `match_pattern`
+    /// (openssh/readconf.c:1844). A reader that kept the quote bytes would
+    /// fail to match and silently fall through to the defaults.
+    #[test]
+    fn a_quoted_host_pattern_matches_the_bare_alias_on_both_sides() {
+        const FIXTURE: &str = "Host \"a\"\n  HostName inside.example.com\n";
+
+        let diff = match run(FIXTURE, "a") {
+            Ok(d) => d,
+            Err(why) => {
+                report_skip("quoted host pattern", &why);
+                return;
+            }
+        };
+        let hostname = diff.cell("hostname").expect("upstream dumps hostname");
+        assert_eq!(
+            hostname.verdict,
+            Verdict::Match,
+            "upstream {:?} vs oc {:?} on {}",
+            hostname.upstream,
+            hostname.oc,
+            diff.oracle_version
+        );
+        assert_eq!(hostname.upstream, vec!["inside.example.com".to_owned()]);
+
+        // Non-vacuity: the quotes are not merely tolerated, they are
+        // CONSUMED - a quote opened mid-token splices, so `Host "a"b`
+        // matches the alias `ab` and NOT `a`.
+        const SPLICED: &str = "Host \"a\"b\n  HostName spliced.example.com\n";
+        let diff = run(SPLICED, "ab").expect("oracle available");
+        let hostname = diff.cell("hostname").expect("upstream dumps hostname");
+        assert_eq!(hostname.upstream, vec!["spliced.example.com".to_owned()]);
+        assert_eq!(hostname.verdict, Verdict::Match);
     }
 }

--- a/crates/rsync_io/src/ssh/mod.rs
+++ b/crates/rsync_io/src/ssh/mod.rs
@@ -84,6 +84,8 @@
 //! (#1687). The stderr channel is socketpair-backed on Unix; see
 //! `aux_channel.rs` for that path.
 
+/// The single ssh_config tokeniser, shared by both config readers.
+mod argv_split;
 #[cfg(all(feature = "async-ssh", feature = "ssh-socketpair-stderr"))]
 mod async_stderr_drain;
 #[cfg(feature = "async-ssh")]


### PR DESCRIPTION
## ⚠ Behaviour change — two config spellings now hard-error

Both abort the whole config load, matching `openssh/readconf.c:2667`. An `ssh://` connection whose `~/.ssh/config` contains either now **fails** where it previously connected using a silently different configuration:

1. A `Host` line with an empty token the match walk reaches (`Host a ""`, `Host "" a`, `Host !a ""` for a non-matching alias) → `<file> line N: keyword host empty argument`, byte-identical to upstream.
2. **Any** line with an unterminated quote, on **any** keyword → `<file> line N: invalid quotes`.

Real `ssh` refuses both. Accepting them was the divergence, and the failure mode it produced — connecting with a config that quietly differs from the one the operator wrote — is worse than the refusal.

## One tokeniser, three eliminated

Upstream splits the value half of *every* config line with a single `argv_split(str, &oac, &oav, 1)` (`openssh/readconf.c:1196`) and each keyword arm consumes tokens from that one vector. Quoting, backslash escapes and comment termination are therefore properties of the **line**, not of any directive — so a second tokeniser anywhere in the parser is a divergence by construction.

New `crates/rsync_io/src/ssh/argv_split.rs` ports `openssh/misc.c:2130-2196`, char-indexed to mirror the C's `s[i+1]` lookahead. Both ssh_config parsers now call it. It also removed a **third** tokeniser not named in the brief: `match_line_applies` was re-splitting the `Match` value with `split_ascii_whitespace`, where upstream hands `match_cfg_line` the one `(ac, av)` split. Two `strip_comment` copies deleted.

Responsibility is split deliberately, following upstream: the tokeniser **produces** the empty token, the `oHost` arm **refuses** it (`openssh/readconf.c:1832-1836`). `Match` criteria carry no such guard, so folding the refusal into the tokeniser would have broken them.

The error enum has exactly one variant because `argv_split` has exactly one failure return (`SSH_ERR_INVALID_FORMAT`, `openssh/misc.c:2174-2179`) — a second would mean inventing a refusal upstream does not have.

## Measured

Oracle is a real `ssh -G` binary (OpenSSH_10.3p1) through the #7784 harness. 16-row boundary table; every fixed cell diverges on base and matches upstream after, each with a non-vacuity companion.

Two decisive rows:

- **Ordering, `Host !a ""`** — proved by running, not inferred: rc 0 for alias `a`, rc 255 for alias `z`. A negated token that *matches* breaks the per-token loop before the empty token is examined. That is the fact deciding where the guard may live, and it is why the guard could not be hoisted to build time in the second parser.
- **`Host "web 1" other`** — `web` → `port 22` (no match), `other` → `port 2222`; bare `Host web 1 other` + `web` → `port 2222`. The quoted/unquoted pair *is* the divergence. `ssh -G` refuses the alias `web 1` itself (`hostname contains invalid characters`), so the grouped token is asserted in-process — the same oracle boundary #7784's Host-matching work hit on `a,b`.

Scoring: mechanical (`assert_eq` per cell, nextest reports the count) for the in-process cells; by eye for the shell probes, which are 3-4 rows of two-column output — stated rather than left to assumption.

8 mutations, all lethal, all reverted (kills: 6/24/3/6/3/2/2/2). Two are worth recording:

- **M7 initially killed 0** — the mutation was wrong (it inserted a check where upstream already has one), so it was redesigned to the genuinely-wrong shape rather than reported as a passing mutation.
- **M8 killing 0 was a real coverage gap** in the second parser, closed with two cells.

The second commit exists because the first pin was weak: it asserted only the quoted arm, so it would still have passed if the tokeniser dropped both shapes. The bare-space control closes that. Stated plainly: as a differential control it has **no unique kill** — M9 kills it along with 38 others.

## Gates (pinned 1.88.0), all after the M9 revert

`check_rustfmt_all.py` 3434 files clean; `clippy -p rsync_io --all-targets --all-features -D warnings` clean; `nextest -p rsync_io --all-features` with `OC_RSYNC_REQUIRE_SSH_G=1` → **1246 passed / 0 failed / 3 skipped**; citation audit non-blocking warning only, blocking half unchanged.

Not run, and not claimed: full-workspace nextest, macOS/Windows/musl cells, the 3.5.0 upstream-testsuite legs, interop. No Windows-conditional behaviour is added — `argv_split` is byte-agnostic and platform-free.

## Scope

Task 1203's deliverable (one **option table**) is untouched and still open — this builds one tokeniser and routes both parsers onto it, which is a different axis.

The second parser deliberately does **not** refuse an empty `Host` token: the ordering above is inexpressible where it builds its pattern list before matching. Documented at `host_patterns_from_tokens`. The first parser hard-errors because it configures the connection; the second keeps its never-fail contract, and the connection `ssh` refuses to make cannot double-compress.

## Residual for the epic

Citation-pin inconsistency: #7784 pinned openssh-portable 10.0p1, but the in-tree citations and the runnable oracle are 10.3p1 (`argv_split` is at `misc.c:2065` in 10.0p1). The epic needs one pin of record. Adjacent to the open question about OpenSSH citations being classified ForeignUpstream and therefore unchecked.
