### PR TITLE
test(daemon): spell the absent merge path the way a directive spells one

### DIFF
--- a/crates/daemon/src/daemon/sections/module_access/tests.rs
+++ b/crates/daemon/src/daemon/sections/module_access/tests.rs
@@ -3713,8 +3713,7 @@ mod module_access_tests {
             .collect()
     }
 
-    /// Writes a merge file under `dir` and returns its path spelled the way a
-    /// daemon parameter spells one: `/`-separated.
+    /// Spells `path` the way a daemon parameter spells one: `/`-separated.
     ///
     /// `Path::display()` would emit the host separator, and a daemon filter path
     /// has exactly one separator - upstream's `parse_merge_name` finds the
@@ -3722,12 +3721,22 @@ mod module_access_tests {
     /// that, so a backslash-spelled path hides the basename from the `e`
     /// modifier. Only the host separator is rewritten, never a byte that could
     /// be part of a legitimate name.
-    fn merge_file(dir: &Path, name: &str, content: &str) -> String {
-        let path = dir.join(name);
-        std::fs::write(&path, content).expect("write merge file");
+    ///
+    /// Every test that puts a temp-dir path into a filter directive spells it
+    /// through here. On Windows `dir.join(..)` yields backslashes, and a
+    /// directive spelled that way behaves differently from the same directive
+    /// on Unix - which is a property of the fixture, not of the daemon.
+    fn daemon_filter_path(path: &Path) -> String {
         path.to_str()
             .expect("utf-8 merge path")
             .replace(std::path::MAIN_SEPARATOR, "/")
+    }
+
+    /// Writes a merge file under `dir` and returns its daemon-spelled path.
+    fn merge_file(dir: &Path, name: &str, content: &str) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, content).expect("write merge file");
+        daemon_filter_path(&path)
     }
 
     #[test]
@@ -3979,8 +3988,7 @@ mod module_access_tests {
         // MEASURED against rsync 3.5.0: `filter = .e NOSUCHFILE` is rc 0 with
         // every file served, while `filter = merge NOSUCHFILE` is rc 5.
         let dir = tempfile::tempdir().expect("temp dir");
-        let missing = dir.path().join("nosuchfile");
-        let missing = missing.to_str().expect("utf-8 path");
+        let missing = daemon_filter_path(&dir.path().join("nosuchfile"));
         assert_eq!(
             filter_patterns(dir.path(), &format!(".e {missing}")),
             vec!["nosuchfile".to_string()]


### PR DESCRIPTION
`a_self_excluded_merge_file_that_does_not_exist_is_not_a_refusal`, added by #7813, builds its path with `dir.path().join(..)`, which emits the host separator. On Windows that puts backslashes into a `filter = .e <path>` directive, so the `e` self-exclude derives its basename from a string containing no `/`, the resulting pattern cannot match the file, the pre-open gate never fires, the open happens, and the absent file refuses the module:

```
filter refused: Custom { kind: NotFound, error: "failed to open exclude file
'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\.tmp4Fir8H\\nosuchfile': ..." }
```

That single test is the whole of the Windows failure set on #7813 — four cells (`Windows daemon`, `Windows (nightly)`, `Feature flag combinations / iconv`, `Feature flag combinations / concurrent-sessions`), each reporting only this name. #7813 auto-merged before the fix landed because none of those four is a required context, so master carries the red today.

`merge_file` already normalises to `/` for exactly this reason, citing upstream's `strrchr(name, '/')` basename scan (exclude.c:1557-1567) — a daemon filter path has one separator and it is not the host's. This splits that spelling out as `daemon_filter_path` so both callers share one owner rather than adding a second `.replace`, and routes the test through it.

Unix behaviour is unchanged: `MAIN_SEPARATOR` is already `/` there, so the replace is a no-op and the sibling tests that already used `merge_file` were never affected.

Verified on the pinned 1.88.0 toolchain: `check_rustfmt_all.py` clean; `cargo nextest run -p daemon --all-features -E 'test(module_access_tests)'` 364/364.