### PR TITLE
fix(filters): take the dir-merge name after the LAST slash, not the first

### DIFF
--- a/crates/cli/src/frontend/filter_rules/parsing/directives.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/directives.rs
@@ -109,19 +109,26 @@ pub(super) fn parse_dir_merge_alias(
         }
     }
 
-    // upstream: exclude.c:599-617 parse_merge_name - a leading '/' on the merge
-    // FILENAME only affects where the merge file is looked up (an ancestor
-    // parent_dirscan); the '/' is stripped from the name and does NOT anchor
-    // the rules loaded from the file. Rule anchoring to the merge directory
-    // happens per-rule in add_rule (exclude.c:200-207) only when the RULE
-    // pattern itself starts with '/'. Setting anchor_root here would wrongly
-    // root-anchor every rule (e.g. `- secret*` in `d1/d2/.rsync-filter` would
-    // become `/d1/d2/secret*` and stop matching `d1/d2/d3/secret.deeper`).
-    // The '/' modifier (dir-merge,/ file) is the real anchor_root source and is
-    // handled in parse_merge_modifiers.
-    if let Some(stripped) = path_text.strip_prefix('/') {
-        path_text = stripped;
-    }
+    // upstream: exclude.c:359-361 add_rule takes the merge name after the LAST
+    // '/', and setup_merge_file (exclude.c:797-801) rewrites `ex->pattern` to
+    // that basename, so the per-directory scan looks for the basename in each
+    // directory. A path portion only steers upstream's ancestor
+    // parent_dirscan; it is never joined onto each scanned directory, and it
+    // does NOT anchor the rules loaded from the file.
+    //
+    // Rule anchoring to the merge directory happens per-rule in add_rule
+    // (exclude.c:200-207) only when the RULE pattern itself starts with '/'.
+    // Setting anchor_root here would wrongly root-anchor every rule (e.g.
+    // `- secret*` in `d1/d2/.rsync-filter` would become `/d1/d2/secret*` and
+    // stop matching `d1/d2/d3/secret.deeper`). The '/' modifier (dir-merge,/
+    // file) is the real anchor_root source and is handled in
+    // parse_merge_modifiers.
+    //
+    // Taking only the leading '/' off would leave `dir/.filt` whole, so each
+    // directory would be searched for `<dir>/dir/.filt` and the merge would
+    // contribute nothing. Same owner as the daemon-side converter in
+    // `transfer/src/generator/filters.rs` and as the `:e` self-exclude.
+    path_text = filters::merge_file_basename(path_text);
 
     Some(Ok(FilterDirective::Rule(FilterRuleSpec::dir_merge(
         path_text.to_owned(),

--- a/crates/cli/src/frontend/filter_rules/parsing/merge.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/merge.rs
@@ -210,7 +210,25 @@ pub(super) fn parse_short_merge_directive(
     };
 
     if is_dir_merge {
-        let rule = FilterRuleSpec::dir_merge(pattern.to_owned(), options);
+        // upstream: exclude.c:359-361 add_rule takes the merge name after the
+        // LAST '/', and setup_merge_file (exclude.c:797-801) rewrites
+        // `ex->pattern` to that basename, so the per-directory open at
+        // exclude.c:910 scans each directory for the basename. A path portion
+        // only steers upstream's ancestor parent_dirscan; it is never joined
+        // onto each scanned directory. Carrying `dir/.filt` through would make
+        // every directory searched for `<dir>/dir/.filt` - a file that need not
+        // exist, so the merge contributes no rules and whatever it was meant to
+        // hide is served instead.
+        //
+        // Only the dir-merge (`:`) arm takes the basename. A plain merge (`.`)
+        // names ONE file resolved once (exclude.c:696-752 parse_merge_name), so
+        // its path portion is load-bearing and stays intact below.
+        //
+        // Same owner as the long `dir-merge` spelling in `directives.rs`, as the
+        // daemon-side converter in `transfer/src/generator/filters.rs`, and as
+        // the `:e` self-exclude.
+        let name = filters::merge_file_basename(pattern);
+        let rule = FilterRuleSpec::dir_merge(name.to_owned(), options);
         return Some(Ok(FilterDirective::Rule(rule)));
     }
 
@@ -448,6 +466,54 @@ mod tests {
         match result {
             FilterDirective::Merge(directive) => {
                 assert_eq!(directive.source(), OsString::from(" "));
+            }
+            other => panic!("expected a merge directive, got {other:?}"),
+        }
+    }
+
+    /// A dir-merge name is a NAME, so a path portion is dropped: upstream's
+    /// `setup_merge_file` (exclude.c:797-801) rewrites `ex->pattern` to the
+    /// basename `add_rule` took (exclude.c:359-361), and the per-directory open
+    /// at exclude.c:910 reads the rewritten value.
+    ///
+    /// MEASURED against rsync 3.5.0 with `-r --filter=': dir/.filt'` over
+    /// `src/.filt` plus `src/sub/{.filt,bait,keep}` where `src/sub/.filt` reads
+    /// `- bait`: upstream hides `bait`. oc carried `dir/.filt` into `Path::join`,
+    /// searched every directory for `<dir>/dir/.filt`, found nothing, and SERVED
+    /// the file the merge existed to hide.
+    #[test]
+    fn parse_short_dir_merge_takes_the_basename_after_the_last_slash() {
+        for (given, want) in [
+            ("dir/.filt", ".filt"),
+            ("a/b/c/.rsync-filter", ".rsync-filter"),
+            ("/.rsync-filter", ".rsync-filter"),
+            (".rsync-filter", ".rsync-filter"),
+        ] {
+            let result = parse_short_merge_directive(arg(&format!(": {given}")))
+                .expect("`:` is a dir-merge directive")
+                .expect("directive parses");
+            match result {
+                FilterDirective::Rule(rule) => {
+                    assert_eq!(rule.pattern(), want, "merge name for {given:?}");
+                }
+                other => panic!("expected a dir-merge rule for {given:?}, got {other:?}"),
+            }
+        }
+    }
+
+    /// The control that keeps the cell above honest, and the reason the basename
+    /// rule is NOT applied to both arms: a plain `merge` names ONE file resolved
+    /// once (exclude.c:696-752 `parse_merge_name`), never re-opened per
+    /// directory, so its path portion is load-bearing. Taking the basename here
+    /// would read a different file.
+    #[test]
+    fn parse_short_plain_merge_keeps_the_whole_path() {
+        let result = parse_short_merge_directive(arg(". dir/.filt"))
+            .expect("`.` is a merge directive")
+            .expect("directive parses");
+        match result {
+            FilterDirective::Merge(directive) => {
+                assert_eq!(directive.source(), OsString::from("dir/.filt"));
             }
             other => panic!("expected a merge directive, got {other:?}"),
         }

--- a/crates/cli/src/frontend/filter_rules/parsing/tests.rs
+++ b/crates/cli/src/frontend/filter_rules/parsing/tests.rs
@@ -269,6 +269,41 @@ fn dir_merge_basic() {
     }
 }
 
+/// WHY: upstream's per-directory scan reads the merge name after the LAST `/`
+/// (`exclude.c:359-361`; `setup_merge_file` at `exclude.c:797-801` rewrites
+/// `ex->pattern` to that basename before the open at `exclude.c:910`). A path
+/// portion steers only upstream's ancestor `parent_dirscan` - it is never
+/// joined onto each scanned directory.
+///
+/// Stripping only a LEADING `/` left `dir/.filt` intact, so every directory
+/// was searched for `<dir>/dir/.filt`, the merge contributed no rules, and
+/// whatever it was meant to hide was SERVED. Measured against real rsync
+/// 3.5.0: `-r --filter=': dir/.filt'` with `- bait` in `src/sub/.filt` and no
+/// directory named `dir` - upstream hides `bait`, oc served it.
+///
+/// Shares `filters::merge_file_basename` with the daemon-side converter in
+/// `transfer/src/generator/filters.rs`, so the two spellings cannot drift.
+#[test]
+fn dir_merge_takes_the_basename_after_the_last_slash() {
+    for (given, want) in [
+        ("dir/.filt", ".filt"),
+        ("a/b/c/.rsync-filter", ".rsync-filter"),
+        ("/.rsync-filter", ".rsync-filter"),
+        (".rsync-filter", ".rsync-filter"),
+    ] {
+        let directive = parse_dir_merge_alias(arg(&format!("dir-merge {given}")))
+            .expect("dir-merge keyword recognised")
+            .expect("directive parses");
+        match directive {
+            FilterDirective::Rule(spec) => {
+                assert_eq!(spec.kind(), FilterRuleKind::DirMerge);
+                assert_eq!(spec.pattern(), want, "merge name for {given:?}");
+            }
+            _ => panic!("expected Rule directive for {given:?}"),
+        }
+    }
+}
+
 #[test]
 fn per_dir_is_not_a_keyword() {
     // upstream: exclude.c recognizes only "dir-merge" (case 'd' RULE_STRCMP);

--- a/crates/engine/src/local_copy/dir_merge/load.rs
+++ b/crates/engine/src/local_copy/dir_merge/load.rs
@@ -348,7 +348,7 @@ impl DirMergeEntries {
         // withheld from the match trace, as it must - it came out of a file.
         if nested.options.excludes_self() {
             let name = nested.pattern.to_string_lossy();
-            let excluded = filters::merge_self_exclude_name(&name).to_owned();
+            let excluded = filters::merge_file_basename(&name).to_owned();
             self.push_rule(FilterRule::exclude(excluded));
         }
         self.nested_dir_merges.push(nested);

--- a/crates/engine/src/local_copy/filter_program/program.rs
+++ b/crates/engine/src/local_copy/filter_program/program.rs
@@ -134,7 +134,7 @@ impl FilterProgram {
                     // LOADED, so a `:e` naming an absent file excluded nothing.
                     if rule.options().excludes_self() {
                         let name = rule.pattern().to_string_lossy();
-                        let excluded = filters::merge_self_exclude_name(&name).to_owned();
+                        let excluded = filters::merge_file_basename(&name).to_owned();
                         let excluded = filters::FilterRule::exclude(excluded);
                         filters::trace_add_rule(
                             excluded.action(),

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -151,7 +151,7 @@ pub use error::FilterError;
 pub use implied::{ImpliedIncludeOptions, ImpliedIncludes};
 pub use merge::{
     FilterFileRecords, MAX_MERGE_DEPTH, MergeFileError, depth_limit_exceeded,
-    filter_file_line_is_rule, filter_file_records, merge_name_overflows, merge_self_exclude_name,
+    filter_file_line_is_rule, filter_file_records, merge_file_basename, merge_name_overflows,
     parse_rules, read_rules, read_rules_recursive,
 };
 pub use overlong::{is_over_long, over_long_filter};

--- a/crates/filters/src/merge/basename.rs
+++ b/crates/filters/src/merge/basename.rs
@@ -1,5 +1,17 @@
-//! The extra exclude a `:e` / `.e` dir-merge directive synthesises for the
-//! merge file's own name.
+//! The basename of a merge-file name: everything after the last `/`.
+//!
+//! upstream performs this same byte scan at TWO sites, and both need it for the
+//! same reason - a merge-file name is a NAME, not a path to join:
+//!
+//! - `exclude.c:359-361` in `add_rule`'s `FILTRULE_PERDIR_MERGE` branch, which
+//!   takes the basename for the mergelist dedup compare and the `[per-dir %s]`
+//!   debug label. `setup_merge_file` (`exclude.c:797-801`) then REWRITES
+//!   `ex->pattern` to that basename, and the per-directory open at
+//!   `exclude.c:910` reads the rewritten value - so the basename is what each
+//!   directory is actually scanned for.
+//! - `exclude.c:1558-1571` for the `:e` / `.e` self-exclude, below.
+//!
+//! ## The `:e` self-exclude
 //!
 //! upstream: `exclude.c:1558-1571`, inside `parse_filter_str`'s
 //! `FILTRULE_MERGE_FILE` branch:
@@ -33,16 +45,17 @@
 //! file's contents at `-vv`. Callers therefore attach the provenance of the
 //! directive they are expanding, not of the rule they are creating.
 
-/// Returns the basename upstream excludes for a `:e` merge directive.
+/// Returns the basename of a merge-file name: the bytes after the last `/`.
 ///
 /// upstream scans back from the end of the pattern to the byte after the last
-/// `/` (`exclude.c:1568-1569`), so this is a byte split, not a path parse: a
-/// pattern ending in `/` yields the empty name and `..` yields `..`, both of
-/// which `Path::file_name` would instead report as absent. Mirroring the scan
-/// keeps those inputs behaving as upstream does rather than as a path API
-/// would prefer.
+/// `/` (`exclude.c:1568-1569` for the self-exclude, `exclude.c:359-361` via
+/// `strrchr` for the per-directory name), so this is a byte split, not a path
+/// parse: a pattern ending in `/` yields the empty name and `..` yields `..`,
+/// both of which `Path::file_name` would instead report as absent. Mirroring
+/// the scan keeps those inputs behaving as upstream does rather than as a path
+/// API would prefer.
 #[must_use]
-pub fn merge_self_exclude_name(pattern: &str) -> &str {
+pub fn merge_file_basename(pattern: &str) -> &str {
     match pattern.rfind('/') {
         Some(slash) => &pattern[slash + 1..],
         None => pattern,
@@ -56,16 +69,16 @@ mod tests {
     /// The ordinary case: a bare merge-file name is its own basename.
     #[test]
     fn a_bare_name_is_unchanged() {
-        assert_eq!(merge_self_exclude_name(".rsync-filter"), ".rsync-filter");
+        assert_eq!(merge_file_basename(".rsync-filter"), ".rsync-filter");
     }
 
     /// WHY: upstream excludes the NAME, not the path it was written with, so
     /// `:e sub/name` hides `name` in each directory - not `sub/name`.
     #[test]
     fn a_qualified_name_keeps_only_the_last_segment() {
-        assert_eq!(merge_self_exclude_name("sub/name"), "name");
-        assert_eq!(merge_self_exclude_name("a/b/c/name"), "name");
-        assert_eq!(merge_self_exclude_name("/leading"), "leading");
+        assert_eq!(merge_file_basename("sub/name"), "name");
+        assert_eq!(merge_file_basename("a/b/c/name"), "name");
+        assert_eq!(merge_file_basename("/leading"), "leading");
     }
 
     /// WHY: the scan is over bytes, so a trailing slash leaves NOTHING after
@@ -73,15 +86,15 @@ mod tests {
     /// a directory upstream never names.
     #[test]
     fn a_trailing_slash_yields_the_empty_name() {
-        assert_eq!(merge_self_exclude_name("sub/"), "");
+        assert_eq!(merge_file_basename("sub/"), "");
     }
 
     /// The other place a path API and upstream's byte scan disagree:
     /// `Path::file_name` returns `None` for `..`, upstream returns `..`.
     #[test]
     fn dot_dot_is_its_own_basename() {
-        assert_eq!(merge_self_exclude_name(".."), "..");
-        assert_eq!(merge_self_exclude_name("sub/.."), "..");
+        assert_eq!(merge_file_basename(".."), "..");
+        assert_eq!(merge_file_basename("sub/.."), "..");
     }
 
     /// The glob in upstream's `filter-merge-content-echo` cell: the literal
@@ -89,6 +102,6 @@ mod tests {
     /// which must never reach a diagnostic when it came out of a file.
     #[test]
     fn a_glob_name_is_carried_through_verbatim() {
-        assert_eq!(merge_self_exclude_name("excl-self-[x]9"), "excl-self-[x]9");
+        assert_eq!(merge_file_basename("excl-self-[x]9"), "excl-self-[x]9");
     }
 }

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -50,7 +50,7 @@ mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
 mod records;
-mod self_exclude;
+mod basename;
 mod skip;
 
 #[cfg(test)]
@@ -63,5 +63,5 @@ pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};
 pub use records::{FilterFileRecords, filter_file_records};
-pub use self_exclude::merge_self_exclude_name;
+pub use basename::merge_file_basename;
 pub use skip::filter_file_line_is_rule;

--- a/crates/filters/src/merge/mod.rs
+++ b/crates/filters/src/merge/mod.rs
@@ -44,18 +44,19 @@
 //! - upstream: exclude.c:parse_filter_file() - reading rules from merge files
 //! - upstream: exclude.c lines 1220-1288 - modifier character handling
 
+mod basename;
 mod depth;
 mod error;
 mod overflow;
 pub(crate) mod parse;
 pub(crate) mod read;
 mod records;
-mod basename;
 mod skip;
 
 #[cfg(test)]
 mod tests;
 
+pub use basename::merge_file_basename;
 pub use depth::{MAX_MERGE_DEPTH, depth_limit_exceeded};
 pub use error::MergeFileError;
 pub use overflow::merge_name_overflows;
@@ -63,5 +64,4 @@ pub use parse::parse_rules;
 pub(crate) use read::scope_local_clear;
 pub use read::{read_rules, read_rules_recursive};
 pub use records::{FilterFileRecords, filter_file_records};
-pub use basename::merge_file_basename;
 pub use skip::filter_file_line_is_rule;

--- a/crates/transfer/src/generator/filters.rs
+++ b/crates/transfer/src/generator/filters.rs
@@ -688,15 +688,26 @@ fn wire_rule_to_dir_merge_config(
         lossy.as_ref()
     };
 
-    // upstream: exclude.c:696-712 parse_merge_name and exclude.c:348-353
-    // add_rule - a leading '/' on the merge FILENAME only decides where the
-    // file is looked up; the per-directory scan uses the name after the last
-    // '/'. It does NOT anchor the rules read out of that file. Strip it so
-    // Path::join() produces a relative path, and nothing more. This mirrors
-    // the client-side spelling in
-    // `cli/src/frontend/filter_rules/parsing/directives.rs`, which strips the
-    // same slash without touching the anchor.
-    let filename = pattern.strip_prefix('/').unwrap_or(pattern);
+    // upstream: exclude.c:359-361 add_rule takes the merge name after the LAST
+    // '/', and setup_merge_file (exclude.c:797-801) rewrites `ex->pattern` to
+    // that basename, so the per-directory open at exclude.c:910 scans each
+    // directory for the basename - never for the path portion. A path portion
+    // only steers upstream's ancestor `parent_dirscan`; it is NOT joined onto
+    // each scanned directory, and it does NOT anchor the rules read out of the
+    // file.
+    //
+    // Stripping only a LEADING '/' would leave `dir/.filt` intact, and
+    // `Path::join` would then look for `<dir>/dir/.filt` in every directory -
+    // a file that need not exist, so the merge silently contributes no rules
+    // and whatever it was meant to hide is served instead.
+    //
+    // `filters::merge_file_basename` is the same owner the `:e` self-exclude
+    // uses (upstream runs the identical byte scan at exclude.c:1568-1569), and
+    // it is a byte split rather than a path parse for the reasons its own doc
+    // records. The client-side spelling in
+    // `cli/src/frontend/filter_rules/parsing/directives.rs` calls it too, so
+    // the two cannot drift apart.
+    let filename = filters::merge_file_basename(pattern);
 
     // upstream: exclude.c:1392-1394 - the `/` MODIFIER (`:/ NAME`) is the sole
     // source of FILTRULE_ABS_PATH on a merge rule: exclude.c:297-300 skips the
@@ -915,6 +926,34 @@ mod tests {
         let config = wire_rule_to_dir_merge_config(&wire_rule, true);
         assert_eq!(config.filename(), ".rsync-filter");
         assert!(!config.is_anchor_root());
+    }
+
+    /// WHY: an INTERIOR `/` is dropped for the same reason the leading one is -
+    /// upstream's per-directory scan reads the name after the LAST `/`
+    /// (`exclude.c:359-361`, and `setup_merge_file` at `exclude.c:797-801`
+    /// rewrites `ex->pattern` to exactly that before the open at
+    /// `exclude.c:910`). Stripping only the leading slash left `dir/.filt`
+    /// whole, so `Path::join` searched each directory for `<dir>/dir/.filt`.
+    ///
+    /// Measured against real rsync 3.5.0 (local `-r --filter=': dir/.filt'`,
+    /// with `- bait` in `src/sub/.filt` and NO directory named `dir`):
+    /// upstream hides `bait`; oc served it, because the merge file it looked
+    /// for could not exist. A filter that fails to hide is a file served.
+    ///
+    /// ⚠ The fixture deliberately names a directory that does NOT exist. With
+    /// an existing one (`: sub/.filt`) both implementations hide `bait` for
+    /// DIFFERENT reasons - oc's join lands on the real `src/sub/.filt` by
+    /// accident - so that shape converges and cannot discriminate.
+    #[test]
+    fn wire_rule_to_dir_merge_config_takes_the_basename_after_the_last_slash() {
+        let wire_rule = make_dir_merge_wire_rule("dir/.filt");
+        let config = wire_rule_to_dir_merge_config(&wire_rule, true);
+        assert_eq!(config.filename(), ".filt");
+        assert!(!config.is_anchor_root());
+
+        let deep = make_dir_merge_wire_rule("a/b/c/.rsync-filter");
+        let deep_config = wire_rule_to_dir_merge_config(&deep, true);
+        assert_eq!(deep_config.filename(), ".rsync-filter");
     }
 
     /// `:/ .rsync-filter` - the `/` MODIFIER, which `wire.rs:585` decodes into


### PR DESCRIPTION
## The defect

A `dir-merge` name is a NAME, not a path to join. Upstream's `add_rule` takes the
basename via `strrchr(pattern,'/')+1` (`exclude.c:359-361`), and `setup_merge_file`
then permanently **rewrites** `ex->pattern` to that basename (`exclude.c:797-801`),
so the per-directory open at `exclude.c:910` scans every directory for the basename
alone. A path portion only steers the ancestor `parent_dirscan`; it is never joined
onto each scanned directory, and it does not anchor the rules read out of the file.

Three sites stripped only a **leading** `/`, leaving `dir/.filt` intact. `Path::join`
then looked for `<dir>/dir/.filt` in every directory — a file that need not exist — so
the merge contributed no rules and whatever it was meant to hide was served instead.

## Measured

Local `-r --filter=<spec>` against real rsync 3.5.0, over a source holding `src/.filt`
plus `src/sub/{.filt,bait,keep}` where `src/sub/.filt` reads `- bait`:

| cell | spec | upstream | oc (base) | oc (fix) |
|---|---|---|---|---|
| control-plain | `: .filt` | hides `bait` | hides `bait` | hides `bait` |
| **path-portion-dir** | `: dir/.filt` | **hides `bait`** | **SERVES `bait`** | **hides `bait`** |
| path-portion-sub | `: sub/.filt` | hides `bait` | hides `bait` | hides `bait` |
| leading-slash | `: /.filt` | hides `bait` | hides `bait` | hides `bait` |
| dotslash | `: ./.filt` | hides `bait` | hides `bait` | hides `bait` |

`: dir/.filt` is the single discriminating cell. A filter that fails to hide is a file
exposed — same class as the merge-file defects in #7729 and #7738. Post-fix all five
cells match upstream.

`: sub/.filt` is worth naming as a **non-discriminating** shape: `sub/.filt` happens to
exist in the fixture, so `Path::join` accidentally lands on a real file and both arms
converge. A fixture built only from that shape would have hidden the defect entirely.

## The fix

The byte scan already had an owner — the `:e` self-exclude helper, which performs the
identical scan for the identical reason (`exclude.c:1568-1569`). Generalised rather
than duplicated:

- `filters/src/merge/self_exclude.rs` → `basename.rs`
- `merge_self_exclude_name` → `merge_file_basename`, module doc citing both upstream anchors

Four call sites now share the one owner (the two pre-existing `:e` callers, plus the two
dir-merge-filename sites), so the spellings cannot drift apart again. It stays a byte
split rather than a path parse for the reason its own doc records: `Path::file_name`
reports `None` for `..` and `sub` for `sub/`, where upstream's scan yields `..` and the
empty name.

Sites fixed:
- `cli/.../parsing/merge.rs` — the short `:` form (what the oracle exercises)
- `cli/.../parsing/directives.rs` — the long `dir-merge` form
- `transfer/src/generator/filters.rs` — the daemon-side wire converter

## Scope boundary, deliberate

Only the **dir-merge** arms take the basename. A plain `merge` (`.` / `merge`) names ONE
file resolved once (`exclude.c:696-752 parse_merge_name`), never re-opened per directory,
so its path portion is load-bearing and is left intact. That boundary is pinned by its
own control test (`parse_short_plain_merge_keeps_the_whole_path`), which stays green
under the mutation that reddens the dir-merge pin.

## Verification

Mutation pass, each site independently (restore the leading-slash-only strip, rebuild,
re-run; `--no-fail-fast` so kill lists are not truncated):

| arm | baseline | mutated | kill |
|---|---|---|---|
| M1 short `:` | 151/151 | 150/151 | `parse_short_dir_merge_takes_the_basename_after_the_last_slash` |
| M2 long `dir-merge` | 151/151 | 150/151 | `dir_merge_takes_the_basename_after_the_last_slash` |
| M3 wire converter | 30/30 | 29/30 | `wire_rule_to_dir_merge_config_takes_the_basename_after_the_last_slash` |

All three reverted green. Each pin is load-bearing for exactly its own site.

Gates at the pinned 1.88.0: whole-tree rustfmt (`tools/ci/check_rustfmt_all.py`) clean
over 3435 files; clippy `-p filters -p cli -p transfer -p engine --all-targets
--all-features -D warnings` clean; nextest those four crates `--lib` 11339/11339.

Touches no expect-manifests, so no derived-tally skew is armed.

**Not run**, and stated rather than implied: full-workspace nextest, root-level
`tests/integration_*.rs`, macOS/Windows/musl cells, the 3.5.0 testsuite legs, interop.
